### PR TITLE
feat: vendored version detection + ADG SPDX pipeline integration

### DIFF
--- a/.windsurf/workflows/run-analysis.md
+++ b/.windsurf/workflows/run-analysis.md
@@ -69,8 +69,9 @@ This downloads:
 2. **Syft baseline** — manifest-based SPDX SBOM for comparison
 3. **Validate deps** — checks `apt_deps` are installed
 4. **Instrumented build** — `bomtrace3 make` intercepts compiler/linker calls
-5. **SPDX generation** — `bomsh_sbom.py` creates SPDX SBOM from ADG data
-6. **SPDX validation** — JSON Schema + semantic validation of generated SPDX
+5a. **SPDX generation (bomsh)** — `bomsh_sbom.py` creates SPDX SBOM from ADG data
+5b. **SPDX generation (ADG)** — per-binary SPDX with vendored version detection via `spdx_from_adg.py`
+6. **SPDX validation** — JSON Schema + semantic validation of all generated SBOMs
 7. **Binary collection** — copies `output_binaries` to `output/binaries/<repo>/`
 8. **Docs** — timestamped build log and runtime metrics
 
@@ -81,6 +82,7 @@ This downloads:
 | Output binaries | `output/binaries/<repo>/<ts>/` |
 | OmniBOR ADG | `output/omnibor/<repo>/` |
 | SPDX SBOM (OmniBOR) | `output/spdx/<repo>/<repo>_omnibor_<ts>.spdx.json` |
+| SPDX SBOM (ADG) | `output/spdx/<repo>/<binary>_adg.spdx.json` |
 | SPDX SBOM (Syft) | `output/spdx/<repo>/<repo>_syft_<ts>.spdx.json` |
 | Build log | `docs/<repo>/<ts>_build.md` |
 | Runtime metrics | `docs/runtime/<ts>_<repo>_runtime.md` |

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1821,6 +1821,8 @@ def _mock_pipeline():
     cloner = MagicMock()
     builder = MagicMock()
     spdx_gen = MagicMock()
+    adg_spdx = MagicMock()
+    adg_spdx.generate.return_value = []
     spdx_validator = MagicMock()
     syft_gen = MagicMock()
     binary_collector = MagicMock()
@@ -1831,6 +1833,7 @@ def _mock_pipeline():
         cloner=cloner,
         builder=builder,
         spdx_gen=spdx_gen,
+        adg_spdx=adg_spdx,
         spdx_validator=spdx_validator,
         syft_gen=syft_gen,
         binary_collector=binary_collector,


### PR DESCRIPTION
## Summary

Add **VendoredVersionDetector** that extracts version info from vendored source files, and integrate **AdgSpdxStep** into the analysis pipeline so ADG SPDX generation runs inside the Docker container where source paths match the treedb.

## VendoredVersionDetector

Scans vendored source directories using four strategies:
1. **VERSION files** — e.g. jemalloc `5.3.0`
2. **`#define` macros** — e.g. `HIREDIS_MAJOR/MINOR/PATCH` → `1.2.0`, `LUA_RELEASE` → `5.1.5`
3. **Header comments** — e.g. `linenoise.h -- VERSION 1.0`
4. **`.pc.in` files** — e.g. `Version: 1.2.0`

### Redis results: 5 of 8 vendored libs detected

| Library | Version | Method |
|---|---|---|
| jemalloc | 5.3.0 | VERSION file |
| lua | 5.1.5 | `#define LUA_RELEASE` |
| hiredis | 1.2.0 | `#define MAJOR/MINOR/PATCH` |
| xxhash | 0.8 | `#define VERSION_MAJOR/MINOR` |
| linenoise | 1.0 | Header comment |
| fast_float | *(omitted)* | No version in source |
| fpconv | *(omitted)* | No version in source |
| hdr_histogram | *(omitted)* | No version in source |

## Pipeline integration

- New `AdgSpdxStep` class in `analyze.py` wraps `spdx_from_adg.AdgSpdxGenerator`
- Runs as **Step 5b** after `bomsh_sbom.py` SPDX generation
- Runs inside the container where `/workspace/repos/` has actual source files
- Generates one `<binary>_adg.spdx.json` per output binary
- ADG SBOMs are also validated in Step 6

## Tests

301 tests pass, 96% overall coverage, 99% on `spdx_from_adg.py`.