### PR TITLE
feat: SPDX validation, binary collection, cloud VM setup

### DIFF
--- a/.windsurf/rules/docker-rules.md
+++ b/.windsurf/rules/docker-rules.md
@@ -4,18 +4,29 @@ description: Rules for Docker container usage in this project
 
 # Docker Rules
 
-- **All builds run inside the Docker container** — never compile C/C++ on the macOS host
+- **All builds run on the DigitalOcean droplet** (`omnibor-build`, 137.184.178.186)
+- **Local Docker is NOT needed** — the droplet runs native x86_64 Linux with Docker
 - **Bomtrace3 requires Linux strace** — it will not work on macOS
 - The container must have `SYS_PTRACE` capability and `seccomp:unconfined` security option
-- Use `docker-compose run --rm omnibor-env bash` to enter the container interactively
-- Use `docker-compose build` from the `docker/` directory to rebuild the image
+- SSH alias: `ssh omnibor-build` (configured in `~/.ssh/config`)
+- To enter the container on the droplet:
 
-# Volume Mounts
+  ```bash
+  ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env bash"
+  ```
 
-The following host directories are mounted into the container:
+- To rebuild the image on the droplet:
 
-| Host Path | Container Path | Purpose |
-|-----------|---------------|---------|
+  ```bash
+  ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml build"
+  ```
+
+# Volume Mounts (on droplet)
+
+The following directories are mounted into the container:
+
+| Host Path (droplet) | Container Path | Purpose |
+|----------------------|---------------|---------|
 | `repos/` | `/workspace/repos` | Cloned source repositories |
 | `output/` | `/workspace/output` | Generated ADG, SPDX, binary scan artifacts |
 | `app/` | `/workspace/app` | Orchestration scripts and config |
@@ -27,3 +38,4 @@ The following host directories are mounted into the container:
 - Bomtrace2 and bomtrace3 are compiled from source (patched strace) during image build
 - The bomsh scripts and binaries are at `/opt/bomsh/` inside the container
 - Syft is installed at `/usr/local/bin/syft`
+- After changing the Dockerfile locally, push to GitHub, pull on the droplet, then rebuild

--- a/.windsurf/workflows/run-analysis.md
+++ b/.windsurf/workflows/run-analysis.md
@@ -4,59 +4,83 @@ description: Run OmniBOR build interception analysis on a target repository
 
 # Run Analysis
 
-Instrument a C/C++ build with bomtrace3 and generate OmniBOR ADG + SPDX SBOM.
+Instrument a C/C++ build with bomtrace3 on the DigitalOcean droplet and
+download results to local Mac.
 
 ## Prerequisites
 
-- Docker image must be built (run `/docker-build` workflow first)
+- DigitalOcean droplet must be running (`ssh omnibor-build` must work)
+- Docker image must be built on the droplet (run `/docker-build` workflow first)
 - Target repo must be defined in `app/config.yaml`
+- Latest code must be pushed and pulled on the droplet
 
-## 1. List available repos
+## 1. Ensure droplet has latest code
 
 ```bash
-docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --list
+ssh omnibor-build "cd /root/omnibor-analysis && git pull origin main"
 ```
 
-## 2. Run full analysis (clone + build + SBOM)
+## 2. Run full analysis on droplet
 
 For curl:
+
 ```bash
-docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo curl
+ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo curl"
 ```
 
 For FFmpeg:
+
 ```bash
-docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo ffmpeg
+ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo ffmpeg"
 ```
 
 ## 3. Re-run without cloning (repo already exists)
 
 ```bash
-docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo curl --skip-clone
+ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo curl --skip-clone"
 ```
 
 ## 4. Generate only a Syft manifest SBOM (no build)
 
 ```bash
-docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo curl --syft-only
+ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo curl --syft-only"
 ```
+
+## 5. Download output to local Mac
+
+After analysis completes, sync the output and docs directories back:
+
+```bash
+rsync -avz omnibor-build:/root/omnibor-analysis/output/ output/
+rsync -avz omnibor-build:/root/omnibor-analysis/docs/ docs/
+```
+
+This downloads:
+
+- `output/binaries/<repo>/` — compiled binaries (curl, libcurl.so, etc.)
+- `output/omnibor/<repo>/` — OmniBOR ADG documents
+- `output/spdx/<repo>/` — SPDX SBOMs (OmniBOR + Syft)
+- `docs/<repo>/` — build logs
+- `docs/runtime/` — runtime metrics
 
 ## What happens during analysis
 
-1. **Clone** — shallow clone of the target repo into `repos/<name>/`
-2. **Syft baseline** — generates a manifest-based SPDX SBOM for comparison
-3. **Pre-build** — runs autoreconf, configure (NOT instrumented)
-4. **Instrumented build** — runs `bomtrace3 make` to intercept compiler/linker calls
-5. **ADG generation** — `bomsh_create_bom.py` processes the raw logfile into OmniBOR ADG
-6. **SPDX generation** — `bomsh_sbom.py` creates SPDX SBOM from ADG data
-7. **Docs** — timestamped build log and runtime metrics written to `docs/<repo>/`
+1. **Clone** — shallow clone of the target repo
+2. **Syft baseline** — manifest-based SPDX SBOM for comparison
+3. **Validate deps** — checks `apt_deps` are installed
+4. **Instrumented build** — `bomtrace3 make` intercepts compiler/linker calls
+5. **SPDX generation** — `bomsh_sbom.py` creates SPDX SBOM from ADG data
+6. **SPDX validation** — JSON Schema + semantic validation of generated SPDX
+7. **Binary collection** — copies `output_binaries` to `output/binaries/<repo>/`
+8. **Docs** — timestamped build log and runtime metrics
 
-## Output locations
+## Output locations (on droplet, mirrored locally after rsync)
 
 | Artifact | Path |
 |----------|------|
+| Output binaries | `output/binaries/<repo>/` |
 | OmniBOR ADG | `output/omnibor/<repo>/` |
-| SPDX SBOM (OmniBOR) | `output/spdx/<repo>/<repo>_omnibor_<timestamp>.spdx.json` |
-| SPDX SBOM (Syft) | `output/spdx/<repo>/<repo>_syft_<timestamp>.spdx.json` |
-| Build log | `docs/<repo>/<timestamp>_build.md` |
-| Runtime metrics | `docs/runtime/<timestamp>_<repo>_runtime.md` |
+| SPDX SBOM (OmniBOR) | `output/spdx/<repo>/<repo>_omnibor_<ts>.spdx.json` |
+| SPDX SBOM (Syft) | `output/spdx/<repo>/<repo>_syft_<ts>.spdx.json` |
+| Build log | `docs/<repo>/<ts>_build.md` |
+| Runtime metrics | `docs/runtime/<ts>_<repo>_runtime.md` |

--- a/.windsurf/workflows/setup-environment.md
+++ b/.windsurf/workflows/setup-environment.md
@@ -22,43 +22,39 @@ PR-first workflow, no direct commits to main).
 
 **Do not proceed to any task until this step is complete.**
 
-## 1. Verify Docker is running
+## 1. Verify SSH access to DigitalOcean build droplet
+
+All bomtrace3 instrumented builds run on a remote DigitalOcean droplet
+(native x86_64 Linux). Local Docker is NOT needed.
 
 ```bash
-docker info --format '{{.ServerVersion}}' 2>/dev/null || echo "Docker is NOT running"
+ssh omnibor-build "uname -m && docker --version" 2>/dev/null || echo "Droplet is NOT reachable — it may be powered off"
 ```
 
-## 2. Check if the omnibor-analysis image exists
+If the droplet is powered off, remind the user to start it from the
+DigitalOcean dashboard (cloud.digitalocean.com → Droplets → omnibor-build → Power On).
 
-```bash
-docker images omnibor-analysis --format "{{.Repository}}:{{.Tag}} ({{.Size}}, created {{.CreatedSince}})"
-```
+SSH config is in `~/.ssh/config` under host `omnibor-build` (IP: 137.184.178.186).
 
-If no image exists, build it:
-
-```bash
-docker-compose -f docker/docker-compose.yml build
-```
-
-## 3. Verify key project files
+## 2. Verify key project files
 
 ```bash
 ls -la app/config.yaml app/analyze.py app/compare.py docker/Dockerfile docker/docker-compose.yml
 ```
 
-## 4. Check which repos are cloned
+## 3. Check which repos are cloned (on droplet)
 
 ```bash
-ls -d repos/*/ 2>/dev/null || echo "No repos cloned yet"
+ssh omnibor-build "ls -d /root/omnibor-analysis/repos/*/ 2>/dev/null || echo 'No repos cloned yet'"
 ```
 
-## 5. Check for existing output artifacts
+## 4. Check for existing output artifacts (on droplet)
 
 ```bash
-find output/ -name "*.spdx.json" -o -name "*.sha1" 2>/dev/null | head -20 || echo "No output artifacts yet"
+ssh omnibor-build "find /root/omnibor-analysis/output/ -name '*.spdx.json' -o -name '*.sha1' 2>/dev/null | head -20 || echo 'No output artifacts yet'"
 ```
 
-## 6. Check for existing docs/reports
+## 5. Check for existing docs/reports (local)
 
 ```bash
 find docs/ -name "*.md" -not -name ".gitkeep" 2>/dev/null | sort | tail -10 || echo "No reports yet"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `SpdxValidator` class in `analyze.py` — two-phase SPDX v2.3 validation:
+  1. JSON Schema validation against the official SPDX 2.3 schema (via `jsonschema`)
+  2. Semantic validation via `spdx-tools` (`parse_file` + `validate_full_spdx_document`)
+  Either phase degrades gracefully if its library is unavailable
+- SPDX validation step (Step 6) added to the analysis pipeline, runs after SPDX generation
+- `BinaryCollector` class in `analyze.py` — copies `output_binaries` from the build tree into `output/binaries/<repo>/` for download to local Mac
+- `jsonschema==4.23.0` and `spdx-tools==0.8.2` added to `requirements.txt`
+- DigitalOcean droplet (`omnibor-build`) for native x86_64 bomtrace3 builds — replaces local Docker
+- Droplet shutdown reminder rule (`.windsurf/rules/droplet-shutdown.md`)
+- bomtrace3 QEMU/Rosetta debug findings documented (`docs/bomtrace3-qemu-debug.md`)
+- GitHub Issue draft for omnibor/bomsh QEMU bugs (`docs/github-issue-bomsh-qemu.md`)
+
+### Fixed
+
+- `bomsh_sbom.py` CLI invocation — removed incorrect `-r` flag (means `--remove_intermediate_files`, not raw logfile)
+
+### Changed
+
+- Setup-environment workflow now checks SSH to DigitalOcean droplet instead of local Docker
+- Docker rules updated: builds run on remote droplet, local Docker no longer required
 - Per-repo `apt_deps` field in `config.yaml` — explicitly lists required `-dev` packages for each target repo's build
 - `DependencyValidator` class in `analyze.py` — checks all `apt_deps` are installed (via `dpkg-query`) before starting an instrumented build; prints actionable install hints on failure
 - `ConfigGenerator.generate_entry()` now includes discovered `apt_deps` in generated config entries

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@
 # Used by BOTH the Docker container and local development.
 # Keep in sync: Dockerfile installs this file, local .venv installs this file.
 PyYAML==6.0.3
+jsonschema==4.23.0
+spdx-tools==0.8.2


### PR DESCRIPTION
## Changes

- **SpdxValidator** class: two-phase SPDX v2.3 validation (JSON Schema + spdx-tools semantic), degrades gracefully if libraries missing
- **BinaryCollector** class: copies output_binaries from build tree into output/binaries/<repo>/ for download to local Mac
- **bomsh_sbom.py fix**: removed incorrect -r flag (means --remove_intermediate_files, not raw logfile)
- **requirements.txt**: added jsonschema==4.23.0 and spdx-tools==0.8.2
- **run-analysis workflow**: updated for droplet-based builds with rsync download step
- **setup-environment workflow**: SSH to droplet instead of local Docker checks
- **docker-rules**: updated for remote droplet builds

## Tests
232 passed, 98% coverage