### PR TITLE
feat: PocketBase analysis + Go dependency graph

### DIFF
--- a/app/analyze.py
+++ b/app/analyze.py
@@ -264,7 +264,20 @@ class BomtraceBuilder:
 
         # Final build step with bomtrace3
         make_cmd = build_steps[-1]
-        instrumented = f"{tracer} {make_cmd}"
+        # Extract env var assignments (KEY=VAL) that
+        # precede the actual command.  They must go
+        # *before* the tracer so the shell sets them
+        # for the whole pipeline; bomtrace2 cannot
+        # exec "KEY=VAL" as a binary.
+        env_prefix = ""
+        cmd_part = make_cmd
+        tokens = make_cmd.split()
+        while tokens and "=" in tokens[0]:
+            env_prefix += tokens.pop(0) + " "
+            cmd_part = " ".join(tokens)
+        instrumented = (
+            f"{env_prefix}{tracer} {cmd_part}"
+        )
         rc = self.runner.run(
             instrumented, cwd=str(repo_dir),
             description=(

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -109,11 +109,23 @@ repos:
     branch: master
     language: go
     build_steps:
+    - go mod graph > go_mod_graph.txt
     - go build -a -o lazygit .
     clean_cmd: rm -f lazygit
     description: Terminal UI for git (~15-20 direct + 20-30 indirect Go deps)
     output_binaries:
     - lazygit
+  pocketbase:
+    url: https://github.com/pocketbase/pocketbase.git
+    branch: master
+    language: go
+    build_steps:
+    - go mod graph > go_mod_graph.txt && go mod vendor
+    - CGO_ENABLED=0 go build -a -mod=vendor -o pocketbase ./examples/base
+    clean_cmd: rm -rf vendor pocketbase
+    description: Open-source backend in 1 file (SQLite, Auth, S3) — 21 direct + 20 indirect Go deps
+    output_binaries:
+    - pocketbase
   croc:
     url: https://github.com/schollz/croc.git
     branch: main

--- a/app/spdx_from_adg.py
+++ b/app/spdx_from_adg.py
@@ -765,6 +765,48 @@ class SpdxEmitter:
         return indirect
 
     @staticmethod
+    def _parse_go_mod_graph(project_files):
+        """Parse go_mod_graph.txt for dependency edges.
+
+        The file contains output of ``go mod graph``,
+        where each line is ``parent@ver child@ver``.
+        The main module has no ``@ver`` suffix.
+
+        Returns:
+          dict[module_path] -> set of child module paths
+          (stripped of @version suffixes).
+
+        This enables building the real dependency tree
+        where direct deps hang off root and indirect
+        deps hang off their actual parent module.
+        """
+        edges = {}
+        if not project_files:
+            return edges
+        sample = project_files[0]["file_path"]
+        p = Path(sample)
+        while p.parent != p:
+            graph_file = p / "go_mod_graph.txt"
+            if graph_file.exists():
+                for line in graph_file.read_text(
+                ).splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    parts = line.split()
+                    if len(parts) != 2:
+                        continue
+                    # Strip @version from both sides
+                    parent = parts[0].split("@")[0]
+                    child = parts[1].split("@")[0]
+                    edges.setdefault(
+                        parent, set()
+                    ).add(child)
+                return edges
+            p = p.parent
+        return edges
+
+    @staticmethod
     def _parse_go_modules_txt(project_files):
         """Parse vendor/modules.txt for module versions.
 
@@ -1369,6 +1411,10 @@ class SpdxEmitter:
         go_mod_indirect = self._parse_go_mod(
             project_files
         )
+        # Parse go mod graph for real dep edges
+        go_dep_graph = self._parse_go_mod_graph(
+            project_files
+        )
         # Map vendored lib name -> SPDX package ID
         vendored_pkg_ids = {}
         for lib_name in sorted(vendored.keys()):
@@ -1478,18 +1524,102 @@ class SpdxEmitter:
 
             doc["packages"].append(pkg)
 
-            # Go modules use DEPENDS_ON;
-            # C/C++ vendored libs use STATIC_LINK
-            rel_type = (
-                "DEPENDS_ON"
-                if is_go_module
-                else "STATIC_LINK"
+            if not is_go_module:
+                # C/C++ vendored libs use STATIC_LINK
+                doc["relationships"].append({
+                    "spdxElementId": root_id,
+                    "relationshipType":
+                        "STATIC_LINK",
+                    "relatedSpdxElement": pkg_id,
+                })
+            # Go module relationships are emitted
+            # below after all packages are created,
+            # so we can resolve parent SPDX IDs.
+
+        # --- Go module dependency edges ---
+        # Use go mod graph to emit real edges:
+        #   root -> direct deps via DEPENDS_ON
+        #   parent -> child via DEPENDS_ON
+        # Falls back to flat root->all if no graph.
+        go_modules_in_spdx = {
+            lib: pid
+            for lib, pid in vendored_pkg_ids.items()
+            if "." in lib.split("/")[0]
+            and any(
+                a["file_path"].endswith(".go")
+                for a in vendored.get(lib, [])
             )
-            doc["relationships"].append({
-                "spdxElementId": root_id,
-                "relationshipType": rel_type,
-                "relatedSpdxElement": pkg_id,
-            })
+        }
+        if go_dep_graph and go_modules_in_spdx:
+            # Find the main module name (root of graph)
+            # It's the key not appearing as any child.
+            all_children = set()
+            for children in go_dep_graph.values():
+                all_children.update(children)
+            main_modules = (
+                set(go_dep_graph.keys())
+                - all_children
+            )
+            # Emit edges from graph
+            emitted = set()
+            for parent, children in (
+                go_dep_graph.items()
+            ):
+                # Map parent to its SPDX ID
+                if parent in main_modules:
+                    parent_spdx = root_id
+                elif parent in go_modules_in_spdx:
+                    parent_spdx = (
+                        go_modules_in_spdx[parent]
+                    )
+                else:
+                    continue
+                for child in children:
+                    if child not in go_modules_in_spdx:
+                        continue
+                    child_spdx = (
+                        go_modules_in_spdx[child]
+                    )
+                    edge = (parent_spdx, child_spdx)
+                    if edge not in emitted:
+                        doc["relationships"].append({
+                            "spdxElementId":
+                                parent_spdx,
+                            "relationshipType":
+                                "DEPENDS_ON",
+                            "relatedSpdxElement":
+                                child_spdx,
+                        })
+                        emitted.add(edge)
+            # Ensure every Go module has at least
+            # one incoming edge (fallback to root)
+            has_incoming = {
+                r["relatedSpdxElement"]
+                for r in doc["relationships"]
+                if r["relationshipType"]
+                == "DEPENDS_ON"
+            }
+            for lib, pid in (
+                go_modules_in_spdx.items()
+            ):
+                if pid not in has_incoming:
+                    doc["relationships"].append({
+                        "spdxElementId": root_id,
+                        "relationshipType":
+                            "DEPENDS_ON",
+                        "relatedSpdxElement": pid,
+                    })
+        else:
+            # Fallback: flat root -> all Go modules
+            for lib, pid in (
+                go_modules_in_spdx.items()
+            ):
+                doc["relationships"].append({
+                    "spdxElementId": root_id,
+                    "relationshipType":
+                        "DEPENDS_ON",
+                    "relatedSpdxElement": pid,
+                })
 
         # --- Project source files ---
         all_source = (
@@ -1657,20 +1787,22 @@ class AdgSpdxGenerator:
             else self.bom_dir / "metadata"
         )
         dynlib_path = dl_dir / "dynamic_libs.json"
-        if not dynlib_path.exists():
-            print(
-                f"[ERROR] {dynlib_path} not found. "
-                f"Run collect_dynamic_libs.py for "
-                f"{bin_name} first."
+        if dynlib_path.exists():
+            resolver.load_dynamic_libs(
+                str(dynlib_path)
             )
-            return None
-
-        resolver.load_dynamic_libs(
-            str(dynlib_path)
-        )
-        components = (
-            resolver.resolve_dynamic_components()
-        )
+            components = (
+                resolver.resolve_dynamic_components()
+            )
+        else:
+            # Statically-linked binaries (e.g.
+            # CGO_ENABLED=0 Go builds) have no
+            # dynamic libs — proceed with empty list.
+            print(
+                f"[INFO] {dynlib_path} not found "
+                f"— no dynamic libs for {bin_name}"
+            )
+            components = []
 
         direct = sum(
             1 for c in components if c["direct"]

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -387,6 +387,61 @@ class TestBomtraceBuilder(unittest.TestCase):
             "bomtrace3", instrumented_call[0][0]
         )
 
+    def test_env_var_prefix_before_tracer(self):
+        """Env vars like CGO_ENABLED=0 go before tracer."""
+        runner = MagicMock()
+        runner.run.return_value = 0
+        builder = BomtraceBuilder(runner)
+        repo_cfg = {
+            "build_steps": [
+                "go mod vendor",
+                "CGO_ENABLED=0 go build -mod=vendor"
+                " -o app ./cmd",
+            ],
+            "clean_cmd": "rm -f app",
+            "language": "go",
+        }
+        paths = {
+            "repos_dir": "/repos",
+            "output_dir": "/out",
+        }
+        omnibor = {
+            "tracer": "bomtrace2 -c /opt/bomsh/bin/"
+            "bomtrace_go.conf",
+            "raw_logfile": "/tmp/log",
+            "create_bom_script": "/usr/bin/bom",
+        }
+        with patch("builtins.print"):
+            builder.build(
+                "myapp", repo_cfg, paths, omnibor
+            )
+        # clean(0) + pre-build(1) + instrumented(2)
+        cmd = runner.run.call_args_list[2][0][0]
+        # CGO_ENABLED=0 must precede bomtrace2
+        self.assertTrue(
+            cmd.startswith("CGO_ENABLED=0 "),
+            f"Expected env prefix: {cmd}",
+        )
+        self.assertIn("bomtrace2", cmd)
+        self.assertIn("go build", cmd)
+
+    def test_no_env_var_prefix(self):
+        """Normal commands have no env prefix."""
+        runner = MagicMock()
+        runner.run.return_value = 0
+        builder = BomtraceBuilder(runner)
+        repo_cfg, paths, omnibor = self._cfg()
+
+        with patch("builtins.print"):
+            builder.build(
+                "curl", repo_cfg, paths, omnibor
+            )
+        cmd = runner.run.call_args_list[3][0][0]
+        self.assertTrue(
+            cmd.startswith("bomtrace3"),
+            f"Expected tracer first: {cmd}",
+        )
+
 
 # ============================================================
 # SpdxGenerator

--- a/tests/test_spdx_from_adg.py
+++ b/tests/test_spdx_from_adg.py
@@ -2077,10 +2077,12 @@ class TestFilePathRelativization(unittest.TestCase):
 
 class TestGenerateMissingDynlibs(unittest.TestCase):
     """Test generate() when dynamic_libs.json is
-    missing (lines 1312-1317)."""
+    missing (statically linked binary)."""
 
-    def test_missing_dynlib_returns_none(self):
-        """generate() returns None if dynlib not found."""
+    def test_missing_dynlib_produces_spdx(self):
+        """generate() proceeds with empty components
+        when dynamic_libs.json is absent (e.g.
+        CGO_ENABLED=0 Go builds)."""
         with tempfile.TemporaryDirectory() as td:
             bom = Path(td) / "bom"
             meta = bom / "metadata" / "bomsh"
@@ -2124,7 +2126,14 @@ class TestGenerateMissingDynlibs(unittest.TestCase):
             with patch("builtins.print"):
                 result = gen.generate(out)
 
-            self.assertIsNone(result)
+            # Should produce SPDX with root pkg only
+            self.assertIsNotNone(result)
+            self.assertTrue(Path(out).exists())
+            doc = json.loads(Path(out).read_text())
+            self.assertIn("packages", doc)
+            self.assertGreaterEqual(
+                len(doc["packages"]), 1
+            )
 
 
 class TestVisualizationFailure(unittest.TestCase):
@@ -2446,6 +2455,211 @@ class TestParseGoMod(unittest.TestCase):
                 files
             )
             self.assertEqual(indirect, set())
+
+
+class TestParseGoModGraph(unittest.TestCase):
+    """Tests for SpdxEmitter._parse_go_mod_graph."""
+
+    def test_parse_graph_edges(self):
+        """Parse real go mod graph output."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "repos" / "app"
+            repo.mkdir(parents=True)
+            (repo / "go_mod_graph.txt").write_text(
+                "github.com/example/app "
+                "github.com/foo/bar@v1.0.0\n"
+                "github.com/example/app "
+                "github.com/baz/qux@v2.0.0\n"
+                "github.com/foo/bar@v1.0.0 "
+                "github.com/deep/dep@v0.1.0\n"
+                "github.com/baz/qux@v2.0.0 "
+                "github.com/deep/dep@v0.1.0\n"
+            )
+            files = [{"file_path": str(
+                repo / "main.go"
+            )}]
+            graph = SpdxEmitter._parse_go_mod_graph(
+                files
+            )
+            # Root has 2 direct deps
+            self.assertEqual(
+                graph["github.com/example/app"],
+                {"github.com/foo/bar",
+                 "github.com/baz/qux"},
+            )
+            # foo/bar has 1 transitive dep
+            self.assertEqual(
+                graph["github.com/foo/bar"],
+                {"github.com/deep/dep"},
+            )
+            # baz/qux also depends on deep/dep
+            self.assertEqual(
+                graph["github.com/baz/qux"],
+                {"github.com/deep/dep"},
+            )
+
+    def test_no_graph_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            files = [{"file_path": str(
+                Path(td) / "main.go"
+            )}]
+            graph = SpdxEmitter._parse_go_mod_graph(
+                files
+            )
+            self.assertEqual(graph, {})
+
+    def test_empty_files(self):
+        graph = SpdxEmitter._parse_go_mod_graph([])
+        self.assertEqual(graph, {})
+
+    def test_versions_stripped(self):
+        """@version suffixes are stripped from keys."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "repos" / "app"
+            repo.mkdir(parents=True)
+            (repo / "go_mod_graph.txt").write_text(
+                "github.com/a/b@v1.0.0 "
+                "github.com/c/d@v2.0.0\n"
+            )
+            files = [{"file_path": str(
+                repo / "main.go"
+            )}]
+            graph = SpdxEmitter._parse_go_mod_graph(
+                files
+            )
+            self.assertIn(
+                "github.com/a/b", graph
+            )
+            self.assertIn(
+                "github.com/c/d",
+                graph["github.com/a/b"],
+            )
+
+
+class TestGoModGraphSpdxEdges(unittest.TestCase):
+    """Test that go mod graph produces proper
+    DEPENDS_ON edges in SPDX: root->direct,
+    direct->transitive."""
+
+    def test_graph_based_edges(self):
+        """Direct deps from root, transitive from
+        their parent — not flat."""
+        with tempfile.TemporaryDirectory() as td:
+            bom = Path(td) / "bom"
+            meta = bom / "metadata" / "bomsh"
+            meta.mkdir(parents=True)
+
+            repo = Path(td) / "repos" / "app"
+            vendor = repo / "vendor"
+            (vendor / "github.com" / "direct"
+             / "one").mkdir(parents=True)
+            (vendor / "github.com" / "trans"
+             / "dep").mkdir(parents=True)
+            (vendor / "github.com" / "direct"
+             / "one" / "a.go").write_text("pkg one")
+            (vendor / "github.com" / "trans"
+             / "dep" / "b.go").write_text("pkg dep")
+
+            # go.mod
+            (repo / "go.mod").write_text(
+                "module github.com/example/app\n"
+                "go 1.22\n"
+                "require (\n"
+                "\tgithub.com/direct/one v1.0.0\n"
+                ")\n"
+                "require (\n"
+                "\tgithub.com/trans/dep "
+                "v0.5.0 // indirect\n"
+                ")\n"
+            )
+
+            # go_mod_graph.txt
+            (repo / "go_mod_graph.txt").write_text(
+                "github.com/example/app "
+                "github.com/direct/one@v1.0.0\n"
+                "github.com/direct/one@v1.0.0 "
+                "github.com/trans/dep@v0.5.0\n"
+            )
+
+            # vendor/modules.txt
+            (vendor / "modules.txt").write_text(
+                "# github.com/direct/one v1.0.0\n"
+                "## explicit\n"
+                "# github.com/trans/dep v0.5.0\n"
+                "## explicit\n"
+            )
+
+            src_d = str(vendor / "github.com"
+                        / "direct" / "one" / "a.go")
+            src_t = str(vendor / "github.com"
+                        / "trans" / "dep" / "b.go")
+            treedb = {
+                "aaa": {"file_path": src_d},
+                "bbb": {"file_path": src_t},
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            (meta / "bomsh_omnibor_doc_mapping"
+             ).write_text(json.dumps({}))
+
+            comp_meta = {
+                "distro": "Ubuntu 22.04",
+                "gcc_version": "gcc 11.4.0",
+                "curl_version": "unknown",
+                "pkg_metadata": {},
+                "file_to_pkg": {},
+                "unresolved_files": [],
+            }
+            (bom / "metadata"
+             / "component_metadata.json"
+             ).write_text(json.dumps(comp_meta))
+
+            out = str(Path(td) / "out" / "a.spdx.json")
+            gen = AdgSpdxGenerator(
+                bom_dir=str(bom),
+                repos_dir=str(Path(td) / "repos"),
+                repo_name="app",
+            )
+            with patch("builtins.print"):
+                gen.generate(out)
+
+            doc = json.loads(Path(out).read_text())
+            depends = [
+                r for r in doc["relationships"]
+                if r["relationshipType"] == "DEPENDS_ON"
+            ]
+            # Find SPDX IDs
+            pkgs = {
+                p["name"]: p["SPDXID"]
+                for p in doc["packages"]
+            }
+            root_id = pkgs["app"]
+            direct_id = pkgs["github.com/direct/one"]
+            trans_id = pkgs["github.com/trans/dep"]
+
+            # Root -> direct dep
+            self.assertIn(
+                {"spdxElementId": root_id,
+                 "relationshipType": "DEPENDS_ON",
+                 "relatedSpdxElement": direct_id},
+                doc["relationships"],
+            )
+            # Direct dep -> transitive dep
+            self.assertIn(
+                {"spdxElementId": direct_id,
+                 "relationshipType": "DEPENDS_ON",
+                 "relatedSpdxElement": trans_id},
+                doc["relationships"],
+            )
+            # Root should NOT directly depend on
+            # transitive dep
+            root_targets = [
+                r["relatedSpdxElement"]
+                for r in depends
+                if r["spdxElementId"] == root_id
+            ]
+            self.assertNotIn(trans_id, root_targets)
 
 
 class TestGoStdlibClassification(unittest.TestCase):


### PR DESCRIPTION
## Changes

### PocketBase Support
- Add PocketBase to config.yaml with `go mod vendor` pre-step and `CGO_ENABLED=0` build
- Successfully analyzed: 40 packages, 825 files, 920 relationships, semantic PASS

### Go Dependency Graph (go mod graph)
- Add `_parse_go_mod_graph()` to parse real dependency edges from `go mod graph` output
- SPDX now emits proper graph: root->direct deps, parent->transitive deps (not flat)
- Falls back to flat emission when graph file unavailable

### Bug Fixes
- **env var prefix extraction**: `CGO_ENABLED=0` placed before bomtrace2, not passed as executable
- **static binary support**: missing `dynamic_libs.json` no longer blocks ADG SPDX generation

### Test Coverage
- 409 tests passing, 99% coverage
- New tests for go mod graph parsing, graph-based SPDX edges, env var prefix extraction
