### PR TITLE
feat: ADG-based SPDX generator with complete component metadata

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,9 @@
 # and are not testable as Python application logic.
 omit =
     app/apply_qemu_fallback.py
+    app/collect_metadata.py
     docker/patches/*
+
+[report]
+exclude_lines =
+    if __name__ == .__main__.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ADG-based SPDX generator** (`app/spdx_from_adg.py`) — generates complete SPDX 2.3 JSON
+  directly from OmniBOR ADG data, replacing the incomplete bomsh_sbom.py output:
+  - `AdgParser`: reads bomsh treedb and classifies all build artifacts
+  - `ComponentResolver`: maps system files to dpkg packages with name, version, supplier,
+    homepage, PURL (`pkg:deb/ubuntu/...`), and CPE 2.3 identifiers
+  - `SpdxEmitter`: produces SPDX with packages, source files, relationships
+    (DEPENDS_ON, BUILD_TOOL_OF, CONTAINS), and OmniBOR ExternalRefs
+  - For curl: 13 packages, 441 source files, 454 relationships (vs 2 packages from bomsh_sbom.py)
+- **Metadata collection script** (`app/collect_metadata.py`) — runs inside the build container
+  to resolve system files to dpkg packages via `dpkg -S` and extract rich metadata
 - `SpdxValidator` class in `analyze.py` — two-phase SPDX v2.3 validation:
   1. JSON Schema validation against the official SPDX 2.3 schema (via `jsonschema`)
   2. Semantic validation via `spdx-tools` (`parse_file` + `validate_full_spdx_document`)

--- a/app/collect_metadata.py
+++ b/app/collect_metadata.py
@@ -1,0 +1,160 @@
+"""Collect dpkg metadata for all system files in the bomsh treedb.
+
+Runs inside the build container to resolve every system file
+(libraries, headers, CRT objects) to its dpkg package and extract
+rich metadata: name, version, source, maintainer, homepage,
+architecture, section.
+
+Outputs component_metadata.json alongside the treedb.
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def main(treedb_path, repos_dir, out_dir):
+    treedb = json.load(open(treedb_path))
+
+    # Collect all system file paths (not under repos)
+    system_files = set()
+    for sha, entry in treedb.items():
+        fp = entry.get("file_path", "")
+        if fp and not fp.startswith(repos_dir):
+            system_files.add(fp)
+
+    print(f"System files in treedb: {len(system_files)}")
+
+    # Resolve canonical paths (some have /../)
+    canonical = {}
+    for fp in system_files:
+        real = os.path.realpath(fp)
+        canonical[fp] = real
+
+    # dpkg -S for each unique real path
+    unique_reals = set(canonical.values())
+    file_to_pkg = {}
+    failed = []
+
+    for real_path in sorted(unique_reals):
+        try:
+            out = subprocess.check_output(
+                ["dpkg", "-S", real_path],
+                text=True, stderr=subprocess.DEVNULL,
+            ).strip()
+            # Format: "pkg1, pkg2: /path"
+            pkg_part = out.split(":")[0]
+            pkg = pkg_part.split(",")[0].strip()
+            file_to_pkg[real_path] = pkg
+        except subprocess.CalledProcessError:
+            failed.append(real_path)
+
+    print(f"Resolved to dpkg packages: {len(file_to_pkg)}")
+    print(f"Failed to resolve: {len(failed)}")
+    for f in failed[:10]:
+        print(f"  unresolved: {f}")
+
+    # Query full metadata for each unique package
+    unique_pkgs = sorted(set(file_to_pkg.values()))
+    print(f"Unique dpkg packages: {len(unique_pkgs)}")
+
+    fields = [
+        "Package", "Version", "Source", "Maintainer",
+        "Homepage", "Architecture", "Section", "Priority",
+    ]
+    fmt = "|".join(["${" + f + "}" for f in fields])
+
+    pkg_metadata = {}
+    for pkg in unique_pkgs:
+        try:
+            out = subprocess.check_output(
+                ["dpkg-query", "-W", "-f", fmt, pkg],
+                text=True, stderr=subprocess.DEVNULL,
+            )
+            parts = out.split("|")
+            meta = {}
+            for i, f in enumerate(fields):
+                if i < len(parts) and parts[i]:
+                    meta[f] = parts[i]
+            pkg_metadata[pkg] = meta
+        except Exception:
+            pass
+
+    # Map original treedb paths to packages
+    treedb_path_to_pkg = {}
+    for fp in system_files:
+        real = canonical.get(fp, fp)
+        pkg = file_to_pkg.get(real)
+        if pkg:
+            treedb_path_to_pkg[fp] = pkg
+
+    # Curl version from curlver.h
+    curl_version = "unknown"
+    curlver = os.path.join(
+        repos_dir, "curl", "include", "curl", "curlver.h"
+    )
+    try:
+        with open(curlver) as f:
+            for line in f:
+                if "LIBCURL_VERSION " in line and '"' in line:
+                    curl_version = line.split('"')[1]
+                    break
+    except Exception:
+        pass
+
+    # Distro info
+    distro = "unknown"
+    try:
+        with open("/etc/os-release") as f:
+            for line in f:
+                if line.startswith("PRETTY_NAME="):
+                    distro = (
+                        line.split("=", 1)[1]
+                        .strip().strip('"')
+                    )
+                    break
+    except Exception:
+        pass
+
+    # GCC version
+    gcc_version = "unknown"
+    try:
+        gcc_version = subprocess.check_output(
+            ["gcc", "--version"], text=True,
+        ).splitlines()[0]
+    except Exception:
+        pass
+
+    result = {
+        "distro": distro,
+        "gcc_version": gcc_version,
+        "curl_version": curl_version,
+        "pkg_metadata": pkg_metadata,
+        "file_to_pkg": treedb_path_to_pkg,
+        "unresolved_files": failed,
+    }
+
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, "component_metadata.json")
+    with open(out_path, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print(f"\nWrote: {out_path}")
+    print(f"Distro: {distro}")
+    print(f"GCC: {gcc_version}")
+    print(f"Curl: {curl_version}")
+    print(f"Packages with metadata: {len(pkg_metadata)}")
+
+
+if __name__ == "__main__":
+    treedb = sys.argv[1] if len(sys.argv) > 1 else (
+        "/workspace/output/omnibor/curl/metadata"
+        "/bomsh/bomsh_omnibor_treedb"
+    )
+    repos = sys.argv[2] if len(sys.argv) > 2 else (
+        "/workspace/repos"
+    )
+    out = sys.argv[3] if len(sys.argv) > 3 else (
+        "/workspace/output/omnibor/curl/metadata"
+    )
+    main(treedb, repos, out)

--- a/tests/test_spdx_from_adg.py
+++ b/tests/test_spdx_from_adg.py
@@ -1,0 +1,733 @@
+"""Tests for spdx_from_adg module."""
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(
+    0, str(Path(__file__).parent.parent / "app")
+)
+
+from spdx_from_adg import (
+    AdgParser,
+    AdgSpdxGenerator,
+    ComponentResolver,
+    SpdxEmitter,
+)
+
+
+class TestAdgParser(unittest.TestCase):
+    """Tests for AdgParser."""
+
+    def _setup_bom_dir(self, td):
+        meta = (
+            Path(td) / "bom" / "metadata" / "bomsh"
+        )
+        meta.mkdir(parents=True)
+        return meta
+
+    def test_classify_artifacts(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "aaa": {
+                    "file_path": (
+                        "/usr/lib/x86_64/libssl.so"
+                    ),
+                },
+                "bbb": {
+                    "file_path": (
+                        "/usr/include/openssl/ssl.h"
+                    ),
+                },
+                "ccc": {
+                    "file_path": (
+                        "/repos/curl/src/main.c"
+                    ),
+                },
+                "ddd": {
+                    "file_path": (
+                        "/repos/curl/src/main.o"
+                    ),
+                    "build_cmd": "gcc -c main.c",
+                },
+                "eee": {
+                    "file_path": (
+                        "/usr/lib/x86_64/crtbeginS.o"
+                    ),
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.parse()
+
+            self.assertEqual(
+                len(result["system_lib"]), 1
+            )
+            self.assertEqual(
+                len(result["system_header"]), 1
+            )
+            self.assertEqual(
+                len(result["project_source"]), 1
+            )
+            self.assertEqual(
+                len(result["build_intermediate"]), 1
+            )
+            self.assertEqual(
+                len(result["crt_object"]), 1
+            )
+            # build_cmd preserved
+            self.assertIn(
+                "build_cmd",
+                result["build_intermediate"][0],
+            )
+
+    def test_load_doc_mapping(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            mapping = {"abc123": "doc456"}
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text(json.dumps(mapping))
+
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.load_doc_mapping()
+            self.assertEqual(
+                result["abc123"], "doc456"
+            )
+
+    def test_load_doc_mapping_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._setup_bom_dir(td)
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.load_doc_mapping()
+            self.assertEqual(result, {})
+
+    def test_load_raw_logfile_hashes(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            sha = "a" * 40
+            (
+                meta / "bomsh_hook_raw_logfile"
+            ).write_text(
+                f"outfile: {sha} path: /repo/curl\n"
+                "some other line\n"
+            )
+
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.load_raw_logfile_hashes()
+            self.assertEqual(result["/repo/curl"], sha)
+            self.assertEqual(len(result), 1)
+
+    def test_load_raw_logfile_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._setup_bom_dir(td)
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.load_raw_logfile_hashes()
+            self.assertEqual(result, {})
+
+    def test_classify_empty_filepath(self):
+        """Entries with empty file_path are skipped."""
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "aaa": {"file_path": ""},
+                "bbb": {},
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.parse()
+            total = sum(
+                len(v) for v in result.values()
+            )
+            self.assertEqual(total, 0)
+
+    def test_classify_static_lib(self):
+        """Static .a files under /usr/lib are system_lib."""
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "aaa": {
+                    "file_path": (
+                        "/usr/lib/x86_64/libfoo.a"
+                    ),
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.parse()
+            self.assertEqual(
+                len(result["system_lib"]), 1
+            )
+
+    def test_classify_other_system_file(self):
+        """Files outside /usr/lib, /usr/include, repos."""
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "aaa": {
+                    "file_path": "/opt/custom/lib.h",
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.parse()
+            self.assertEqual(
+                len(result["system_header"]), 1
+            )
+
+
+class TestComponentResolver(unittest.TestCase):
+    """Tests for ComponentResolver."""
+
+    def _write_metadata(self, td, metadata):
+        path = Path(td) / "component_metadata.json"
+        path.write_text(json.dumps(metadata))
+        return str(path)
+
+    def _base_metadata(self):
+        return {
+            "distro": "Ubuntu 22.04.5 LTS",
+            "gcc_version": "gcc (Ubuntu 11.4.0) 11.4.0",
+            "curl_version": "8.19.0-DEV",
+            "pkg_metadata": {
+                "libssl3": {
+                    "Package": "libssl3",
+                    "Version": "3.0.2-0ubuntu1.21",
+                    "Source": "openssl",
+                    "Maintainer": "Ubuntu Developers",
+                    "Homepage": "https://www.openssl.org/",
+                    "Architecture": "amd64",
+                },
+                "zlib1g-dev": {
+                    "Package": "zlib1g-dev",
+                    "Version": "1:1.2.11.dfsg-2ubuntu9.2",
+                    "Source": "zlib",
+                    "Maintainer": "Ubuntu Developers",
+                    "Homepage": "http://zlib.net/",
+                    "Architecture": "amd64",
+                },
+            },
+            "file_to_pkg": {
+                "/usr/lib/libssl.so": "libssl3",
+                "/usr/lib/libcrypto.so": "libssl3",
+                "/usr/include/zlib.h": "zlib1g-dev",
+            },
+            "unresolved_files": [],
+        }
+
+    def test_resolve_components(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            artifacts = [
+                {"sha1": "a1", "file_path": "/usr/lib/libssl.so"},
+                {"sha1": "a2", "file_path": "/usr/lib/libcrypto.so"},
+                {"sha1": "a3", "file_path": "/usr/include/zlib.h"},
+            ]
+            components = (
+                resolver.resolve_system_components(
+                    artifacts
+                )
+            )
+            self.assertEqual(len(components), 2)
+            names = [c["name"] for c in components]
+            self.assertIn("openssl", names)
+            self.assertIn("zlib", names)
+
+    def test_purl_format(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            artifacts = [
+                {"sha1": "a1", "file_path": "/usr/lib/libssl.so"},
+            ]
+            components = (
+                resolver.resolve_system_components(
+                    artifacts
+                )
+            )
+            purl = components[0]["purl"]
+            self.assertIn("pkg:deb/ubuntu/", purl)
+            self.assertIn("distro=ubuntu-22.04", purl)
+            self.assertIn("arch=amd64", purl)
+
+    def test_cpe_format(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            artifacts = [
+                {"sha1": "a1", "file_path": "/usr/lib/libssl.so"},
+            ]
+            components = (
+                resolver.resolve_system_components(
+                    artifacts
+                )
+            )
+            cpe = components[0]["cpe23"]
+            self.assertTrue(
+                cpe.startswith("cpe:2.3:a:")
+            )
+            self.assertIn("openssl", cpe)
+            self.assertIn("3.0.2", cpe)
+
+    def test_clean_version(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            # Epoch removal
+            self.assertEqual(
+                resolver._clean_version(
+                    "1:1.2.11.dfsg-2ubuntu9.2"
+                ),
+                "1.2.11",
+            )
+            # dfsg removal
+            self.assertEqual(
+                resolver._clean_version(
+                    "1.4.8+dfsg-3build1"
+                ),
+                "1.4.8",
+            )
+            # Simple version
+            self.assertEqual(
+                resolver._clean_version("3.0.2-0ubuntu1.21"),
+                "3.0.2",
+            )
+
+    def test_distro_codename(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+            self.assertEqual(
+                resolver.distro_codename,
+                "ubuntu-22.04",
+            )
+
+    def test_unresolved_artifacts_skipped(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            artifacts = [
+                {"sha1": "x", "file_path": "/unknown/path"},
+            ]
+            components = (
+                resolver.resolve_system_components(
+                    artifacts
+                )
+            )
+            self.assertEqual(len(components), 0)
+
+
+class TestSpdxEmitter(unittest.TestCase):
+    """Tests for SpdxEmitter."""
+
+    def test_emit_basic_structure(self):
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+            bomtrace_version="6.11",
+            bomsh_version="0.0.1-abc",
+        )
+        doc = emitter.emit(
+            components=[],
+            project_files=[],
+            doc_mapping={},
+            logfile_hashes={},
+        )
+        self.assertEqual(
+            doc["spdxVersion"], "SPDX-2.3"
+        )
+        self.assertEqual(
+            doc["dataLicense"], "CC0-1.0"
+        )
+        self.assertIn(
+            "omnibor.io",
+            doc["documentNamespace"],
+        )
+        self.assertEqual(
+            doc["SPDXID"], "SPDXRef-DOCUMENT"
+        )
+        # Root package + gcc = 2
+        self.assertEqual(len(doc["packages"]), 2)
+        # DESCRIBES + BUILD_TOOL_OF = 2
+        self.assertEqual(
+            len(doc["relationships"]), 2
+        )
+
+    def test_emit_with_components(self):
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+        )
+        components = [{
+            "name": "openssl",
+            "version": "3.0.2",
+            "supplier": "Ubuntu Developers",
+            "homepage": "https://www.openssl.org/",
+            "dpkg_packages": ["libssl3"],
+            "architecture": "amd64",
+            "purl": "pkg:deb/ubuntu/libssl3@3.0.2",
+            "cpe23": "cpe:2.3:a:openssl:openssl:3.0.2:*:*:*:*:*:*:*",
+            "files": ["/usr/lib/libssl.so"],
+        }]
+        doc = emitter.emit(
+            components=components,
+            project_files=[],
+            doc_mapping={},
+            logfile_hashes={},
+        )
+        # Root + openssl + gcc = 3
+        self.assertEqual(len(doc["packages"]), 3)
+        ssl_pkg = doc["packages"][1]
+        self.assertEqual(ssl_pkg["name"], "openssl")
+        ref_types = [
+            r["referenceType"]
+            for r in ssl_pkg["externalRefs"]
+        ]
+        self.assertIn("purl", ref_types)
+        self.assertIn("cpe23Type", ref_types)
+
+    def test_emit_with_omnibor_ref(self):
+        sha = "a" * 40
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+        )
+        doc = emitter.emit(
+            components=[],
+            project_files=[],
+            doc_mapping={sha: "omnibor_doc_123"},
+            logfile_hashes={
+                "/repo/src/.libs/curl": sha,
+            },
+        )
+        root = doc["packages"][0]
+        gitoid_refs = [
+            r for r in root["externalRefs"]
+            if "gitoid" in r.get(
+                "referenceLocator", ""
+            )
+        ]
+        self.assertEqual(len(gitoid_refs), 1)
+        self.assertIn(
+            "omnibor_doc_123",
+            gitoid_refs[0]["referenceLocator"],
+        )
+
+    def test_emit_with_source_files(self):
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+        )
+        project_files = [
+            {"sha1": "abc", "file_path": "/repos/curl/src/main.c"},
+            {"sha1": "def", "file_path": "/repos/curl/src/util.h"},
+            {"sha1": "ghi", "file_path": "/repos/curl/Makefile"},
+        ]
+        doc = emitter.emit(
+            components=[],
+            project_files=project_files,
+            doc_mapping={},
+            logfile_hashes={},
+        )
+        # .c and .h included, Makefile excluded
+        self.assertEqual(len(doc["files"]), 2)
+        fnames = [
+            f["fileName"] for f in doc["files"]
+        ]
+        self.assertTrue(
+            any("main.c" in f for f in fnames)
+        )
+
+    def test_creators(self):
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+            bomtrace_version="6.11-dirty",
+            bomsh_version="0.0.1-abc",
+        )
+        doc = emitter.emit(
+            components=[], project_files=[],
+            doc_mapping={}, logfile_hashes={},
+        )
+        creators = doc["creationInfo"]["creators"]
+        self.assertIn(
+            "Tool: bomtrace3-6.11-dirty", creators
+        )
+        self.assertIn(
+            "Tool: bomsh-0.0.1-abc", creators
+        )
+        self.assertTrue(
+            any("omnibor-analysis" in c for c in creators)
+        )
+
+
+class TestComponentResolverEdgeCases(
+    unittest.TestCase
+):
+    """Edge-case tests for ComponentResolver."""
+
+    def test_non_ubuntu_distro_fallback(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = {
+                "distro": "Debian GNU/Linux 12",
+                "gcc_version": "gcc 12",
+                "curl_version": "8.0",
+                "pkg_metadata": {},
+                "file_to_pkg": {},
+                "unresolved_files": [],
+            }
+            path = Path(td) / "meta.json"
+            path.write_text(json.dumps(meta))
+            resolver = ComponentResolver(str(path))
+            self.assertEqual(
+                resolver.distro_codename, "linux"
+            )
+
+
+class TestAdgSpdxGenerator(unittest.TestCase):
+    """Tests for AdgSpdxGenerator facade."""
+
+    def _setup_full(self, td):
+        """Create a complete test environment."""
+        bom = Path(td) / "bom"
+        meta = bom / "metadata" / "bomsh"
+        meta.mkdir(parents=True)
+
+        sha = "a" * 40
+        treedb = {
+            sha: {
+                "file_path": "/repos/curl/src/main.c",
+            },
+            "b" * 40: {
+                "file_path": "/usr/lib/libssl.so",
+            },
+        }
+        (meta / "bomsh_omnibor_treedb").write_text(
+            json.dumps(treedb)
+        )
+        (meta / "bomsh_omnibor_doc_mapping").write_text(
+            json.dumps({sha: "omnibor_doc"})
+        )
+        (meta / "bomsh_hook_raw_logfile").write_text(
+            f"outfile: {sha} path: /repos/curl\n"
+        )
+
+        comp_meta = {
+            "distro": "Ubuntu 22.04",
+            "gcc_version": "gcc 11.4.0",
+            "curl_version": "8.19.0",
+            "pkg_metadata": {
+                "libssl3": {
+                    "Package": "libssl3",
+                    "Version": "3.0.2",
+                    "Source": "openssl",
+                    "Maintainer": "Ubuntu",
+                    "Homepage": "https://openssl.org",
+                    "Architecture": "amd64",
+                },
+            },
+            "file_to_pkg": {
+                "/usr/lib/libssl.so": "libssl3",
+            },
+            "unresolved_files": [],
+        }
+        (bom / "metadata" / "component_metadata.json").write_text(
+            json.dumps(comp_meta)
+        )
+
+        return str(bom)
+
+    def test_generate_success(self):
+        with tempfile.TemporaryDirectory() as td:
+            bom_dir = self._setup_full(td)
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+
+            gen = AdgSpdxGenerator(
+                bom_dir=bom_dir,
+                repos_dir="/repos",
+                repo_name="curl",
+                bomtrace_version="6.11",
+                bomsh_version="0.0.1",
+            )
+            with patch("builtins.print"):
+                result = gen.generate(out)
+
+            self.assertIsNotNone(result)
+            doc = json.loads(Path(out).read_text())
+            self.assertEqual(
+                doc["spdxVersion"], "SPDX-2.3"
+            )
+            # Root + openssl + gcc = 3
+            self.assertEqual(
+                len(doc["packages"]), 3
+            )
+
+    def test_generate_missing_metadata(self):
+        with tempfile.TemporaryDirectory() as td:
+            bom = Path(td) / "bom"
+            meta = bom / "metadata" / "bomsh"
+            meta.mkdir(parents=True)
+            treedb = {
+                "aaa": {
+                    "file_path": "/repos/curl/x.c"
+                },
+            }
+            (
+                meta / "bomsh_omnibor_treedb"
+            ).write_text(json.dumps(treedb))
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text("{}")
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+
+            gen = AdgSpdxGenerator(
+                bom_dir=str(bom),
+                repos_dir="/repos",
+                repo_name="curl",
+            )
+            with patch("builtins.print"):
+                result = gen.generate(out)
+
+            self.assertIsNone(result)
+
+
+class TestCli(unittest.TestCase):
+    """Tests for CLI main() function."""
+
+    def test_main_success(self):
+        from spdx_from_adg import main
+        with tempfile.TemporaryDirectory() as td:
+            # Reuse full setup from generator test
+            bom = Path(td) / "bom"
+            meta = bom / "metadata" / "bomsh"
+            meta.mkdir(parents=True)
+            sha = "a" * 40
+            treedb = {
+                sha: {
+                    "file_path": "/repos/curl/src/x.c",
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text(json.dumps({}))
+            comp_meta = {
+                "distro": "Ubuntu 22.04",
+                "gcc_version": "gcc 11.4.0",
+                "curl_version": "8.19.0",
+                "pkg_metadata": {},
+                "file_to_pkg": {},
+                "unresolved_files": [],
+            }
+            (
+                bom / "metadata"
+                / "component_metadata.json"
+            ).write_text(json.dumps(comp_meta))
+
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+            args = [
+                "--bom-dir", str(bom),
+                "--repos-dir", "/repos",
+                "--repo-name", "curl",
+                "--output", out,
+                "--bomtrace-version", "6.11",
+                "--bomsh-version", "0.0.1",
+            ]
+            with patch(
+                "sys.argv",
+                ["spdx_from_adg.py"] + args,
+            ), patch("builtins.print"):
+                main()
+
+            self.assertTrue(Path(out).exists())
+
+    def test_main_failure(self):
+        from spdx_from_adg import main
+        with tempfile.TemporaryDirectory() as td:
+            bom = Path(td) / "bom"
+            meta = bom / "metadata" / "bomsh"
+            meta.mkdir(parents=True)
+            (
+                meta / "bomsh_omnibor_treedb"
+            ).write_text(json.dumps({}))
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text(json.dumps({}))
+            # No component_metadata.json
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+            args = [
+                "--bom-dir", str(bom),
+                "--repos-dir", "/repos",
+                "--repo-name", "curl",
+                "--output", out,
+            ]
+            with patch(
+                "sys.argv",
+                ["spdx_from_adg.py"] + args,
+            ), patch("builtins.print"):
+                with self.assertRaises(SystemExit):
+                    main()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Generates complete SPDX 2.3 JSON directly from OmniBOR ADG data, replacing the incomplete bomsh_sbom.py output (2 packages) with a comprehensive SBOM built from verified build provenance.

## New Modules

### `app/spdx_from_adg.py`
- **`AdgParser`**: reads bomsh treedb, classifies artifacts into system libs, headers, project source, build intermediates, CRT objects
- **`ComponentResolver`**: maps system files to dpkg packages with name, version, supplier, homepage, PURL (`pkg:deb/ubuntu/...`), and CPE 2.3 identifiers
- **`SpdxEmitter`**: produces SPDX with packages, source files, relationships (`DEPENDS_ON`, `BUILD_TOOL_OF`, `CONTAINS`), and OmniBOR ExternalRefs
- **`AdgSpdxGenerator`**: facade orchestrating the pipeline

### `app/collect_metadata.py`
Runs inside the build container to resolve system files via `dpkg -S` and extract rich package metadata into `component_metadata.json`.

## Results (curl)

| | bomsh_sbom.py | **ADG-based (new)** |
|---|---|---|
| Packages | 2 | **13** |
| Files | 1 | **441** |
| Relationships | 3 | **454** |
| OmniBOR ExternalRef | broken | **yes** |
| PURLs | no | **yes** |
| CPEs | no | **yes** |
| Source files | no | **yes (441)** |
| Build provenance | no | **yes (gcc BUILD_TOOL_OF)** |

## Quality

- 24 new tests, 99% coverage on spdx_from_adg.py
- 274 total tests pass