### PR TITLE
feat: add dura Rust repo to OmniBOR analysis pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Rust crate SPDX packages with STATIC_LINK relationships and `pkg:cargo` PURLs
   - `.rs` source files included in SPDX file entries
 - **oxipng** as first Rust analysis target (94 packages, 85 files, 179 relationships, 44 crates)
+- **dura** as second Rust analysis target (Git background auto-commit, ~42 direct + 35 transitive deps)
 - Anti-hang rules in `command-execution.md` (no inline multiline Python, no interactive gh/git)
 
 ### Fixed

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -154,6 +154,16 @@ repos:
     description: Multithreaded lossless PNG optimizer (~12 direct Rust crate deps)
     output_binaries:
     - target/release/oxipng
+  dura:
+    url: https://github.com/tkellogg/dura.git
+    branch: master
+    language: rust
+    build_steps:
+    - cargo build --release
+    clean_cmd: cargo clean
+    description: Git background auto-commit tool (~42 direct + 35 transitive Rust crate deps, complex Git-binding layer)
+    output_binaries:
+    - target/release/dura
 paths:
   repos_dir: /workspace/repos
   output_dir: /workspace/output


### PR DESCRIPTION
Add dura (Git background auto-commit tool) as second Rust analysis target. ~42 direct + 35 transitive crate deps with complex git2-rs binding layer.