### PR TITLE
docs: Windsurf greenfield onboarding + infrastructure profile system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ output/binary-scan/*/
 !output/**/.gitkeep
 
 # ============================================================
+# User-specific infrastructure profile (IPs, instance IDs, SSH config)
+# ============================================================
+.windsurf/rules/infrastructure/active-profile.md
+
+# ============================================================
 # Credentials and secrets
 # ============================================================
 keys.json

--- a/.windsurf/rules/docker-rules.md
+++ b/.windsurf/rules/docker-rules.md
@@ -4,38 +4,77 @@ description: Rules for Docker container usage in this project
 
 # Docker Rules
 
-- **All builds run on the DigitalOcean droplet** (`omnibor-build`, 137.184.178.186)
-- **Local Docker is NOT needed** — the droplet runs native x86_64 Linux with Docker
-- **Bomtrace3 requires Linux strace** — it will not work on macOS
+## Platform Requirements
+
+- **Bomtrace3 requires native Linux x86_64** — it uses ptrace via `<sys/reg.h>`
+- It does NOT work on: macOS, Windows, ARM64/Graviton, Alpine (musl), or under QEMU/Rosetta
 - The container must have `SYS_PTRACE` capability and `seccomp:unconfined` security option
-- SSH alias: `ssh omnibor-build` (configured in `~/.ssh/config`)
-- To enter the container on the droplet:
+- Supported hosts: any x86_64 Linux with Docker 20.10+ (bare metal, VM, or cloud instance)
+- Supported base images: Ubuntu 18.04–22.04, Debian 10–11
 
-  ```bash
-  ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env bash"
-  ```
+## Running the Container
 
-- To rebuild the image on the droplet:
+Enter the container interactively:
 
-  ```bash
-  ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml build"
-  ```
+```bash
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env bash
+```
 
-# Volume Mounts (on droplet)
+Run analysis directly:
 
-The following directories are mounted into the container:
+```bash
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
+  python3 /workspace/app/analyze.py --repo <REPO_NAME>
+```
 
-| Host Path (droplet) | Container Path | Purpose |
-|----------------------|---------------|---------|
+Rebuild the image (after Dockerfile changes):
+
+```bash
+docker-compose -f docker/docker-compose.yml build
+```
+
+## Remote Host Usage
+
+If running on a remote Linux host, your SSH alias, IP, repo path, and sync
+commands are defined in your **infrastructure profile**:
+
+```
+.windsurf/rules/infrastructure/active-profile.md
+```
+
+See `.windsurf/rules/infrastructure/README.md` for how to set up a profile.
+Templates are provided for DigitalOcean, AWS EC2, and local Linux.
+
+General pattern for remote execution:
+
+```bash
+ssh <SSH_ALIAS> "cd <REPO_PATH> && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
+```
+
+General pattern for syncing results:
+
+```bash
+rsync -avz <SSH_ALIAS>:<REPO_PATH>/output/ output/
+rsync -avz <SSH_ALIAS>:<REPO_PATH>/docs/ docs/
+```
+
+## Volume Mounts
+
+The following directories are mounted into the container (defined in docker-compose.yml):
+
+| Host Path | Container Path | Purpose |
+|-----------|---------------|---------|
 | `repos/` | `/workspace/repos` | Cloned source repositories |
 | `output/` | `/workspace/output` | Generated ADG, SPDX, binary scan artifacts |
 | `app/` | `/workspace/app` | Orchestration scripts and config |
 | `docs/` | `/workspace/docs` | Timestamped markdown reports |
+| `scripts/` | `/workspace/scripts` | Helper scripts |
+| `tests/` | `/workspace/tests` | Test suite |
 
-# Dockerfile Maintenance
+## Dockerfile Maintenance
 
 - When adding a new target repo, add its build dependencies to the Dockerfile
 - Bomtrace2 and bomtrace3 are compiled from source (patched strace) during image build
 - The bomsh scripts and binaries are at `/opt/bomsh/` inside the container
 - Syft is installed at `/usr/local/bin/syft`
-- After changing the Dockerfile locally, push to GitHub, pull on the droplet, then rebuild
+- After changing the Dockerfile, rebuild the image before running analysis

--- a/.windsurf/rules/droplet-shutdown.md
+++ b/.windsurf/rules/droplet-shutdown.md
@@ -1,29 +1,44 @@
 ---
-description: Reminder to stop DigitalOcean droplet when done for the day
+description: Reminder to stop cloud compute resources when done for the day
 ---
 
-# DigitalOcean Droplet Shutdown Reminder
+# Cloud Compute Shutdown Reminder
 
 At the **end of every work session** (when the user says they're done, wrapping up,
-or about to close/sleep their laptop), Cascade **must** remind the user:
+or about to close/sleep their laptop), Cascade **must**:
 
-> **Don't forget to stop your DigitalOcean droplet!**
-> Go to [cloud.digitalocean.com](https://cloud.digitalocean.com) → Droplets →
-> `omnibor-build` → Power → **Turn off droplet**.
->
-> A stopped droplet still charges for disk ($0.007/hr) but not CPU.
-> To stop all charges, **destroy** the droplet (you can recreate it later).
+1. Read `.windsurf/rules/infrastructure/active-profile.md` for the user's provider
+2. Use the **Power Management** commands from that profile to remind the user
+
+If the active profile shows **Provider: Local**, skip this reminder (no cost).
+
+> **Don't forget to stop your build server!**
+> Check your active infrastructure profile for the shutdown command.
 
 ## When to Trigger
 
 - User says "done for the day", "wrapping up", "going to sleep", "signing off", etc.
 - User says they're closing or sleeping their laptop
-- End of a long session where the droplet was used
+- End of a long session where cloud compute was used
 
-## Droplet Details
+## Why This Matters
 
-- **Name:** omnibor-build
-- **IP:** 137.184.178.186
-- **SSH alias:** `omnibor-build` (configured in ~/.ssh/config)
-- **Provider:** DigitalOcean
-- **Cost:** ~$0.018/hr running, ~$0.007/hr stopped (disk only), $0 destroyed
+- Cloud VMs charge per hour/minute even when idle
+- The OmniBOR analysis container only needs to run during active analysis
+- Stopping the VM preserves disk state; destroying it saves all costs
+- Always verify no analysis is in progress before stopping
+
+## Where to Find Shutdown Commands
+
+The user's specific shutdown commands are in:
+
+```
+.windsurf/rules/infrastructure/active-profile.md → Power Management section
+```
+
+If that file doesn't exist, remind the user to set one up:
+
+```
+cp .windsurf/rules/infrastructure/templates/<provider>.md \
+   .windsurf/rules/infrastructure/active-profile.md
+```

--- a/.windsurf/rules/getting-started.md
+++ b/.windsurf/rules/getting-started.md
@@ -1,0 +1,63 @@
+---
+description: First-time setup instructions for new contributors using Windsurf Cascade
+---
+
+# Getting Started with OmniBOR Analysis
+
+This rule provides context for Cascade AI when a new contributor opens this project
+for the first time in Windsurf IDE.
+
+## First Session Checklist
+
+When a new user opens this project, Cascade should:
+
+1. **Read all rules** in `.windsurf/rules/` to load project conventions
+2. **Read all workflows** in `.windsurf/workflows/` to understand available commands
+3. **Run `/setup-environment`** to verify the local development environment
+4. **Explain the project** — this is an OmniBOR build interception pipeline that
+   generates SPDX 2.3 SBOMs from instrumented C/C++ builds
+5. **Offer to run `/add-repo`** if the user wants to analyze a new GitHub repository
+
+## Recommended Cascade Model
+
+For best results with this codebase, use **Claude Opus 4** or newer. The pipeline
+involves complex multi-step analysis with SPDX generation, vendored dependency
+detection, and D3.js visualization — larger models handle this better.
+
+To set the model in Windsurf:
+- Open Settings → Cascade → Model
+- Select Claude Opus 4 (or latest available)
+
+## What This Project Does
+
+1. Takes any C/C++ GitHub repository
+2. Instruments the build with bomtrace3 (ptrace-based interception)
+3. Captures every compiler/linker invocation
+4. Generates SPDX 2.3 SBOMs with:
+   - Vendored static libraries (STATIC_LINK)
+   - Dynamic system libraries (DYNAMIC_LINK)
+   - Build tools (BUILD_TOOL_OF)
+   - Automatic version detection for vendored libs
+5. Produces interactive D3.js HTML dependency graphs
+6. Optionally compares against proprietary binary scanner SBOMs
+
+## Quick Start for New Users
+
+Tell Cascade:
+- "Add [repo name] for analysis" → runs `/add-repo` workflow
+- "Run analysis on [repo]" → runs `/run-analysis` workflow
+- "Compare SBOMs for [repo]" → runs `/run-comparison` workflow
+- "Build the Docker container" → runs `/docker-build` workflow
+
+## Infrastructure Options
+
+The Docker container requires **Linux x86_64** with ptrace support. Options:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Local Linux x86_64** | Fastest, no network | Must have Docker installed |
+| **Cloud VM** (DO, EC2, etc.) | Easy setup, disposable | Costs money, network latency |
+| **GitHub Codespaces** | Zero setup | May not support SYS_PTRACE |
+| **WSL2 on Windows** | Free, local | Requires Windows + WSL2 + Docker |
+
+The project is designed to work with any of these — Docker handles the environment.

--- a/.windsurf/rules/infrastructure/README.md
+++ b/.windsurf/rules/infrastructure/README.md
@@ -1,0 +1,69 @@
+---
+description: Infrastructure profile system for OmniBOR build hosts
+---
+
+# Infrastructure Profiles
+
+Each contributor runs OmniBOR analysis on their own Linux x86_64 build host.
+This directory contains **provider templates** (tracked in git) and each user's
+**active profile** (local-only, gitignored).
+
+## How It Works
+
+```
+infrastructure/
+├── README.md                  ← You are here (tracked)
+├── active-profile.md          ← YOUR setup: IP, SSH, paths (gitignored)
+├── templates/
+│   ├── digitalocean.md        ← Template for DigitalOcean droplets (tracked)
+│   ├── aws-ec2.md             ← Template for AWS EC2 instances (tracked)
+│   └── local-linux.md         ← Template for local/WSL2/bare metal (tracked)
+```
+
+- **Templates** are checked into git as references. They contain placeholder values.
+- **`active-profile.md`** is gitignored. It contains YOUR real IPs, SSH aliases,
+  instance IDs, and provider-specific commands. Cascade reads this file to know
+  how to run builds and manage your infrastructure.
+
+## First-Time Setup
+
+1. Pick the template closest to your setup
+2. Copy it to `active-profile.md`
+3. Fill in your real values (IP, SSH key path, instance ID, etc.)
+
+Example:
+
+```bash
+cp .windsurf/rules/infrastructure/templates/digitalocean.md \
+   .windsurf/rules/infrastructure/active-profile.md
+# Then edit active-profile.md with your actual values
+```
+
+## What Cascade Does With This
+
+When Cascade needs to:
+
+- **Run a build** → reads `active-profile.md` for SSH alias and repo path
+- **Sync results** → reads `active-profile.md` for rsync commands
+- **Stop/start the host** → reads `active-profile.md` for provider CLI commands
+- **Remind you to shut down** → reads `active-profile.md` for cost info
+
+If `active-profile.md` doesn't exist, Cascade will ask you to set one up.
+
+## Switching Providers
+
+To migrate from DigitalOcean to AWS (or vice versa):
+
+1. Copy the new template: `cp templates/aws-ec2.md active-profile.md`
+2. Fill in your values
+3. That's it — Cascade will use the new profile immediately
+
+Your old profile is just a local file — delete it or rename it for reference.
+
+## Security
+
+- `active-profile.md` is **gitignored** — your IPs, instance IDs, and SSH
+  config never leave your machine
+- Templates contain only placeholder values and are safe to commit
+- Never put API keys, tokens, or passwords in any of these files —
+  use environment variables or `~/.ssh/config` instead

--- a/.windsurf/rules/infrastructure/templates/aws-ec2.md
+++ b/.windsurf/rules/infrastructure/templates/aws-ec2.md
@@ -1,0 +1,139 @@
+---
+description: AWS EC2 instance template for OmniBOR build host
+---
+
+# AWS EC2 — Build Host Profile
+
+Copy this file to `../active-profile.md` and fill in your values.
+
+## Host Details
+
+| Field | Value |
+|-------|-------|
+| **Provider** | AWS EC2 |
+| **Instance ID** | `i-<YOUR_INSTANCE_ID>` |
+| **SSH alias** | `omnibor-build` |
+| **IP** | `<YOUR_ELASTIC_IP or PUBLIC_IP>` |
+| **Region** | `<REGION>` (e.g. us-west-2) |
+| **Instance Type** | `t3.medium` (recommended) |
+| **AMI** | Ubuntu 22.04 x86_64 |
+| **Repo path on host** | `/home/ubuntu/omnibor-analysis` |
+
+## Recommended Instance Types
+
+| Instance | vCPU | RAM | Cost/hr | Notes |
+|----------|------|-----|---------|-------|
+| `t3.small` | 2 | 2 GB | ~$0.021 | Minimum viable |
+| `t3.medium` | 2 | 4 GB | ~$0.042 | Recommended for most repos |
+| `t3.large` | 2 | 8 GB | ~$0.083 | FFmpeg or large repos |
+| `c6i.large` | 2 | 4 GB | ~$0.085 | Compute-optimized, faster builds |
+
+## SSH Config
+
+Add to `~/.ssh/config`:
+
+```
+Host omnibor-build
+    HostName <YOUR_IP>
+    User ubuntu
+    IdentityFile ~/.ssh/<YOUR_KEY>.pem
+```
+
+## CLI Tool
+
+- **aws** — AWS CLI v2
+- Install: `brew install awscli` (macOS) or see https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
+- Configure: `aws configure` (set region, access key, secret key)
+
+### Power Management
+
+```bash
+# Check status
+aws ec2 describe-instances --instance-ids i-<YOUR_INSTANCE_ID> \
+  --query 'Reservations[].Instances[].{ID:InstanceId,State:State.Name,IP:PublicIpAddress}' \
+  --output table
+
+# Start instance
+aws ec2 start-instances --instance-ids i-<YOUR_INSTANCE_ID>
+
+# Stop instance (preserves EBS, charges for storage only)
+aws ec2 stop-instances --instance-ids i-<YOUR_INSTANCE_ID>
+
+# Terminate (destroy — deletes everything)
+aws ec2 terminate-instances --instance-ids i-<YOUR_INSTANCE_ID>
+```
+
+### Cost
+
+| State | Cost (t3.medium) |
+|-------|------|
+| Running | ~$0.042/hr (~$30/mo) |
+| Stopped (EBS only) | ~$0.003/hr (~$2.40/mo for 30 GB gp3) |
+| Terminated | $0 |
+
+**Tip:** Use a Spot Instance for up to 70% savings if you can tolerate interruptions:
+
+```bash
+aws ec2 run-instances \
+  --instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"persistent","InstanceInterruptionBehavior":"stop"}}' \
+  ...
+```
+
+## Creating a New Instance
+
+```bash
+# Launch
+aws ec2 run-instances \
+  --image-id ami-0735c191cf914754d \
+  --instance-type t3.medium \
+  --key-name <YOUR_KEY_NAME> \
+  --security-group-ids <YOUR_SG_ID> \
+  --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=omnibor-build}]' \
+  --block-device-mappings '[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]'
+
+# Allocate Elastic IP (optional, for stable IP across stop/start)
+aws ec2 allocate-address --domain vpc
+aws ec2 associate-address --instance-id i-<ID> --allocation-id eipalloc-<ID>
+```
+
+Then install Docker:
+
+```bash
+ssh omnibor-build "curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker ubuntu"
+# Log out and back in for group change
+```
+
+## Security Group (Minimum)
+
+| Direction | Port | Source | Purpose |
+|-----------|------|--------|---------|
+| Inbound | 22 | Your IP/32 | SSH |
+| Outbound | All | 0.0.0.0/0 | apt, git, Docker pulls |
+
+## Running Analysis
+
+```bash
+# Ensure latest code
+ssh omnibor-build "cd ~/omnibor-analysis && git pull origin main"
+
+# Run analysis
+ssh omnibor-build "cd ~/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
+
+# Enter container interactively
+ssh omnibor-build "cd ~/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env bash"
+
+# Rebuild Docker image
+ssh omnibor-build "cd ~/omnibor-analysis && docker-compose -f docker/docker-compose.yml build"
+```
+
+## Syncing Results
+
+```bash
+# Download results to local machine
+rsync -avz omnibor-build:~/omnibor-analysis/output/ output/
+rsync -avz omnibor-build:~/omnibor-analysis/docs/ docs/
+
+# Upload code to instance
+rsync -avz --exclude='.venv' --exclude='output' --exclude='repos' --exclude='.git' \
+  ./ omnibor-build:~/omnibor-analysis/
+```

--- a/.windsurf/rules/infrastructure/templates/digitalocean.md
+++ b/.windsurf/rules/infrastructure/templates/digitalocean.md
@@ -1,0 +1,104 @@
+---
+description: DigitalOcean droplet template for OmniBOR build host
+---
+
+# DigitalOcean Droplet — Build Host Profile
+
+Copy this file to `../active-profile.md` and fill in your values.
+
+## Host Details
+
+| Field | Value |
+|-------|-------|
+| **Provider** | DigitalOcean |
+| **Droplet Name** | `<YOUR_DROPLET_NAME>` |
+| **SSH alias** | `omnibor-build` |
+| **IP** | `<YOUR_DROPLET_IP>` |
+| **Droplet ID** | `<YOUR_DROPLET_ID>` |
+| **Region** | `<REGION>` (e.g. SFO3, NYC1) |
+| **Size** | `s-1vcpu-2gb` (minimum) or `s-2vcpu-4gb` (recommended) |
+| **OS** | Ubuntu 22.04 x86_64 |
+| **Repo path on host** | `/root/omnibor-analysis` |
+
+## SSH Config
+
+Add to `~/.ssh/config`:
+
+```
+Host omnibor-build
+    HostName <YOUR_DROPLET_IP>
+    User root
+    IdentityFile ~/.ssh/<YOUR_KEY>
+```
+
+## CLI Tool
+
+- **doctl** — DigitalOcean CLI
+- Install: `brew install doctl` (macOS) or `snap install doctl` (Linux)
+- Authenticate: `doctl auth init`
+
+### Power Management
+
+```bash
+# Check status
+doctl compute droplet list --format ID,Name,Status,PublicIPv4
+
+# Power on
+doctl compute droplet-action power-on <YOUR_DROPLET_ID> --wait
+
+# Power off (preserves disk, still charges for storage)
+doctl compute droplet-action power-off <YOUR_DROPLET_ID> --wait
+```
+
+### Cost
+
+| State | Cost (s-1vcpu-2gb) |
+|-------|------|
+| Running | ~$0.018/hr (~$12/mo) |
+| Stopped (disk preserved) | ~$0.007/hr (~$5/mo) |
+| Destroyed | $0 |
+
+## Creating a New Droplet
+
+```bash
+doctl compute droplet create omnibor-build \
+  --image ubuntu-22-04-x64 \
+  --size s-2vcpu-4gb \
+  --region sfo3 \
+  --ssh-keys <YOUR_SSH_KEY_FINGERPRINT> \
+  --wait
+```
+
+Then install Docker:
+
+```bash
+ssh omnibor-build "curl -fsSL https://get.docker.com | sh"
+```
+
+## Running Analysis
+
+```bash
+# Ensure latest code
+ssh omnibor-build "cd /root/omnibor-analysis && git pull origin main"
+
+# Run analysis
+ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
+
+# Enter container interactively
+ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env bash"
+
+# Rebuild Docker image
+ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml build"
+```
+
+## Syncing Results
+
+```bash
+# Download results to local machine
+rsync -avz omnibor-build:/root/omnibor-analysis/output/ output/
+rsync -avz omnibor-build:/root/omnibor-analysis/docs/ docs/
+
+# Upload code to droplet
+rsync -avz --exclude='.venv' --exclude='output' --exclude='repos' --exclude='.git' \
+  ./ omnibor-build:/root/omnibor-analysis/
+```

--- a/.windsurf/rules/infrastructure/templates/local-linux.md
+++ b/.windsurf/rules/infrastructure/templates/local-linux.md
@@ -1,0 +1,82 @@
+---
+description: Local Linux / WSL2 / bare metal template for OmniBOR build host
+---
+
+# Local Linux — Build Host Profile
+
+Copy this file to `../active-profile.md` and fill in your values.
+Use this template if Docker runs directly on your local machine (native Linux,
+WSL2 on Windows, or a local VM).
+
+## Host Details
+
+| Field | Value |
+|-------|-------|
+| **Provider** | Local |
+| **SSH alias** | _(none — runs locally)_ |
+| **OS** | Ubuntu 22.04 x86_64 |
+| **Repo path** | `<YOUR_CLONE_PATH>` (e.g. `/home/user/omnibor-analysis`) |
+
+## Prerequisites
+
+- Linux x86_64 (native or WSL2 — NOT ARM64, NOT Rosetta)
+- Docker 20.10+ with docker-compose
+- At least 2 GB free RAM, 10 GB free disk
+
+### Verify Architecture
+
+```bash
+uname -m
+# Must show: x86_64
+```
+
+### Install Docker (if not installed)
+
+```bash
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+# Log out and back in for group change
+```
+
+## Power Management
+
+No cloud provider CLI needed. Docker runs locally.
+
+```bash
+# Docker is managed via systemd
+sudo systemctl start docker
+sudo systemctl stop docker
+```
+
+### Cost
+
+| State | Cost |
+|-------|------|
+| All states | $0 (local hardware) |
+
+## Running Analysis
+
+```bash
+# Run analysis (from repo root)
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
+  python3 /workspace/app/analyze.py --repo <REPO_NAME>
+
+# Enter container interactively
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env bash
+
+# Rebuild Docker image
+docker-compose -f docker/docker-compose.yml build
+```
+
+## Syncing Results
+
+No sync needed — output is written directly to your local `output/` and `docs/`
+directories via Docker volume mounts.
+
+## WSL2 Notes
+
+If using WSL2 on Windows:
+
+- Install Docker Desktop with WSL2 backend, OR install Docker Engine inside WSL2
+- Clone the repo inside WSL2 filesystem (not `/mnt/c/`) for performance
+- Access HTML visualizations from Windows browser at `\\wsl$\Ubuntu\path\to\output\`

--- a/.windsurf/rules/omnibor-rules.md
+++ b/.windsurf/rules/omnibor-rules.md
@@ -9,17 +9,29 @@ description: Rules for OmniBOR/Bomsh build interception workflow
 - **Build Interception** — instrumenting the compiler/linker to observe what is actually compiled
 - **Bomtrace3** — the preferred tracer (20% overhead vs 2-5x for bomtrace2)
 - **ADG** — Artifact Dependency Graph (OmniBOR's output format)
+- **Treedb** — bomsh's hash-tree database mapping gitoid hashes to file paths
+- **Vendored library** — third-party source compiled into the project (STATIC_LINK)
 - **Build Metadata Extraction** (Yocto SBOM, Maven plugins) is NOT true build interception;
   it is essentially manifest scanning enhanced with build-system context
 
-## Workflow Sequence
+## Full Pipeline Sequence
 
 1. Clone target repo into `repos/<name>/`
-2. Run pre-build steps (autoreconf, configure) WITHOUT bomtrace instrumentation
-3. Run the final `make` step WITH bomtrace3: `bomtrace3 make -j$(nproc)`
-4. Run `bomsh_create_bom.py` to generate ADG from raw logfile
-5. Run `bomsh_sbom.py` to generate SPDX SBOM from ADG
-6. Optionally run `syft` for a manifest-based baseline SBOM
+2. Syft baseline SBOM (manifest-based, for comparison)
+3. Validate apt dependencies are installed
+4. Run pre-build steps (autoreconf, configure) WITHOUT bomtrace instrumentation
+5. Run the final `make` step WITH bomtrace3: `bomtrace3 make -j$(nproc)`
+6. `bomsh_create_bom.py` generates ADG from raw logfile → treedb + gitoid mappings
+7. `bomsh_sbom.py` generates OmniBOR SPDX SBOM from ADG
+8. `collect_metadata.py` resolves system files in treedb to dpkg packages
+9. `collect_dynamic_libs.py` identifies per-binary dynamic libs via ldd/readelf
+10. `spdx_from_adg.py` generates per-binary ADG SPDX with:
+    - Vendored static lib detection (STATIC_LINK)
+    - Dynamic system lib resolution (DYNAMIC_LINK)
+    - Build tool identification (BUILD_TOOL_OF)
+    - Automatic version detection for vendored libs
+    - Interactive D3.js HTML dependency graph
+11. SPDX validation (JSON Schema + semantic)
 
 ## Key Paths Inside Container
 
@@ -29,11 +41,14 @@ description: Rules for OmniBOR/Bomsh build interception workflow
 | `/opt/bomsh/scripts/` | Bomsh Python scripts |
 | `/tmp/bomsh_hook_raw_logfile.sha1` | Raw build log (default location) |
 | `/tmp/bomsh_createbom_jsonfile` | Generated hash-tree database |
+| `/workspace/app/` | Analysis scripts (analyze.py, spdx_from_adg.py, etc.) |
+| `/workspace/output/` | All generated artifacts |
 
 ## Important Notes
 
 - Only the final `make` step should be instrumented — configure/autoreconf are not builds
-- bomsh_hook2.py must be in /tmp/ for bomtrace2 (already copied in Dockerfile)
 - bomtrace3 does NOT need bomsh_hook2.py — it has the functionality built in as C code
 - ADG output defaults to `${PWD}/.omnibor` but we redirect to `output/omnibor/<repo>/` via `-b` flag
 - SPDX v2.3 is the supported version
+- `vendored_dirs` in config.yaml allows per-repo vendored directory patterns
+- `direct_only` mode prevents duplicate deps when a project has both executables and shared libs

--- a/.windsurf/rules/project-context.md
+++ b/.windsurf/rules/project-context.md
@@ -5,40 +5,70 @@ description: Project context and architecture for omnibor-analysis
 # Project: OmniBOR Analysis
 
 This project instruments C/C++ open-source builds with OmniBOR/Bomsh (build interception)
-to generate SPDX SBOMs, then compares those against SBOMs from proprietary binary scanning
-tools (e.g., BDBA) to evaluate accuracy, completeness, and consistency.
+to generate SPDX 2.3 SBOMs with full dependency breakdown (vendored static libs, dynamic
+system libs, build tools), then optionally compares those against SBOMs from proprietary
+binary scanning tools (e.g., BDBA) to evaluate accuracy and completeness.
 
-## Architecture
+## Directory Structure
 
-- **docker/** — Linux container environment (Ubuntu 22.04) with gcc, clang, bomtrace3, syft
-- **repos/** — Cloned target repositories (gitignored, not tracked)
-- **output/** — Raw machine-readable artifacts (ADG, SPDX JSON, binary scan results)
-- **docs/** — Timestamped human-readable markdown results, per-repo and cross-repo
-- **app/** — Orchestration scripts (analyze.py, compare.py) and config.yaml
+- **app/** — Orchestration scripts, SPDX generation, config.yaml
+- **docker/** — Linux container environment (Ubuntu 22.04) with gcc, bomtrace3, syft
+- **tests/** — Unit tests (349+ tests, 98% coverage)
+- **scripts/** — Helper/utility scripts
+- **docs/** — Timestamped results and summary documentation
+- **repos/** — Cloned target repositories (gitignored)
+- **output/** — Generated artifacts: ADG, SPDX JSON, HTML visualizations (gitignored)
+- **.windsurf/** — Cascade AI rules and workflows
 
 ## Key Technologies
 
-- **Bomsh/Bomtrace3** — strace-based build interception from omnibor/bomsh (Linux only)
+- **Bomsh/Bomtrace3** — ptrace-based build interception from omnibor/bomsh (Linux x86_64 only)
 - **OmniBOR** — Artifact Dependency Graph (ADG) standard (omnibor.io)
-- **SPDX** — SBOM format (v2.3 supported by bomsh)
+- **SPDX 2.3** — SBOM format (JSON output)
 - **Syft** — Manifest-based SBOM generation (baseline comparison)
-- **Docker** — Required because bomtrace uses strace (not available on macOS)
+- **D3.js** — Interactive HTML dependency graph visualization
+- **Docker** — Required because bomtrace3 uses Linux ptrace (not available on macOS/Windows)
+
+## Analysis Pipeline (8 steps in analyze.py)
+
+1. Clone target repo
+2. Syft baseline SBOM (manifest-based)
+3. Validate apt dependencies
+4. Instrumented build with bomtrace3
+5a. OmniBOR SPDX via bomsh_sbom.py
+5b. Metadata collection (collect_metadata.py + collect_dynamic_libs.py)
+5c. Per-binary ADG SPDX with vendored detection + HTML visualization
+6. SPDX validation (JSON Schema + semantic)
+7. Binary collection
+8. Documentation generation
+
+## Key Application Files
+
+| File | Purpose |
+|------|---------|
+| `app/analyze.py` | Main pipeline orchestrator (AnalysisPipeline facade) |
+| `app/spdx_from_adg.py` | Per-binary SPDX from ADG: vendored detection, version extraction |
+| `app/spdx_visualize.py` | D3.js HTML dependency graph generator |
+| `app/collect_metadata.py` | Resolve system files to dpkg packages |
+| `app/collect_dynamic_libs.py` | Per-binary ldd/readelf dynamic lib analysis |
+| `app/compare.py` | Compare OmniBOR SBOM vs binary scanner SBOM |
+| `app/add_repo.py` | Auto-discover and add new target repos from GitHub |
+| `app/data_loader.py` | Shared data loading utilities |
+| `app/config.yaml` | Single source of truth: repos, build steps, tool paths |
 
 ## Target Repositories
 
-| Repo | URL | Size | Build System |
-|------|-----|------|-------------|
-| curl | https://github.com/curl/curl | ~170K LoC | autoconf/make |
-| FFmpeg | https://github.com/FFmpeg/FFmpeg | ~1.2M LoC | autoconf/make |
-
-## File Naming Convention
-
-All docs use: `YYYY-MM-DD_HHMM_<type>.md`
-Types: build, omnibor, spdx, binary-scan, comparison, runtime
+| Repo | Binaries | Vendored | Dynamic | Build Time |
+|------|----------|----------|---------|------------|
+| curl | curl, libcurl.so | — (/deps/) | ~10 | ~5 min |
+| redis | redis-server | 8 libs | ~5 | ~3 min |
+| ffmpeg | 6 bins/libs | — | 20+ | ~24 min |
+| nmap | nmap, ncat, nping | 7 libs | 14 | ~3.3 min |
 
 ## Important Constraints
 
-- All builds and bomtrace instrumentation run inside the Docker container, never on macOS host
-- The Docker container requires `SYS_PTRACE` capability and `seccomp:unconfined` for strace
-- repos/ and output/ are gitignored — only docs/, app/, and docker/ are tracked
+- All builds run inside the Docker container on a Linux x86_64 host, never on macOS
+- The container requires `SYS_PTRACE` capability and `seccomp:unconfined` for ptrace
+- repos/ and output/ are gitignored — only docs/, app/, tests/, docker/ are tracked
 - config.yaml is the single source of truth for repo URLs, build commands, and paths
+- Per-file test coverage must be 95%+, overall 97%+ (enforced in pre-commit.md)

--- a/.windsurf/rules/virtual-environment.md
+++ b/.windsurf/rules/virtual-environment.md
@@ -20,12 +20,25 @@ python3 -m venv .venv
 
 ## System CLI tools
 
-Tools that are not Python packages (e.g. `doctl`, `gh`, `rsync`, `ssh`)
-are installed via Homebrew and are available system-wide. These do NOT
-go in the virtual environment.
+These tools are NOT Python packages and should be installed system-wide
+(e.g. via Homebrew on macOS, apt on Linux):
 
-Required system tools:
-- `gh` — GitHub CLI (PRs, issues)
-- `doctl` — DigitalOcean CLI (droplet power on/off)
-- `rsync` — file sync from droplet
-- `ssh` — remote access to droplet
+**Always needed:**
+
+- `git` — version control
+- `gh` — GitHub CLI (PRs, issues) — optional but recommended
+
+**If using a remote build host:**
+
+- `rsync` — file sync from remote build host
+- `ssh` — remote access to build host
+
+**If using local Docker:**
+
+- `docker` / `docker-compose` — container management
+
+**Provider-specific CLI** (depends on your infrastructure profile):
+
+- `doctl` — DigitalOcean CLI (`brew install doctl`)
+- `aws` — AWS CLI v2 (`brew install awscli`)
+- See `.windsurf/rules/infrastructure/active-profile.md` for your setup

--- a/.windsurf/workflows/add-repo.md
+++ b/.windsurf/workflows/add-repo.md
@@ -12,7 +12,7 @@ the `config.yaml` entry. Requires `gh` CLI authenticated on the host.
 The user provides just a repo name. Cascade runs:
 
 ```bash
-source .venv/bin/activate && python3 app/add_repo.py <NAME>
+.venv/bin/python3 app/add_repo.py <NAME>
 ```
 
 Accepts: repo name (`curl`), owner/repo (`curl/curl`), or full GitHub URL.
@@ -37,7 +37,7 @@ Show the user the generated entry and ask them to confirm or adjust:
 Once the user approves:
 
 ```bash
-source .venv/bin/activate && python3 app/add_repo.py <NAME> --write
+.venv/bin/python3 app/add_repo.py <NAME> --write
 ```
 
 This writes the entry to `app/config.yaml` and creates output directories.

--- a/.windsurf/workflows/first-time-setup.md
+++ b/.windsurf/workflows/first-time-setup.md
@@ -1,0 +1,100 @@
+---
+description: Complete first-time setup for a new contributor cloning this repo
+---
+
+# First-Time Setup
+
+Run this workflow when you've just cloned the omnibor-analysis repository into
+a fresh Windsurf IDE installation and want to get everything working.
+
+## 0. Read all project rules and workflows
+
+**This step is mandatory before any other work.**
+
+Read every rule and workflow file to load project conventions:
+
+```bash
+for f in .windsurf/rules/*.md; do echo "=== $f ==="; cat "$f"; echo; done
+for f in .windsurf/workflows/*.md; do echo "=== $f ==="; cat "$f"; echo; done
+```
+
+After reading, confirm to the user which rules and workflows were loaded.
+
+## 1. Create and verify the Python virtual environment
+
+// turbo
+```bash
+python3 -m venv .venv && .venv/bin/pip install --upgrade pip && .venv/bin/pip install -r requirements.txt
+```
+
+Verify it works:
+
+// turbo
+```bash
+.venv/bin/python3 --version && .venv/bin/pip check 2>&1 | tail -3
+```
+
+## 2. Run the test suite to verify everything is healthy
+
+// turbo
+```bash
+.venv/bin/python3 -m pytest tests/ -x -q --cov=app --cov-report=term-missing 2>&1 | tail -15
+```
+
+All tests should pass with 97%+ overall coverage.
+
+## 3. Verify Docker is available
+
+The analysis pipeline runs inside a Docker container. Check if Docker is
+available locally:
+
+```bash
+docker --version && docker-compose --version
+```
+
+If Docker is not available locally, you have two options:
+
+**Option A: Local Linux x86_64 host with Docker**
+
+Build the image:
+```bash
+docker-compose -f docker/docker-compose.yml build
+```
+
+**Option B: Remote Linux x86_64 host**
+
+Set up SSH access to a remote Linux server, clone the repo there, and build:
+```bash
+ssh <YOUR_HOST> "cd /path/to/omnibor-analysis && docker-compose -f docker/docker-compose.yml build"
+```
+
+## 4. Verify bomtrace3 inside the container
+
+```bash
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env bomtrace3 --version
+```
+
+If this fails, the image needs to be rebuilt (step 3).
+
+## 5. List available target repositories
+
+```bash
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --list
+```
+
+## 6. Ready to analyze!
+
+You're now ready to:
+- **Add a new repo:** Tell Cascade "add [repo name] for analysis" or use `/add-repo`
+- **Run analysis:** Tell Cascade "run analysis on [repo]" or use `/run-analysis`
+- **Compare SBOMs:** Tell Cascade "compare SBOMs for [repo]" or use `/run-comparison`
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `python3 -m venv` fails | Install Python 3.9+ (brew install python3 on macOS) |
+| `docker-compose` not found | Install Docker Desktop or `pip install docker-compose` |
+| bomtrace3 fails with "Exec format error" | You're on ARM64 — need x86_64 Linux host |
+| Tests fail on import | Run `.venv/bin/pip install -r requirements.txt` |
+| SYS_PTRACE error | Docker must run with --cap-add=SYS_PTRACE (set in docker-compose.yml) |

--- a/.windsurf/workflows/run-analysis.md
+++ b/.windsurf/workflows/run-analysis.md
@@ -4,85 +4,102 @@ description: Run OmniBOR build interception analysis on a target repository
 
 # Run Analysis
 
-Instrument a C/C++ build with bomtrace3 on the DigitalOcean droplet and
-download results to local Mac.
+Instrument a C/C++ build with bomtrace3 and generate SPDX SBOMs with
+dependency visualization.
 
 ## Prerequisites
 
-- DigitalOcean droplet must be running (`ssh omnibor-build` must work)
-- Docker image must be built on the droplet (run `/docker-build` workflow first)
-- Target repo must be defined in `app/config.yaml`
-- Latest code must be pushed and pulled on the droplet
+- Docker image must be built (run `/docker-build` workflow first)
+- Target repo must be defined in `app/config.yaml` (run `/add-repo` to add new ones)
+- Must be running on a Linux x86_64 host (local or remote)
+- Infrastructure profile must be set up (see `.windsurf/rules/infrastructure/active-profile.md`)
 
-## 1. Ensure droplet has latest code
+## 0. Read infrastructure profile
 
-```bash
-ssh omnibor-build "cd /root/omnibor-analysis && git pull origin main"
-```
-
-## 2. Run full analysis on droplet
-
-For curl:
+Before running analysis, read the active profile to get SSH alias, repo path, and
+sync commands for the user's build host:
 
 ```bash
-ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo curl"
+cat .windsurf/rules/infrastructure/active-profile.md
 ```
 
-For FFmpeg:
+Use the **SSH alias** and **Repo path on host** from the profile in all commands below.
+If **Provider** is `Local`, skip SSH prefixes and run Docker commands directly.
+
+## 1. Run full analysis
+
+**Local Docker host (Provider: Local):**
 
 ```bash
-ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo ffmpeg"
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
+  python3 /workspace/app/analyze.py --repo <REPO_NAME>
 ```
 
-## 3. Re-run without cloning (repo already exists)
+**Remote host (Provider: DigitalOcean, AWS, etc.):**
+
+Use the SSH alias and repo path from the active profile:
 
 ```bash
-ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo curl --skip-clone"
+ssh <SSH_ALIAS> "cd <REPO_PATH> && git pull origin main && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
 ```
 
-## 4. Generate only a Syft manifest SBOM (no build)
+## 2. Re-run without cloning (repo already exists)
 
 ```bash
-ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /workspace/app/analyze.py --repo curl --syft-only"
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
+  python3 /workspace/app/analyze.py --repo <REPO_NAME> --skip-clone
 ```
 
-## 5. Download output to local Mac
-
-After analysis completes, sync the output and docs directories back:
+## 3. Generate only a Syft manifest SBOM (no build)
 
 ```bash
-rsync -avz omnibor-build:/root/omnibor-analysis/output/ output/
-rsync -avz omnibor-build:/root/omnibor-analysis/docs/ docs/
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
+  python3 /workspace/app/analyze.py --repo <REPO_NAME> --syft-only
 ```
 
-This downloads:
+## 4. List available repos
 
-- `output/binaries/<repo>/<timestamp>/` — compiled binaries (curl, libcurl.so, etc.)
-- `output/omnibor/<repo>/` — OmniBOR ADG documents
-- `output/spdx/<repo>/` — SPDX SBOMs (OmniBOR + Syft)
-- `docs/<repo>/` — build logs
-- `docs/runtime/` — runtime metrics
+```bash
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
+  python3 /workspace/app/analyze.py --list
+```
 
-## What happens during analysis
+## 5. Download output from remote host (if applicable)
+
+If running on a remote host, use the sync commands from your active profile.
+General pattern:
+
+```bash
+rsync -avz <SSH_ALIAS>:<REPO_PATH>/output/ output/
+rsync -avz <SSH_ALIAS>:<REPO_PATH>/docs/ docs/
+```
+
+See `.windsurf/rules/infrastructure/active-profile.md` for your exact commands.
+
+## What happens during analysis (8 steps)
 
 1. **Clone** — shallow clone of the target repo
 2. **Syft baseline** — manifest-based SPDX SBOM for comparison
-3. **Validate deps** — checks `apt_deps` are installed
+3. **Validate deps** — checks `apt_deps` are installed in the container
 4. **Instrumented build** — `bomtrace3 make` intercepts compiler/linker calls
 5a. **SPDX generation (bomsh)** — `bomsh_sbom.py` creates SPDX SBOM from ADG data
-5b. **SPDX generation (ADG)** — per-binary SPDX with vendored version detection via `spdx_from_adg.py`
+5b. **Metadata collection** — `collect_metadata.py` resolves system files to dpkg packages; `collect_dynamic_libs.py` identifies dynamic libs per binary
+5c. **ADG SPDX generation** — per-binary SPDX with vendored detection, version extraction, dynamic lib resolution + HTML visualization
 6. **SPDX validation** — JSON Schema + semantic validation of all generated SBOMs
 7. **Binary collection** — copies `output_binaries` to `output/binaries/<repo>/`
 8. **Docs** — timestamped build log and runtime metrics
 
-## Output locations (on droplet, mirrored locally after rsync)
+## Output locations
 
 | Artifact | Path |
 |----------|------|
-| Output binaries | `output/binaries/<repo>/<ts>/` |
 | OmniBOR ADG | `output/omnibor/<repo>/` |
+| Component metadata | `output/omnibor/<repo>/metadata/component_metadata.json` |
+| Dynamic libs (per binary) | `output/omnibor/<repo>/metadata/<binary>/dynamic_libs.json` |
 | SPDX SBOM (OmniBOR) | `output/spdx/<repo>/<repo>_omnibor_<ts>.spdx.json` |
-| SPDX SBOM (ADG) | `output/spdx/<repo>/<binary>_adg.spdx.json` |
+| SPDX SBOM (ADG, per binary) | `output/spdx/<repo>/<binary>_adg.spdx.json` |
+| Visualization (per binary) | `output/spdx/<repo>/<binary>_adg.spdx.html` |
 | SPDX SBOM (Syft) | `output/spdx/<repo>/<repo>_syft_<ts>.spdx.json` |
+| Output binaries | `output/binaries/<repo>/<ts>/` |
 | Build log | `docs/<repo>/<ts>_build.md` |
 | Runtime metrics | `docs/runtime/<ts>_<repo>_runtime.md` |

--- a/.windsurf/workflows/setup-environment.md
+++ b/.windsurf/workflows/setup-environment.md
@@ -10,10 +10,10 @@ Run this workflow when opening the omnibor-analysis workspace.
 
 **This step is non-negotiable. Do it before ANY other work.**
 
-Read every file in `.windsurf/rules/` to refresh all project rules:
+Read every file in `.windsurf/rules/` (including subdirectories) to refresh all project rules:
 
 ```bash
-for f in .windsurf/rules/*.md; do echo "=== $f ==="; cat "$f"; echo; done
+find .windsurf/rules/ -name "*.md" | sort | while read f; do echo "=== $f ==="; cat "$f"; echo; done
 ```
 
 After reading, confirm to the user which rules you've loaded and acknowledge
@@ -26,6 +26,7 @@ PR-first workflow, no direct commits to main).
 
 All local development uses `.venv/`. Verify it exists and has dependencies:
 
+// turbo
 ```bash
 .venv/bin/python3 --version && .venv/bin/pip check 2>&1 | tail -3
 ```
@@ -35,48 +36,72 @@ If missing, create it:
 python3 -m venv .venv && .venv/bin/pip install --upgrade pip && .venv/bin/pip install -r requirements.txt
 ```
 
-## 2. Verify system CLI tools
+## 2. Verify key project files
 
+// turbo
 ```bash
-which gh doctl rsync ssh 2>&1
+ls -la app/config.yaml app/analyze.py app/compare.py app/spdx_from_adg.py app/spdx_visualize.py docker/Dockerfile docker/docker-compose.yml
 ```
 
-If `doctl` is missing: `brew install doctl && doctl auth init`
+## 3. Run quick test check
 
-## 3. Verify SSH access to DigitalOcean build droplet
-
-All bomtrace3 instrumented builds run on a remote DigitalOcean droplet
-(native x86_64 Linux). Local Docker is NOT needed.
-
+// turbo
 ```bash
-ssh omnibor-build "uname -m && docker --version" 2>/dev/null || echo "Droplet is NOT reachable — it may be powered off"
+.venv/bin/python3 -m pytest tests/ -x -q 2>&1 | tail -5
 ```
 
-If the droplet is powered off, remind the user to start it from the
-DigitalOcean dashboard (cloud.digitalocean.com → Droplets → omnibor-build → Power On).
+## 4. Check infrastructure profile
 
-SSH config is in `~/.ssh/config` under host `omnibor-build` (IP: 137.184.178.186).
+Check if the user has set up their build host profile:
 
-## 4. Verify key project files
-
+// turbo
 ```bash
-ls -la app/config.yaml app/analyze.py app/compare.py docker/Dockerfile docker/docker-compose.yml
+if [ -f .windsurf/rules/infrastructure/active-profile.md ]; then
+  echo "=== Active Infrastructure Profile ==="
+  head -20 .windsurf/rules/infrastructure/active-profile.md
+else
+  echo "No infrastructure profile found."
+  echo "Set one up by copying a template:"
+  echo "  cp .windsurf/rules/infrastructure/templates/digitalocean.md .windsurf/rules/infrastructure/active-profile.md"
+  echo "  cp .windsurf/rules/infrastructure/templates/aws-ec2.md .windsurf/rules/infrastructure/active-profile.md"
+  echo "  cp .windsurf/rules/infrastructure/templates/local-linux.md .windsurf/rules/infrastructure/active-profile.md"
+  echo "Then edit active-profile.md with your actual values."
+fi
 ```
 
-## 5. Check which repos are cloned (on droplet)
+## 5. Check Docker availability
+
+Check if Docker is available (locally or remotely):
 
 ```bash
-ssh omnibor-build "ls -d /root/omnibor-analysis/repos/*/ 2>/dev/null || echo 'No repos cloned yet'"
+docker --version 2>/dev/null || echo "Docker not available locally — you may need a remote Linux x86_64 host"
 ```
 
-## 6. Check for existing output artifacts (on droplet)
+If Docker is available locally:
+```bash
+docker-compose -f docker/docker-compose.yml run --rm omnibor-env bomtrace3 --version 2>/dev/null || echo "Container image not built yet — run /docker-build workflow"
+```
+
+## 6. Check for existing output artifacts
 
 ```bash
-ssh omnibor-build "find /root/omnibor-analysis/output/ -name '*.spdx.json' -o -name '*.sha1' 2>/dev/null | head -20 || echo 'No output artifacts yet'"
+find output/ -name "*.spdx.json" -o -name "*.spdx.html" 2>/dev/null | head -20 || echo "No output artifacts yet"
 ```
 
-## 7. Check for existing docs/reports (local)
+## 7. Check for existing docs/reports
 
+// turbo
 ```bash
 find docs/ -name "*.md" -not -name ".gitkeep" 2>/dev/null | sort | tail -10 || echo "No reports yet"
 ```
+
+## 8. Report status to user
+
+Summarize:
+- Python venv status
+- Test suite status (count + coverage)
+- Infrastructure profile (provider, host, connection)
+- Docker availability
+- Available repos (from config.yaml)
+- Existing output artifacts
+- Available workflows: `/add-repo`, `/run-analysis`, `/run-comparison`, `/docker-build`

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,201 @@
+# OmniBOR Analysis — Onboarding Guide
+
+Welcome! This guide will get you from a fresh clone to running OmniBOR build
+interception analysis on any C/C++ GitHub repository, with Windsurf Cascade AI
+handling the heavy lifting.
+
+## What This Project Does
+
+This project **instruments C/C++ builds** using [OmniBOR/Bomsh](https://github.com/omnibor/bomsh)
+to capture every compiler and linker invocation, then generates **SPDX 2.3 SBOMs**
+with full dependency breakdown:
+
+- **Vendored static libraries** (STATIC_LINK) — detected from source directory structure
+- **Dynamic system libraries** (DYNAMIC_LINK) — resolved via ldd/readelf + dpkg
+- **Build tools** (BUILD_TOOL_OF) — gcc/clang version tracking
+- **Interactive HTML dependency graphs** — D3.js force-directed visualizations
+
+## Prerequisites
+
+| Requirement | Purpose |
+|---|---|
+| **Windsurf IDE** | IDE with Cascade AI assistant |
+| **Python 3.9+** | Local development, testing, and repo configuration |
+| **Docker 20.10+** on a **Linux x86_64** host | Running the analysis container |
+| **Git** | Version control |
+
+> **Important:** The analysis container requires native Linux x86_64 with ptrace
+> support. It does NOT work on macOS, Windows, ARM64, or under QEMU/Rosetta.
+> You can develop and test locally on any OS, but the actual build analysis
+> must run on a Linux x86_64 host (local, cloud VM, or remote server).
+
+## Step 1: Clone and Open in Windsurf
+
+```bash
+git clone https://github.com/tedg-dev/omnibor-analysis.git
+cd omnibor-analysis
+```
+
+Open this directory in Windsurf IDE.
+
+## Step 2: Configure Cascade
+
+1. Open Windsurf Settings → Cascade → Model
+2. Select **Claude Opus 4** (or latest available) for best results
+3. The `.windsurf/` directory contains all rules and workflows that Cascade
+   reads automatically — no manual configuration needed
+
+## Step 3: First-Time Setup
+
+In the Cascade chat, type:
+
+```
+/first-time-setup
+```
+
+This will:
+- Read all project rules and workflows
+- Create the Python virtual environment
+- Install dependencies from `requirements.txt`
+- Run the test suite (349+ tests, 98% coverage)
+- Check Docker availability
+- Report the environment status
+
+## Step 4: Set Up Your Linux Build Host
+
+### Option A: Local Linux x86_64
+
+If you're already on Linux x86_64:
+
+```bash
+docker-compose -f docker/docker-compose.yml build
+```
+
+This takes 10-20 minutes on first build (compiles bomtrace3 from source).
+
+### Option B: Cloud VM (DigitalOcean, AWS EC2, etc.)
+
+1. Create an x86_64 Linux VM (Ubuntu 22.04 recommended, 2+ GB RAM)
+2. Install Docker: `curl -fsSL https://get.docker.com | sh`
+3. Clone the repo on the VM
+4. Build the image: `docker-compose -f docker/docker-compose.yml build`
+5. Set up SSH access from your local machine
+
+### Option C: WSL2 on Windows
+
+1. Install WSL2 with Ubuntu 22.04
+2. Install Docker Desktop with WSL2 backend
+3. Clone and build inside WSL2
+
+## Step 5: Analyze a Repository
+
+### Use a pre-configured repo
+
+Tell Cascade:
+
+```
+Run analysis on curl
+```
+
+Or use the workflow directly:
+
+```
+/run-analysis
+```
+
+Pre-configured repos: **curl**, **redis**, **ffmpeg**, **nmap**
+
+### Add a new repo from GitHub
+
+Tell Cascade:
+
+```
+Add openssl for analysis
+```
+
+Or use the workflow:
+
+```
+/add-repo
+```
+
+This auto-discovers the repo's build system, configure flags, output binaries,
+and required apt packages from GitHub. You review and approve before it writes
+to `config.yaml`.
+
+## Step 6: View Results
+
+After analysis completes, you'll find:
+
+| Output | Location | Description |
+|---|---|---|
+| SPDX SBOM (per binary) | `output/spdx/<repo>/<binary>_adg.spdx.json` | Full dependency breakdown |
+| HTML visualization | `output/spdx/<repo>/<binary>_adg.spdx.html` | Interactive D3.js graph |
+| OmniBOR ADG | `output/omnibor/<repo>/` | Cryptographic build provenance |
+| Component metadata | `output/omnibor/<repo>/metadata/` | dpkg package resolution |
+
+Open the `.spdx.html` files in a browser to see interactive dependency graphs
+with color-coded nodes (purple=root, teal=vendored, red=dynamic, yellow=build tool).
+
+## Available Cascade Commands
+
+| Command | What it does |
+|---|---|
+| `/setup-environment` | Verify environment on every startup |
+| `/first-time-setup` | Complete first-time setup (one-time) |
+| `/add-repo` | Add a new GitHub repo for analysis |
+| `/run-analysis` | Run build interception + SBOM generation |
+| `/run-comparison` | Compare OmniBOR SBOM vs binary scanner SBOM |
+| `/docker-build` | Build or rebuild the Docker container |
+| `/merge-pr` | Merge a feature branch (after approval) |
+
+## Project Structure
+
+```
+omnibor-analysis/
+├── app/                    # Core application code
+│   ├── analyze.py          # Main pipeline orchestrator
+│   ├── spdx_from_adg.py    # Per-binary SPDX generation
+│   ├── spdx_visualize.py   # D3.js HTML visualization
+│   ├── collect_metadata.py # dpkg package resolution
+│   ├── collect_dynamic_libs.py # ldd/readelf analysis
+│   ├── compare.py          # SBOM comparison tool
+│   ├── add_repo.py         # Auto-discover repos from GitHub
+│   └── config.yaml         # Repository and tool configuration
+├── docker/                 # Container environment
+│   ├── Dockerfile          # Ubuntu 22.04 + bomtrace3 + syft
+│   └── docker-compose.yml  # Container orchestration
+├── tests/                  # Unit tests (349+ tests, 98% coverage)
+├── docs/                   # Documentation and analysis reports
+│   └── summary/            # Architecture and deep-dive docs
+├── .windsurf/              # Cascade AI configuration
+│   ├── rules/              # Project rules (always loaded)
+│   └── workflows/          # Slash commands (/add-repo, etc.)
+├── repos/                  # Cloned target repos (gitignored)
+└── output/                 # Generated artifacts (gitignored)
+```
+
+## Development Workflow
+
+1. All changes go through feature branches (never commit directly to main)
+2. Pre-commit gates: all tests pass + per-file 95%+ coverage + overall 97%+
+3. Cascade handles branch names, commits, and merges via `/merge-pr`
+4. Every commit includes a markdown doc in `docs/summary/` describing changes
+
+## Troubleshooting
+
+| Problem | Solution |
+|---|---|
+| Tests fail | `pip install -r requirements.txt` in the venv |
+| Docker build fails | Check Docker is installed and x86_64: `uname -m` should show `x86_64` |
+| bomtrace3 "Exec format error" | You're on ARM64 — need an x86_64 host |
+| "SYS_PTRACE" error | Docker must have `--cap-add=SYS_PTRACE` (set in docker-compose.yml) |
+| SBOM has no vendored libs | Add `vendored_dirs` to config.yaml (see nmap example) |
+| Analysis takes too long | FFmpeg is ~24 min; curl/redis/nmap are 3-5 min |
+
+## Further Reading
+
+- `docs/summary/spdx-generation-deep-dive.md` — Full technical pipeline documentation
+- `docs/summary/workflow-guide.md` — Detailed workflow descriptions
+- `docs/summary/nmap-target-vendored-dirs.md` — Vendored directory detection explained
+- `docs/aws-ec2-migration-recommendation.md` — Cloud infrastructure options


### PR DESCRIPTION
## Summary

Prepares the repo for greenfield onboarding — any new contributor can clone, set up their environment, and run the full OmniBOR analysis pipeline with Cascade AI guidance.

## Changes

### New files
- **ONBOARDING.md** — comprehensive guide at repo root
- **.windsurf/rules/getting-started.md** — first-time Cascade AI setup rule
- **.windsurf/rules/infrastructure/** — modular build host profile system
  - README.md, templates for DigitalOcean, AWS EC2, and local Linux
  - `active-profile.md` is gitignored (user-specific IPs/secrets stay local)
- **.windsurf/workflows/first-time-setup.md** — greenfield contributor workflow

### Updated files
- **docker-rules.md** — remote host section references infrastructure profile
- **droplet-shutdown.md** — reads active profile for provider-specific shutdown commands
- **virtual-environment.md** — provider-specific CLI tools section
- **omnibor-rules.md** — reflects full 8-step pipeline
- **project-context.md** — updated architecture with all repos/tools
- **setup-environment.md** — added infrastructure profile check step (step 4)
- **run-analysis.md** — reads active profile before running, updated sync commands
- **add-repo.md** — fixed venv activation to use .venv/bin/python3 directly
- **.gitignore** — added active-profile.md

## Testing
349 tests pass, 98% coverage. No code changes — docs/rules/workflows only.