### PR TITLE
feat: per-binary SPDX generation (curl + libcurl.so)

### DIFF
--- a/docs/three-way-spdx-comparison.md
+++ b/docs/three-way-spdx-comparison.md
@@ -1,20 +1,22 @@
-# Three-Way SPDX Comparison: curl Binary
+# Three-Way SPDX Comparison: curl
 
 **Date:** February 13, 2026
 **Target:** curl 8.19.0-DEV (built from source on Ubuntu 22.04 with gcc 11.4.0)
-**Binary:** dynamically linked ELF 64-bit x86-64
+**Binaries:** `curl` (CLI executable) + `libcurl.so` (shared library) — both dynamically linked ELF 64-bit x86-64
 
 ## Summary
 
 Four tools were used to generate or analyze SBOMs for the same curl build. Each tool examines a fundamentally different data source, resulting in **completely disjoint findings** with zero package overlap between categories.
 
-| Category | ADG (OmniBOR) | Syft | GitHub | BDBA |
-|---|:---:|:---:|:---:|:---:|
-| **Dynamically linked libraries (.so)** | **23** | 0 | 0 | 0 |
-| Project binary / build compiler | 2 | 2 | 1 | 1 |
-| Python CI/dev tools (pip) | 0 | 13 | 14 | 0 |
-| GitHub Actions (CI workflows) | 0 | 11 | 11 | 0 |
-| **Total (unique)** | **25** | **26** | **26** | **1** |
+ADG (OmniBOR) generates **two separate SBOMs** — one per binary — reflecting the actual two-tier dependency structure: the `curl` CLI depends on `libcurl.so`, which in turn depends on openssl, nghttp2, brotli, etc.
+
+| Category | ADG: curl | ADG: libcurl.so | Syft | GitHub | BDBA |
+|---|:---:|:---:|:---:|:---:|:---:|
+| **Dynamically linked libraries (.so)** | **23** | **10** | 0 | 0 | 0 |
+| Project binary / build compiler | 2 | 2 | 2 | 1 | 1 |
+| Python CI/dev tools (pip) | 0 | 0 | 13 | 14 | 0 |
+| GitHub Actions (CI workflows) | 0 | 0 | 11 | 11 | 0 |
+| **Total (unique)** | **25** | **12** | **26** | **26** | **1** |
 
 ## What Each Tool Scans
 
@@ -27,48 +29,68 @@ Four tools were used to generate or analyze SBOMs for the same curl build. Each 
 
 ## Dynamically Linked Libraries
 
-These are `.so` (shared object) files — Linux's equivalent of Windows DLLs — that the dynamic linker (`ld-linux`) loads into memory when curl runs. They are **not compiled into** the curl binary; they are separate files on disk that curl depends on at runtime.
+These are `.so` (shared object) files — Linux's equivalent of Windows DLLs — that the dynamic linker (`ld-linux`) loads into memory when the binary runs. They are **not compiled into** the binary; they are separate files on disk that the binary depends on at runtime.
 
 **Only ADG detects these. Neither Syft, GitHub, nor BDBA find any of them.**
 
-### Direct Dependencies (3)
+The curl project produces two binaries with distinct dependency profiles. ADG generates a **separate SBOM for each binary**, reflecting the actual two-tier dependency hierarchy.
 
-Listed in the curl binary's ELF `NEEDED` entries (discovered via `readelf -d`). The binary explicitly requests these at load time.
+### SBOM 1: `curl` (CLI executable) — `curl_adg.spdx.json`
 
-| Component | Version | Sonames |
-|---|---|---|
-| **curl** (libcurl) | 7.81.0-1ubuntu1.21 | `libcurl.so.4` |
-| **glibc** | 2.35-0ubuntu3.13 | `libc.so.6`, `libresolv.so.2` |
-| **zlib** | 1:1.2.11.dfsg-2ubuntu9.2 | `libz.so.1` |
+The curl binary has only 3 direct dependencies (ELF `NEEDED` entries from `readelf -d`). The remaining 20 are transitive — pulled in by `libcurl.so` and its own dependencies (discovered via `ldd`).
 
-### Transitive Dependencies (20)
+**Root package:** `curl` 8.19.0-DEV (`primaryPackagePurpose: APPLICATION`)
 
-Pulled in by `libcurl.so` and its own dependencies. Discovered via `ldd`, which recursively resolves the full shared library dependency chain.
+| Linkage | Component | Version | Sonames |
+|---|---|---|---|
+| **DIRECT** | **curl** (libcurl) | 7.81.0-1ubuntu1.21 | `libcurl.so.4` |
+| **DIRECT** | **glibc** | 2.35-0ubuntu3.13 | `libc.so.6`, `libresolv.so.2` |
+| **DIRECT** | **zlib** | 1:1.2.11.dfsg-2ubuntu9.2 | `libz.so.1` |
+| transitive | **brotli** | 1.0.9-2build6 | `libbrotlidec.so.1`, `libbrotlicommon.so.1` |
+| transitive | **cyrus-sasl2** | 2.1.27+dfsg2-3ubuntu1.2 | `libsasl2.so.2` |
+| transitive | **e2fsprogs** | 1.46.5-2ubuntu1.2 | `libcom_err.so.2` |
+| transitive | **gmp** | 2:6.2.1+dfsg-3ubuntu1 | `libgmp.so.10` |
+| transitive | **gnutls28** | 3.7.3-4ubuntu1.7 | `libgnutls.so.30` |
+| transitive | **keyutils** | 1.6.1-2ubuntu3 | `libkeyutils.so.1` |
+| transitive | **krb5** | 1.19.2-2ubuntu0.7 | `libgssapi_krb5.so.2`, `libkrb5.so.3`, `libk5crypto.so.3`, `libkrb5support.so.0` |
+| transitive | **libffi** | 3.4.2-4 | `libffi.so.8` |
+| transitive | **libidn2** | 2.3.2-2build1 | `libidn2.so.0` |
+| transitive | **libpsl** | 0.21.0-1.2build2 | `libpsl.so.5` |
+| transitive | **libssh** | 0.9.6-2ubuntu0.22.04.5 | `libssh.so.4` |
+| transitive | **libtasn1-6** | 4.18.0-4ubuntu0.1 | `libtasn1.so.6` |
+| transitive | **libunistring** | 1.0-1 | `libunistring.so.2` |
+| transitive | **libzstd** | 1.4.8+dfsg-3build1 | `libzstd.so.1` |
+| transitive | **nettle** | 3.7.3-1build2 | `libnettle.so.8`, `libhogweed.so.6` |
+| transitive | **nghttp2** | 1.43.0-1ubuntu0.2 | `libnghttp2.so.14` |
+| transitive | **openldap** | 2.5.20+dfsg-0ubuntu0.22.04.1 | `libldap-2.5.so.0`, `liblber-2.5.so.0` |
+| transitive | **openssl** | 3.0.2-0ubuntu1.21 | `libssl.so.3`, `libcrypto.so.3` |
+| transitive | **p11-kit** | 0.24.0-6build1 | `libp11-kit.so.0` |
+| transitive | **rtmpdump** | 2.4+20151223.gitfa8646d.1-2build4 | `librtmp.so.1` |
 
-| Component | Version | Sonames |
-|---|---|---|
-| **brotli** | 1.0.9-2build6 | `libbrotlidec.so.1`, `libbrotlicommon.so.1` |
-| **cyrus-sasl2** | 2.1.27+dfsg2-3ubuntu1.2 | `libsasl2.so.2` |
-| **e2fsprogs** | 1.46.5-2ubuntu1.2 | `libcom_err.so.2` |
-| **gmp** | 2:6.2.1+dfsg-3ubuntu1 | `libgmp.so.10` |
-| **gnutls28** | 3.7.3-4ubuntu1.7 | `libgnutls.so.30` |
-| **keyutils** | 1.6.1-2ubuntu3 | `libkeyutils.so.1` |
-| **krb5** | 1.19.2-2ubuntu0.7 | `libgssapi_krb5.so.2`, `libkrb5.so.3`, `libk5crypto.so.3`, `libkrb5support.so.0` |
-| **libffi** | 3.4.2-4 | `libffi.so.8` |
-| **libidn2** | 2.3.2-2build1 | `libidn2.so.0` |
-| **libpsl** | 0.21.0-1.2build2 | `libpsl.so.5` |
-| **libssh** | 0.9.6-2ubuntu0.22.04.5 | `libssh.so.4` |
-| **libtasn1-6** | 4.18.0-4ubuntu0.1 | `libtasn1.so.6` |
-| **libunistring** | 1.0-1 | `libunistring.so.2` |
-| **libzstd** | 1.4.8+dfsg-3build1 | `libzstd.so.1` |
-| **nettle** | 3.7.3-1build2 | `libnettle.so.8`, `libhogweed.so.6` |
-| **nghttp2** | 1.43.0-1ubuntu0.2 | `libnghttp2.so.14` |
-| **openldap** | 2.5.20+dfsg-0ubuntu0.22.04.1 | `libldap-2.5.so.0`, `liblber-2.5.so.0` |
-| **openssl** | 3.0.2-0ubuntu1.21 | `libssl.so.3`, `libcrypto.so.3` |
-| **p11-kit** | 0.24.0-6build1 | `libp11-kit.so.0` |
-| **rtmpdump** | 2.4+20151223.gitfa8646d.1-2build4 | `librtmp.so.1` |
+**25 packages, 441 source files, 466 relationships**
 
-### Build Tool (1)
+### SBOM 2: `libcurl.so` (shared library) — `libcurl_adg.spdx.json`
+
+The libcurl shared library has 9 direct dependencies — these are the libraries that libcurl itself explicitly links against. Only 1 is transitive.
+
+**Root package:** `libcurl.so` 8.19.0-DEV (`primaryPackagePurpose: LIBRARY`)
+
+| Linkage | Component | Version | Sonames |
+|---|---|---|---|
+| **DIRECT** | **brotli** | 1.0.9-2build6 | `libbrotlidec.so.1` |
+| **DIRECT** | **glibc** | 2.35-0ubuntu3.13 | `libc.so.6` |
+| **DIRECT** | **libidn2** | 2.3.2-2build1 | `libidn2.so.0` |
+| **DIRECT** | **libpsl** | 0.21.0-1.2build2 | `libpsl.so.5` |
+| **DIRECT** | **libssh2** | 1.10.0-3 | `libssh2.so.1` |
+| **DIRECT** | **libzstd** | 1.4.8+dfsg-3build1 | `libzstd.so.1` |
+| **DIRECT** | **nghttp2** | 1.43.0-1ubuntu0.2 | `libnghttp2.so.14` |
+| **DIRECT** | **openssl** | 3.0.2-0ubuntu1.21 | `libssl.so.3`, `libcrypto.so.3` |
+| **DIRECT** | **zlib** | 1:1.2.11.dfsg-2ubuntu9.2 | `libz.so.1` |
+| transitive | **libunistring** | 1.0-1 | `libunistring.so.2` |
+
+**12 packages, 441 source files, 453 relationships**
+
+### Build Tool (both SBOMs)
 
 | Component | Version | SPDX Relationship |
 |---|---|---|
@@ -115,28 +137,31 @@ These are GitHub Actions referenced in `.github/workflows/*.yml` files. They run
 
 ## SPDX Document Details
 
-| Property | ADG (OmniBOR) | Syft | GitHub |
-|---|---|---|---|
-| **SPDX version** | 2.3 | 2.3 | 2.3 |
-| **Packages** | 25 | 43 (with duplicates) | 26 |
-| **Files** | 441 | 23 | 0 |
-| **Relationships** | 466 | 85 | 26 |
-| **Relationship types** | `DYNAMIC_LINK` (23), `BUILD_TOOL_OF` (1), `CONTAINS` (441), `DESCRIBES` (1) | `CONTAINS` (42), `OTHER` (42), `DESCRIBES` (1) | `DEPENDS_ON` (25), `DESCRIBES` (1) |
-| **Package purpose** | `APPLICATION` (curl, gcc), `LIBRARY` (23 libs) | `FILE` (1), unset (42) | unset (26) |
-| **PURLs** | `pkg:deb/ubuntu/...` | mixed | `pkg:pypi/...`, `pkg:githubactions/...` |
-| **CPEs** | ✓ (all 23 libs) | ✗ | ✗ |
-| **OmniBOR ExternalRef** | ✓ (gitoid on root package) | ✗ | ✗ |
-| **Source files** | 441 (.c, .h, .S, .inc) | 0 | 0 |
+| Property | ADG: curl | ADG: libcurl.so | Syft | GitHub |
+|---|---|---|---|---|
+| **SPDX version** | 2.3 | 2.3 | 2.3 | 2.3 |
+| **Packages** | 25 | 12 | 43 (with duplicates) | 26 |
+| **Files** | 441 | 441 | 23 | 0 |
+| **Relationships** | 466 | 453 | 85 | 26 |
+| **Relationship types** | `DYNAMIC_LINK` (23), `BUILD_TOOL_OF` (1), `CONTAINS` (441), `DESCRIBES` (1) | `DYNAMIC_LINK` (10), `BUILD_TOOL_OF` (1), `CONTAINS` (441), `DESCRIBES` (1) | `CONTAINS` (42), `OTHER` (42), `DESCRIBES` (1) | `DEPENDS_ON` (25), `DESCRIBES` (1) |
+| **Root purpose** | `APPLICATION` | `LIBRARY` | `FILE` | unset |
+| **Lib purpose** | `LIBRARY` (23 libs) | `LIBRARY` (10 libs) | unset | unset |
+| **PURLs** | `pkg:deb/ubuntu/...` | `pkg:deb/ubuntu/...` | mixed | `pkg:pypi/...`, `pkg:githubactions/...` |
+| **CPEs** | ✓ (all 23 libs) | ✓ (all 10 libs) | ✗ | ✗ |
+| **OmniBOR ExternalRef** | ✓ (gitoid on root) | ✓ (gitoid on root) | ✗ | ✗ |
+| **Source files** | 441 (.c, .h, .S, .inc) | 441 (.c, .h, .S, .inc) | 0 | 0 |
 
 ## Conclusions
 
-1. **ADG (OmniBOR) is the only tool that identifies the 23 shared libraries actually loaded at runtime.** These represent the real attack surface and vulnerability exposure of the curl binary.
+1. **ADG (OmniBOR) is the only tool that identifies the shared libraries actually loaded at runtime.** It produces per-binary SBOMs: 23 libraries for the curl CLI, 10 for libcurl.so. These represent the real attack surface and vulnerability exposure.
 
-2. **Syft and GitHub find the same CI/dev tooling** (pip packages and GitHub Actions) from manifest files. These are useful for supply chain auditing of the build pipeline but are not present in the compiled binary.
+2. **Per-binary SBOMs reflect the actual dependency hierarchy.** The curl binary depends on libcurl.so, which in turn depends on openssl, nghttp2, brotli, etc. Someone shipping only libcurl.so gets an accurate SBOM for their use case.
 
-3. **BDBA binary scanning detected only curl itself** — it cannot identify the dynamically linked third-party libraries.
+3. **Syft and GitHub find the same CI/dev tooling** (pip packages and GitHub Actions) from manifest files. These are useful for supply chain auditing of the build pipeline but are not present in the compiled binaries.
 
-4. **The three approaches are complementary, not competing.** A complete supply chain SBOM would combine:
+4. **BDBA binary scanning detected only curl itself** — it cannot identify the dynamically linked third-party libraries.
+
+5. **The three approaches are complementary, not competing.** A complete supply chain SBOM would combine:
    - ADG for runtime dependencies (what's in the binary)
    - Syft/GitHub for build pipeline dependencies (what built the binary)
    - OmniBOR for cryptographic build provenance (how the binary was built)


### PR DESCRIPTION
## Summary

Generate separate SBOMs for each binary, reflecting the actual two-tier dependency hierarchy.

### Per-binary SBOMs

| | curl_adg.spdx.json | libcurl_adg.spdx.json |
|---|---|---|
| **Root** | curl (APPLICATION) | libcurl.so (LIBRARY) |
| **Direct deps** | 3 (libcurl.so, zlib, glibc) | 9 (openssl, nghttp2, brotli, zstd, libssh2, libidn2, libpsl, zlib, glibc) |
| **Transitive** | 20 | 1 |
| **Total packages** | 25 | 12 |
| **Relationships** | 466 | 453 |

### Changes

- `SpdxEmitter`: `binary_name` param, auto-detect LIBRARY vs APPLICATION from .so suffix
- `AdgSpdxGenerator.generate()`: `binary_name` + `dynlib_dir` params
- CLI: `--binary-name` and `--dynlib-dir` arguments
- Updated `docs/three-way-spdx-comparison.md` with two-tier structure

### Quality
- 282 tests pass, 97% overall, 98% on spdx_from_adg.py