### PR TITLE
docs: update project structure for app/ package hierarchy

### DIFF
--- a/.windsurf/rules/project-context.md
+++ b/.windsurf/rules/project-context.md
@@ -12,11 +12,15 @@ and completeness.
 
 ## Directory Structure
 
-- **app/** — Orchestration scripts, SPDX generation, config.yaml
+- **app/** — Orchestration scripts, modular packages, config.yaml
+  - **app/pipeline/** — Analysis pipeline (12 modules, extracted from analyze.py)
+  - **app/spdx/** — SPDX generation (6 modules, extracted from spdx_from_adg.py)
+  - **app/repo_discovery/** — Repo discovery (8 modules, extracted from add_repo.py)
+  - **app/config.py** — Shared config loading, timestamp, lang_subdir
+  - **app/runner.py** — CommandRunner utility
 - **docker/** — Linux container environment (Ubuntu 22.04) with gcc, bomtrace3, syft
-- **tests/** — Unit tests (349+ tests, 98% coverage)
-- **scripts/** — Helper/utility scripts
-- **docs/** — Timestamped results and summary documentation, organized by language (`c-cpp/`, `go/`)
+- **tests/** — Unit tests (427+ tests, 99% coverage)
+- **docs/** — Timestamped results and summary documentation, organized by language (`c-cpp/`, `go/`, `rust/`)
 - **repos/** — Cloned target repositories (gitignored)
 - **output/** — Generated artifacts organized by language: `output/{category}/{lang}/{repo}/{ts}/` (gitignored)
 - **.windsurf/** — Cascade AI rules and workflows
@@ -64,14 +68,21 @@ and traces the openat syscall. The `-a` flag bypasses Go's build cache.
 
 | File | Purpose |
 |------|---------|
-| `app/analyze.py` | Main pipeline orchestrator (AnalysisPipeline facade) |
-| `app/spdx_from_adg.py` | Per-binary SPDX from ADG: vendored detection, version extraction |
+| `app/analyze.py` | Main entry point — thin shim re-exporting from `app.pipeline` |
+| `app/spdx_from_adg.py` | SPDX entry point — thin shim re-exporting from `app.spdx` |
+| `app/add_repo.py` | Repo discovery entry point — thin shim re-exporting from `app.repo_discovery` |
+| `app/pipeline/facade.py` | AnalysisPipeline orchestrator |
+| `app/pipeline/runners.py` | main(), _run_c_cpp_pipeline, _run_rust_pipeline, _run_go_pipeline |
+| `app/spdx/generator.py` | AdgSpdxGenerator: per-binary SPDX from ADG |
+| `app/spdx/emitter.py` | SpdxEmitter: SPDX 2.3 JSON document assembly |
+| `app/repo_discovery/facade.py` | RepoDiscovery: GitHub search + config generation |
 | `app/spdx_visualize.py` | D3.js HTML dependency graph generator |
 | `app/collect_metadata.py` | Resolve system files to dpkg packages |
 | `app/collect_dynamic_libs.py` | Per-binary ldd/readelf dynamic lib analysis |
 | `app/compare.py` | Compare OmniBOR SBOM vs binary scanner SBOM |
-| `app/add_repo.py` | Auto-discover and add new target repos from GitHub |
 | `app/data_loader.py` | Shared data loading utilities |
+| `app/config.py` | Shared config loading, timestamp, lang_subdir |
+| `app/runner.py` | CommandRunner utility |
 | `app/config.yaml` | Single source of truth: repos, build steps, tool paths |
 
 ## Target Repositories

--- a/README.md
+++ b/README.md
@@ -55,14 +55,46 @@ omnibor-analysis/
 │   ├── upstream-changes.md     Tracking upstream bomsh fixes
 │   └── summary/            Cross-repo findings and methodology
 ├── app/                    Orchestration scripts and configuration
-│   ├── analyze.py          Clone, build, instrument, generate SBOMs
-│   ├── spdx_from_adg.py    Per-binary SPDX from ADG with vendored detection
+│   ├── analyze.py          Main entry point (thin shim → app.pipeline)
+│   ├── spdx_from_adg.py    SPDX entry point (thin shim → app.spdx)
+│   ├── add_repo.py         Repo discovery entry point (thin shim → app.repo_discovery)
 │   ├── spdx_visualize.py   D3.js interactive HTML dependency graph generator
 │   ├── collect_metadata.py Resolve system files to dpkg packages
 │   ├── collect_dynamic_libs.py  Per-binary ldd/readelf dynamic lib analysis
-│   ├── add_repo.py         Auto-discover and add repos from GitHub
+│   ├── compare.py          Compare OmniBOR SBOM vs binary scanner SBOM
 │   ├── data_loader.py      Shared data loading utilities
+│   ├── config.py           Shared config loading, timestamp, lang_subdir
+│   ├── runner.py           CommandRunner utility
 │   ├── config.yaml         Repo definitions, build commands, paths
+│   ├── pipeline/           Analysis pipeline package (from analyze.py)
+│   │   ├── facade.py       AnalysisPipeline orchestrator
+│   │   ├── runners.py      main(), per-language pipeline runners
+│   │   ├── cloner.py       RepoCloner
+│   │   ├── builder.py      BomtraceBuilder
+│   │   ├── spdx_generator.py  SpdxGenerator (bomsh_sbom)
+│   │   ├── spdx_validator.py  SpdxValidator (JSON Schema + semantic)
+│   │   ├── metadata_collector.py  MetadataCollector
+│   │   ├── binary_collector.py    BinaryCollector
+│   │   ├── doc_writer.py   DocWriter
+│   │   ├── adg_spdx.py     AdgSpdxStep
+│   │   ├── syft.py         SyftGenerator
+│   │   └── validator.py    DependencyValidator
+│   ├── spdx/               SPDX generation package (from spdx_from_adg.py)
+│   │   ├── generator.py    AdgSpdxGenerator orchestrator
+│   │   ├── parser.py       AdgParser
+│   │   ├── resolver.py     ComponentResolver
+│   │   ├── version_detector.py  VendoredVersionDetector
+│   │   ├── emitter.py      SpdxEmitter
+│   │   └── cli.py          CLI entry point
+│   ├── repo_discovery/     Repo discovery package (from add_repo.py)
+│   │   ├── facade.py       RepoDiscovery orchestrator
+│   │   ├── github_client.py GitHubClient
+│   │   ├── build_system_detector.py  BuildSystemDetector
+│   │   ├── dependency_analyzer.py    DependencyAnalyzer
+│   │   ├── binary_detector.py        BinaryDetector
+│   │   ├── build_step_generator.py   BuildStepGenerator
+│   │   ├── config_generator.py       ConfigGenerator
+│   │   └── cli.py          CLI entry point
 │   └── templates/          Report templates
 ├── terraform/              AWS EC2 infrastructure as code
 ├── tests/                  Unit tests (427 tests, 99% coverage)

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,110 @@
+# app/ — Application Code
+
+This directory contains the OmniBOR Analysis application: orchestration scripts,
+SPDX generation, repo discovery, and supporting utilities.
+
+## Entry Points
+
+These are the three main scripts. Each is a **thin shim** that re-exports from
+its corresponding package for backward compatibility. Run them directly or import
+from the packages.
+
+| Entry Point | Package | Purpose |
+|-------------|---------|---------|
+| `analyze.py` | `app.pipeline` | Clone, build, instrument, generate SBOMs |
+| `spdx_from_adg.py` | `app.spdx` | Per-binary SPDX 2.3 from ADG data |
+| `add_repo.py` | `app.repo_discovery` | Auto-discover repos from GitHub |
+
+```bash
+# Run analysis (inside Docker container)
+python3 /workspace/app/analyze.py --repo curl
+
+# Generate SPDX from ADG (inside Docker container)
+python3 /workspace/app/spdx_from_adg.py /path/to/adg_dir --binary curl
+
+# Add a repo (local, uses GitHub API)
+python3 app/add_repo.py openssl --write
+```
+
+## Packages
+
+### `pipeline/` — Analysis Pipeline (from `analyze.py`)
+
+Full build interception and SBOM generation pipeline.
+
+| Module | Class/Function | Purpose |
+|--------|---------------|---------|
+| `facade.py` | `AnalysisPipeline` | Top-level orchestrator |
+| `runners.py` | `main()`, `_run_c_cpp_pipeline()`, `_run_rust_pipeline()`, `_run_go_pipeline()` | CLI and per-language runners |
+| `cloner.py` | `RepoCloner` | Git clone with depth/branch control |
+| `builder.py` | `BomtraceBuilder` | bomtrace2/3 instrumented builds |
+| `spdx_generator.py` | `SpdxGenerator` | bomsh_sbom.py SPDX generation |
+| `spdx_validator.py` | `SpdxValidator` | JSON Schema + semantic validation |
+| `syft.py` | `SyftGenerator` | Syft manifest-based SPDX baseline |
+| `metadata_collector.py` | `MetadataCollector` | dpkg package resolution + ldd |
+| `adg_spdx.py` | `AdgSpdxStep` | Per-binary ADG→SPDX + visualization |
+| `binary_collector.py` | `BinaryCollector` | Copy output binaries to output dir |
+| `doc_writer.py` | `DocWriter` | Generate build.md and runtime.md |
+| `validator.py` | `DependencyValidator` | Verify apt deps are installed |
+
+### `spdx/` — SPDX Generation (from `spdx_from_adg.py`)
+
+Converts OmniBOR ADG data into SPDX 2.3 JSON with vendored detection,
+version extraction, and relationship classification.
+
+| Module | Class | Purpose |
+|--------|-------|---------|
+| `generator.py` | `AdgSpdxGenerator` | Top-level orchestrator |
+| `parser.py` | `AdgParser` | Parse bomsh ADG tree database |
+| `resolver.py` | `ComponentResolver` | Group source files into components |
+| `version_detector.py` | `VendoredVersionDetector` | Extract versions from configure.ac, CMakeLists, Cargo.lock, etc. |
+| `emitter.py` | `SpdxEmitter` | Assemble SPDX 2.3 JSON document |
+| `cli.py` | `main()` | CLI entry point |
+
+### `repo_discovery/` — Repo Discovery (from `add_repo.py`)
+
+Searches GitHub, detects build systems, and generates `config.yaml` entries.
+
+| Module | Class | Purpose |
+|--------|-------|---------|
+| `facade.py` | `RepoDiscovery` | Top-level orchestrator |
+| `github_client.py` | `GitHubClient` | GitHub API via `gh` CLI |
+| `build_system_detector.py` | `BuildSystemDetector` | Detect autoconf/cmake/meson/make |
+| `dependency_analyzer.py` | `DependencyAnalyzer` | Parse configure.ac/CMakeLists for deps |
+| `binary_detector.py` | `BinaryDetector` | Parse Makefile.am for output binaries |
+| `build_step_generator.py` | `BuildStepGenerator` | Generate build_steps for config.yaml |
+| `config_generator.py` | `ConfigGenerator` | Write config.yaml entries |
+| `cli.py` | `main()` | CLI entry point |
+
+## Shared Utilities
+
+| File | Purpose |
+|------|---------|
+| `config.py` | `load_config()`, `timestamp()`, `lang_subdir()` — used by all packages |
+| `runner.py` | `CommandRunner` — subprocess wrapper with logging |
+| `data_loader.py` | Shared data loading (ADG, metadata, component data) |
+| `config.yaml` | Single source of truth: repo URLs, build steps, language, paths |
+
+## Other Scripts
+
+| File | Purpose |
+|------|---------|
+| `spdx_visualize.py` | D3.js interactive HTML dependency graph generator |
+| `collect_metadata.py` | Resolve system files to dpkg packages |
+| `collect_dynamic_libs.py` | Per-binary ldd/readelf dynamic library analysis |
+| `compare.py` | Compare OmniBOR SBOM vs proprietary binary scanner SBOM |
+
+## Import Patterns
+
+```python
+# New style (preferred) — import from packages directly
+from app.pipeline.facade import AnalysisPipeline
+from app.spdx.generator import AdgSpdxGenerator
+from app.repo_discovery.github_client import GitHubClient
+from app.config import load_config, timestamp
+
+# Legacy style (still works via thin shims)
+from analyze import AnalysisPipeline, CommandRunner
+from spdx_from_adg import AdgSpdxGenerator
+from add_repo import GitHubClient, RepoDiscovery
+```

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -181,15 +181,20 @@ with color-coded nodes (purple=root, teal=vendored, red=dynamic, yellow=build to
 ```
 omnibor-analysis/
 ├── app/                    # Core application code
-│   ├── analyze.py          # Main pipeline orchestrator
-│   ├── spdx_from_adg.py    # Per-binary SPDX generation
+│   ├── analyze.py          # Main entry point (thin shim → app.pipeline)
+│   ├── spdx_from_adg.py    # SPDX entry point (thin shim → app.spdx)
+│   ├── add_repo.py         # Repo discovery entry point (thin shim → app.repo_discovery)
 │   ├── spdx_visualize.py   # D3.js HTML visualization
 │   ├── collect_metadata.py # dpkg package resolution
 │   ├── collect_dynamic_libs.py # ldd/readelf analysis
 │   ├── compare.py          # SBOM comparison tool
-│   ├── add_repo.py         # Auto-discover repos from GitHub
 │   ├── data_loader.py      # Shared data loading utilities
-│   └── config.yaml         # Repository and tool configuration
+│   ├── config.py           # Shared config loading, timestamp, lang_subdir
+│   ├── runner.py           # CommandRunner utility
+│   ├── config.yaml         # Repository and tool configuration
+│   ├── pipeline/           # Analysis pipeline (12 modules from analyze.py)
+│   ├── spdx/               # SPDX generation (6 modules from spdx_from_adg.py)
+│   └── repo_discovery/     # Repo discovery (8 modules from add_repo.py)
 ├── docker/                 # Container environment
 │   ├── Dockerfile          # Ubuntu 22.04 + gcc + Rust + Go + bomtrace
 │   └── docker-compose.yml  # Container orchestration

--- a/docs/summary/spdx-generation-deep-dive.md
+++ b/docs/summary/spdx-generation-deep-dive.md
@@ -80,7 +80,7 @@ Source Code
 └──────────────────────────────┘
 ```
 
-Each stage is orchestrated by `app/analyze.py` via the `AnalysisPipeline` facade.
+Each stage is orchestrated by `app/analyze.py` (entry point) via the `AnalysisPipeline` facade in `app/pipeline/facade.py`.
 
 ---
 


### PR DESCRIPTION
## Summary

Update all documentation to reflect the new `app/` package hierarchy from PR #35.

## Changes

- **README.md** — Expanded `app/` tree showing `pipeline/`, `spdx/`, `repo_discovery/` packages with all modules
- **docs/ONBOARDING.md** — Updated project structure section with new packages
- **`.windsurf/rules/project-context.md`** — Updated directory structure (added sub-packages) and Key Application Files table (thin shims + key package modules)
- **docs/summary/spdx-generation-deep-dive.md** — Clarified `analyze.py` → `app/pipeline/facade.py` orchestration
- **NEW `app/README.md`** — Developer-level module map with:
  - Entry points table (analyze.py → pipeline, spdx_from_adg.py → spdx, add_repo.py → repo_discovery)
  - Per-package module tables with class names and purposes
  - Shared utilities and standalone scripts
  - Import patterns (new package-style vs legacy shim-style)
