### PR TITLE
feat: consistent {repo}/{ts}/ output structure across all artifact types

### DIFF
--- a/.windsurf/rules/sync-results.md
+++ b/.windsurf/rules/sync-results.md
@@ -1,0 +1,26 @@
+---
+description: Always sync results locally after successful remote analysis
+---
+
+# Sync Results After Remote Analysis
+
+After every successful analysis run on a remote build host, **always** sync
+output and docs back to the local machine before reporting completion.
+
+## Required sync commands
+
+Read the active infrastructure profile to get the SSH alias and repo path,
+then run:
+
+```bash
+rsync -avz <SSH_ALIAS>:<REPO_PATH>/output/ output/
+rsync -avz <SSH_ALIAS>:<REPO_PATH>/docs/ docs/
+```
+
+## Rules
+
+1. **Never skip sync.** If the analysis succeeded, sync results immediately.
+2. **Sync both `output/` and `docs/`.** Both contain timestamped run artifacts.
+3. **Report sync status.** Confirm to the user that results are available locally.
+4. **On sync failure**, retry once. If it fails again, alert the user.
+5. This rule does **not** apply when running analysis locally (Provider: Local).

--- a/.windsurf/workflows/run-analysis.md
+++ b/.windsurf/workflows/run-analysis.md
@@ -64,17 +64,17 @@ docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
   python3 /workspace/app/analyze.py --list
 ```
 
-## 5. Download output from remote host (if applicable)
+## 5. Sync results locally (REQUIRED for remote hosts)
 
-If running on a remote host, use the sync commands from your active profile.
-General pattern:
+**After every successful remote analysis, always sync results back.**
+See `.windsurf/rules/sync-results.md` for the full rule.
 
 ```bash
 rsync -avz <SSH_ALIAS>:<REPO_PATH>/output/ output/
 rsync -avz <SSH_ALIAS>:<REPO_PATH>/docs/ docs/
 ```
 
-See `.windsurf/rules/infrastructure/active-profile.md` for your exact commands.
+Never report analysis as complete until both syncs succeed.
 
 ## What happens during analysis (8 steps)
 
@@ -91,15 +91,18 @@ See `.windsurf/rules/infrastructure/active-profile.md` for your exact commands.
 
 ## Output locations
 
+All output uses a consistent `{category}/{repo}/{ts}/` folder structure.
+The `<ts>` timestamp is generated once per run and shared across all output types.
+
 | Artifact | Path |
 |----------|------|
-| OmniBOR ADG | `output/omnibor/<repo>/` |
-| Component metadata | `output/omnibor/<repo>/metadata/component_metadata.json` |
-| Dynamic libs (per binary) | `output/omnibor/<repo>/metadata/<binary>/dynamic_libs.json` |
-| SPDX SBOM (OmniBOR) | `output/spdx/<repo>/<repo>_omnibor_<ts>.spdx.json` |
-| SPDX SBOM (ADG, per binary) | `output/spdx/<repo>/<binary>_adg.spdx.json` |
-| Visualization (per binary) | `output/spdx/<repo>/<binary>_adg.spdx.html` |
-| SPDX SBOM (Syft) | `output/spdx/<repo>/<repo>_syft_<ts>.spdx.json` |
+| OmniBOR ADG | `output/omnibor/<repo>/<ts>/` |
+| Component metadata | `output/omnibor/<repo>/<ts>/metadata/component_metadata.json` |
+| Dynamic libs (per binary) | `output/omnibor/<repo>/<ts>/metadata/<binary>/dynamic_libs.json` |
+| SPDX SBOM (OmniBOR) | `output/spdx/<repo>/<ts>/<repo>_omnibor.spdx.json` |
+| SPDX SBOM (ADG, per binary) | `output/spdx/<repo>/<ts>/<binary>_adg.spdx.json` |
+| Visualization (per binary) | `output/spdx/<repo>/<ts>/<binary>_adg.spdx.html` |
+| SPDX SBOM (Syft) | `output/spdx/<repo>/<ts>/<repo>_syft.spdx.json` |
 | Output binaries | `output/binaries/<repo>/<ts>/` |
-| Build log | `docs/<repo>/<ts>_build.md` |
-| Runtime metrics | `docs/runtime/<ts>_<repo>_runtime.md` |
+| Build log | `docs/<repo>/<ts>/build.md` |
+| Runtime metrics | `docs/runtime/<repo>/<ts>/runtime.md` |

--- a/app/analyze.py
+++ b/app/analyze.py
@@ -197,17 +197,19 @@ class BomtraceBuilder:
     def build(
         self, repo_name, repo_cfg,
         paths_cfg, omnibor_cfg,
+        run_ts=None,
     ):
         """Run pre-build steps, instrumented build, and ADG generation.
 
         Returns True on success, False on failure.
         """
+        ts = run_ts or timestamp()
         repo_dir = (
             Path(paths_cfg["repos_dir"]) / repo_name
         )
         bom_dir = (
             Path(paths_cfg["output_dir"])
-            / "omnibor" / repo_name
+            / "omnibor" / repo_name / ts
         )
         tracer = omnibor_cfg["tracer"]
         raw_logfile = omnibor_cfg["raw_logfile"]
@@ -566,6 +568,7 @@ class SpdxGenerator:
     def generate(
         self, repo_name, repo_cfg,
         paths_cfg, omnibor_cfg,
+        run_ts=None,
     ):
         """Generate SPDX SBOM. Returns output file path.
 
@@ -577,13 +580,14 @@ class SpdxGenerator:
         It generates one SPDX per artifact, then we
         rename the first to our standard naming.
         """
+        ts = run_ts or timestamp()
         bom_dir = (
             Path(paths_cfg["output_dir"])
-            / "omnibor" / repo_name
+            / "omnibor" / repo_name / ts
         )
         spdx_dir = (
             Path(paths_cfg["output_dir"])
-            / "spdx" / repo_name
+            / "spdx" / repo_name / ts
         )
         spdx_dir.mkdir(parents=True, exist_ok=True)
 
@@ -629,10 +633,9 @@ class SpdxGenerator:
         # extension (e.g. omnibor.<bin>.syft.spdx-json,
         # <bin>.syft.spdx-json).  Rename ALL to use the
         # standard .spdx.json extension.
-        ts = timestamp()
         spdx_file = (
             spdx_dir
-            / f"{repo_name}_omnibor_{ts}.spdx.json"
+            / f"{repo_name}_omnibor.spdx.json"
         )
         generated = sorted(spdx_dir.glob(
             "*.spdx-json"
@@ -894,21 +897,22 @@ class SyftGenerator:
     def __init__(self, runner=None):
         self.runner = runner or CommandRunner()
 
-    def generate(self, repo_name, paths_cfg):
+    def generate(self, repo_name, paths_cfg,
+                 run_ts=None):
         """Generate Syft SBOM. Returns output file path."""
+        ts = run_ts or timestamp()
         repo_dir = (
             Path(paths_cfg["repos_dir"]) / repo_name
         )
         spdx_dir = (
             Path(paths_cfg["output_dir"])
-            / "spdx" / repo_name
+            / "spdx" / repo_name / ts
         )
         spdx_dir.mkdir(parents=True, exist_ok=True)
 
-        ts = timestamp()
         spdx_file = (
             spdx_dir
-            / f"{repo_name}_syft_{ts}.spdx.json"
+            / f"{repo_name}_syft.spdx.json"
         )
 
         rc = self.runner.run(
@@ -948,15 +952,17 @@ class MetadataCollector:
 
     def collect(
         self, repo_name, repo_cfg, paths_cfg,
+        run_ts=None,
     ):
         """Collect metadata and dynamic libs.
 
         Returns True if at least component_metadata.json
         was created successfully.
         """
+        ts = run_ts or timestamp()
         bom_dir = (
             Path(paths_cfg["output_dir"])
-            / "omnibor" / repo_name
+            / "omnibor" / repo_name / ts
         )
         meta_dir = bom_dir / "metadata"
         repos_dir = paths_cfg["repos_dir"]
@@ -1065,21 +1071,23 @@ class AdgSpdxStep:
     """
 
     @staticmethod
-    def generate(repo_name, repo_cfg, paths_cfg):
+    def generate(repo_name, repo_cfg, paths_cfg,
+                 run_ts=None):
         """Generate ADG SPDX for each output binary.
 
         Returns list of output file paths.
         """
         from spdx_from_adg import AdgSpdxGenerator
 
+        ts = run_ts or timestamp()
         bom_dir = (
             Path(paths_cfg["output_dir"])
-            / "omnibor" / repo_name
+            / "omnibor" / repo_name / ts
         )
         repos_dir = paths_cfg["repos_dir"]
         spdx_dir = (
             Path(paths_cfg["output_dir"])
-            / "spdx" / repo_name
+            / "spdx" / repo_name / ts
         )
         spdx_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1162,7 +1170,8 @@ class BinaryCollector:
     """
 
     @staticmethod
-    def collect(repo_name, repo_cfg, paths_cfg):
+    def collect(repo_name, repo_cfg, paths_cfg,
+                run_ts=None):
         """Copy each listed binary to a timestamped dir.
 
         Returns a list of (src, dst) tuples for binaries
@@ -1170,6 +1179,7 @@ class BinaryCollector:
         """
         import shutil
 
+        ts = run_ts or timestamp()
         bins = repo_cfg.get("output_binaries", [])
         if not bins:
             print(
@@ -1181,7 +1191,6 @@ class BinaryCollector:
         repo_dir = (
             Path(paths_cfg["repos_dir"]) / repo_name
         )
-        ts = timestamp()
         out_dir = (
             Path(paths_cfg["output_dir"])
             / "binaries" / repo_name / ts
@@ -1229,14 +1238,16 @@ class DocWriter:
     def write_build_doc(
         repo_name, repo_cfg,
         paths_cfg, success, duration_sec,
+        run_ts=None,
     ):
-        """Write a timestamped build log to docs/<repo>/."""
+        """Write build log to docs/<repo>/<ts>/."""
+        ts = run_ts or timestamp()
         docs_dir = (
-            Path(paths_cfg["docs_dir"]) / repo_name
+            Path(paths_cfg["docs_dir"])
+            / repo_name / ts
         )
         docs_dir.mkdir(parents=True, exist_ok=True)
-        ts = timestamp()
-        doc_path = docs_dir / f"{ts}_build.md"
+        doc_path = docs_dir / "build.md"
 
         status = "SUCCESS" if success else "FAILED"
         content = (
@@ -1283,18 +1294,19 @@ class DocWriter:
     def write_runtime_doc(
         repo_name, paths_cfg,
         duration_sec, baseline_sec=None,
+        run_ts=None,
     ):
         """Write runtime performance metrics."""
+        ts = run_ts or timestamp()
         runtime_dir = (
-            Path(paths_cfg["docs_dir"]) / "runtime"
+            Path(paths_cfg["docs_dir"])
+            / "runtime" / repo_name / ts
         )
         runtime_dir.mkdir(
             parents=True, exist_ok=True
         )
-        ts = timestamp()
         doc_path = (
-            runtime_dir
-            / f"{ts}_{repo_name}_runtime.md"
+            runtime_dir / "runtime.md"
         )
 
         overhead_pct = ""
@@ -1463,6 +1475,15 @@ def main():
     paths_cfg = config["paths"]
     omnibor_cfg = config["omnibor"]
 
+    # Single timestamp for the entire run — all
+    # output folders use this consistently:
+    #   output/binaries/{repo}/{run_ts}/
+    #   output/spdx/{repo}/{run_ts}/
+    #   output/omnibor/{repo}/{run_ts}/
+    #   docs/{repo}/{run_ts}/
+    #   docs/runtime/{repo}/{run_ts}/
+    run_ts = timestamp()
+
     print(f"\n{'#'*60}")
     print(f"  OmniBOR Analysis: {args.repo}")
     desc = repo_cfg.get("description", "")
@@ -1477,7 +1498,7 @@ def main():
 
     # Step 2: Syft baseline SBOM
     pipeline.syft_gen.generate(
-        args.repo, paths_cfg
+        args.repo, paths_cfg, run_ts=run_ts
     )
 
     if args.syft_only:
@@ -1505,6 +1526,7 @@ def main():
     success = pipeline.builder.build(
         args.repo, repo_cfg,
         paths_cfg, omnibor_cfg,
+        run_ts=run_ts,
     )
     duration = time.time() - start
 
@@ -1514,19 +1536,22 @@ def main():
         spdx_file = pipeline.spdx_gen.generate(
             args.repo, repo_cfg,
             paths_cfg, omnibor_cfg,
+            run_ts=run_ts,
         )
 
     # Step 5b: Collect component metadata + dynamic libs
     if success:
         pipeline.metadata_collector.collect(
             args.repo, repo_cfg, paths_cfg,
+            run_ts=run_ts,
         )
 
     # Step 5c: Generate per-binary ADG SPDX
     adg_files = []
     if success:
         adg_files = pipeline.adg_spdx.generate(
-            args.repo, repo_cfg, paths_cfg
+            args.repo, repo_cfg, paths_cfg,
+            run_ts=run_ts,
         )
 
     # Step 6: Validate SPDX documents
@@ -1538,16 +1563,19 @@ def main():
     # Step 7: Collect output binaries
     if success:
         pipeline.binary_collector.collect(
-            args.repo, repo_cfg, paths_cfg
+            args.repo, repo_cfg, paths_cfg,
+            run_ts=run_ts,
         )
 
     # Step 8: Write docs
     pipeline.docs.write_build_doc(
         args.repo, repo_cfg, paths_cfg,
         success, duration,
+        run_ts=run_ts,
     )
     pipeline.docs.write_runtime_doc(
-        args.repo, paths_cfg, duration
+        args.repo, paths_cfg, duration,
+        run_ts=run_ts,
     )
 
     status = "COMPLETE" if success else "FAILED"

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -450,7 +450,8 @@ class TestSpdxGenerator(unittest.TestCase):
 
             # Simulate bomsh_sbom.py output
             spdx_dir = (
-                Path(td) / "output" / "spdx" / "curl"
+                Path(td) / "output" / "spdx"
+                / "curl" / "2026-02-12_1300"
             )
             spdx_dir.mkdir(parents=True)
             (
@@ -466,10 +467,12 @@ class TestSpdxGenerator(unittest.TestCase):
                 result = gen.generate(
                     "curl", repo_cfg,
                     paths, omnibor,
+                    run_ts="2026-02-12_1300",
                 )
             self.assertIsNotNone(result)
-            self.assertIn("curl_omnibor_", result)
-            self.assertIn(".spdx.json", result)
+            self.assertIn(
+                "curl_omnibor.spdx.json", result
+            )
             self.assertTrue(Path(result).exists())
 
     def test_generate_renames_all_spdx_json_files(self):
@@ -490,7 +493,8 @@ class TestSpdxGenerator(unittest.TestCase):
 
             # Simulate multiple bomsh_sbom.py outputs
             spdx_dir = (
-                Path(td) / "output" / "spdx" / "curl"
+                Path(td) / "output" / "spdx"
+                / "curl" / "2026-02-12_1300"
             )
             spdx_dir.mkdir(parents=True)
             (
@@ -514,6 +518,7 @@ class TestSpdxGenerator(unittest.TestCase):
                 result = gen.generate(
                     "curl", repo_cfg,
                     paths, omnibor,
+                    run_ts="2026-02-12_1300",
                 )
             self.assertIsNotNone(result)
 
@@ -823,6 +828,7 @@ class TestSpdxGeneratorMetadata(unittest.TestCase):
             spdx_dir = (
                 Path(td) / "output"
                 / "spdx" / "curl"
+                / "2026-02-12_1300"
             )
             spdx_dir.mkdir(parents=True)
             (
@@ -842,10 +848,12 @@ class TestSpdxGeneratorMetadata(unittest.TestCase):
                 result = gen.generate(
                     "curl", repo_cfg,
                     paths, omnibor,
+                    run_ts="2026-02-12_1300",
                 )
             bom_dir = str(
                 Path(td) / "output"
                 / "omnibor" / "curl"
+                / "2026-02-12_1300"
             )
             mock_patch.assert_called_once_with(
                 result, bom_dir
@@ -1486,9 +1494,13 @@ class TestSyftGenerator(unittest.TestCase):
             }
 
             with patch("builtins.print"):
-                result = gen.generate("curl", paths)
-            self.assertIn("curl_syft_", result)
-            self.assertIn(".spdx.json", result)
+                result = gen.generate(
+                    "curl", paths,
+                    run_ts="2026-02-12_1300",
+                )
+            self.assertIn(
+                "curl_syft.spdx.json", result
+            )
 
     def test_generate_warns_on_failure(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2243,6 +2255,7 @@ class TestAdgSpdxStep(unittest.TestCase):
             }
             result = AdgSpdxStep.generate(
                 "test", {}, paths,
+                run_ts="2026-02-12_1300",
             )
             self.assertEqual(result, [])
 
@@ -2253,11 +2266,13 @@ class TestAdgSpdxStep(unittest.TestCase):
             # Create dirs
             bom_dir = (
                 Path(td) / "omnibor" / "nmap"
+                / "2026-02-12_1300"
                 / "metadata" / "nmap"
             )
             bom_dir.mkdir(parents=True)
             spdx_dir = (
                 Path(td) / "spdx" / "nmap"
+                / "2026-02-12_1300"
             )
             spdx_dir.mkdir(parents=True)
 
@@ -2281,6 +2296,7 @@ class TestAdgSpdxStep(unittest.TestCase):
             ):
                 result = AdgSpdxStep.generate(
                     "nmap", repo_cfg, paths,
+                    run_ts="2026-02-12_1300",
                 )
 
             self.assertEqual(len(result), 1)
@@ -2303,6 +2319,7 @@ class TestAdgSpdxStep(unittest.TestCase):
             # Create per-binary metadata dir
             meta = (
                 Path(td) / "omnibor" / "curl"
+                / "2026-02-12_1300"
                 / "metadata" / "curl"
             )
             meta.mkdir(parents=True)
@@ -2327,6 +2344,7 @@ class TestAdgSpdxStep(unittest.TestCase):
             ):
                 result = AdgSpdxStep.generate(
                     "curl", repo_cfg, paths,
+                    run_ts="2026-02-12_1300",
                 )
 
             # curl binary should have direct_only=True
@@ -2362,6 +2380,7 @@ class TestMetadataCollector(unittest.TestCase):
                 result = mc.collect(
                     "nmap", {"output_binaries": []},
                     paths,
+                    run_ts="2026-02-12_1300",
                 )
             self.assertFalse(result)
 
@@ -2371,6 +2390,7 @@ class TestMetadataCollector(unittest.TestCase):
             # Set up directory structure
             bom_dir = (
                 Path(td) / "omnibor" / "nmap"
+                / "2026-02-12_1300"
             )
             meta_dir = bom_dir / "metadata"
             bomsh = meta_dir / "bomsh"
@@ -2423,6 +2443,7 @@ class TestMetadataCollector(unittest.TestCase):
                 mock_meta.side_effect = write_meta
                 result = mc.collect(
                     "nmap", repo_cfg, paths,
+                    run_ts="2026-02-12_1300",
                 )
 
             self.assertTrue(result)
@@ -2434,6 +2455,7 @@ class TestMetadataCollector(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             bom_dir = (
                 Path(td) / "omnibor" / "nmap"
+                / "2026-02-12_1300"
             )
             meta_dir = bom_dir / "metadata"
             bomsh = meta_dir / "bomsh"
@@ -2471,6 +2493,7 @@ class TestMetadataCollector(unittest.TestCase):
             ):
                 result = mc.collect(
                     "nmap", repo_cfg, paths,
+                    run_ts="2026-02-12_1300",
                 )
             self.assertTrue(result)
 
@@ -2479,6 +2502,7 @@ class TestMetadataCollector(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             bom_dir = (
                 Path(td) / "omnibor" / "nmap"
+                / "2026-02-12_1300"
             )
             meta_dir = bom_dir / "metadata"
             bomsh = meta_dir / "bomsh"
@@ -2504,6 +2528,7 @@ class TestMetadataCollector(unittest.TestCase):
             with patch("builtins.print"):
                 result = mc.collect(
                     "nmap", repo_cfg, paths,
+                    run_ts="2026-02-12_1300",
                 )
             self.assertTrue(result)
 
@@ -2512,6 +2537,7 @@ class TestMetadataCollector(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             bom_dir = (
                 Path(td) / "omnibor" / "nmap"
+                / "2026-02-12_1300"
             )
             meta_dir = bom_dir / "metadata"
             bomsh = meta_dir / "bomsh"
@@ -2535,6 +2561,7 @@ class TestMetadataCollector(unittest.TestCase):
             ), patch("builtins.print"):
                 result = mc.collect(
                     "nmap", {}, paths,
+                    run_ts="2026-02-12_1300",
                 )
             self.assertFalse(result)
 


### PR DESCRIPTION
Standardizes output folder structure so all artifact types use consistent {category}/{repo}/{ts}/ datetime-stamped subfolders, with no redundant datetime in filenames. Single run_ts generated in main() and threaded to all 8 pipeline steps. Includes sync-results rule and updated run-analysis workflow. All 349 tests passing, 98% coverage.