### PR TITLE
feat: add Go language support to analysis pipeline

### DIFF
--- a/.windsurf/rules/omnibor-rules.md
+++ b/.windsurf/rules/omnibor-rules.md
@@ -14,7 +14,7 @@ description: Rules for OmniBOR/Bomsh build interception workflow
 - **Build Metadata Extraction** (Yocto SBOM, Maven plugins) is NOT true build interception;
   it is essentially manifest scanning enhanced with build-system context
 
-## Full Pipeline Sequence
+## Full Pipeline Sequence (C/C++)
 
 1. Clone target repo into `repos/<name>/`
 2. Syft baseline SBOM (manifest-based, for comparison)
@@ -32,6 +32,20 @@ description: Rules for OmniBOR/Bomsh build interception workflow
     - Automatic version detection for vendored libs
     - Interactive D3.js HTML dependency graph
 11. SPDX validation (JSON Schema + semantic)
+
+## Go Pipeline Sequence
+
+bomtrace3 intercepts C/C++ compiler calls (gcc, g++) via ptrace. It does **not**
+intercept `go build`, which is a single static binary. For Go repos:
+
+1. Clone target repo into `repos/<name>/`
+2. Syft SBOM (primary — parses go.mod/go.sum for direct + indirect deps)
+4. Plain build via `PlainBuilder` (runs `go build` without bomtrace3)
+6. Validate Syft SPDX
+7. Collect output binaries
+8. Write docs
+
+Steps 3, 5–5c are skipped. Syft is the primary SBOM generator for Go.
 
 ## Key Paths Inside Container
 

--- a/.windsurf/rules/project-context.md
+++ b/.windsurf/rules/project-context.md
@@ -4,10 +4,11 @@ description: Project context and architecture for omnibor-analysis
 
 # Project: OmniBOR Analysis
 
-This project instruments open-source builds (C/C++, Go) with OmniBOR/Bomsh (build interception)
-to generate SPDX 2.3 SBOMs with full dependency breakdown (vendored static libs, dynamic
-system libs, build tools), then optionally compares those against SBOMs from proprietary
-binary scanning tools (e.g., BDBA) to evaluate accuracy and completeness.
+This project instruments open-source builds with OmniBOR/Bomsh (build interception for C/C++)
+or Syft (manifest-based for Go) to generate SPDX 2.3 SBOMs with full dependency breakdown
+(vendored static libs, dynamic system libs, build tools), then optionally compares those
+against SBOMs from proprietary binary scanning tools (e.g., BDBA) to evaluate accuracy
+and completeness.
 
 ## Directory Structure
 
@@ -22,15 +23,17 @@ binary scanning tools (e.g., BDBA) to evaluate accuracy and completeness.
 
 ## Key Technologies
 
-- **Bomsh/Bomtrace3** — ptrace-based build interception from omnibor/bomsh (Linux x86_64 only)
+- **Bomsh/Bomtrace3** — ptrace-based build interception from omnibor/bomsh (Linux x86_64 only, C/C++)
 - **OmniBOR** — Artifact Dependency Graph (ADG) standard (omnibor.io)
 - **SPDX 2.3** — SBOM format (JSON output)
-- **Syft** — Manifest-based SBOM generation (baseline comparison)
+- **Syft** — Manifest-based SBOM generation (primary for Go, baseline for C/C++)
+- **Go SDK** — Go 1.23+ installed in the container for building Go targets
 - **D3.js** — Interactive HTML dependency graph visualization
 - **Docker** — Required because bomtrace3 uses Linux ptrace (not available on macOS/Windows)
 
-## Analysis Pipeline (8 steps in analyze.py)
+## Analysis Pipeline (analyze.py)
 
+### C/C++ repos (full OmniBOR instrumentation)
 1. Clone target repo
 2. Syft baseline SBOM (manifest-based)
 3. Validate apt dependencies
@@ -41,6 +44,16 @@ binary scanning tools (e.g., BDBA) to evaluate accuracy and completeness.
 6. SPDX validation (JSON Schema + semantic)
 7. Binary collection
 8. Documentation generation
+
+### Go repos (Syft-primary, plain build)
+1. Clone target repo
+2. Syft SBOM (primary — parses go.mod/go.sum)
+4. Plain build via PlainBuilder (no bomtrace3)
+6. SPDX validation
+7. Binary collection
+8. Documentation generation
+
+Steps 3, 5a-5c are skipped for Go because bomtrace3 does not intercept `go build`.
 
 ## Key Application Files
 
@@ -69,7 +82,13 @@ binary scanning tools (e.g., BDBA) to evaluate accuracy and completeness.
 
 ### Go (`language: go`)
 
-No Go repos configured yet. Use `/add-repo` to add one.
+| Repo | Binary | Direct deps | Indirect deps |
+|------|--------|-------------|---------------|
+| fzf | fzf | ~7 | ~4 |
+| lazygit | lazygit | ~15-20 | ~20-30 |
+| croc | croc | ~10-15 | ~15 |
+| dive | dive | ~15-20 | ~25 |
+| gdu | gdu | ~10-15 | ~15-20 |
 
 ## Important Constraints
 
@@ -78,4 +97,6 @@ No Go repos configured yet. Use `/add-repo` to add one.
 - repos/ and output/ are gitignored — only docs/, app/, tests/, docker/ are tracked
 - config.yaml is the single source of truth for repo URLs, build commands, language, and paths
 - Each repo has a `language` field (`c-cpp`, `go`) that determines its output subfolder
+- Go repos use `PlainBuilder` (no bomtrace3) and Syft as the primary SBOM generator
+- C/C++ repos use `BomtraceBuilder` (bomtrace3 instrumentation) and bomsh for OmniBOR SBOMs
 - Per-file test coverage must be 95%+, overall 97%+ (enforced in pre-commit.md)

--- a/.windsurf/workflows/run-analysis.md
+++ b/.windsurf/workflows/run-analysis.md
@@ -4,8 +4,8 @@ description: Run OmniBOR build interception analysis on a target repository
 
 # Run Analysis
 
-Instrument a C/C++ build with bomtrace3 and generate SPDX SBOMs with
-dependency visualization.
+Instrument a C/C++ build with bomtrace3 or build a Go project with
+`go build`, then generate SPDX SBOMs with dependency visualization.
 
 ## Prerequisites
 
@@ -76,8 +76,9 @@ rsync -avz <SSH_ALIAS>:<REPO_PATH>/docs/ docs/
 
 Never report analysis as complete until both syncs succeed.
 
-## What happens during analysis (8 steps)
+## What happens during analysis
 
+### C/C++ repos (8 steps)
 1. **Clone** — shallow clone of the target repo
 2. **Syft baseline** — manifest-based SPDX SBOM for comparison
 3. **Validate deps** — checks `apt_deps` are installed in the container
@@ -87,6 +88,14 @@ Never report analysis as complete until both syncs succeed.
 5c. **ADG SPDX generation** — per-binary SPDX with vendored detection, version extraction, dynamic lib resolution + HTML visualization
 6. **SPDX validation** — JSON Schema + semantic validation of all generated SBOMs
 7. **Binary collection** — copies `output_binaries` to `output/binaries/<lang>/<repo>/`
+8. **Docs** — timestamped build log and runtime metrics
+
+### Go repos (5 steps — bomtrace3 skipped)
+1. **Clone** — shallow clone of the target repo
+2. **Syft SBOM** — primary SBOM (parses go.mod/go.sum for direct + indirect deps)
+4. **Plain build** — `go build` via PlainBuilder (no bomtrace3)
+6. **SPDX validation** — validates the Syft SPDX
+7. **Binary collection** — copies output binaries
 8. **Docs** — timestamped build log and runtime metrics
 
 ## Output locations

--- a/app/analyze.py
+++ b/app/analyze.py
@@ -194,6 +194,65 @@ class RepoCloner:
 
 
 # ============================================================
+# Plain (uninstrumented) build
+# ============================================================
+
+class PlainBuilder:
+    """Runs build steps without bomtrace3 instrumentation.
+
+    Used for Go and other languages where bomtrace3 does not
+    intercept compiler calls.  The build steps come directly
+    from config.yaml (e.g. ``go build -o fzf .``).
+    """
+
+    def __init__(self, runner=None):
+        self.runner = runner or CommandRunner()
+
+    def build(
+        self, repo_name, repo_cfg,
+        paths_cfg, run_ts=None,
+    ):
+        """Run all build steps sequentially.
+
+        Returns True on success, False on failure.
+        """
+        repo_dir = (
+            Path(paths_cfg["repos_dir"]) / repo_name
+        )
+
+        # Optional clean step
+        clean_cmd = repo_cfg.get("clean_cmd")
+        if clean_cmd:
+            self.runner.run(
+                clean_cmd, cwd=str(repo_dir),
+                description=(
+                    f"Clean: {clean_cmd}"
+                ),
+            )
+
+        build_steps = repo_cfg.get("build_steps", [])
+        for step in build_steps:
+            rc = self.runner.run(
+                step, cwd=str(repo_dir),
+                description=(
+                    f"Build: {step[:60]}"
+                ),
+            )
+            if rc != 0:
+                print(
+                    f"[ERROR] Build step failed: "
+                    f"{step}"
+                )
+                return False
+
+        print(
+            f"[OK] Plain build completed for "
+            f"{repo_name}"
+        )
+        return True
+
+
+# ============================================================
 # Bomtrace3 instrumented build
 # ============================================================
 
@@ -1370,10 +1429,10 @@ class DocWriter:
 class AnalysisPipeline:
     """Orchestrates the full OmniBOR analysis workflow.
 
-    Composes CommandRunner, RepoCloner, BomtraceBuilder,
-    SpdxGenerator, MetadataCollector, AdgSpdxStep,
-    SpdxValidator, SyftGenerator, BinaryCollector,
-    and DocWriter.
+    Composes CommandRunner, RepoCloner, PlainBuilder,
+    BomtraceBuilder, SpdxGenerator, MetadataCollector,
+    AdgSpdxStep, SpdxValidator, SyftGenerator,
+    BinaryCollector, and DocWriter.
     """
 
     def __init__(
@@ -1382,6 +1441,7 @@ class AnalysisPipeline:
         validator=None,
         cloner=None,
         builder=None,
+        plain_builder=None,
         spdx_gen=None,
         metadata_collector=None,
         adg_spdx=None,
@@ -1400,6 +1460,10 @@ class AnalysisPipeline:
         )
         self.builder = builder or BomtraceBuilder(
             self.runner
+        )
+        self.plain_builder = (
+            plain_builder
+            or PlainBuilder(self.runner)
         )
         self.spdx_gen = spdx_gen or SpdxGenerator(
             self.runner
@@ -1507,13 +1571,16 @@ def main():
     print(f"  {desc}")
     print(f"{'#'*60}\n")
 
+    lang = lang_subdir(repo_cfg)
+
     # Step 1: Clone
     if not args.skip_clone:
         pipeline.cloner.clone(
             args.repo, repo_cfg, paths_cfg
         )
 
-    # Step 2: Syft baseline SBOM
+    # Step 2: Syft SBOM (manifest-based — works for
+    # all languages; primary SBOM for Go repos)
     pipeline.syft_gen.generate(
         args.repo, repo_cfg, paths_cfg,
         run_ts=run_ts,
@@ -1522,10 +1589,52 @@ def main():
     if args.syft_only:
         print(
             "\n[DONE] Syft-only mode — "
-            "skipping instrumented build."
+            "skipping build."
         )
         return
 
+    # -------------------------------------------------
+    # Language-specific pipeline branch
+    # -------------------------------------------------
+    if lang == "c-cpp":
+        success, duration = _run_c_cpp_pipeline(
+            pipeline, args.repo, repo_cfg,
+            paths_cfg, omnibor_cfg, run_ts,
+        )
+    else:
+        success, duration = _run_go_pipeline(
+            pipeline, args.repo, repo_cfg,
+            paths_cfg, run_ts,
+        )
+
+    # Step 8: Write docs (all languages)
+    pipeline.docs.write_build_doc(
+        args.repo, repo_cfg, paths_cfg,
+        success, duration,
+        run_ts=run_ts,
+    )
+    pipeline.docs.write_runtime_doc(
+        args.repo, repo_cfg, paths_cfg,
+        duration, run_ts=run_ts,
+    )
+
+    status = "COMPLETE" if success else "FAILED"
+    print(f"\n{'#'*60}")
+    print(f"  Analysis {status}: {args.repo}")
+    print(f"  Duration: {duration:.1f}s")
+    print(f"{'#'*60}\n")
+
+
+def _run_c_cpp_pipeline(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_cfg, run_ts,
+):
+    """C/C++ pipeline: apt validation, bomtrace3 build,
+    OmniBOR SPDX, metadata, ADG SPDX, validation,
+    binary collection.
+
+    Returns (success, duration_sec).
+    """
     # Step 3: Validate apt dependencies
     deps_ok, missing = (
         pipeline.validator.validate(repo_cfg)
@@ -1542,17 +1651,17 @@ def main():
     # Step 4: Instrumented build
     start = time.time()
     success = pipeline.builder.build(
-        args.repo, repo_cfg,
+        repo_name, repo_cfg,
         paths_cfg, omnibor_cfg,
         run_ts=run_ts,
     )
     duration = time.time() - start
 
-    # Step 5a: Generate SPDX from OmniBOR (bomsh_sbom.py)
+    # Step 5a: Generate SPDX from OmniBOR
     spdx_file = None
     if success:
         spdx_file = pipeline.spdx_gen.generate(
-            args.repo, repo_cfg,
+            repo_name, repo_cfg,
             paths_cfg, omnibor_cfg,
             run_ts=run_ts,
         )
@@ -1560,7 +1669,7 @@ def main():
     # Step 5b: Collect component metadata + dynamic libs
     if success:
         pipeline.metadata_collector.collect(
-            args.repo, repo_cfg, paths_cfg,
+            repo_name, repo_cfg, paths_cfg,
             run_ts=run_ts,
         )
 
@@ -1568,7 +1677,7 @@ def main():
     adg_files = []
     if success:
         adg_files = pipeline.adg_spdx.generate(
-            args.repo, repo_cfg, paths_cfg,
+            repo_name, repo_cfg, paths_cfg,
             run_ts=run_ts,
         )
 
@@ -1581,26 +1690,55 @@ def main():
     # Step 7: Collect output binaries
     if success:
         pipeline.binary_collector.collect(
-            args.repo, repo_cfg, paths_cfg,
+            repo_name, repo_cfg, paths_cfg,
             run_ts=run_ts,
         )
 
-    # Step 8: Write docs
-    pipeline.docs.write_build_doc(
-        args.repo, repo_cfg, paths_cfg,
-        success, duration,
+    return success, duration
+
+
+def _run_go_pipeline(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, run_ts,
+):
+    """Go pipeline: plain build, binary collection,
+    Syft SPDX validation.
+
+    bomtrace3 does not intercept ``go build`` compiler
+    calls, so OmniBOR ADG steps are skipped.  Syft is
+    the primary SBOM generator for Go repos (it parses
+    go.mod/go.sum natively).
+
+    Returns (success, duration_sec).
+    """
+    # Step 4: Plain build (no bomtrace3)
+    start = time.time()
+    success = pipeline.plain_builder.build(
+        repo_name, repo_cfg, paths_cfg,
         run_ts=run_ts,
     )
-    pipeline.docs.write_runtime_doc(
-        args.repo, repo_cfg, paths_cfg,
-        duration, run_ts=run_ts,
-    )
+    duration = time.time() - start
 
-    status = "COMPLETE" if success else "FAILED"
-    print(f"\n{'#'*60}")
-    print(f"  Analysis {status}: {args.repo}")
-    print(f"  Duration: {duration:.1f}s")
-    print(f"{'#'*60}\n")
+    # Step 6: Validate Syft SPDX
+    lang = lang_subdir(repo_cfg)
+    syft_spdx = (
+        Path(paths_cfg["output_dir"])
+        / "spdx" / lang / repo_name / run_ts
+        / f"{repo_name}_syft.spdx.json"
+    )
+    if syft_spdx.exists():
+        pipeline.spdx_validator.validate(
+            str(syft_spdx)
+        )
+
+    # Step 7: Collect output binaries
+    if success:
+        pipeline.binary_collector.collect(
+            repo_name, repo_cfg, paths_cfg,
+            run_ts=run_ts,
+        )
+
+    return success, duration
 
 
 if __name__ == "__main__":

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -94,6 +94,56 @@ repos:
     output_binaries:
     - src/redis-server
     - src/redis-cli
+  fzf:
+    url: https://github.com/junegunn/fzf.git
+    branch: master
+    language: go
+    build_steps:
+    - go build -o fzf .
+    clean_cmd: rm -f fzf
+    description: Fuzzy finder CLI (~7 direct + 4 indirect Go deps)
+    output_binaries:
+    - fzf
+  lazygit:
+    url: https://github.com/jesseduffield/lazygit.git
+    branch: master
+    language: go
+    build_steps:
+    - go build -o lazygit .
+    clean_cmd: rm -f lazygit
+    description: Terminal UI for git (~15-20 direct + 20-30 indirect Go deps)
+    output_binaries:
+    - lazygit
+  croc:
+    url: https://github.com/schollz/croc.git
+    branch: main
+    language: go
+    build_steps:
+    - go build -o croc .
+    clean_cmd: rm -f croc
+    description: Secure file transfer tool (~10-15 direct + 15 indirect Go deps)
+    output_binaries:
+    - croc
+  dive:
+    url: https://github.com/wagoodman/dive.git
+    branch: main
+    language: go
+    build_steps:
+    - go build -o dive .
+    clean_cmd: rm -f dive
+    description: Docker image layer explorer (~15-20 direct + 25 indirect Go deps)
+    output_binaries:
+    - dive
+  gdu:
+    url: https://github.com/dundee/gdu.git
+    branch: master
+    language: go
+    build_steps:
+    - go build -o gdu ./cmd/gdu
+    clean_cmd: rm -f gdu
+    description: Fast disk usage analyzer with TUI (~10-15 direct + 15-20 indirect Go deps)
+    output_binaries:
+    - gdu
 paths:
   repos_dir: /workspace/repos
   output_dir: /workspace/output

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,6 +80,18 @@ RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
 # ============================================================
+# Install Go SDK (for building Go target repositories)
+# ============================================================
+# Go 1.23+ is required by fzf and other Go targets.
+# We install the official tarball to /usr/local/go.
+ENV GO_VERSION=1.23.6
+RUN wget -q "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O /tmp/go.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go.tar.gz && \
+    rm /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
+ENV GOPATH="/root/go"
+
+# ============================================================
 # Build bomtrace2 and bomtrace3 from omnibor/bomsh
 # ============================================================
 #

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -17,10 +17,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "app"))
 import analyze
 from analyze import (
     CommandRunner, DependencyValidator,
-    RepoCloner, BomtraceBuilder,
+    RepoCloner, PlainBuilder, BomtraceBuilder,
     SpdxGenerator, MetadataCollector, SpdxValidator,
     SyftGenerator, BinaryCollector, DocWriter,
     AnalysisPipeline, load_config, timestamp,
+    _run_go_pipeline,
 )
 
 
@@ -385,6 +386,117 @@ class TestBomtraceBuilder(unittest.TestCase):
         self.assertIn(
             "bomtrace3", instrumented_call[0][0]
         )
+
+
+# ============================================================
+# PlainBuilder
+# ============================================================
+
+class TestPlainBuilder(unittest.TestCase):
+    """Tests for PlainBuilder (Go / non-instrumented)."""
+
+    def test_success(self):
+        runner = MagicMock()
+        runner.run.return_value = 0
+        builder = PlainBuilder(runner)
+        repo_cfg = {
+            "build_steps": ["go build -o fzf ."],
+            "language": "go",
+        }
+        paths = {"repos_dir": "/repos"}
+
+        with patch("builtins.print"):
+            result = builder.build(
+                "fzf", repo_cfg, paths
+            )
+        self.assertTrue(result)
+        runner.run.assert_called_once()
+
+    def test_failure(self):
+        runner = MagicMock()
+        runner.run.return_value = 1
+        builder = PlainBuilder(runner)
+        repo_cfg = {
+            "build_steps": ["go build -o fzf ."],
+            "language": "go",
+        }
+        paths = {"repos_dir": "/repos"}
+
+        with patch("builtins.print"):
+            result = builder.build(
+                "fzf", repo_cfg, paths
+            )
+        self.assertFalse(result)
+
+    def test_clean_cmd(self):
+        runner = MagicMock()
+        runner.run.return_value = 0
+        builder = PlainBuilder(runner)
+        repo_cfg = {
+            "build_steps": ["go build -o fzf ."],
+            "clean_cmd": "rm -f fzf",
+            "language": "go",
+        }
+        paths = {"repos_dir": "/repos"}
+
+        with patch("builtins.print"):
+            builder.build("fzf", repo_cfg, paths)
+        # clean + build = 2 calls
+        self.assertEqual(runner.run.call_count, 2)
+
+    def test_multiple_steps(self):
+        runner = MagicMock()
+        runner.run.return_value = 0
+        builder = PlainBuilder(runner)
+        repo_cfg = {
+            "build_steps": [
+                "go mod download",
+                "go build -o fzf .",
+            ],
+            "language": "go",
+        }
+        paths = {"repos_dir": "/repos"}
+
+        with patch("builtins.print"):
+            result = builder.build(
+                "fzf", repo_cfg, paths
+            )
+        self.assertTrue(result)
+        self.assertEqual(runner.run.call_count, 2)
+
+    def test_first_step_fails(self):
+        runner = MagicMock()
+        runner.run.side_effect = [1]
+        builder = PlainBuilder(runner)
+        repo_cfg = {
+            "build_steps": [
+                "go mod download",
+                "go build -o fzf .",
+            ],
+            "language": "go",
+        }
+        paths = {"repos_dir": "/repos"}
+
+        with patch("builtins.print"):
+            result = builder.build(
+                "fzf", repo_cfg, paths
+            )
+        self.assertFalse(result)
+        # Should stop after first failure
+        self.assertEqual(runner.run.call_count, 1)
+
+    def test_no_build_steps(self):
+        runner = MagicMock()
+        builder = PlainBuilder(runner)
+        repo_cfg = {"language": "go"}
+        paths = {"repos_dir": "/repos"}
+
+        with patch("builtins.print"):
+            result = builder.build(
+                "fzf", repo_cfg, paths
+            )
+        self.assertTrue(result)
+        runner.run.assert_not_called()
 
 
 # ============================================================
@@ -1797,6 +1909,9 @@ class TestAnalysisPipeline(unittest.TestCase):
             p.builder, BomtraceBuilder
         )
         self.assertIsInstance(
+            p.plain_builder, PlainBuilder
+        )
+        self.assertIsInstance(
             p.spdx_gen, SpdxGenerator
         )
         self.assertIsInstance(
@@ -1850,6 +1965,7 @@ def _mock_pipeline():
     validator.validate.return_value = (True, [])
     cloner = MagicMock()
     builder = MagicMock()
+    plain_builder = MagicMock()
     spdx_gen = MagicMock()
     metadata_collector = MagicMock()
     adg_spdx = MagicMock()
@@ -1863,6 +1979,7 @@ def _mock_pipeline():
         validator=validator,
         cloner=cloner,
         builder=builder,
+        plain_builder=plain_builder,
         spdx_gen=spdx_gen,
         metadata_collector=metadata_collector,
         adg_spdx=adg_spdx,
@@ -2032,6 +2149,134 @@ class TestMainFullRun(unittest.TestCase):
         p.syft_gen.generate.assert_called_once()
         p.builder.build.assert_not_called()
         p.spdx_gen.generate.assert_not_called()
+
+
+# ============================================================
+# Go pipeline (main + _run_go_pipeline)
+# ============================================================
+
+class TestMainGoRepo(unittest.TestCase):
+    """Tests for main() with Go repos."""
+
+    @patch("analyze.time.time")
+    @patch("analyze.AnalysisPipeline")
+    @patch(
+        "sys.argv",
+        ["analyze.py", "--repo", "fzf"],
+    )
+    def test_go_uses_plain_builder(
+        self, mock_cls, mock_time
+    ):
+        p = _mock_pipeline()
+        mock_cls.return_value = p
+        p.plain_builder.build.return_value = True
+        mock_time.side_effect = [100.0, 110.0]
+
+        with patch("builtins.print"):
+            analyze.main()
+
+        # Go path: plain_builder used, NOT builder
+        p.plain_builder.build.assert_called_once()
+        p.builder.build.assert_not_called()
+        # No bomtrace steps
+        p.validator.validate.assert_not_called()
+        p.spdx_gen.generate.assert_not_called()
+        p.metadata_collector.collect.assert_not_called()
+        p.adg_spdx.generate.assert_not_called()
+        # Common steps still called
+        p.cloner.clone.assert_called_once()
+        p.syft_gen.generate.assert_called_once()
+        p.binary_collector.collect.assert_called_once()
+        p.docs.write_build_doc.assert_called_once()
+        p.docs.write_runtime_doc.assert_called_once()
+
+    @patch("analyze.time.time")
+    @patch("analyze.AnalysisPipeline")
+    @patch(
+        "sys.argv",
+        ["analyze.py", "--repo", "fzf"],
+    )
+    def test_go_build_failure(
+        self, mock_cls, mock_time
+    ):
+        p = _mock_pipeline()
+        mock_cls.return_value = p
+        p.plain_builder.build.return_value = False
+        mock_time.side_effect = [100.0, 110.0]
+
+        with patch("builtins.print"):
+            analyze.main()
+
+        p.binary_collector.collect.assert_not_called()
+        p.docs.write_build_doc.assert_called_once()
+
+    @patch("analyze.time.time")
+    @patch("analyze.AnalysisPipeline")
+    @patch(
+        "sys.argv",
+        [
+            "analyze.py", "--repo", "fzf",
+            "--syft-only",
+        ],
+    )
+    def test_go_syft_only(
+        self, mock_cls, mock_time
+    ):
+        p = _mock_pipeline()
+        mock_cls.return_value = p
+
+        with patch("builtins.print"):
+            analyze.main()
+
+        p.syft_gen.generate.assert_called_once()
+        p.plain_builder.build.assert_not_called()
+        p.builder.build.assert_not_called()
+
+
+class TestRunGoPipeline(unittest.TestCase):
+    """Unit tests for _run_go_pipeline."""
+
+    def test_validates_syft_spdx(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = _mock_pipeline()
+            p.plain_builder.build.return_value = True
+            repo_cfg = {"language": "go"}
+            paths_cfg = {"output_dir": td}
+
+            # Create the Syft SPDX file
+            spdx_dir = (
+                Path(td) / "spdx" / "go"
+                / "fzf" / "2026-03-04_1200"
+            )
+            spdx_dir.mkdir(parents=True)
+            (
+                spdx_dir / "fzf_syft.spdx.json"
+            ).write_text("{}")
+
+            with patch("builtins.print"):
+                success, duration = _run_go_pipeline(
+                    p, "fzf", repo_cfg,
+                    paths_cfg, "2026-03-04_1200",
+                )
+
+            self.assertTrue(success)
+            p.spdx_validator.validate.assert_called_once()
+
+    def test_skips_validation_no_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = _mock_pipeline()
+            p.plain_builder.build.return_value = True
+            repo_cfg = {"language": "go"}
+            paths_cfg = {"output_dir": td}
+
+            with patch("builtins.print"):
+                success, duration = _run_go_pipeline(
+                    p, "fzf", repo_cfg,
+                    paths_cfg, "2026-03-04_1200",
+                )
+
+            self.assertTrue(success)
+            p.spdx_validator.validate.assert_not_called()
 
 
 # ============================================================


### PR DESCRIPTION
- Add PlainBuilder class for non-instrumented builds (Go)
- Add _run_go_pipeline / _run_c_cpp_pipeline to branch by language
- Add Go 1.23 SDK to Dockerfile
- Add 5 Go repos to config.yaml: fzf, lazygit, croc, dive, gdu
- Go repos skip bomtrace3/bomsh steps, use Syft as primary SBOM
- Update AnalysisPipeline with plain_builder component
- Add PlainBuilder, Go pipeline, and main() Go tests (372 pass, 99%)
- Update project-context.md, omnibor-rules.md, run-analysis.md