### PR TITLE
fix: make DocWriter templates language-aware for Go repos

### DIFF
--- a/app/analyze.py
+++ b/app/analyze.py
@@ -1345,12 +1345,26 @@ class DocWriter:
         ):
             content += f"{i}. `{step}`\n"
 
+        lang = lang_subdir(repo_cfg)
+        if lang == "c-cpp":
+            content += (
+                "\n## Instrumentation\n\n"
+                "- **Tracer:** bomtrace3\n"
+                "- **Raw logfile:** "
+                "/tmp/bomsh_hook_raw_logfile"
+                ".sha1\n"
+            )
+        else:
+            content += (
+                "\n## Instrumentation\n\n"
+                "- **Builder:** PlainBuilder "
+                "(no bomtrace3)\n"
+                "- **SBOM source:** Syft "
+                "(go.mod/go.sum)\n"
+            )
+
         content += (
-            "\n## Instrumentation\n\n"
-            "- **Tracer:** bomtrace3\n"
-            "- **Raw logfile:** "
-            "/tmp/bomsh_hook_raw_logfile.sha1\n\n"
-            "## Output Binaries\n\n"
+            "\n## Output Binaries\n\n"
         )
         for binary in repo_cfg.get(
             "output_binaries", []
@@ -1396,19 +1410,34 @@ class DocWriter:
                 f"{pct:.1f}%"
             )
 
+        if lang == "c-cpp":
+            build_label = "Instrumented build time"
+            notes = (
+                "- Measured wall-clock time for the "
+                "instrumented `make` step only\n"
+                "- Baseline (uninstrumented) build "
+                "time should be recorded separately "
+                "for comparison\n"
+            )
+        else:
+            build_label = "Build time"
+            notes = (
+                "- Measured wall-clock time for "
+                "`go build` (plain, no "
+                "bomtrace3)\n"
+                "- Syft SBOM generated from "
+                "go.mod/go.sum manifest\n"
+            )
+
         content = (
             f"# Runtime Metrics — {repo_name}\n\n"
             f"**Date:** "
             f"{datetime.now().isoformat()}\n"
-            f"**Instrumented build time:** "
+            f"**{build_label}:** "
             f"{duration_sec:.1f} seconds\n"
             f"{overhead_pct}\n\n"
             "## Notes\n\n"
-            "- Measured wall-clock time for the "
-            "instrumented `make` step only\n"
-            "- Baseline (uninstrumented) build time "
-            "should be recorded separately "
-            "for comparison\n"
+            f"{notes}"
         )
 
         with open(

--- a/docs/curl/2026-02-11_2209_build.md
+++ b/docs/curl/2026-02-11_2209_build.md
@@ -1,0 +1,27 @@
+# Build Log — curl
+
+**Date:** 2026-02-11T22:09:36.304442
+**Status:** FAILED
+**Duration:** 59.1 seconds
+
+## Repository
+
+- **URL:** https://github.com/curl/curl.git
+- **Branch:** master
+- **Description:** HTTP transfer library and CLI tool (~170K LoC)
+
+## Build Steps
+
+1. `autoreconf -fi`
+2. `./configure --with-openssl --with-zlib --with-nghttp2 --with-libssh2 --with-brotli`
+3. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/.libs/curl`
+- `lib/.libs/libcurl.so`

--- a/docs/curl/2026-02-11_2338_build.md
+++ b/docs/curl/2026-02-11_2338_build.md
@@ -1,0 +1,27 @@
+# Build Log — curl
+
+**Date:** 2026-02-11T23:38:29.200883
+**Status:** FAILED
+**Duration:** 466.1 seconds
+
+## Repository
+
+- **URL:** https://github.com/curl/curl.git
+- **Branch:** master
+- **Description:** HTTP transfer library and CLI tool (~170K LoC)
+
+## Build Steps
+
+1. `autoreconf -fi`
+2. `./configure --with-openssl --with-zlib --with-nghttp2 --with-libssh2 --with-brotli`
+3. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/.libs/curl`
+- `lib/.libs/libcurl.so`

--- a/docs/curl/2026-02-11_2350_build.md
+++ b/docs/curl/2026-02-11_2350_build.md
@@ -1,0 +1,27 @@
+# Build Log — curl
+
+**Date:** 2026-02-11T23:50:16.853935
+**Status:** FAILED
+**Duration:** 394.0 seconds
+
+## Repository
+
+- **URL:** https://github.com/curl/curl.git
+- **Branch:** master
+- **Description:** HTTP transfer library and CLI tool (~170K LoC)
+
+## Build Steps
+
+1. `autoreconf -fi`
+2. `./configure --with-openssl --with-zlib --with-nghttp2 --with-libssh2 --with-brotli`
+3. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/.libs/curl`
+- `lib/.libs/libcurl.so`

--- a/docs/curl/2026-02-26_2215_build.md
+++ b/docs/curl/2026-02-26_2215_build.md
@@ -1,0 +1,27 @@
+# Build Log — curl
+
+**Date:** 2026-02-26T22:15:16.163465
+**Status:** SUCCESS
+**Duration:** 70.2 seconds
+
+## Repository
+
+- **URL:** https://github.com/curl/curl.git
+- **Branch:** master
+- **Description:** HTTP transfer library and CLI tool (~170K LoC)
+
+## Build Steps
+
+1. `autoreconf -fi`
+2. `./configure --with-openssl --with-zlib --with-nghttp2 --with-libssh2 --with-brotli`
+3. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/.libs/curl`
+- `lib/.libs/libcurl.so`

--- a/docs/curl/2026-02-26_2307/build.md
+++ b/docs/curl/2026-02-26_2307/build.md
@@ -1,0 +1,27 @@
+# Build Log — curl
+
+**Date:** 2026-02-26T23:08:39.105248
+**Status:** SUCCESS
+**Duration:** 71.1 seconds
+
+## Repository
+
+- **URL:** https://github.com/curl/curl.git
+- **Branch:** master
+- **Description:** HTTP transfer library and CLI tool (~170K LoC)
+
+## Build Steps
+
+1. `autoreconf -fi`
+2. `./configure --with-openssl --with-zlib --with-nghttp2 --with-libssh2 --with-brotli`
+3. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/.libs/curl`
+- `lib/.libs/libcurl.so`

--- a/docs/ffmpeg/2026-02-26_2230_build.md
+++ b/docs/ffmpeg/2026-02-26_2230_build.md
@@ -1,0 +1,30 @@
+# Build Log — ffmpeg
+
+**Date:** 2026-02-26T22:30:12.623985
+**Status:** SUCCESS
+**Duration:** 732.6 seconds
+
+## Repository
+
+- **URL:** https://github.com/FFmpeg/FFmpeg.git
+- **Branch:** master
+- **Description:** Multimedia framework (~1.2M LoC, 20+ third-party libs)
+
+## Build Steps
+
+1. `./configure --enable-gpl --enable-nonfree --enable-shared --disable-static --enable-libx264 --enable-libx265 --enable-libvpx --enable-libopus --enable-libmp3lame --enable-libfdk-aac --enable-libfreetype --enable-libfontconfig --enable-libfribidi --enable-libass --enable-openssl`
+2. `make -j1`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `ffmpeg`
+- `ffprobe`
+- `libavcodec/libavcodec.so`
+- `libavformat/libavformat.so`
+- `libavutil/libavutil.so`
+- `libswscale/libswscale.so`

--- a/docs/ffmpeg/2026-03-04_1949/build.md
+++ b/docs/ffmpeg/2026-03-04_1949/build.md
@@ -1,0 +1,30 @@
+# Build Log — ffmpeg
+
+**Date:** 2026-03-04T20:02:39.819859
+**Status:** SUCCESS
+**Duration:** 744.4 seconds
+
+## Repository
+
+- **URL:** https://github.com/FFmpeg/FFmpeg.git
+- **Branch:** master
+- **Description:** Multimedia framework (~1.2M LoC, 20+ third-party libs)
+
+## Build Steps
+
+1. `./configure --enable-gpl --enable-nonfree --enable-shared --disable-static --enable-libx264 --enable-libx265 --enable-libvpx --enable-libopus --enable-libmp3lame --enable-libfdk-aac --enable-libfreetype --enable-libfontconfig --enable-libfribidi --enable-libass --enable-openssl`
+2. `make -j1`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `ffmpeg`
+- `ffprobe`
+- `libavcodec/libavcodec.so`
+- `libavformat/libavformat.so`
+- `libavutil/libavutil.so`
+- `libswscale/libswscale.so`

--- a/docs/go/lazygit/2026-03-04_2255/build.md
+++ b/docs/go/lazygit/2026-03-04_2255/build.md
@@ -1,0 +1,24 @@
+# Build Log — lazygit
+
+**Date:** 2026-03-04T22:55:44.787500
+**Status:** SUCCESS
+**Duration:** 28.0 seconds
+
+## Repository
+
+- **URL:** https://github.com/jesseduffield/lazygit.git
+- **Branch:** master
+- **Description:** Terminal UI for git (~15-20 direct + 20-30 indirect Go deps)
+
+## Build Steps
+
+1. `go build -o lazygit .`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `lazygit`

--- a/docs/nmap/2026-02-26_2216_build.md
+++ b/docs/nmap/2026-02-26_2216_build.md
@@ -1,0 +1,27 @@
+# Build Log — nmap
+
+**Date:** 2026-02-26T22:16:37.524302
+**Status:** SUCCESS
+**Duration:** 54.6 seconds
+
+## Repository
+
+- **URL:** https://github.com/nmap/nmap.git
+- **Branch:** master
+- **Description:** Network scanner with 10 vendored libs + 10+ dynamic system deps (~420 source files, C/C++)
+
+## Build Steps
+
+1. `./configure --with-libpcre=/usr --with-libz=/usr --with-libssh2=/usr --with-openssl=/usr --with-libdnet=included --with-liblua=included --with-liblinear=included --without-zenmap --without-ndiff`
+2. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `nmap`
+- `ncat/ncat`
+- `nping/nping`

--- a/docs/nmap/2026-03-04_1948/build.md
+++ b/docs/nmap/2026-03-04_1948/build.md
@@ -1,0 +1,27 @@
+# Build Log — nmap
+
+**Date:** 2026-03-04T19:49:12.347203
+**Status:** SUCCESS
+**Duration:** 50.8 seconds
+
+## Repository
+
+- **URL:** https://github.com/nmap/nmap.git
+- **Branch:** master
+- **Description:** Network scanner with 10 vendored libs + 10+ dynamic system deps (~420 source files, C/C++)
+
+## Build Steps
+
+1. `./configure --with-libpcre=/usr --with-libz=/usr --with-libssh2=/usr --with-openssl=/usr --with-libdnet=included --with-liblua=included --with-liblinear=included --without-zenmap --without-ndiff`
+2. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `nmap`
+- `ncat/ncat`
+- `nping/nping`

--- a/docs/redis/2026-02-13_2321_build.md
+++ b/docs/redis/2026-02-13_2321_build.md
@@ -1,0 +1,25 @@
+# Build Log — redis
+
+**Date:** 2026-02-13T23:21:24.043257
+**Status:** SUCCESS
+**Duration:** 172.3 seconds
+
+## Repository
+
+- **URL:** https://github.com/redis/redis.git
+- **Branch:** unstable
+- **Description:** In-memory data store with 8 vendored libs (jemalloc, lua, hiredis, etc.) (~293K LoC, C)
+
+## Build Steps
+
+1. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/redis-server`
+- `src/redis-cli`

--- a/docs/redis/2026-02-26_2213_build.md
+++ b/docs/redis/2026-02-26_2213_build.md
@@ -1,0 +1,25 @@
+# Build Log — redis
+
+**Date:** 2026-02-26T22:13:33.075241
+**Status:** SUCCESS
+**Duration:** 73.8 seconds
+
+## Repository
+
+- **URL:** https://github.com/redis/redis.git
+- **Branch:** unstable
+- **Description:** In-memory data store with 8 vendored libs (jemalloc, lua, hiredis, etc.) (~293K LoC, C)
+
+## Build Steps
+
+1. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/redis-server`
+- `src/redis-cli`

--- a/docs/redis/2026-03-04_1946/build.md
+++ b/docs/redis/2026-03-04_1946/build.md
@@ -1,0 +1,25 @@
+# Build Log — redis
+
+**Date:** 2026-03-04T19:47:46.997650
+**Status:** SUCCESS
+**Duration:** 40.2 seconds
+
+## Repository
+
+- **URL:** https://github.com/redis/redis.git
+- **Branch:** unstable
+- **Description:** In-memory data store with 8 vendored libs (jemalloc, lua, hiredis, etc.) (~293K LoC, C)
+
+## Build Steps
+
+1. `make -j$(nproc)`
+
+## Instrumentation
+
+- **Tracer:** bomtrace3
+- **Raw logfile:** /tmp/bomsh_hook_raw_logfile.sha1
+
+## Output Binaries
+
+- `src/redis-server`
+- `src/redis-cli`

--- a/docs/runtime/2026-02-11_2209_curl_runtime.md
+++ b/docs/runtime/2026-02-11_2209_curl_runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — curl
+
+**Date:** 2026-02-11T22:09:36.309242
+**Instrumented build time:** 59.1 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/2026-02-11_2338_curl_runtime.md
+++ b/docs/runtime/2026-02-11_2338_curl_runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — curl
+
+**Date:** 2026-02-11T23:38:29.215338
+**Instrumented build time:** 466.1 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/2026-02-11_2350_curl_runtime.md
+++ b/docs/runtime/2026-02-11_2350_curl_runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — curl
+
+**Date:** 2026-02-11T23:50:16.858070
+**Instrumented build time:** 394.0 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/2026-02-13_2321_redis_runtime.md
+++ b/docs/runtime/2026-02-13_2321_redis_runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — redis
+
+**Date:** 2026-02-13T23:21:24.043492
+**Instrumented build time:** 172.3 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/2026-02-26_2213_redis_runtime.md
+++ b/docs/runtime/2026-02-26_2213_redis_runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — redis
+
+**Date:** 2026-02-26T22:13:33.075387
+**Instrumented build time:** 73.8 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/2026-02-26_2215_curl_runtime.md
+++ b/docs/runtime/2026-02-26_2215_curl_runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — curl
+
+**Date:** 2026-02-26T22:15:16.163599
+**Instrumented build time:** 70.2 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/2026-02-26_2216_nmap_runtime.md
+++ b/docs/runtime/2026-02-26_2216_nmap_runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — nmap
+
+**Date:** 2026-02-26T22:16:37.524413
+**Instrumented build time:** 54.6 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/2026-02-26_2230_ffmpeg_runtime.md
+++ b/docs/runtime/2026-02-26_2230_ffmpeg_runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — ffmpeg
+
+**Date:** 2026-02-26T22:30:12.624103
+**Instrumented build time:** 732.6 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/curl/2026-02-26_2307/runtime.md
+++ b/docs/runtime/curl/2026-02-26_2307/runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — curl
+
+**Date:** 2026-02-26T23:08:39.105390
+**Instrumented build time:** 71.1 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/ffmpeg/2026-03-04_1949/runtime.md
+++ b/docs/runtime/ffmpeg/2026-03-04_1949/runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — ffmpeg
+
+**Date:** 2026-03-04T20:02:39.820031
+**Instrumented build time:** 744.4 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/go/lazygit/2026-03-04_2255/runtime.md
+++ b/docs/runtime/go/lazygit/2026-03-04_2255/runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — lazygit
+
+**Date:** 2026-03-04T22:55:44.787670
+**Instrumented build time:** 28.0 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/nmap/2026-03-04_1948/runtime.md
+++ b/docs/runtime/nmap/2026-03-04_1948/runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — nmap
+
+**Date:** 2026-03-04T19:49:12.347375
+**Instrumented build time:** 50.8 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/runtime/redis/2026-03-04_1946/runtime.md
+++ b/docs/runtime/redis/2026-03-04_1946/runtime.md
@@ -1,0 +1,10 @@
+# Runtime Metrics — redis
+
+**Date:** 2026-03-04T19:47:46.998391
+**Instrumented build time:** 40.2 seconds
+
+
+## Notes
+
+- Measured wall-clock time for the instrumented `make` step only
+- Baseline (uninstrumented) build time should be recorded separately for comparison

--- a/docs/three-way-spdx-comparison copy.md
+++ b/docs/three-way-spdx-comparison copy.md
@@ -1,0 +1,146 @@
+# Three-Way SPDX Comparison: curl Binary
+
+**Date:** February 13, 2026
+**Target:** curl 8.19.0-DEV (built from source on Ubuntu 22.04 with gcc 11.4.0)
+**Binary:** dynamically linked ELF 64-bit x86-64
+
+## Summary
+
+Four tools were used to generate or analyze SBOMs for the same curl build. Each tool examines a fundamentally different data source, resulting in **completely disjoint findings** with zero package overlap between categories.
+
+| Category | ADG (OmniBOR) | Syft | GitHub | BDBA |
+|---|:---:|:---:|:---:|:---:|
+| **Dynamically linked libraries (.so)** | **23** | 0 | 0 | 0 |
+| Project binary / build compiler | 2 | 2 | 1 | 1 |
+| Python CI/dev tools (pip) | 0 | 13 | 14 | 0 |
+| GitHub Actions (CI workflows) | 0 | 11 | 11 | 0 |
+| **Total (unique)** | **25** | **26** | **26** | **1** |
+
+## What Each Tool Scans
+
+| Tool | Method | Data Source | Finds |
+|---|---|---|---|
+| **ADG (OmniBOR)** | `ldd`/`readelf` on compiled binary + `dpkg` metadata | ELF headers of the built binary | Shared libraries (`.so`) loaded at runtime by the dynamic linker |
+| **Syft** | Source tree manifest scan | `.github/workflows/*.yml`, `requirements.txt` | CI/dev tooling references checked into the repo |
+| **GitHub** | Dependency graph API | Same manifest files as Syft | CI/dev tooling — pip packages + GitHub Actions |
+| **BDBA** | Binary signature fingerprinting | The curl binary file itself | Only recognizes curl's own binary signature |
+
+## Dynamically Linked Libraries
+
+These are `.so` (shared object) files — Linux's equivalent of Windows DLLs — that the dynamic linker (`ld-linux`) loads into memory when curl runs. They are **not compiled into** the curl binary; they are separate files on disk that curl depends on at runtime.
+
+**Only ADG detects these. Neither Syft, GitHub, nor BDBA find any of them.**
+
+### Direct Dependencies (3)
+
+Listed in the curl binary's ELF `NEEDED` entries (discovered via `readelf -d`). The binary explicitly requests these at load time.
+
+| Component | Version | Sonames |
+|---|---|---|
+| **curl** (libcurl) | 7.81.0-1ubuntu1.21 | `libcurl.so.4` |
+| **glibc** | 2.35-0ubuntu3.13 | `libc.so.6`, `libresolv.so.2` |
+| **zlib** | 1:1.2.11.dfsg-2ubuntu9.2 | `libz.so.1` |
+
+### Transitive Dependencies (20)
+
+Pulled in by `libcurl.so` and its own dependencies. Discovered via `ldd`, which recursively resolves the full shared library dependency chain.
+
+| Component | Version | Sonames |
+|---|---|---|
+| **brotli** | 1.0.9-2build6 | `libbrotlidec.so.1`, `libbrotlicommon.so.1` |
+| **cyrus-sasl2** | 2.1.27+dfsg2-3ubuntu1.2 | `libsasl2.so.2` |
+| **e2fsprogs** | 1.46.5-2ubuntu1.2 | `libcom_err.so.2` |
+| **gmp** | 2:6.2.1+dfsg-3ubuntu1 | `libgmp.so.10` |
+| **gnutls28** | 3.7.3-4ubuntu1.7 | `libgnutls.so.30` |
+| **keyutils** | 1.6.1-2ubuntu3 | `libkeyutils.so.1` |
+| **krb5** | 1.19.2-2ubuntu0.7 | `libgssapi_krb5.so.2`, `libkrb5.so.3`, `libk5crypto.so.3`, `libkrb5support.so.0` |
+| **libffi** | 3.4.2-4 | `libffi.so.8` |
+| **libidn2** | 2.3.2-2build1 | `libidn2.so.0` |
+| **libpsl** | 0.21.0-1.2build2 | `libpsl.so.5` |
+| **libssh** | 0.9.6-2ubuntu0.22.04.5 | `libssh.so.4` |
+| **libtasn1-6** | 4.18.0-4ubuntu0.1 | `libtasn1.so.6` |
+| **libunistring** | 1.0-1 | `libunistring.so.2` |
+| **libzstd** | 1.4.8+dfsg-3build1 | `libzstd.so.1` |
+| **nettle** | 3.7.3-1build2 | `libnettle.so.8`, `libhogweed.so.6` |
+| **nghttp2** | 1.43.0-1ubuntu0.2 | `libnghttp2.so.14` |
+| **openldap** | 2.5.20+dfsg-0ubuntu0.22.04.1 | `libldap-2.5.so.0`, `liblber-2.5.so.0` |
+| **openssl** | 3.0.2-0ubuntu1.21 | `libssl.so.3`, `libcrypto.so.3` |
+| **p11-kit** | 0.24.0-6build1 | `libp11-kit.so.0` |
+| **rtmpdump** | 2.4+20151223.gitfa8646d.1-2build4 | `librtmp.so.1` |
+
+### Build Tool (1)
+
+| Component | Version | SPDX Relationship |
+|---|---|---|
+| **gcc** | 11.4.0 | `BUILD_TOOL_OF` |
+
+## Python CI/Dev Tools (pip)
+
+These are development and CI dependencies declared in `requirements.txt` files within the curl source repository. **None of these are compiled into or loaded by the curl binary.**
+
+| Package | Version | In Syft | In GitHub |
+|---|:---:|:---:|:---:|
+| cmakelang | 0.6.13 | ✓ | ✓ |
+| codespell | 2.4.1 | ✓ | ✓ |
+| cryptography | 46.0.5 | ✓ | ✓ |
+| filelock | 3.20.3 | ✓ | ✓ |
+| impacket | >= 0.11.0 | ✗ | ✓ |
+| proselint | 0.16.0 | ✓ | ✓ |
+| psutil | 7.2.2 | ✓ | ✓ |
+| pyspelling | 2.12.1 | ✓ | ✓ |
+| pytest | 9.0.2 | ✓ | ✓ |
+| pytest-xdist | 3.8.0 | ✓ | ✓ |
+| pytype | 2024.10.11 | ✓ | ✓ |
+| reuse | 6.2.0 | ✓ | ✓ |
+| ruff | 0.14.14 | ✓ | ✓ |
+| websockets | 16.0 | ✓ | ✓ |
+
+## GitHub Actions (CI Workflows)
+
+These are GitHub Actions referenced in `.github/workflows/*.yml` files. They run in CI pipelines and have **no presence in the compiled binary**.
+
+| Action | In Syft | In GitHub |
+|---|:---:|:---:|
+| actions/cache | ✓ | ✓ |
+| actions/checkout | ✓ | ✓ |
+| actions/download-artifact | ✓ | ✓ |
+| actions/labeler | ✓ | ✓ |
+| actions/upload-artifact | ✓ | ✓ |
+| cross-platform-actions/action | ✓ | ✓ |
+| curl/curl-fuzzer/.github/workflows/ci.yml | ✓ | ✓ |
+| cygwin/cygwin-install-action | ✓ | ✓ |
+| github/codeql-action/analyze | ✓ | ✓ |
+| github/codeql-action/init | ✓ | ✓ |
+| msys2/setup-msys2 | ✓ | ✓ |
+
+## SPDX Document Details
+
+| Property | ADG (OmniBOR) | Syft | GitHub |
+|---|---|---|---|
+| **SPDX version** | 2.3 | 2.3 | 2.3 |
+| **Packages** | 25 | 43 (with duplicates) | 26 |
+| **Files** | 441 | 23 | 0 |
+| **Relationships** | 466 | 85 | 26 |
+| **Relationship types** | `DYNAMIC_LINK` (23), `BUILD_TOOL_OF` (1), `CONTAINS` (441), `DESCRIBES` (1) | `CONTAINS` (42), `OTHER` (42), `DESCRIBES` (1) | `DEPENDS_ON` (25), `DESCRIBES` (1) |
+| **Package purpose** | `APPLICATION` (curl, gcc), `LIBRARY` (23 libs) | `FILE` (1), unset (42) | unset (26) |
+| **PURLs** | `pkg:deb/ubuntu/...` | mixed | `pkg:pypi/...`, `pkg:githubactions/...` |
+| **CPEs** | ✓ (all 23 libs) | ✗ | ✗ |
+| **OmniBOR ExternalRef** | ✓ (gitoid on root package) | ✗ | ✗ |
+| **Source files** | 441 (.c, .h, .S, .inc) | 0 | 0 |
+
+## Conclusions
+
+1. **ADG (OmniBOR) is the only tool that identifies the 23 shared libraries actually loaded at runtime.** These represent the real attack surface and vulnerability exposure of the curl binary.
+
+2. **Syft and GitHub find the same CI/dev tooling** (pip packages and GitHub Actions) from manifest files. These are useful for supply chain auditing of the build pipeline but are not present in the compiled binary.
+
+3. **BDBA binary scanning detected only curl itself** — it cannot identify the dynamically linked third-party libraries.
+
+4. **The three approaches are complementary, not competing.** A complete supply chain SBOM would combine:
+   - ADG for runtime dependencies (what's in the binary)
+   - Syft/GitHub for build pipeline dependencies (what built the binary)
+   - OmniBOR for cryptographic build provenance (how the binary was built)
+
+---
+
+*Generated by omnibor-analysis ([github.com/tedg-dev/omnibor-analysis](https://github.com/tedg-dev/omnibor-analysis))*

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1890,6 +1890,64 @@ class TestDocWriter(unittest.TestCase):
             content = Path(result).read_text()
             self.assertNotIn("overhead", content)
 
+    def test_write_build_doc_go(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = {"docs_dir": tmpdir}
+            cfg = {
+                "url": "https://github.com/x/y.git",
+                "branch": "master",
+                "description": "Go CLI tool",
+                "build_steps": [
+                    "go build -o fzf .",
+                ],
+                "output_binaries": ["fzf"],
+                "language": "go",
+            }
+            with patch("builtins.print"):
+                result = DocWriter.write_build_doc(
+                    "fzf", cfg, paths,
+                    True, 10.0,
+                )
+            content = Path(result).read_text()
+            self.assertIn("PlainBuilder", content)
+            self.assertIn("Syft", content)
+            self.assertNotIn(
+                "**Tracer:** bomtrace3", content
+            )
+            self.assertIn("fzf", content)
+
+    def test_write_runtime_doc_go(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = {"docs_dir": tmpdir}
+            repo_cfg = {"language": "go"}
+            with patch("builtins.print"):
+                result = DocWriter.write_runtime_doc(
+                    "fzf", repo_cfg, paths, 10.0,
+                )
+            content = Path(result).read_text()
+            self.assertIn("Build time", content)
+            self.assertIn("go build", content)
+            self.assertNotIn("Instrumented", content)
+
+    def test_write_build_doc_c_cpp_has_bomtrace(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = {"docs_dir": tmpdir}
+            cfg = {
+                "url": "https://github.com/x/y.git",
+                "branch": "main",
+                "build_steps": ["make"],
+                "output_binaries": ["app"],
+                "language": "c-cpp",
+            }
+            with patch("builtins.print"):
+                result = DocWriter.write_build_doc(
+                    "myrepo", cfg, paths,
+                    True, 42.5,
+                )
+            content = Path(result).read_text()
+            self.assertIn("bomtrace3", content)
+            self.assertNotIn("PlainBuilder", content)
+
 
 # ============================================================
 # AnalysisPipeline


### PR DESCRIPTION
- Build doc: Go repos show PlainBuilder/Syft instead of bomtrace3
- Runtime doc: Go repos show 'Build time' instead of 'Instrumented build time'
- Remove duplicate lang_subdir call in write_runtime_doc
- Add 3 Go-specific DocWriter tests (375 pass, 99%)