### PR TITLE
fix: curl SBOM includes only direct deps (--direct-only)

### DIFF
--- a/docs/three-way-spdx-comparison.md
+++ b/docs/three-way-spdx-comparison.md
@@ -12,11 +12,11 @@ ADG (OmniBOR) generates **two separate SBOMs** — one per binary — reflecting
 
 | Category | ADG: curl | ADG: libcurl.so | Syft | GitHub | BDBA |
 |---|:---:|:---:|:---:|:---:|:---:|
-| **Dynamically linked libraries (.so)** | **23** | **10** | 0 | 0 | 0 |
+| **Dynamically linked libraries (.so)** | **3** (direct only) | **10** | 0 | 0 | 0 |
 | Project binary / build compiler | 2 | 2 | 2 | 1 | 1 |
 | Python CI/dev tools (pip) | 0 | 0 | 13 | 14 | 0 |
 | GitHub Actions (CI workflows) | 0 | 0 | 11 | 11 | 0 |
-| **Total (unique)** | **25** | **12** | **26** | **26** | **1** |
+| **Total (unique)** | **5** | **12** | **26** | **26** | **1** |
 
 ## What Each Tool Scans
 
@@ -37,37 +37,17 @@ The curl project produces two binaries with distinct dependency profiles. ADG ge
 
 ### SBOM 1: `curl` (CLI executable) — `curl_adg.spdx.json`
 
-The curl binary has only 3 direct dependencies (ELF `NEEDED` entries from `readelf -d`). The remaining 20 are transitive — pulled in by `libcurl.so` and its own dependencies (discovered via `ldd`).
+The curl binary has only 3 direct dependencies (ELF `NEEDED` entries from `readelf -d`). Transitive dependencies (brotli, openssl, nghttp2, etc.) are **not included** — they belong to the `libcurl.so` SBOM, since it is libcurl that actually links against them.
 
 **Root package:** `curl` 8.19.0-DEV (`primaryPackagePurpose: APPLICATION`)
 
-| Linkage | Component | Version | Sonames |
+| Component | Version | Sonames | Notes |
 |---|---|---|---|
-| **DIRECT** | **curl** (libcurl) | 7.81.0-1ubuntu1.21 | `libcurl.so.4` |
-| **DIRECT** | **glibc** | 2.35-0ubuntu3.13 | `libc.so.6`, `libresolv.so.2` |
-| **DIRECT** | **zlib** | 1:1.2.11.dfsg-2ubuntu9.2 | `libz.so.1` |
-| transitive | **brotli** | 1.0.9-2build6 | `libbrotlidec.so.1`, `libbrotlicommon.so.1` |
-| transitive | **cyrus-sasl2** | 2.1.27+dfsg2-3ubuntu1.2 | `libsasl2.so.2` |
-| transitive | **e2fsprogs** | 1.46.5-2ubuntu1.2 | `libcom_err.so.2` |
-| transitive | **gmp** | 2:6.2.1+dfsg-3ubuntu1 | `libgmp.so.10` |
-| transitive | **gnutls28** | 3.7.3-4ubuntu1.7 | `libgnutls.so.30` |
-| transitive | **keyutils** | 1.6.1-2ubuntu3 | `libkeyutils.so.1` |
-| transitive | **krb5** | 1.19.2-2ubuntu0.7 | `libgssapi_krb5.so.2`, `libkrb5.so.3`, `libk5crypto.so.3`, `libkrb5support.so.0` |
-| transitive | **libffi** | 3.4.2-4 | `libffi.so.8` |
-| transitive | **libidn2** | 2.3.2-2build1 | `libidn2.so.0` |
-| transitive | **libpsl** | 0.21.0-1.2build2 | `libpsl.so.5` |
-| transitive | **libssh** | 0.9.6-2ubuntu0.22.04.5 | `libssh.so.4` |
-| transitive | **libtasn1-6** | 4.18.0-4ubuntu0.1 | `libtasn1.so.6` |
-| transitive | **libunistring** | 1.0-1 | `libunistring.so.2` |
-| transitive | **libzstd** | 1.4.8+dfsg-3build1 | `libzstd.so.1` |
-| transitive | **nettle** | 3.7.3-1build2 | `libnettle.so.8`, `libhogweed.so.6` |
-| transitive | **nghttp2** | 1.43.0-1ubuntu0.2 | `libnghttp2.so.14` |
-| transitive | **openldap** | 2.5.20+dfsg-0ubuntu0.22.04.1 | `libldap-2.5.so.0`, `liblber-2.5.so.0` |
-| transitive | **openssl** | 3.0.2-0ubuntu1.21 | `libssl.so.3`, `libcrypto.so.3` |
-| transitive | **p11-kit** | 0.24.0-6build1 | `libp11-kit.so.0` |
-| transitive | **rtmpdump** | 2.4+20151223.gitfa8646d.1-2build4 | `librtmp.so.1` |
+| **curl** (libcurl) | 7.81.0-1ubuntu1.21 | `libcurl.so.4` | See libcurl.so SBOM for its own deps |
+| **glibc** | 2.35-0ubuntu3.13 | `libc.so.6`, `libresolv.so.2` | |
+| **zlib** | 1:1.2.11.dfsg-2ubuntu9.2 | `libz.so.1` | |
 
-**25 packages, 441 source files, 466 relationships**
+**5 packages, 441 source files, 446 relationships**
 
 ### SBOM 2: `libcurl.so` (shared library) — `libcurl_adg.spdx.json`
 
@@ -140,22 +120,22 @@ These are GitHub Actions referenced in `.github/workflows/*.yml` files. They run
 | Property | ADG: curl | ADG: libcurl.so | Syft | GitHub |
 |---|---|---|---|---|
 | **SPDX version** | 2.3 | 2.3 | 2.3 | 2.3 |
-| **Packages** | 25 | 12 | 43 (with duplicates) | 26 |
+| **Packages** | 5 | 12 | 43 (with duplicates) | 26 |
 | **Files** | 441 | 441 | 23 | 0 |
-| **Relationships** | 466 | 453 | 85 | 26 |
-| **Relationship types** | `DYNAMIC_LINK` (23), `BUILD_TOOL_OF` (1), `CONTAINS` (441), `DESCRIBES` (1) | `DYNAMIC_LINK` (10), `BUILD_TOOL_OF` (1), `CONTAINS` (441), `DESCRIBES` (1) | `CONTAINS` (42), `OTHER` (42), `DESCRIBES` (1) | `DEPENDS_ON` (25), `DESCRIBES` (1) |
+| **Relationships** | 446 | 453 | 85 | 26 |
+| **Relationship types** | `DYNAMIC_LINK` (3), `BUILD_TOOL_OF` (1), `CONTAINS` (441), `DESCRIBES` (1) | `DYNAMIC_LINK` (10), `BUILD_TOOL_OF` (1), `CONTAINS` (441), `DESCRIBES` (1) | `CONTAINS` (42), `OTHER` (42), `DESCRIBES` (1) | `DEPENDS_ON` (25), `DESCRIBES` (1) |
 | **Root purpose** | `APPLICATION` | `LIBRARY` | `FILE` | unset |
-| **Lib purpose** | `LIBRARY` (23 libs) | `LIBRARY` (10 libs) | unset | unset |
+| **Lib purpose** | `LIBRARY` (3 libs) | `LIBRARY` (10 libs) | unset | unset |
 | **PURLs** | `pkg:deb/ubuntu/...` | `pkg:deb/ubuntu/...` | mixed | `pkg:pypi/...`, `pkg:githubactions/...` |
-| **CPEs** | ✓ (all 23 libs) | ✓ (all 10 libs) | ✗ | ✗ |
+| **CPEs** | ✓ (all 3 libs) | ✓ (all 10 libs) | ✗ | ✗ |
 | **OmniBOR ExternalRef** | ✓ (gitoid on root) | ✓ (gitoid on root) | ✗ | ✗ |
 | **Source files** | 441 (.c, .h, .S, .inc) | 441 (.c, .h, .S, .inc) | 0 | 0 |
 
 ## Conclusions
 
-1. **ADG (OmniBOR) is the only tool that identifies the shared libraries actually loaded at runtime.** It produces per-binary SBOMs: 23 libraries for the curl CLI, 10 for libcurl.so. These represent the real attack surface and vulnerability exposure.
+1. **ADG (OmniBOR) is the only tool that identifies the shared libraries actually loaded at runtime.** It produces per-binary SBOMs with no redundancy: 3 direct deps for the curl CLI, 10 for libcurl.so. These represent the real attack surface and vulnerability exposure.
 
-2. **Per-binary SBOMs reflect the actual dependency hierarchy.** The curl binary depends on libcurl.so, which in turn depends on openssl, nghttp2, brotli, etc. Someone shipping only libcurl.so gets an accurate SBOM for their use case.
+2. **Per-binary SBOMs eliminate redundancy.** The curl SBOM lists only its 3 direct dependencies (libcurl.so, glibc, zlib). Libraries like openssl, brotli, and nghttp2 appear only in the libcurl.so SBOM, because it is libcurl — not curl — that links against them. Someone shipping only libcurl.so gets an accurate SBOM for their use case.
 
 3. **Syft and GitHub find the same CI/dev tooling** (pip packages and GitHub Actions) from manifest files. These are useful for supply chain auditing of the build pipeline but are not present in the compiled binaries.
 


### PR DESCRIPTION
## Problem

The curl SBOM incorrectly listed 25 packages including transitive deps (openssl, brotli, nghttp2, etc.) that actually belong to libcurl.so's dependency tree. The curl binary's ELF NEEDED entries are only: libcurl.so, libc.so.6, libz.so.1.

## Fix

- Added `direct_only` param to `SpdxEmitter.emit()` — filters out transitive deps
- Wired through `AdgSpdxGenerator.generate()` and CLI (`--direct-only` flag)
- Regenerated curl_adg.spdx.json: **5 packages** (was 25)
- libcurl_adg.spdx.json unchanged: 12 packages
- Updated three-way-spdx-comparison.md

283 tests pass, 97% coverage.