### PR TITLE
docs: add AWS setup guide, terraform config, and analysis reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ repos/*/
 # ============================================================
 output/omnibor/*/
 output/spdx/*/
+output/binaries/*/
 output/binary-scan/*/
 !output/**/.gitkeep
 
@@ -70,6 +71,17 @@ htmlcov/
 ehthumbs.db
 Thumbs.db
 Desktop.ini
+
+# ============================================================
+# Terraform
+# ============================================================
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup
+terraform/terraform.tfvars
+terraform/*.tfplan
+terraform/tfplan
 
 # ============================================================
 # Logs and temp files

--- a/.windsurf/rules/getting-started.md
+++ b/.windsurf/rules/getting-started.md
@@ -55,9 +55,19 @@ The Docker container requires **Linux x86_64** with ptrace support. Options:
 
 | Option | Pros | Cons |
 |--------|------|------|
+| **AWS EC2** (recommended for Cisco) | Terraform IaC, fast builds | Duo SSO re-auth every 1 hour |
 | **Local Linux x86_64** | Fastest, no network | Must have Docker installed |
-| **Cloud VM** (DO, EC2, etc.) | Easy setup, disposable | Costs money, network latency |
-| **GitHub Codespaces** | Zero setup | May not support SYS_PTRACE |
+| **DigitalOcean Droplet** | Simple, cheap | Slower than EC2 compute-optimized |
 | **WSL2 on Windows** | Free, local | Requires Windows + WSL2 + Docker |
 
-The project is designed to work with any of these — Docker handles the environment.
+### Cisco Engineers: AWS EC2 with Duo SSO
+
+For Cisco employees, the recommended path is AWS EC2 with Terraform:
+
+- Full setup guide: `docs/aws-setup-guide.md`
+- Terraform IaC: `terraform/` directory
+- Authentication: Cisco Duo SSO → SAML → AWS STS (1-hour sessions)
+- CLI tools needed: `aws`, `terraform`, `duo-sso`
+- Infrastructure profile template: `.windsurf/rules/infrastructure/templates/aws-ec2.md`
+
+The project is designed to work with any Linux x86_64 host — Docker handles the environment.

--- a/.windsurf/rules/infrastructure/templates/aws-ec2.md
+++ b/.windsurf/rules/infrastructure/templates/aws-ec2.md
@@ -39,11 +39,89 @@ Host omnibor-build
     IdentityFile ~/.ssh/<YOUR_KEY>.pem
 ```
 
-## CLI Tool
+## CLI Tools
 
-- **aws** — AWS CLI v2
-- Install: `brew install awscli` (macOS) or see https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
-- Configure: `aws configure` (set region, access key, secret key)
+### AWS CLI v2
+
+- Install: `brew install awscli` (macOS)
+- Docs: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
+
+### duo-sso (Cisco SSO → AWS)
+
+Cisco users authenticate to AWS via **Duo SSO** (SAML), not IAM access keys.
+Sessions expire every **1 hour** — you must re-authenticate frequently.
+
+**Install:**
+
+```bash
+brew tap ats-operations/homebrew-tap https://wwwin-github.cisco.com/ATS-operations/homebrew-tap
+brew install ats-operations/tap/duo-sso
+```
+
+**Configure** (`~/.config/duo-sso/config.json`):
+
+```json
+{
+  "url": "<YOUR_DUO_SSO_URL>",
+  "partner_spid": "https://signin.aws.amazon.com/saml",
+  "aws_urn": "https://signin.aws.amazon.com/saml",
+  "session_duration_seconds": 3600,
+  "profiles": {
+    "<YOUR_PROFILE>": {
+      "aws_account_id": "<YOUR_ACCOUNT_ID>",
+      "aws_role_name": "<YOUR_ROLE>",
+      "session_duration_seconds": 3600
+    }
+  }
+}
+```
+
+**AWS config** (`~/.aws/config`) — region only, NO role_arn/source_profile:
+
+```ini
+[profile <YOUR_PROFILE>]
+region=<YOUR_REGION>
+```
+
+> **Warning:** Do NOT add `role_arn` or `source_profile` to `~/.aws/config`.
+> duo-sso already assumes the role and writes STS credentials directly.
+> Adding those fields causes a circular reference error.
+
+### Authentication Flow (Browserless Mode)
+
+duo-sso defaults to interactive Chrome mode. If you prefer browserless:
+
+1. Create a **SAML bookmarklet** in your browser (see duo-sso README)
+2. Go to `https://go2.cisco.com/aws` and complete Cisco SSO + Duo MFA
+3. Click the bookmarklet → downloads `saml.txt`
+4. Run:
+
+```bash
+duo-sso -saml $(cat ~/Downloads/saml.txt) -profile <YOUR_PROFILE> -set-aws-region <YOUR_REGION>
+```
+
+5. **Fix credentials profile name** (duo-sso writes `[default]`, not your profile name):
+
+```bash
+sed -i '' 's/^\[default\]/[<YOUR_PROFILE>]/' ~/.aws/credentials   # macOS
+sed -i 's/^\[default\]/[<YOUR_PROFILE>]/' ~/.aws/credentials      # Linux
+```
+
+6. Verify:
+
+```bash
+aws sts get-caller-identity --profile <YOUR_PROFILE> --no-cli-pager
+```
+
+> **Reminder:** Sessions last 1 hour. Re-run steps 2–6 when credentials expire.
+> You'll see `ExpiredToken` or `InvalidClientTokenId` errors when they do.
+
+### Terraform
+
+- Install: `brew install terraform` (macOS)
+- Terraform uses the same `ted-admin` profile from `~/.aws/credentials`
+- All Terraform files live in `terraform/` in the project root
+- Run `terraform init` once, then `terraform plan` and `terraform apply`
 
 ### Power Management
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -73,7 +73,26 @@ docker-compose -f docker/docker-compose.yml build
 
 This takes 10-20 minutes on first build (compiles bomtrace3 from source).
 
-### Option B: Cloud VM (DigitalOcean, AWS EC2, etc.)
+### Option B: AWS EC2 (Recommended for Cisco Engineers)
+
+Follow the comprehensive setup guide:
+
+**[docs/aws-setup-guide.md](docs/aws-setup-guide.md)**
+
+This covers Cisco Duo SSO authentication, Terraform provisioning, and
+everything needed to go from zero to running builds. The guide handles:
+
+- Installing duo-sso, AWS CLI, and Terraform
+- Authenticating via Cisco Duo SSO (SAML → AWS STS)
+- Provisioning an EC2 instance with Terraform (IaC)
+- SSH configuration and infrastructure profile setup
+- Re-authentication (sessions expire every 1 hour)
+- Cost management and daily workflow
+
+> **Note:** Cisco Duo SSO sessions expire every **1 hour**. The guide
+> documents the re-authentication flow in detail.
+
+### Option B2: Other Cloud VM (DigitalOcean, etc.)
 
 1. Create an x86_64 Linux VM (Ubuntu 22.04 recommended, 2+ GB RAM)
 2. Install Docker: `curl -fsSL https://get.docker.com | sh`
@@ -195,7 +214,8 @@ omnibor-analysis/
 
 ## Further Reading
 
+- `docs/aws-setup-guide.md` — **Greenfield AWS EC2 setup (Cisco Duo SSO + Terraform)**
+- `docs/aws-ec2-migration-recommendation.md` — Instance sizing and cost comparison
 - `docs/summary/spdx-generation-deep-dive.md` — Full technical pipeline documentation
 - `docs/summary/workflow-guide.md` — Detailed workflow descriptions
 - `docs/summary/nmap-target-vendored-dirs.md` — Vendored directory detection explained
-- `docs/aws-ec2-migration-recommendation.md` — Cloud infrastructure options

--- a/docs/aws-setup-guide.md
+++ b/docs/aws-setup-guide.md
@@ -1,0 +1,492 @@
+# AWS EC2 Setup Guide — Greenfield Install
+
+**Purpose:** Step-by-step instructions for a Cisco engineer to go from a fresh
+`omnibor-analysis` clone to a fully provisioned AWS EC2 build host running
+OmniBOR analysis.
+
+**Audience:** Cisco employees using Duo SSO for AWS authentication.
+
+> **Time estimate:** ~30 minutes for first-time setup (excluding Duo enrollment).
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Install CLI Tools](#step-1-install-cli-tools)
+- [Step 2: Install and Configure duo-sso](#step-2-install-and-configure-duo-sso)
+- [Step 3: Authenticate to AWS](#step-3-authenticate-to-aws)
+- [Step 4: Provision EC2 with Terraform](#step-4-provision-ec2-with-terraform)
+- [Step 5: Configure Infrastructure Profile](#step-5-configure-infrastructure-profile)
+- [Step 6: Verify the Build Host](#step-6-verify-the-build-host)
+- [Daily Workflow](#daily-workflow)
+- [Re-Authentication](#re-authentication)
+- [Cost Management](#cost-management)
+- [Troubleshooting](#troubleshooting)
+- [Tearing Down](#tearing-down)
+
+---
+
+## Prerequisites
+
+| Requirement | How to get it |
+|---|---|
+| **Cisco CEC account** | Your standard Cisco login |
+| **Duo MFA enrolled** | Enroll at https://disco.cisco.com |
+| **AWS account with Duo SSO** | Request via your team's cloud access process |
+| **macOS or Linux workstation** | For running CLI tools |
+| **Homebrew** (macOS) | https://brew.sh |
+| **Git** | `brew install git` or `apt install git` |
+
+> **Important:** You must be enrolled in Duo MFA before proceeding.
+> The Duo SSO URL and AWS account/role details come from your team's AWS setup.
+
+## Step 1: Install CLI Tools
+
+### macOS (Homebrew)
+
+```bash
+# AWS CLI v2
+brew install awscli
+
+# Terraform
+brew install terraform
+
+# duo-sso (Cisco internal Homebrew tap — requires VPN or on-network)
+brew tap ats-operations/homebrew-tap https://wwwin-github.cisco.com/ATS-operations/homebrew-tap
+brew install ats-operations/tap/duo-sso
+```
+
+### Verify installations
+
+```bash
+aws --version          # aws-cli/2.x.x ...
+terraform --version    # Terraform v1.x.x
+duo-sso --version      # duo-sso v3.x.x
+```
+
+### Optional: Nix (alternative for duo-sso)
+
+If Homebrew tap doesn't work (e.g., off-network), install Nix and use:
+
+```bash
+# Install Nix
+sh <(curl -L https://nixos.org/nix/install) --daemon
+
+# Run duo-sso via Nix (always gets latest version)
+nix run "git+https://wwwin-github.cisco.com/ATS-operations/duo-sso.git" --
+```
+
+## Step 2: Install and Configure duo-sso
+
+### 2a. Create duo-sso config
+
+Create `~/.config/duo-sso/config.json`:
+
+```bash
+mkdir -p ~/.config/duo-sso
+```
+
+```json
+{
+  "url": "<YOUR_DUO_SSO_URL>",
+  "partner_spid": "https://signin.aws.amazon.com/saml",
+  "aws_urn": "https://signin.aws.amazon.com/saml",
+  "session_duration_seconds": 3600,
+  "profiles": {
+    "<YOUR_PROFILE_NAME>": {
+      "aws_account_id": "<YOUR_AWS_ACCOUNT_ID>",
+      "aws_role_name": "<YOUR_ROLE_NAME>",
+      "session_duration_seconds": 3600
+    }
+  }
+}
+```
+
+> **Important:** Both `session_duration_seconds` values must be `3600` (1 hour).
+> The duo-sso README shows a default of `28800` (8 hours), but AWS administrators
+> typically enforce a maximum of 1 hour. Using `28800` causes the error:
+> *"The requested DurationSeconds exceeds the MaxSessionDuration"*
+
+Replace the placeholders with values from your team:
+
+| Placeholder | Example | Where to find it |
+|---|---|---|
+| `<YOUR_DUO_SSO_URL>` | `https://sso-XXXXXXXX.sso.duosecurity.com/saml2/sp/XXXX/sso` | Your team's Duo SSO configuration |
+| `<YOUR_PROFILE_NAME>` | `ted-admin` | Choose any name you like |
+| `<YOUR_AWS_ACCOUNT_ID>` | `697220083013` | AWS console → top-right → account ID |
+| `<YOUR_ROLE_NAME>` | `admin` | The IAM role your Duo SSO maps to |
+
+### 2b. Create AWS CLI config
+
+Create `~/.aws/config` with **region only** — no `role_arn` or `source_profile`:
+
+```ini
+[profile <YOUR_PROFILE_NAME>]
+region=us-west-1
+```
+
+> **⚠ Critical:** Do NOT add `role_arn` or `source_profile` to `~/.aws/config`.
+> duo-sso already assumes the role and writes STS credentials directly to
+> `~/.aws/credentials`. Adding those fields causes an "Infinite loop in
+> credential configuration" error.
+
+## Step 3: Authenticate to AWS
+
+duo-sso supports two authentication modes. **Sessions expire every 1 hour**
+(enforced by Cisco policy).
+
+### Option A: Interactive Browser Mode (requires Chrome/Chromium)
+
+```bash
+duo-sso -profile <YOUR_PROFILE_NAME> -set-aws-region us-west-1
+```
+
+This opens Chrome with the Duo SSO login page. Complete MFA and it
+writes credentials automatically.
+
+### Option B: Browserless Mode (recommended if Chrome is not your default)
+
+1. **Create a SAML bookmarklet** in your browser. Create a new bookmark with
+   this JavaScript as the URL:
+
+   ```
+   javascript:void(function(){if(window.location.hostname!=='signin.aws.amazon.com'){alert('This bookmarklet can only be used on https://signin.aws.amazon.com/saml');return;}const saml=document.querySelector('input[name=SAMLResponse]');if(!saml){alert('SAML Response not found!');return;}if(!saml.value||saml.value.length<100){alert('SAML Response is empty or too short! Complete authentication first.');return;}const blob=new Blob([saml.value],{type:'text/plain'});const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download='saml.txt';document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(url);console.log('SAML downloaded:',a.download);})()
+   ```
+
+2. **Authenticate:**
+
+   - Go to `https://go2.cisco.com/aws` in your browser
+   - Complete Cisco SSO + Duo MFA
+   - On the AWS SAML page, click the bookmarklet → downloads `saml.txt`
+
+3. **Exchange SAML for AWS credentials:**
+
+   ```bash
+   duo-sso -saml $(cat ~/Downloads/saml.txt) -profile <YOUR_PROFILE_NAME> -set-aws-region us-west-1
+   ```
+
+### Fix the credential profile name
+
+duo-sso writes credentials under `[default]` instead of your profile name.
+Fix this after every authentication:
+
+```bash
+# macOS
+sed -i '' 's/^\[default\]/[<YOUR_PROFILE_NAME>]/' ~/.aws/credentials
+
+# Linux
+sed -i 's/^\[default\]/[<YOUR_PROFILE_NAME>]/' ~/.aws/credentials
+```
+
+### Verify
+
+```bash
+aws sts get-caller-identity --profile <YOUR_PROFILE_NAME> --no-cli-pager
+```
+
+Expected output:
+
+```json
+{
+    "UserId": "AROAXXXXXXXXXXXXXXXXX:you@cisco.com",
+    "Account": "<YOUR_AWS_ACCOUNT_ID>",
+    "Arn": "arn:aws:sts::<YOUR_AWS_ACCOUNT_ID>:assumed-role/<YOUR_ROLE_NAME>/you@cisco.com"
+}
+```
+
+## Step 4: Provision EC2 with Terraform
+
+The `terraform/` directory contains Infrastructure as Code for the build host.
+
+### 4a. Review and customize (optional)
+
+```bash
+cd terraform/
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars if you want to change instance type, region, etc.
+```
+
+Defaults (no `terraform.tfvars` needed if these work for you):
+
+| Variable | Default | Notes |
+|---|---|---|
+| `aws_profile` | `ted-admin` | Must match your duo-sso profile |
+| `aws_region` | `us-west-1` | Must match your `~/.aws/config` |
+| `instance_type` | `c6i.xlarge` | 4 vCPU, 8 GB — see sizing below |
+| `ebs_volume_size_gb` | `50` | gp3 with 3000 IOPS |
+| `ssh_public_key_path` | `~/.ssh/id_ed25519.pub` | Your SSH public key |
+
+If your profile name is different from `ted-admin`, you **must** create
+`terraform.tfvars`:
+
+```hcl
+aws_profile = "your-profile-name"
+```
+
+### Instance Type Selection
+
+| Instance | vCPU | RAM | Cost/hr | Best for |
+|---|---|---|---|---|
+| `t3.medium` | 2 | 4 GB | ~$0.042 | Budget, small repos (curl, redis) |
+| `t3.large` | 2 | 8 GB | ~$0.083 | Comfortable for most repos |
+| `c6i.xlarge` | 4 | 8 GB | ~$0.170 | Recommended — fast builds (ffmpeg in ~5 min) |
+
+> **Constraint:** Must be x86_64 instance type (t3, c6i, m6i, etc.).
+> Do NOT use Graviton/ARM instances (t4g, c7g, m7g) — bomtrace3 requires x86_64.
+
+### 4b. Initialize and apply
+
+```bash
+# Ensure your AWS session is valid (re-auth if needed — see Step 3)
+aws sts get-caller-identity --profile <YOUR_PROFILE_NAME> --no-cli-pager
+
+# One-time initialization
+terraform init
+
+# Preview what will be created
+terraform plan -out=tfplan
+
+# Create the infrastructure
+terraform apply tfplan
+```
+
+Terraform will output:
+
+- **Elastic IP** — your stable public IP
+- **Instance ID** — for power management commands
+- **SSH config entry** — copy this to `~/.ssh/config`
+- **Power management commands** — start/stop/check status
+
+**Save the output!** You'll need the instance ID and IP for the next steps.
+
+### 4c. What Terraform creates
+
+| Resource | Purpose |
+|---|---|
+| EC2 Instance | Ubuntu 22.04 x86_64 build host |
+| 50 GB gp3 EBS | Root volume (3000 IOPS baseline) |
+| Elastic IP | Static IP that persists across stop/start |
+| Security Group | SSH (port 22 + 443) from your current IP only |
+| Key Pair | Your ed25519 public key |
+
+### 4d. VPN and SSH access
+
+> **Important:** Cisco VPN blocks outbound SSH (port 22) to AWS IPs and
+> intercepts port 443. **Work off-VPN for SSH access.**
+>
+> VPN is NOT required for any part of this workflow — AWS CLI, Terraform,
+> and SSH all work off-VPN. You only needed VPN for the one-time `duo-sso`
+> brew tap install.
+
+The security group auto-detects your public IP during `terraform plan/apply`.
+If your IP changes (switching networks, VPN on/off), just re-run:
+
+```bash
+terraform plan -out=tfplan && terraform apply tfplan
+```
+
+sshd listens on both port 22 (standard) and port 443 (fallback). Use
+whichever works on your network.
+
+### 4e. Bootstrap (automatic)
+
+The instance runs `user-data.sh` on first boot which:
+
+1. Configures sshd on ports 22 and 443
+2. Updates system packages
+3. Installs Docker and docker-compose
+4. Attempts to clone the omnibor-analysis repository
+5. Builds the Docker analysis image (~10-20 minutes)
+
+> **Note:** If the repo is private, the automatic clone will fail.
+> Use `rsync` to push the repo from your local machine instead:
+>
+> ```bash
+> rsync -avz --exclude '.git' --exclude '__pycache__' --exclude '.venv' \
+>   --exclude 'output/' --exclude 'terraform/.terraform/' \
+>   --exclude 'terraform/terraform.tfstate*' --exclude 'terraform/terraform.tfvars' \
+>   -e ssh ./ omnibor-build:~/omnibor-analysis/
+> ```
+>
+> Then build the Docker image manually:
+>
+> ```bash
+> ssh omnibor-build "cd ~/omnibor-analysis && docker-compose -f docker/docker-compose.yml build"
+> ```
+
+Check bootstrap progress:
+
+```bash
+ssh omnibor-build "tail -f /var/log/cloud-init-output.log"
+```
+
+## Step 5: Configure Infrastructure Profile
+
+### 5a. Add SSH config
+
+Add the SSH config entry from Terraform output to `~/.ssh/config`:
+
+```
+Host omnibor-build
+    HostName <ELASTIC_IP from terraform output>
+    User ubuntu
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+Test SSH:
+
+```bash
+ssh omnibor-build "uname -m && docker --version"
+# Should show: x86_64 and Docker version
+```
+
+### 5b. Set up the infrastructure profile
+
+Copy the AWS template and fill in your values:
+
+```bash
+cp .windsurf/rules/infrastructure/templates/aws-ec2.md \
+   .windsurf/rules/infrastructure/active-profile.md
+```
+
+Edit `active-profile.md` with the Terraform output values (instance ID,
+Elastic IP, etc.). This file is gitignored — your specific details stay local.
+
+## Step 6: Verify the Build Host
+
+### Check Docker and bomtrace3
+
+```bash
+ssh omnibor-build "docker-compose -f ~/omnibor-analysis/docker/docker-compose.yml \
+  run --rm omnibor-env bomtrace3 --version"
+```
+
+### Run a test analysis
+
+```bash
+# From your local machine, tell Cascade:
+/run-analysis
+# Choose "redis" for a quick ~2 min test
+```
+
+Or manually:
+
+```bash
+ssh omnibor-build "cd ~/omnibor-analysis && \
+  docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
+  python3 /workspace/app/analyze.py --repo redis"
+```
+
+### Sync results back
+
+```bash
+rsync -avz omnibor-build:~/omnibor-analysis/output/ output/
+rsync -avz omnibor-build:~/omnibor-analysis/docs/ docs/
+```
+
+---
+
+## Daily Workflow
+
+```bash
+# 1. Authenticate (every hour — set a timer!)
+duo-sso -saml $(cat ~/Downloads/saml.txt) -profile <YOUR_PROFILE_NAME> -set-aws-region us-west-1
+sed -i '' 's/^\[default\]/[<YOUR_PROFILE_NAME>]/' ~/.aws/credentials
+
+# 2. Start the instance
+aws ec2 start-instances --profile <YOUR_PROFILE_NAME> --instance-ids <INSTANCE_ID> --no-cli-pager
+
+# 3. Wait for it to be running
+aws ec2 wait instance-running --profile <YOUR_PROFILE_NAME> --instance-ids <INSTANCE_ID>
+
+# 4. Do your work (SSH, run analysis, etc.)
+
+# 5. Stop the instance when done (saves money!)
+aws ec2 stop-instances --profile <YOUR_PROFILE_NAME> --instance-ids <INSTANCE_ID> --no-cli-pager
+```
+
+## Re-Authentication
+
+Cisco Duo SSO sessions last **1 hour**. When credentials expire, you'll see:
+
+```
+An error occurred (ExpiredToken) when calling the DescribeInstances operation
+```
+
+or:
+
+```
+An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity operation
+```
+
+To fix: re-run [Step 3](#step-3-authenticate-to-aws) (takes ~30 seconds).
+
+**Tip:** Set a recurring 55-minute timer when you start working. Re-auth
+before it expires to avoid interrupting long-running Terraform operations.
+
+> **Terraform note:** `terraform apply` typically completes in under 2 minutes.
+> If you need to run `terraform destroy` + `terraform apply`, do both in the
+> same session. A single re-auth gives you a full hour.
+
+## Cost Management
+
+### Pay-per-use model
+
+| Usage Pattern | c6i.xlarge/mo | t3.medium/mo |
+|---|---|---|
+| 4 hours/day × 20 days | ~$14 | ~$3.40 |
+| 8 hours/day × 20 days | ~$27 | ~$6.70 |
+| Always running | ~$124 | ~$30 |
+| Stopped (EBS + EIP) | ~$7.60 | ~$7.60 |
+
+### Cost-saving tips
+
+1. **Always stop the instance when done** — this is the biggest savings
+2. **Release the Elastic IP** if not using the instance for weeks
+   (`terraform destroy` handles this)
+3. **Use t3.medium** if you mostly analyze small repos (curl, redis)
+4. **Use c6i.xlarge** only when building large repos (ffmpeg, nmap)
+5. Consider changing instance type between sessions:
+   ```bash
+   # Stop first, then change type, then start
+   aws ec2 stop-instances --profile <YOUR_PROFILE_NAME> --instance-ids <ID> --no-cli-pager
+   aws ec2 modify-instance-attribute --profile <YOUR_PROFILE_NAME> --instance-ids <ID> --instance-type '{"Value":"t3.medium"}' --no-cli-pager
+   aws ec2 start-instances --profile <YOUR_PROFILE_NAME> --instance-ids <ID> --no-cli-pager
+   ```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| "Infinite loop in credential configuration" | `~/.aws/config` has `role_arn` + `source_profile` | Remove both — keep only `region` |
+| `ExpiredToken` errors | Duo SSO session expired (1 hour) | Re-authenticate (Step 3) |
+| `duo-sso: command not found` | Homebrew tap not installed | Must be on Cisco VPN/network for internal tap |
+| `terraform init` fails | AWS provider can't authenticate | Check `aws sts get-caller-identity` works first |
+| SSH "Operation timed out" on port 22 | Cisco VPN blocks port 22 to AWS | Disconnect VPN — SSH works off-VPN. Or use port 443: `ssh -p 443 omnibor-build` |
+| SSH "Connection reset" on port 443 | Cisco VPN proxy intercepts port 443 | Disconnect VPN — this is the VPN web proxy rejecting non-TLS traffic |
+| SSH "Connection refused" | Instance not running or wrong IP | Check instance state; Elastic IP doesn't change |
+| SSH "Permission denied" | Wrong key or wrong user | User is `ubuntu` (not `root`), key is `id_ed25519` |
+| Git clone fails on EC2 | Private repo, no credentials on instance | Use `rsync` from local machine (see Step 4e) |
+| `bomtrace3: Exec format error` | ARM64 instance | Must use x86_64 instance type (t3, c6i, m6i) |
+| Docker build fails on instance | Cloud-init still running | Wait for bootstrap: `tail -f /var/log/cloud-init-output.log` |
+| Security group blocks SSH | IP changed since `terraform apply` | Run `terraform apply` again to update SG with new IP |
+
+## Tearing Down
+
+To completely remove all AWS resources:
+
+```bash
+cd terraform/
+terraform destroy
+```
+
+This removes the EC2 instance, EBS volume, Elastic IP, security group, and
+key pair. **All data on the instance will be lost** — sync results first!
+
+```bash
+# Sync before destroying
+rsync -avz omnibor-build:~/omnibor-analysis/output/ output/
+rsync -avz omnibor-build:~/omnibor-analysis/docs/ docs/
+
+# Then destroy
+terraform destroy
+```

--- a/docs/curl/2026-02-26_2307/build.md
+++ b/docs/curl/2026-02-26_2307/build.md
@@ -1,0 +1,27 @@
+# Build Log — curl
+
+**Date:** 2026-02-26T23:08:39.105248
+**Status:** SUCCESS
+**Duration:** 71.1 seconds
+
+## Repository
+
+- **URL:** https://github.com/curl/curl.git
+- **Branch:** master
+- **Description:** HTTP transfer library and CLI tool (~170K LoC)
+
+## Build Steps
+
+1. `autoreconf -fi`
+2. `./configure --with-openssl --with-zlib --with-nghttp2 --with-libssh2 --with-brotli`
+3. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/.libs/curl`
+- `lib/.libs/libcurl.so`

--- a/docs/ffmpeg/2026-03-04_1949/build.md
+++ b/docs/ffmpeg/2026-03-04_1949/build.md
@@ -1,0 +1,30 @@
+# Build Log — ffmpeg
+
+**Date:** 2026-03-04T20:02:39.819859
+**Status:** SUCCESS
+**Duration:** 744.4 seconds
+
+## Repository
+
+- **URL:** https://github.com/FFmpeg/FFmpeg.git
+- **Branch:** master
+- **Description:** Multimedia framework (~1.2M LoC, 20+ third-party libs)
+
+## Build Steps
+
+1. `./configure --enable-gpl --enable-nonfree --enable-shared --disable-static --enable-libx264 --enable-libx265 --enable-libvpx --enable-libopus --enable-libmp3lame --enable-libfdk-aac --enable-libfreetype --enable-libfontconfig --enable-libfribidi --enable-libass --enable-openssl`
+2. `make -j1`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `ffmpeg`
+- `ffprobe`
+- `libavcodec/libavcodec.so`
+- `libavformat/libavformat.so`
+- `libavutil/libavutil.so`
+- `libswscale/libswscale.so`

--- a/docs/nmap/2026-03-04_1948/build.md
+++ b/docs/nmap/2026-03-04_1948/build.md
@@ -1,0 +1,27 @@
+# Build Log — nmap
+
+**Date:** 2026-03-04T19:49:12.347203
+**Status:** SUCCESS
+**Duration:** 50.8 seconds
+
+## Repository
+
+- **URL:** https://github.com/nmap/nmap.git
+- **Branch:** master
+- **Description:** Network scanner with 10 vendored libs + 10+ dynamic system deps (~420 source files, C/C++)
+
+## Build Steps
+
+1. `./configure --with-libpcre=/usr --with-libz=/usr --with-libssh2=/usr --with-openssl=/usr --with-libdnet=included --with-liblua=included --with-liblinear=included --without-zenmap --without-ndiff`
+2. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `nmap`
+- `ncat/ncat`
+- `nping/nping`

--- a/docs/redis/2026-03-04_1946/build.md
+++ b/docs/redis/2026-03-04_1946/build.md
@@ -1,0 +1,25 @@
+# Build Log — redis
+
+**Date:** 2026-03-04T19:47:46.997650
+**Status:** SUCCESS
+**Duration:** 40.2 seconds
+
+## Repository
+
+- **URL:** https://github.com/redis/redis.git
+- **Branch:** unstable
+- **Description:** In-memory data store with 8 vendored libs (jemalloc, lua, hiredis, etc.) (~293K LoC, C)
+
+## Build Steps
+
+1. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/redis-server`
+- `src/redis-cli`

--- a/docs/runtime/curl/2026-02-26_2307/runtime.md
+++ b/docs/runtime/curl/2026-02-26_2307/runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — curl
+
+**Date:** 2026-02-26T23:08:39.105390
+**Instrumented build time:** 71.1 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/ffmpeg/2026-03-04_1949/runtime.md
+++ b/docs/runtime/ffmpeg/2026-03-04_1949/runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — ffmpeg
+
+**Date:** 2026-03-04T20:02:39.820031
+**Instrumented build time:** 744.4 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/nmap/2026-03-04_1948/runtime.md
+++ b/docs/runtime/nmap/2026-03-04_1948/runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — nmap
+
+**Date:** 2026-03-04T19:49:12.347375
+**Instrumented build time:** 50.8 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/redis/2026-03-04_1946/runtime.md
+++ b/docs/runtime/redis/2026-03-04_1946/runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — redis
+
+**Date:** 2026-03-04T19:47:46.998391
+**Instrumented build time:** 40.2 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,84 @@
+# Terraform — OmniBOR AWS EC2 Build Host
+
+Infrastructure as Code for provisioning the OmniBOR build analysis EC2 instance.
+
+## What It Creates
+
+| Resource | Description |
+|----------|-------------|
+| EC2 Instance | Ubuntu 22.04 x86_64, c6i.xlarge (default) |
+| EBS Volume | 50 GB gp3 (3000 IOPS) |
+| Elastic IP | Static IP that persists across stop/start |
+| Security Group | SSH (port 22) from your current IP only |
+| Key Pair | Your ed25519 public key |
+
+## Prerequisites
+
+1. **AWS CLI v2**: `brew install awscli`
+2. **Terraform**: `brew install terraform`
+3. **duo-sso**: See `.windsurf/rules/infrastructure/templates/aws-ec2.md` for install + auth
+
+## Authentication
+
+Cisco users authenticate via duo-sso (SAML → STS). **Sessions expire every 1 hour.**
+
+```bash
+# Browserless mode (recommended)
+# 1. Go to https://go2.cisco.com/aws → complete SSO + Duo MFA
+# 2. Click SAML bookmarklet → downloads saml.txt
+# 3. Run:
+duo-sso -saml $(cat ~/Downloads/saml.txt) -profile ted-admin -set-aws-region us-west-1
+sed -i '' 's/^\[default\]/[ted-admin]/' ~/.aws/credentials   # macOS
+
+# Verify
+aws sts get-caller-identity --profile ted-admin --no-cli-pager
+```
+
+## Quick Start
+
+```bash
+cd terraform/
+
+# One-time init
+terraform init
+
+# Review what will be created
+terraform plan -out=tfplan
+
+# Apply
+terraform apply tfplan
+
+# When done — tear down everything
+terraform destroy
+```
+
+## Customization
+
+Copy the example vars file and edit:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
+```
+
+## Cost
+
+| State | c6i.xlarge | t3.medium |
+|-------|-----------|-----------|
+| Running | ~$0.170/hr | ~$0.042/hr |
+| Stopped (EBS only) | ~$4/mo | ~$4/mo |
+| Elastic IP (while stopped) | ~$3.60/mo | ~$3.60/mo |
+| Destroyed | $0 | $0 |
+
+**Tip:** At 4 hours/day × 20 days/month, c6i.xlarge costs ~$14/mo on-demand.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.tf` | Provider, EC2 instance, security group, Elastic IP |
+| `variables.tf` | Configurable variables with defaults |
+| `outputs.tf` | Post-apply output (IP, SSH config, power commands) |
+| `user-data.sh` | Bootstrap script (Docker, repo clone, image build) |
+| `terraform.tfvars.example` | Example overrides (copy to terraform.tfvars) |
+| `terraform.tfvars` | Your overrides (gitignored) |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,155 @@
+# =============================================================================
+# OmniBOR Analysis — AWS EC2 Build Host
+# =============================================================================
+# Provisions an EC2 instance for running OmniBOR build interception analysis.
+# See docs/aws-ec2-migration-recommendation.md for sizing rationale.
+#
+# Authentication: Uses duo-sso STS credentials via AWS profile.
+# Sessions expire every 1 hour — re-authenticate before running terraform.
+#
+# Usage:
+#   terraform init                          # one-time
+#   terraform plan  -out=tfplan             # review changes
+#   terraform apply tfplan                  # apply changes
+#   terraform destroy                       # tear down everything
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+# ---------------------------------------------------------------------------
+# Data Sources
+# ---------------------------------------------------------------------------
+
+# Latest Ubuntu 22.04 LTS x86_64 AMI from Canonical
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+# Current public IP for SSH security group rule
+data "http" "my_ip" {
+  url = "https://checkip.amazonaws.com"
+}
+
+# ---------------------------------------------------------------------------
+# SSH Key Pair
+# ---------------------------------------------------------------------------
+
+resource "aws_key_pair" "omnibor" {
+  key_name   = "${var.project_name}-key"
+  public_key = file(var.ssh_public_key_path)
+
+  tags = {
+    Name    = "${var.project_name}-key"
+    Project = var.project_name
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Security Group
+# ---------------------------------------------------------------------------
+
+resource "aws_security_group" "omnibor" {
+  name        = "${var.project_name}-sg"
+  description = "SSH access for OmniBOR build host"
+
+  # SSH on port 22 (standard — works off-VPN)
+  ingress {
+    description = "SSH-22"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${chomp(data.http.my_ip.response_body)}/32"]
+  }
+
+  # SSH on port 443 (Cisco VPN blocks port 22 to AWS IPs)
+  ingress {
+    description = "SSH-443"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["${chomp(data.http.my_ip.response_body)}/32"]
+  }
+
+  # All outbound (apt, git, Docker Hub, etc.)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-sg"
+    Project = var.project_name
+  }
+}
+
+# ---------------------------------------------------------------------------
+# EC2 Instance
+# ---------------------------------------------------------------------------
+
+resource "aws_instance" "omnibor_build" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  key_name               = aws_key_pair.omnibor.key_name
+  vpc_security_group_ids = [aws_security_group.omnibor.id]
+
+  root_block_device {
+    volume_size           = var.ebs_volume_size_gb
+    volume_type           = "gp3"
+    iops                  = 3000
+    throughput            = 125
+    delete_on_termination = true
+  }
+
+  user_data = file("${path.module}/user-data.sh")
+
+  tags = {
+    Name    = "${var.project_name}-build"
+    Project = var.project_name
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Elastic IP (persists across stop/start)
+# ---------------------------------------------------------------------------
+
+resource "aws_eip" "omnibor" {
+  instance = aws_instance.omnibor_build.id
+  domain   = "vpc"
+
+  tags = {
+    Name    = "${var.project_name}-eip"
+    Project = var.project_name
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,66 @@
+# =============================================================================
+# Outputs — Displayed after terraform apply
+# =============================================================================
+
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.omnibor_build.id
+}
+
+output "elastic_ip" {
+  description = "Elastic IP address (stable across stop/start)"
+  value       = aws_eip.omnibor.public_ip
+}
+
+output "ami_id" {
+  description = "AMI used for the instance"
+  value       = data.aws_ami.ubuntu.id
+}
+
+output "ami_name" {
+  description = "AMI name (includes date)"
+  value       = data.aws_ami.ubuntu.name
+}
+
+output "instance_type" {
+  description = "EC2 instance type"
+  value       = aws_instance.omnibor_build.instance_type
+}
+
+output "security_group_id" {
+  description = "Security group ID"
+  value       = aws_security_group.omnibor.id
+}
+
+output "ssh_command" {
+  description = "SSH command to connect"
+  value       = "ssh -i ${var.ssh_public_key_path} ubuntu@${aws_eip.omnibor.public_ip}"
+}
+
+output "ssh_config_entry" {
+  description = "Add this to ~/.ssh/config"
+  value       = <<-EOT
+
+    Host omnibor-build
+        HostName ${aws_eip.omnibor.public_ip}
+        User ubuntu
+        IdentityFile ~/.ssh/id_ed25519
+
+  EOT
+}
+
+output "power_commands" {
+  description = "AWS CLI commands for power management"
+  value       = <<-EOT
+
+    # Check status
+    aws ec2 describe-instances --profile ${var.aws_profile} --instance-ids ${aws_instance.omnibor_build.id} --query 'Reservations[].Instances[].{State:State.Name,IP:PublicIpAddress}' --output table --no-cli-pager
+
+    # Stop (saves money, keeps EBS)
+    aws ec2 stop-instances --profile ${var.aws_profile} --instance-ids ${aws_instance.omnibor_build.id} --no-cli-pager
+
+    # Start
+    aws ec2 start-instances --profile ${var.aws_profile} --instance-ids ${aws_instance.omnibor_build.id} --no-cli-pager
+
+  EOT
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,23 @@
+# =============================================================================
+# Terraform Variables — Copy to terraform.tfvars and edit
+# =============================================================================
+# terraform.tfvars is gitignored — safe for user-specific values
+#
+# Most defaults are fine. Override only what you need.
+# =============================================================================
+
+# AWS profile name (from duo-sso authentication)
+# aws_profile = "ted-admin"
+
+# AWS region
+# aws_region = "us-west-1"
+
+# EC2 instance type — must be x86_64, NOT Graviton/ARM
+# Options: t3.medium (budget), t3.large (comfortable), c6i.xlarge (recommended)
+# instance_type = "c6i.xlarge"
+
+# Root EBS volume size in GB
+# ebs_volume_size_gb = 50
+
+# Path to your SSH public key
+# ssh_public_key_path = "~/.ssh/id_ed25519.pub"

--- a/terraform/user-data.sh
+++ b/terraform/user-data.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# =============================================================================
+# EC2 User Data — Bootstrap script for OmniBOR build host
+# =============================================================================
+# Runs once on first boot. Installs Docker, clones repo, builds container.
+# Cloud-init logs: /var/log/cloud-init-output.log
+#
+# NOTE: Cisco VPN blocks port 22 to AWS IPs. SSH is configured on port 443.
+# =============================================================================
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "=== OmniBOR build host bootstrap starting ==="
+
+# --- Configure SSH to also listen on port 443 ---
+# Cisco VPN blocks port 22 to AWS IPs. Use a drop-in config file
+# to avoid conflicting with the default sshd_config.
+mkdir -p /etc/ssh/sshd_config.d
+cat > /etc/ssh/sshd_config.d/omnibor-ports.conf <<'EOF'
+# Listen on both 22 (off-VPN) and 443 (on Cisco VPN)
+Port 22
+Port 443
+EOF
+# Comment out any Port directive in the main config to avoid conflicts
+sed -i 's/^Port /#Port /' /etc/ssh/sshd_config
+systemctl restart sshd
+echo "=== SSH configured on ports 22 and 443 ==="
+
+# --- System updates ---
+apt-get update -y
+apt-get upgrade -y
+
+# --- Install Docker ---
+curl -fsSL https://get.docker.com | sh
+usermod -aG docker ubuntu
+
+# --- Install docker-compose (standalone v2) ---
+DOCKER_COMPOSE_VERSION="v2.29.2"
+curl -fsSL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64" \
+  -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+# --- Install git and build essentials ---
+apt-get install -y git rsync
+
+# --- Clone omnibor-analysis repo ---
+# If the repo is private, clone will fail here. User can clone manually via SSH.
+if sudo -u ubuntu git clone https://github.com/tedg-cisco/omnibor-analysis.git /home/ubuntu/omnibor-analysis 2>/dev/null; then
+  echo "=== Repo cloned, building Docker image ==="
+  cd /home/ubuntu/omnibor-analysis
+  sudo -u ubuntu docker-compose -f docker/docker-compose.yml build
+else
+  echo "=== Repo clone failed (private repo?) — user must clone manually ==="
+  echo "=== SSH in and run: git clone <repo_url> ~/omnibor-analysis ==="
+fi
+
+echo "=== OmniBOR build host bootstrap complete ==="
+echo "=== Check cloud-init-output.log for details ==="

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,45 @@
+# =============================================================================
+# Variables — Override via terraform.tfvars (gitignored)
+# =============================================================================
+
+variable "aws_profile" {
+  description = "AWS CLI profile name (from ~/.aws/credentials, populated by duo-sso)"
+  type        = string
+  default     = "ted-admin"
+}
+
+variable "aws_region" {
+  description = "AWS region for all resources"
+  type        = string
+  default     = "us-west-1"
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming and tagging"
+  type        = string
+  default     = "omnibor"
+}
+
+variable "instance_type" {
+  description = <<-EOT
+    EC2 instance type. Must be x86_64 (NOT Graviton/ARM).
+    Recommended options (see docs/aws-ec2-migration-recommendation.md):
+      t3.medium   — 2 vCPU, 4 GB RAM, ~$0.042/hr (budget)
+      t3.large    — 2 vCPU, 8 GB RAM, ~$0.083/hr (comfortable)
+      c6i.xlarge  — 4 vCPU, 8 GB RAM, ~$0.170/hr (performance, recommended)
+  EOT
+  type        = string
+  default     = "c6i.xlarge"
+}
+
+variable "ebs_volume_size_gb" {
+  description = "Root EBS volume size in GB (gp3)"
+  type        = number
+  default     = 50
+}
+
+variable "ssh_public_key_path" {
+  description = "Path to SSH public key for EC2 access"
+  type        = string
+  default     = "~/.ssh/id_ed25519.pub"
+}

--- a/tests/test_spdx_from_adg.py
+++ b/tests/test_spdx_from_adg.py
@@ -1733,5 +1733,471 @@ class TestCli(unittest.TestCase):
                     main()
 
 
+class TestProjectBuiltLibs(unittest.TestCase):
+    """Tests for project-built shared library detection
+    and SPDX emission (lines 318-326, 951-968)."""
+
+    def _write_metadata(self, td, metadata):
+        path = Path(td) / "component_metadata.json"
+        path.write_text(json.dumps(metadata))
+        return str(path)
+
+    def _base_metadata(self):
+        return {
+            "distro": "Ubuntu 22.04.5 LTS",
+            "gcc_version": "gcc (Ubuntu 11.4.0) 11.4.0",
+            "curl_version": "8.19.0-DEV",
+            "pkg_metadata": {},
+            "file_to_pkg": {},
+            "unresolved_files": [],
+        }
+
+    def test_resolve_project_built_libs(self):
+        """project_built_libs in dynlibs produces
+        components with project_built=True."""
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._base_metadata()
+            path = self._write_metadata(td, meta)
+            resolver = ComponentResolver(path)
+
+            dynlibs = {
+                "binary": "/repos/ffmpeg/ffmpeg",
+                "direct_needed": ["libavcodec.so"],
+                "dynamic_libs": {},
+                "libcurl_needed": [],
+                "project_built_libs": {
+                    "libavcodec.so": {
+                        "name": "libavcodec",
+                        "direct": True,
+                    },
+                    "libavutil.so": {
+                        "direct": False,
+                    },
+                },
+            }
+            dynlib_path = Path(td) / "dynamic_libs.json"
+            dynlib_path.write_text(json.dumps(dynlibs))
+            resolver.load_dynamic_libs(str(dynlib_path))
+            components = (
+                resolver.resolve_dynamic_components()
+            )
+            proj = [
+                c for c in components
+                if c.get("project_built")
+            ]
+            self.assertEqual(len(proj), 2)
+            names = [c["name"] for c in proj]
+            self.assertIn("libavcodec", names)
+            # Falls back to soname when no "name" key
+            self.assertIn("libavutil.so", names)
+            # Check direct flag
+            avcodec = [
+                c for c in proj
+                if c["name"] == "libavcodec"
+            ][0]
+            self.assertTrue(avcodec["direct"])
+            avutil = [
+                c for c in proj
+                if c["name"] == "libavutil.so"
+            ][0]
+            self.assertFalse(avutil["direct"])
+
+    def test_emit_project_built_component(self):
+        """project_built components become SPDX packages
+        with LIBRARY purpose and project version."""
+        emitter = SpdxEmitter(
+            repo_name="ffmpeg",
+            repo_version="6.1",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+            binary_name="ffmpeg",
+        )
+        components = [{
+            "name": "libavcodec",
+            "source": "libavcodec",
+            "sonames": ["libavcodec.so"],
+            "direct": True,
+            "project_built": True,
+        }]
+        doc = emitter.emit(
+            components=components,
+            project_files=[],
+            doc_mapping={},
+            logfile_hashes={},
+        )
+        # Root + libavcodec + gcc = 3
+        self.assertEqual(len(doc["packages"]), 3)
+        avcodec = [
+            p for p in doc["packages"]
+            if p["name"] == "libavcodec"
+        ][0]
+        self.assertEqual(
+            avcodec["primaryPackagePurpose"],
+            "LIBRARY",
+        )
+        self.assertIn(
+            "Project-built", avcodec["comment"]
+        )
+        self.assertIn(
+            "libavcodec.so", avcodec["comment"]
+        )
+        self.assertEqual(
+            avcodec["versionInfo"], "6.1"
+        )
+        self.assertEqual(
+            avcodec["downloadLocation"],
+            "NOASSERTION",
+        )
+
+    def test_emit_project_built_no_version(self):
+        """project_built without repo_version omits
+        versionInfo."""
+        emitter = SpdxEmitter(
+            repo_name="ffmpeg",
+            repo_version=None,
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+        )
+        components = [{
+            "name": "libavcodec",
+            "source": "libavcodec",
+            "sonames": ["libavcodec.so"],
+            "direct": True,
+            "project_built": True,
+        }]
+        doc = emitter.emit(
+            components=components,
+            project_files=[],
+            doc_mapping={},
+            logfile_hashes={},
+        )
+        avcodec = [
+            p for p in doc["packages"]
+            if p["name"] == "libavcodec"
+        ][0]
+        self.assertNotIn("versionInfo", avcodec)
+
+
+class TestHeaderCommentBreak(unittest.TestCase):
+    """Test _parse_header_comment line limit (line 527)."""
+
+    def test_version_after_line_10_not_found(self):
+        """VERSION past the 10-line window is ignored."""
+        with tempfile.TemporaryDirectory() as td:
+            h = Path(td) / "big.h"
+            lines = ["/* no version */\n"] * 11
+            lines.append(
+                "/* VERSION 9.9.9 */\n"
+            )
+            h.write_text("".join(lines))
+            det = VendoredVersionDetector()
+            result = det._parse_header_comment(str(h))
+            self.assertIsNone(result)
+
+    def test_version_within_first_10_lines(self):
+        """VERSION within 10-line window IS found."""
+        with tempfile.TemporaryDirectory() as td:
+            h = Path(td) / "ok.h"
+            lines = ["/* padding */\n"] * 5
+            lines.append("/* VERSION 3.2.1 */\n")
+            h.write_text("".join(lines))
+            det = VendoredVersionDetector()
+            result = det._parse_header_comment(str(h))
+            self.assertEqual(result, "3.2.1")
+
+
+class TestSubComponentRemainingFiles(
+    unittest.TestCase
+):
+    """Tests for remaining-file assignment in
+    sub-component splitting (lines 718-719, 745-747)."""
+
+    def _emitter(self):
+        return SpdxEmitter(
+            repo_name="redis",
+            repo_version="7.2.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+            binary_name="redis-server",
+        )
+
+    def test_non_source_files_go_to_remaining(self):
+        """Non .c/.h files skip sub-component detection
+        and go to remaining (lines 718-719)."""
+        with tempfile.TemporaryDirectory() as td:
+            lua_dir = Path(td) / "deps" / "lua" / "src"
+            lua_dir.mkdir(parents=True)
+            (lua_dir / "lapi.c").write_text("")
+            (lua_dir / "lua_cjson.c").write_text(
+                '#define CJSON_VERSION "2.1.0"\n'
+            )
+            # .o file — not .c or .h
+            (lua_dir / "lapi.o").write_text("")
+            emitter = self._emitter()
+            files = [
+                {"sha1": "a1", "file_path":
+                    str(lua_dir / "lapi.c")},
+                {"sha1": "a2", "file_path":
+                    str(lua_dir / "lua_cjson.c")},
+                {"sha1": "a3", "file_path":
+                    str(lua_dir / "lapi.o")},
+            ]
+            vendored, own = (
+                emitter._detect_vendored_groups(files)
+            )
+            # .o goes to parent (lua) as remaining
+            self.assertIn("lua", vendored)
+            # lapi.c + lapi.o in lua group
+            lua_paths = [
+                f["file_path"]
+                for f in vendored["lua"]
+            ]
+            self.assertTrue(
+                any("lapi.o" in p for p in lua_paths)
+            )
+
+    def test_remaining_files_matched_to_subcomponent(
+        self,
+    ):
+        """Non-source files whose basename contains a
+        sub-component key are assigned to it
+        (lines 745-747)."""
+        with tempfile.TemporaryDirectory() as td:
+            lua_dir = Path(td) / "deps" / "lua" / "src"
+            lua_dir.mkdir(parents=True)
+            (lua_dir / "lapi.c").write_text("")
+            (lua_dir / "lua_cjson.c").write_text(
+                '#define CJSON_VERSION "2.1.0"\n'
+            )
+            # .o file whose name contains "cjson"
+            (lua_dir / "lua_cjson.o").write_text("")
+            emitter = self._emitter()
+            files = [
+                {"sha1": "a1", "file_path":
+                    str(lua_dir / "lapi.c")},
+                {"sha1": "a2", "file_path":
+                    str(lua_dir / "lua_cjson.c")},
+                {"sha1": "a3", "file_path":
+                    str(lua_dir / "lua_cjson.o")},
+            ]
+            vendored, own = (
+                emitter._detect_vendored_groups(files)
+            )
+            self.assertIn("lua-cjson", vendored)
+            # lua_cjson.c + lua_cjson.o
+            self.assertEqual(
+                len(vendored["lua-cjson"]), 2
+            )
+
+
+class TestGenericPrefixSkip(unittest.TestCase):
+    """Test that generic prefix names like VERSION,
+    LIB are skipped (line 799)."""
+
+    def _emitter(self):
+        return SpdxEmitter(
+            repo_name="redis",
+            repo_version="7.2.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+            binary_name="redis-server",
+        )
+
+    def test_generic_version_prefix_skipped(self):
+        """#define VERSION_VERSION is skipped as
+        a generic name."""
+        with tempfile.TemporaryDirectory() as td:
+            lua_dir = Path(td) / "deps" / "lua" / "src"
+            lua_dir.mkdir(parents=True)
+            (lua_dir / "lapi.c").write_text(
+                '#define VERSION "1.0.0"\n'
+            )
+            emitter = self._emitter()
+            files = [
+                {"sha1": "a1", "file_path":
+                    str(lua_dir / "lapi.c")},
+            ]
+            vendored, own = (
+                emitter._detect_vendored_groups(files)
+            )
+            # Should stay as "lua", no "version" sub
+            self.assertIn("lua", vendored)
+            self.assertNotIn("version", vendored)
+
+    def test_generic_lib_prefix_skipped(self):
+        """#define LIB_VERSION is skipped."""
+        with tempfile.TemporaryDirectory() as td:
+            lua_dir = Path(td) / "deps" / "lua" / "src"
+            lua_dir.mkdir(parents=True)
+            (lua_dir / "lapi.c").write_text(
+                '#define LIB_VERSION "2.0"\n'
+            )
+            emitter = self._emitter()
+            files = [
+                {"sha1": "a1", "file_path":
+                    str(lua_dir / "lapi.c")},
+            ]
+            vendored, own = (
+                emitter._detect_vendored_groups(files)
+            )
+            self.assertIn("lua", vendored)
+            self.assertNotIn("lib", vendored)
+
+
+class TestFilePathRelativization(unittest.TestCase):
+    """Test ValueError/IndexError in file path
+    relativization (lines 1190-1191)."""
+
+    def test_short_path_falls_back(self):
+        """A very short file_path triggers the
+        except branch and uses the raw path."""
+        emitter = SpdxEmitter(
+            repo_name="curl",
+            repo_version="8.19.0",
+            distro="Ubuntu 22.04",
+            gcc_version="gcc 11.4.0",
+        )
+        # Bare filename (1 part) → parents[-2] raises
+        # IndexError, so rel_path stays as-is
+        files = [
+            {"sha1": "abc123", "file_path": "x.c"},
+        ]
+        doc = emitter.emit(
+            components=[],
+            project_files=files,
+            doc_mapping={},
+            logfile_hashes={},
+        )
+        self.assertEqual(len(doc["files"]), 1)
+        # Should still work, using raw path
+        self.assertEqual(
+            doc["files"][0]["fileName"], "x.c"
+        )
+
+
+class TestGenerateMissingDynlibs(unittest.TestCase):
+    """Test generate() when dynamic_libs.json is
+    missing (lines 1312-1317)."""
+
+    def test_missing_dynlib_returns_none(self):
+        """generate() returns None if dynlib not found."""
+        with tempfile.TemporaryDirectory() as td:
+            bom = Path(td) / "bom"
+            meta = bom / "metadata" / "bomsh"
+            meta.mkdir(parents=True)
+
+            sha = "a" * 40
+            treedb = {
+                sha: {
+                    "file_path": "/repos/curl/src/x.c"
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text(json.dumps({}))
+
+            comp_meta = {
+                "distro": "Ubuntu 22.04",
+                "gcc_version": "gcc 11.4.0",
+                "curl_version": "8.19.0",
+                "pkg_metadata": {},
+                "file_to_pkg": {},
+                "unresolved_files": [],
+            }
+            (
+                bom / "metadata"
+                / "component_metadata.json"
+            ).write_text(json.dumps(comp_meta))
+            # NOTE: no dynamic_libs.json created
+
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+            gen = AdgSpdxGenerator(
+                bom_dir=str(bom),
+                repos_dir="/repos",
+                repo_name="curl",
+            )
+            with patch("builtins.print"):
+                result = gen.generate(out)
+
+            self.assertIsNone(result)
+
+
+class TestVisualizationFailure(unittest.TestCase):
+    """Test HTML visualization failure handling
+    (lines 1384-1385)."""
+
+    def test_visualization_exception_caught(self):
+        """generate() succeeds even when visualization
+        raises an exception."""
+        with tempfile.TemporaryDirectory() as td:
+            bom = Path(td) / "bom"
+            meta = bom / "metadata" / "bomsh"
+            meta.mkdir(parents=True)
+
+            sha = "a" * 40
+            treedb = {
+                sha: {
+                    "file_path": "/repos/curl/src/x.c"
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            (
+                meta / "bomsh_omnibor_doc_mapping"
+            ).write_text(json.dumps({}))
+            (
+                meta / "bomsh_hook_raw_logfile"
+            ).write_text("")
+
+            comp_meta = {
+                "distro": "Ubuntu 22.04",
+                "gcc_version": "gcc 11.4.0",
+                "curl_version": "8.19.0",
+                "pkg_metadata": {},
+                "file_to_pkg": {},
+                "unresolved_files": [],
+            }
+            (
+                bom / "metadata"
+                / "component_metadata.json"
+            ).write_text(json.dumps(comp_meta))
+
+            dynlibs = {
+                "binary": "/repos/curl/src/.libs/curl",
+                "direct_needed": [],
+                "dynamic_libs": {},
+                "libcurl_needed": [],
+            }
+            (
+                bom / "metadata"
+                / "dynamic_libs.json"
+            ).write_text(json.dumps(dynlibs))
+
+            out = str(
+                Path(td) / "out" / "curl.spdx.json"
+            )
+            gen = AdgSpdxGenerator(
+                bom_dir=str(bom),
+                repos_dir="/repos",
+                repo_name="curl",
+            )
+            # Make spdx_visualize.generate_html raise
+            with patch(
+                "spdx_visualize.generate_html",
+                side_effect=RuntimeError("viz failed"),
+            ), patch("builtins.print"):
+                result = gen.generate(out)
+
+            # Should still succeed
+            self.assertIsNotNone(result)
+            self.assertTrue(Path(out).exists())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add AWS EC2 setup guide, Terraform IaC config, and build/runtime reports for all 4 repos (curl, redis, nmap, ffmpeg) in the new {ts}/ subfolder format. Update .gitignore to exclude output/binaries/. Clean up old-format doc files with datetime in filenames.