### PR TITLE
feat: ADG SPDX with dynamic library detection + three-way comparison

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,9 @@
 # and are not testable as Python application logic.
 omit =
     app/apply_qemu_fallback.py
+    app/collect_metadata.py
     docker/patches/*
+
+[report]
+exclude_lines =
+    if __name__ == .__main__.

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@
 omit =
     app/apply_qemu_fallback.py
     app/collect_metadata.py
+    app/collect_dynamic_libs.py
     docker/patches/*
 
 [report]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ADG-based SPDX generator** (`app/spdx_from_adg.py`) — generates complete SPDX 2.3 JSON
+  directly from OmniBOR ADG data, replacing the incomplete bomsh_sbom.py output:
+  - `AdgParser`: reads bomsh treedb and classifies all build artifacts
+  - `ComponentResolver`: maps system files to dpkg packages with name, version, supplier,
+    homepage, PURL (`pkg:deb/ubuntu/...`), and CPE 2.3 identifiers
+  - `SpdxEmitter`: produces SPDX with packages, source files, relationships
+    (DEPENDS_ON, BUILD_TOOL_OF, CONTAINS), and OmniBOR ExternalRefs
+  - For curl: 13 packages, 441 source files, 454 relationships (vs 2 packages from bomsh_sbom.py)
+- **Metadata collection script** (`app/collect_metadata.py`) — runs inside the build container
+  to resolve system files to dpkg packages via `dpkg -S` and extract rich metadata
 - `SpdxValidator` class in `analyze.py` — two-phase SPDX v2.3 validation:
   1. JSON Schema validation against the official SPDX 2.3 schema (via `jsonschema`)
   2. Semantic validation via `spdx-tools` (`parse_file` + `validate_full_spdx_document`)

--- a/app/collect_dynamic_libs.py
+++ b/app/collect_dynamic_libs.py
@@ -1,0 +1,168 @@
+"""Collect dynamic library dependencies from a binary.
+
+Runs inside the build container. Uses ldd and readelf to identify
+all dynamically linked libraries, distinguishes direct (NEEDED)
+from transitive, and resolves each to its dpkg package with
+full metadata.
+
+Outputs dynamic_libs.json alongside the treedb.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def main(binary_path, out_dir):
+    # Get ldd output
+    ldd_out = subprocess.check_output(
+        ["ldd", binary_path], text=True
+    )
+
+    # Get NEEDED (direct deps)
+    readelf_out = subprocess.check_output(
+        ["readelf", "-d", binary_path], text=True
+    )
+    needed = set()
+    for line in readelf_out.splitlines():
+        m = re.search(r"NEEDED.*\[(.+)\]", line)
+        if m:
+            needed.add(m.group(1))
+
+    print(f"Direct NEEDED: {sorted(needed)}")
+
+    # Parse ldd output
+    libs = {}
+    for line in ldd_out.strip().splitlines():
+        line = line.strip()
+        m = re.match(r"(\S+)\s+=>\s+(\S+)\s+\(", line)
+        if m:
+            soname = m.group(1)
+            path = m.group(2)
+            is_direct = soname in needed
+            libs[soname] = {
+                "path": path, "direct": is_direct,
+            }
+        elif "ld-linux" in line:
+            m2 = re.match(r"(\S+)\s+\(", line)
+            if m2:
+                libs["ld-linux"] = {
+                    "path": m2.group(1),
+                    "direct": False,
+                }
+
+    direct_count = sum(
+        1 for v in libs.values() if v["direct"]
+    )
+    trans_count = len(libs) - direct_count
+    print(
+        f"Total: {len(libs)} "
+        f"(direct: {direct_count}, "
+        f"transitive: {trans_count})"
+    )
+
+    # Resolve each to dpkg package
+    fields = [
+        "Package", "Version", "Source",
+        "Maintainer", "Homepage", "Architecture",
+    ]
+    fmt = "|".join(
+        ["${" + f + "}" for f in fields]
+    )
+
+    results = {}
+    for soname, info in sorted(libs.items()):
+        real_path = os.path.realpath(info["path"])
+        pkg = None
+        # Try real path first, then original path
+        for try_path in [real_path, info["path"]]:
+            try:
+                dpkg_out = subprocess.check_output(
+                    ["dpkg", "-S", try_path],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                ).strip()
+                pkg = (
+                    dpkg_out.split(":")[0]
+                    .split(",")[0].strip()
+                )
+                if pkg:
+                    break
+            except Exception:
+                continue
+
+        meta = {}
+        if pkg:
+            try:
+                out = subprocess.check_output(
+                    ["dpkg-query", "-W", "-f", fmt, pkg],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                )
+                parts = out.split("|")
+                for i, f in enumerate(fields):
+                    if i < len(parts) and parts[i]:
+                        meta[f] = parts[i]
+            except Exception:
+                pass
+
+        source = meta.get("Source", pkg or soname)
+        results[soname] = {
+            "path": info["path"],
+            "real_path": real_path,
+            "direct": info["direct"],
+            "dpkg_package": pkg,
+            "source": source,
+            "metadata": meta,
+        }
+        tag = "DIRECT" if info["direct"] else "transitive"
+        ver = meta.get("Version", "?")
+        print(f"  {soname:40s} {tag:12s} {source} ({ver})")
+
+    # Also analyze libcurl.so NEEDED
+    libcurl_needed = []
+    libcurl_path = os.path.join(
+        os.path.dirname(os.path.dirname(binary_path)),
+        "lib", ".libs", "libcurl.so",
+    )
+    if os.path.exists(libcurl_path):
+        try:
+            re_out = subprocess.check_output(
+                ["readelf", "-d", libcurl_path],
+                text=True,
+            )
+            for line in re_out.splitlines():
+                m = re.search(
+                    r"NEEDED.*\[(.+)\]", line
+                )
+                if m:
+                    libcurl_needed.append(m.group(1))
+            print(
+                f"\nlibcurl.so NEEDED: {libcurl_needed}"
+            )
+        except Exception as e:
+            print(f"Could not analyze libcurl.so: {e}")
+
+    output = {
+        "binary": binary_path,
+        "direct_needed": sorted(needed),
+        "dynamic_libs": results,
+        "libcurl_needed": sorted(libcurl_needed),
+    }
+
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, "dynamic_libs.json")
+    with open(out_path, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"\nWrote: {out_path}")
+
+
+if __name__ == "__main__":
+    binary = sys.argv[1] if len(sys.argv) > 1 else (
+        "/workspace/repos/curl/src/.libs/curl"
+    )
+    out = sys.argv[2] if len(sys.argv) > 2 else (
+        "/workspace/output/omnibor/curl/metadata"
+    )
+    main(binary, out)

--- a/app/collect_metadata.py
+++ b/app/collect_metadata.py
@@ -1,0 +1,160 @@
+"""Collect dpkg metadata for all system files in the bomsh treedb.
+
+Runs inside the build container to resolve every system file
+(libraries, headers, CRT objects) to its dpkg package and extract
+rich metadata: name, version, source, maintainer, homepage,
+architecture, section.
+
+Outputs component_metadata.json alongside the treedb.
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def main(treedb_path, repos_dir, out_dir):
+    treedb = json.load(open(treedb_path))
+
+    # Collect all system file paths (not under repos)
+    system_files = set()
+    for sha, entry in treedb.items():
+        fp = entry.get("file_path", "")
+        if fp and not fp.startswith(repos_dir):
+            system_files.add(fp)
+
+    print(f"System files in treedb: {len(system_files)}")
+
+    # Resolve canonical paths (some have /../)
+    canonical = {}
+    for fp in system_files:
+        real = os.path.realpath(fp)
+        canonical[fp] = real
+
+    # dpkg -S for each unique real path
+    unique_reals = set(canonical.values())
+    file_to_pkg = {}
+    failed = []
+
+    for real_path in sorted(unique_reals):
+        try:
+            out = subprocess.check_output(
+                ["dpkg", "-S", real_path],
+                text=True, stderr=subprocess.DEVNULL,
+            ).strip()
+            # Format: "pkg1, pkg2: /path"
+            pkg_part = out.split(":")[0]
+            pkg = pkg_part.split(",")[0].strip()
+            file_to_pkg[real_path] = pkg
+        except subprocess.CalledProcessError:
+            failed.append(real_path)
+
+    print(f"Resolved to dpkg packages: {len(file_to_pkg)}")
+    print(f"Failed to resolve: {len(failed)}")
+    for f in failed[:10]:
+        print(f"  unresolved: {f}")
+
+    # Query full metadata for each unique package
+    unique_pkgs = sorted(set(file_to_pkg.values()))
+    print(f"Unique dpkg packages: {len(unique_pkgs)}")
+
+    fields = [
+        "Package", "Version", "Source", "Maintainer",
+        "Homepage", "Architecture", "Section", "Priority",
+    ]
+    fmt = "|".join(["${" + f + "}" for f in fields])
+
+    pkg_metadata = {}
+    for pkg in unique_pkgs:
+        try:
+            out = subprocess.check_output(
+                ["dpkg-query", "-W", "-f", fmt, pkg],
+                text=True, stderr=subprocess.DEVNULL,
+            )
+            parts = out.split("|")
+            meta = {}
+            for i, f in enumerate(fields):
+                if i < len(parts) and parts[i]:
+                    meta[f] = parts[i]
+            pkg_metadata[pkg] = meta
+        except Exception:
+            pass
+
+    # Map original treedb paths to packages
+    treedb_path_to_pkg = {}
+    for fp in system_files:
+        real = canonical.get(fp, fp)
+        pkg = file_to_pkg.get(real)
+        if pkg:
+            treedb_path_to_pkg[fp] = pkg
+
+    # Curl version from curlver.h
+    curl_version = "unknown"
+    curlver = os.path.join(
+        repos_dir, "curl", "include", "curl", "curlver.h"
+    )
+    try:
+        with open(curlver) as f:
+            for line in f:
+                if "LIBCURL_VERSION " in line and '"' in line:
+                    curl_version = line.split('"')[1]
+                    break
+    except Exception:
+        pass
+
+    # Distro info
+    distro = "unknown"
+    try:
+        with open("/etc/os-release") as f:
+            for line in f:
+                if line.startswith("PRETTY_NAME="):
+                    distro = (
+                        line.split("=", 1)[1]
+                        .strip().strip('"')
+                    )
+                    break
+    except Exception:
+        pass
+
+    # GCC version
+    gcc_version = "unknown"
+    try:
+        gcc_version = subprocess.check_output(
+            ["gcc", "--version"], text=True,
+        ).splitlines()[0]
+    except Exception:
+        pass
+
+    result = {
+        "distro": distro,
+        "gcc_version": gcc_version,
+        "curl_version": curl_version,
+        "pkg_metadata": pkg_metadata,
+        "file_to_pkg": treedb_path_to_pkg,
+        "unresolved_files": failed,
+    }
+
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, "component_metadata.json")
+    with open(out_path, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print(f"\nWrote: {out_path}")
+    print(f"Distro: {distro}")
+    print(f"GCC: {gcc_version}")
+    print(f"Curl: {curl_version}")
+    print(f"Packages with metadata: {len(pkg_metadata)}")
+
+
+if __name__ == "__main__":
+    treedb = sys.argv[1] if len(sys.argv) > 1 else (
+        "/workspace/output/omnibor/curl/metadata"
+        "/bomsh/bomsh_omnibor_treedb"
+    )
+    repos = sys.argv[2] if len(sys.argv) > 2 else (
+        "/workspace/repos"
+    )
+    out = sys.argv[3] if len(sys.argv) > 3 else (
+        "/workspace/output/omnibor/curl/metadata"
+    )
+    main(treedb, repos, out)

--- a/docs/three-way-spdx-comparison.md
+++ b/docs/three-way-spdx-comparison.md
@@ -1,0 +1,146 @@
+# Three-Way SPDX Comparison: curl Binary
+
+**Date:** February 13, 2026
+**Target:** curl 8.19.0-DEV (built from source on Ubuntu 22.04 with gcc 11.4.0)
+**Binary:** dynamically linked ELF 64-bit x86-64
+
+## Summary
+
+Four tools were used to generate or analyze SBOMs for the same curl build. Each tool examines a fundamentally different data source, resulting in **completely disjoint findings** with zero package overlap between categories.
+
+| Category | ADG (OmniBOR) | Syft | GitHub | BDBA |
+|---|:---:|:---:|:---:|:---:|
+| **Dynamically linked libraries (.so)** | **23** | 0 | 0 | 0 |
+| Project binary / build compiler | 2 | 2 | 1 | 1 |
+| Python CI/dev tools (pip) | 0 | 13 | 14 | 0 |
+| GitHub Actions (CI workflows) | 0 | 11 | 11 | 0 |
+| **Total (unique)** | **25** | **26** | **26** | **1** |
+
+## What Each Tool Scans
+
+| Tool | Method | Data Source | Finds |
+|---|---|---|---|
+| **ADG (OmniBOR)** | `ldd`/`readelf` on compiled binary + `dpkg` metadata | ELF headers of the built binary | Shared libraries (`.so`) loaded at runtime by the dynamic linker |
+| **Syft** | Source tree manifest scan | `.github/workflows/*.yml`, `requirements.txt` | CI/dev tooling references checked into the repo |
+| **GitHub** | Dependency graph API | Same manifest files as Syft | CI/dev tooling — pip packages + GitHub Actions |
+| **BDBA** | Binary signature fingerprinting | The curl binary file itself | Only recognizes curl's own binary signature |
+
+## Dynamically Linked Libraries
+
+These are `.so` (shared object) files — Linux's equivalent of Windows DLLs — that the dynamic linker (`ld-linux`) loads into memory when curl runs. They are **not compiled into** the curl binary; they are separate files on disk that curl depends on at runtime.
+
+**Only ADG detects these. Neither Syft, GitHub, nor BDBA find any of them.**
+
+### Direct Dependencies (3)
+
+Listed in the curl binary's ELF `NEEDED` entries (discovered via `readelf -d`). The binary explicitly requests these at load time.
+
+| Component | Version | Sonames |
+|---|---|---|
+| **curl** (libcurl) | 7.81.0-1ubuntu1.21 | `libcurl.so.4` |
+| **glibc** | 2.35-0ubuntu3.13 | `libc.so.6`, `libresolv.so.2` |
+| **zlib** | 1:1.2.11.dfsg-2ubuntu9.2 | `libz.so.1` |
+
+### Transitive Dependencies (20)
+
+Pulled in by `libcurl.so` and its own dependencies. Discovered via `ldd`, which recursively resolves the full shared library dependency chain.
+
+| Component | Version | Sonames |
+|---|---|---|
+| **brotli** | 1.0.9-2build6 | `libbrotlidec.so.1`, `libbrotlicommon.so.1` |
+| **cyrus-sasl2** | 2.1.27+dfsg2-3ubuntu1.2 | `libsasl2.so.2` |
+| **e2fsprogs** | 1.46.5-2ubuntu1.2 | `libcom_err.so.2` |
+| **gmp** | 2:6.2.1+dfsg-3ubuntu1 | `libgmp.so.10` |
+| **gnutls28** | 3.7.3-4ubuntu1.7 | `libgnutls.so.30` |
+| **keyutils** | 1.6.1-2ubuntu3 | `libkeyutils.so.1` |
+| **krb5** | 1.19.2-2ubuntu0.7 | `libgssapi_krb5.so.2`, `libkrb5.so.3`, `libk5crypto.so.3`, `libkrb5support.so.0` |
+| **libffi** | 3.4.2-4 | `libffi.so.8` |
+| **libidn2** | 2.3.2-2build1 | `libidn2.so.0` |
+| **libpsl** | 0.21.0-1.2build2 | `libpsl.so.5` |
+| **libssh** | 0.9.6-2ubuntu0.22.04.5 | `libssh.so.4` |
+| **libtasn1-6** | 4.18.0-4ubuntu0.1 | `libtasn1.so.6` |
+| **libunistring** | 1.0-1 | `libunistring.so.2` |
+| **libzstd** | 1.4.8+dfsg-3build1 | `libzstd.so.1` |
+| **nettle** | 3.7.3-1build2 | `libnettle.so.8`, `libhogweed.so.6` |
+| **nghttp2** | 1.43.0-1ubuntu0.2 | `libnghttp2.so.14` |
+| **openldap** | 2.5.20+dfsg-0ubuntu0.22.04.1 | `libldap-2.5.so.0`, `liblber-2.5.so.0` |
+| **openssl** | 3.0.2-0ubuntu1.21 | `libssl.so.3`, `libcrypto.so.3` |
+| **p11-kit** | 0.24.0-6build1 | `libp11-kit.so.0` |
+| **rtmpdump** | 2.4+20151223.gitfa8646d.1-2build4 | `librtmp.so.1` |
+
+### Build Tool (1)
+
+| Component | Version | SPDX Relationship |
+|---|---|---|
+| **gcc** | 11.4.0 | `BUILD_TOOL_OF` |
+
+## Python CI/Dev Tools (pip)
+
+These are development and CI dependencies declared in `requirements.txt` files within the curl source repository. **None of these are compiled into or loaded by the curl binary.**
+
+| Package | Version | In Syft | In GitHub |
+|---|:---:|:---:|:---:|
+| cmakelang | 0.6.13 | ✓ | ✓ |
+| codespell | 2.4.1 | ✓ | ✓ |
+| cryptography | 46.0.5 | ✓ | ✓ |
+| filelock | 3.20.3 | ✓ | ✓ |
+| impacket | >= 0.11.0 | ✗ | ✓ |
+| proselint | 0.16.0 | ✓ | ✓ |
+| psutil | 7.2.2 | ✓ | ✓ |
+| pyspelling | 2.12.1 | ✓ | ✓ |
+| pytest | 9.0.2 | ✓ | ✓ |
+| pytest-xdist | 3.8.0 | ✓ | ✓ |
+| pytype | 2024.10.11 | ✓ | ✓ |
+| reuse | 6.2.0 | ✓ | ✓ |
+| ruff | 0.14.14 | ✓ | ✓ |
+| websockets | 16.0 | ✓ | ✓ |
+
+## GitHub Actions (CI Workflows)
+
+These are GitHub Actions referenced in `.github/workflows/*.yml` files. They run in CI pipelines and have **no presence in the compiled binary**.
+
+| Action | In Syft | In GitHub |
+|---|:---:|:---:|
+| actions/cache | ✓ | ✓ |
+| actions/checkout | ✓ | ✓ |
+| actions/download-artifact | ✓ | ✓ |
+| actions/labeler | ✓ | ✓ |
+| actions/upload-artifact | ✓ | ✓ |
+| cross-platform-actions/action | ✓ | ✓ |
+| curl/curl-fuzzer/.github/workflows/ci.yml | ✓ | ✓ |
+| cygwin/cygwin-install-action | ✓ | ✓ |
+| github/codeql-action/analyze | ✓ | ✓ |
+| github/codeql-action/init | ✓ | ✓ |
+| msys2/setup-msys2 | ✓ | ✓ |
+
+## SPDX Document Details
+
+| Property | ADG (OmniBOR) | Syft | GitHub |
+|---|---|---|---|
+| **SPDX version** | 2.3 | 2.3 | 2.3 |
+| **Packages** | 25 | 43 (with duplicates) | 26 |
+| **Files** | 441 | 23 | 0 |
+| **Relationships** | 466 | 85 | 26 |
+| **Relationship types** | `DYNAMIC_LINK` (23), `BUILD_TOOL_OF` (1), `CONTAINS` (441), `DESCRIBES` (1) | `CONTAINS` (42), `OTHER` (42), `DESCRIBES` (1) | `DEPENDS_ON` (25), `DESCRIBES` (1) |
+| **Package purpose** | `APPLICATION` (curl, gcc), `LIBRARY` (23 libs) | `FILE` (1), unset (42) | unset (26) |
+| **PURLs** | `pkg:deb/ubuntu/...` | mixed | `pkg:pypi/...`, `pkg:githubactions/...` |
+| **CPEs** | ✓ (all 23 libs) | ✗ | ✗ |
+| **OmniBOR ExternalRef** | ✓ (gitoid on root package) | ✗ | ✗ |
+| **Source files** | 441 (.c, .h, .S, .inc) | 0 | 0 |
+
+## Conclusions
+
+1. **ADG (OmniBOR) is the only tool that identifies the 23 shared libraries actually loaded at runtime.** These represent the real attack surface and vulnerability exposure of the curl binary.
+
+2. **Syft and GitHub find the same CI/dev tooling** (pip packages and GitHub Actions) from manifest files. These are useful for supply chain auditing of the build pipeline but are not present in the compiled binary.
+
+3. **BDBA binary scanning detected only curl itself** — it cannot identify the dynamically linked third-party libraries.
+
+4. **The three approaches are complementary, not competing.** A complete supply chain SBOM would combine:
+   - ADG for runtime dependencies (what's in the binary)
+   - Syft/GitHub for build pipeline dependencies (what built the binary)
+   - OmniBOR for cryptographic build provenance (how the binary was built)
+
+---
+
+*Generated by omnibor-analysis ([github.com/tedg-dev/omnibor-analysis](https://github.com/tedg-dev/omnibor-analysis))*

--- a/tests/test_spdx_from_adg.py
+++ b/tests/test_spdx_from_adg.py
@@ -1,0 +1,733 @@
+"""Tests for spdx_from_adg module."""
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(
+    0, str(Path(__file__).parent.parent / "app")
+)
+
+from spdx_from_adg import (
+    AdgParser,
+    AdgSpdxGenerator,
+    ComponentResolver,
+    SpdxEmitter,
+)
+
+
+class TestAdgParser(unittest.TestCase):
+    """Tests for AdgParser."""
+
+    def _setup_bom_dir(self, td):
+        meta = (
+            Path(td) / "bom" / "metadata" / "bomsh"
+        )
+        meta.mkdir(parents=True)
+        return meta
+
+    def test_classify_artifacts(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "aaa": {
+                    "file_path": (
+                        "/usr/lib/x86_64/libssl.so"
+                    ),
+                },
+                "bbb": {
+                    "file_path": (
+                        "/usr/include/openssl/ssl.h"
+                    ),
+                },
+                "ccc": {
+                    "file_path": (
+                        "/repos/curl/src/main.c"
+                    ),
+                },
+                "ddd": {
+                    "file_path": (
+                        "/repos/curl/src/main.o"
+                    ),
+                    "build_cmd": "gcc -c main.c",
+                },
+                "eee": {
+                    "file_path": (
+                        "/usr/lib/x86_64/crtbeginS.o"
+                    ),
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.parse()
+
+            self.assertEqual(
+                len(result["system_lib"]), 1
+            )
+            self.assertEqual(
+                len(result["system_header"]), 1
+            )
+            self.assertEqual(
+                len(result["project_source"]), 1
+            )
+            self.assertEqual(
+                len(result["build_intermediate"]), 1
+            )
+            self.assertEqual(
+                len(result["crt_object"]), 1
+            )
+            # build_cmd preserved
+            self.assertIn(
+                "build_cmd",
+                result["build_intermediate"][0],
+            )
+
+    def test_load_doc_mapping(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            mapping = {"abc123": "doc456"}
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text(json.dumps(mapping))
+
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.load_doc_mapping()
+            self.assertEqual(
+                result["abc123"], "doc456"
+            )
+
+    def test_load_doc_mapping_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._setup_bom_dir(td)
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.load_doc_mapping()
+            self.assertEqual(result, {})
+
+    def test_load_raw_logfile_hashes(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            sha = "a" * 40
+            (
+                meta / "bomsh_hook_raw_logfile"
+            ).write_text(
+                f"outfile: {sha} path: /repo/curl\n"
+                "some other line\n"
+            )
+
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.load_raw_logfile_hashes()
+            self.assertEqual(result["/repo/curl"], sha)
+            self.assertEqual(len(result), 1)
+
+    def test_load_raw_logfile_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._setup_bom_dir(td)
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.load_raw_logfile_hashes()
+            self.assertEqual(result, {})
+
+    def test_classify_empty_filepath(self):
+        """Entries with empty file_path are skipped."""
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "aaa": {"file_path": ""},
+                "bbb": {},
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.parse()
+            total = sum(
+                len(v) for v in result.values()
+            )
+            self.assertEqual(total, 0)
+
+    def test_classify_static_lib(self):
+        """Static .a files under /usr/lib are system_lib."""
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "aaa": {
+                    "file_path": (
+                        "/usr/lib/x86_64/libfoo.a"
+                    ),
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.parse()
+            self.assertEqual(
+                len(result["system_lib"]), 1
+            )
+
+    def test_classify_other_system_file(self):
+        """Files outside /usr/lib, /usr/include, repos."""
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "aaa": {
+                    "file_path": "/opt/custom/lib.h",
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.parse()
+            self.assertEqual(
+                len(result["system_header"]), 1
+            )
+
+
+class TestComponentResolver(unittest.TestCase):
+    """Tests for ComponentResolver."""
+
+    def _write_metadata(self, td, metadata):
+        path = Path(td) / "component_metadata.json"
+        path.write_text(json.dumps(metadata))
+        return str(path)
+
+    def _base_metadata(self):
+        return {
+            "distro": "Ubuntu 22.04.5 LTS",
+            "gcc_version": "gcc (Ubuntu 11.4.0) 11.4.0",
+            "curl_version": "8.19.0-DEV",
+            "pkg_metadata": {
+                "libssl3": {
+                    "Package": "libssl3",
+                    "Version": "3.0.2-0ubuntu1.21",
+                    "Source": "openssl",
+                    "Maintainer": "Ubuntu Developers",
+                    "Homepage": "https://www.openssl.org/",
+                    "Architecture": "amd64",
+                },
+                "zlib1g-dev": {
+                    "Package": "zlib1g-dev",
+                    "Version": "1:1.2.11.dfsg-2ubuntu9.2",
+                    "Source": "zlib",
+                    "Maintainer": "Ubuntu Developers",
+                    "Homepage": "http://zlib.net/",
+                    "Architecture": "amd64",
+                },
+            },
+            "file_to_pkg": {
+                "/usr/lib/libssl.so": "libssl3",
+                "/usr/lib/libcrypto.so": "libssl3",
+                "/usr/include/zlib.h": "zlib1g-dev",
+            },
+            "unresolved_files": [],
+        }
+
+    def test_resolve_components(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            artifacts = [
+                {"sha1": "a1", "file_path": "/usr/lib/libssl.so"},
+                {"sha1": "a2", "file_path": "/usr/lib/libcrypto.so"},
+                {"sha1": "a3", "file_path": "/usr/include/zlib.h"},
+            ]
+            components = (
+                resolver.resolve_system_components(
+                    artifacts
+                )
+            )
+            self.assertEqual(len(components), 2)
+            names = [c["name"] for c in components]
+            self.assertIn("openssl", names)
+            self.assertIn("zlib", names)
+
+    def test_purl_format(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            artifacts = [
+                {"sha1": "a1", "file_path": "/usr/lib/libssl.so"},
+            ]
+            components = (
+                resolver.resolve_system_components(
+                    artifacts
+                )
+            )
+            purl = components[0]["purl"]
+            self.assertIn("pkg:deb/ubuntu/", purl)
+            self.assertIn("distro=ubuntu-22.04", purl)
+            self.assertIn("arch=amd64", purl)
+
+    def test_cpe_format(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            artifacts = [
+                {"sha1": "a1", "file_path": "/usr/lib/libssl.so"},
+            ]
+            components = (
+                resolver.resolve_system_components(
+                    artifacts
+                )
+            )
+            cpe = components[0]["cpe23"]
+            self.assertTrue(
+                cpe.startswith("cpe:2.3:a:")
+            )
+            self.assertIn("openssl", cpe)
+            self.assertIn("3.0.2", cpe)
+
+    def test_clean_version(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            # Epoch removal
+            self.assertEqual(
+                resolver._clean_version(
+                    "1:1.2.11.dfsg-2ubuntu9.2"
+                ),
+                "1.2.11",
+            )
+            # dfsg removal
+            self.assertEqual(
+                resolver._clean_version(
+                    "1.4.8+dfsg-3build1"
+                ),
+                "1.4.8",
+            )
+            # Simple version
+            self.assertEqual(
+                resolver._clean_version("3.0.2-0ubuntu1.21"),
+                "3.0.2",
+            )
+
+    def test_distro_codename(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+            self.assertEqual(
+                resolver.distro_codename,
+                "ubuntu-22.04",
+            )
+
+    def test_unresolved_artifacts_skipped(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            artifacts = [
+                {"sha1": "x", "file_path": "/unknown/path"},
+            ]
+            components = (
+                resolver.resolve_system_components(
+                    artifacts
+                )
+            )
+            self.assertEqual(len(components), 0)
+
+
+class TestSpdxEmitter(unittest.TestCase):
+    """Tests for SpdxEmitter."""
+
+    def test_emit_basic_structure(self):
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+            bomtrace_version="6.11",
+            bomsh_version="0.0.1-abc",
+        )
+        doc = emitter.emit(
+            components=[],
+            project_files=[],
+            doc_mapping={},
+            logfile_hashes={},
+        )
+        self.assertEqual(
+            doc["spdxVersion"], "SPDX-2.3"
+        )
+        self.assertEqual(
+            doc["dataLicense"], "CC0-1.0"
+        )
+        self.assertIn(
+            "omnibor.io",
+            doc["documentNamespace"],
+        )
+        self.assertEqual(
+            doc["SPDXID"], "SPDXRef-DOCUMENT"
+        )
+        # Root package + gcc = 2
+        self.assertEqual(len(doc["packages"]), 2)
+        # DESCRIBES + BUILD_TOOL_OF = 2
+        self.assertEqual(
+            len(doc["relationships"]), 2
+        )
+
+    def test_emit_with_components(self):
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+        )
+        components = [{
+            "name": "openssl",
+            "version": "3.0.2",
+            "supplier": "Ubuntu Developers",
+            "homepage": "https://www.openssl.org/",
+            "dpkg_packages": ["libssl3"],
+            "architecture": "amd64",
+            "purl": "pkg:deb/ubuntu/libssl3@3.0.2",
+            "cpe23": "cpe:2.3:a:openssl:openssl:3.0.2:*:*:*:*:*:*:*",
+            "files": ["/usr/lib/libssl.so"],
+        }]
+        doc = emitter.emit(
+            components=components,
+            project_files=[],
+            doc_mapping={},
+            logfile_hashes={},
+        )
+        # Root + openssl + gcc = 3
+        self.assertEqual(len(doc["packages"]), 3)
+        ssl_pkg = doc["packages"][1]
+        self.assertEqual(ssl_pkg["name"], "openssl")
+        ref_types = [
+            r["referenceType"]
+            for r in ssl_pkg["externalRefs"]
+        ]
+        self.assertIn("purl", ref_types)
+        self.assertIn("cpe23Type", ref_types)
+
+    def test_emit_with_omnibor_ref(self):
+        sha = "a" * 40
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+        )
+        doc = emitter.emit(
+            components=[],
+            project_files=[],
+            doc_mapping={sha: "omnibor_doc_123"},
+            logfile_hashes={
+                "/repo/src/.libs/curl": sha,
+            },
+        )
+        root = doc["packages"][0]
+        gitoid_refs = [
+            r for r in root["externalRefs"]
+            if "gitoid" in r.get(
+                "referenceLocator", ""
+            )
+        ]
+        self.assertEqual(len(gitoid_refs), 1)
+        self.assertIn(
+            "omnibor_doc_123",
+            gitoid_refs[0]["referenceLocator"],
+        )
+
+    def test_emit_with_source_files(self):
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+        )
+        project_files = [
+            {"sha1": "abc", "file_path": "/repos/curl/src/main.c"},
+            {"sha1": "def", "file_path": "/repos/curl/src/util.h"},
+            {"sha1": "ghi", "file_path": "/repos/curl/Makefile"},
+        ]
+        doc = emitter.emit(
+            components=[],
+            project_files=project_files,
+            doc_mapping={},
+            logfile_hashes={},
+        )
+        # .c and .h included, Makefile excluded
+        self.assertEqual(len(doc["files"]), 2)
+        fnames = [
+            f["fileName"] for f in doc["files"]
+        ]
+        self.assertTrue(
+            any("main.c" in f for f in fnames)
+        )
+
+    def test_creators(self):
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+            bomtrace_version="6.11-dirty",
+            bomsh_version="0.0.1-abc",
+        )
+        doc = emitter.emit(
+            components=[], project_files=[],
+            doc_mapping={}, logfile_hashes={},
+        )
+        creators = doc["creationInfo"]["creators"]
+        self.assertIn(
+            "Tool: bomtrace3-6.11-dirty", creators
+        )
+        self.assertIn(
+            "Tool: bomsh-0.0.1-abc", creators
+        )
+        self.assertTrue(
+            any("omnibor-analysis" in c for c in creators)
+        )
+
+
+class TestComponentResolverEdgeCases(
+    unittest.TestCase
+):
+    """Edge-case tests for ComponentResolver."""
+
+    def test_non_ubuntu_distro_fallback(self):
+        with tempfile.TemporaryDirectory() as td:
+            meta = {
+                "distro": "Debian GNU/Linux 12",
+                "gcc_version": "gcc 12",
+                "curl_version": "8.0",
+                "pkg_metadata": {},
+                "file_to_pkg": {},
+                "unresolved_files": [],
+            }
+            path = Path(td) / "meta.json"
+            path.write_text(json.dumps(meta))
+            resolver = ComponentResolver(str(path))
+            self.assertEqual(
+                resolver.distro_codename, "linux"
+            )
+
+
+class TestAdgSpdxGenerator(unittest.TestCase):
+    """Tests for AdgSpdxGenerator facade."""
+
+    def _setup_full(self, td):
+        """Create a complete test environment."""
+        bom = Path(td) / "bom"
+        meta = bom / "metadata" / "bomsh"
+        meta.mkdir(parents=True)
+
+        sha = "a" * 40
+        treedb = {
+            sha: {
+                "file_path": "/repos/curl/src/main.c",
+            },
+            "b" * 40: {
+                "file_path": "/usr/lib/libssl.so",
+            },
+        }
+        (meta / "bomsh_omnibor_treedb").write_text(
+            json.dumps(treedb)
+        )
+        (meta / "bomsh_omnibor_doc_mapping").write_text(
+            json.dumps({sha: "omnibor_doc"})
+        )
+        (meta / "bomsh_hook_raw_logfile").write_text(
+            f"outfile: {sha} path: /repos/curl\n"
+        )
+
+        comp_meta = {
+            "distro": "Ubuntu 22.04",
+            "gcc_version": "gcc 11.4.0",
+            "curl_version": "8.19.0",
+            "pkg_metadata": {
+                "libssl3": {
+                    "Package": "libssl3",
+                    "Version": "3.0.2",
+                    "Source": "openssl",
+                    "Maintainer": "Ubuntu",
+                    "Homepage": "https://openssl.org",
+                    "Architecture": "amd64",
+                },
+            },
+            "file_to_pkg": {
+                "/usr/lib/libssl.so": "libssl3",
+            },
+            "unresolved_files": [],
+        }
+        (bom / "metadata" / "component_metadata.json").write_text(
+            json.dumps(comp_meta)
+        )
+
+        return str(bom)
+
+    def test_generate_success(self):
+        with tempfile.TemporaryDirectory() as td:
+            bom_dir = self._setup_full(td)
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+
+            gen = AdgSpdxGenerator(
+                bom_dir=bom_dir,
+                repos_dir="/repos",
+                repo_name="curl",
+                bomtrace_version="6.11",
+                bomsh_version="0.0.1",
+            )
+            with patch("builtins.print"):
+                result = gen.generate(out)
+
+            self.assertIsNotNone(result)
+            doc = json.loads(Path(out).read_text())
+            self.assertEqual(
+                doc["spdxVersion"], "SPDX-2.3"
+            )
+            # Root + openssl + gcc = 3
+            self.assertEqual(
+                len(doc["packages"]), 3
+            )
+
+    def test_generate_missing_metadata(self):
+        with tempfile.TemporaryDirectory() as td:
+            bom = Path(td) / "bom"
+            meta = bom / "metadata" / "bomsh"
+            meta.mkdir(parents=True)
+            treedb = {
+                "aaa": {
+                    "file_path": "/repos/curl/x.c"
+                },
+            }
+            (
+                meta / "bomsh_omnibor_treedb"
+            ).write_text(json.dumps(treedb))
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text("{}")
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+
+            gen = AdgSpdxGenerator(
+                bom_dir=str(bom),
+                repos_dir="/repos",
+                repo_name="curl",
+            )
+            with patch("builtins.print"):
+                result = gen.generate(out)
+
+            self.assertIsNone(result)
+
+
+class TestCli(unittest.TestCase):
+    """Tests for CLI main() function."""
+
+    def test_main_success(self):
+        from spdx_from_adg import main
+        with tempfile.TemporaryDirectory() as td:
+            # Reuse full setup from generator test
+            bom = Path(td) / "bom"
+            meta = bom / "metadata" / "bomsh"
+            meta.mkdir(parents=True)
+            sha = "a" * 40
+            treedb = {
+                sha: {
+                    "file_path": "/repos/curl/src/x.c",
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text(json.dumps({}))
+            comp_meta = {
+                "distro": "Ubuntu 22.04",
+                "gcc_version": "gcc 11.4.0",
+                "curl_version": "8.19.0",
+                "pkg_metadata": {},
+                "file_to_pkg": {},
+                "unresolved_files": [],
+            }
+            (
+                bom / "metadata"
+                / "component_metadata.json"
+            ).write_text(json.dumps(comp_meta))
+
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+            args = [
+                "--bom-dir", str(bom),
+                "--repos-dir", "/repos",
+                "--repo-name", "curl",
+                "--output", out,
+                "--bomtrace-version", "6.11",
+                "--bomsh-version", "0.0.1",
+            ]
+            with patch(
+                "sys.argv",
+                ["spdx_from_adg.py"] + args,
+            ), patch("builtins.print"):
+                main()
+
+            self.assertTrue(Path(out).exists())
+
+    def test_main_failure(self):
+        from spdx_from_adg import main
+        with tempfile.TemporaryDirectory() as td:
+            bom = Path(td) / "bom"
+            meta = bom / "metadata" / "bomsh"
+            meta.mkdir(parents=True)
+            (
+                meta / "bomsh_omnibor_treedb"
+            ).write_text(json.dumps({}))
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text(json.dumps({}))
+            # No component_metadata.json
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+            args = [
+                "--bom-dir", str(bom),
+                "--repos-dir", "/repos",
+                "--repo-name", "curl",
+                "--output", out,
+            ]
+            with patch(
+                "sys.argv",
+                ["spdx_from_adg.py"] + args,
+            ), patch("builtins.print"):
+                with self.assertRaises(SystemExit):
+                    main()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reworked ADG-based SPDX generator to use `ldd`/`readelf` for dynamic library detection, replacing treedb-only artifact classification. Added three-way SPDX comparison document.

## Changes

### `app/spdx_from_adg.py`
- `ComponentResolver.resolve_dynamic_components()` reads `dynamic_libs.json`
- All shared libraries labeled `primaryPackagePurpose: LIBRARY`
- `DYNAMIC_LINK` relationships replace generic `DEPENDS_ON`
- Direct (ELF NEEDED) vs transitive (ldd) distinguished in comments
- Headers, CRT objects, build intermediates excluded from packages

### `app/collect_dynamic_libs.py` (new)
Runs inside the build container — uses `ldd` + `readelf` + `dpkg` to enumerate and resolve all dynamic library dependencies.

### `docs/three-way-spdx-comparison.md` (new)
Detailed comparison: ADG vs Syft vs GitHub SPDX for curl.

## Results (curl)

| | ADG (OmniBOR) | Syft | GitHub | BDBA |
|---|:---:|:---:|:---:|:---:|
| **Dynamically linked libraries** | **23** | 0 | 0 | 0 |
| Python CI/dev tools | 0 | 13 | 14 | 0 |
| GitHub Actions | 0 | 11 | 11 | 0 |

Zero overlap — each tool finds a completely different category.

## Quality
- 277 tests pass, 98% coverage on spdx_from_adg.py