### PR TITLE
refactor: remove all hardcoded repo names, make codebase fully generic

### DIFF
--- a/.windsurf/rules/generic-code.md
+++ b/.windsurf/rules/generic-code.md
@@ -1,0 +1,38 @@
+# Generic Code — No Hardcoded Repo Names
+
+## Rule
+
+All application code MUST be generic and repo-agnostic. This is a universal analysis
+tool that works on ANY repository defined in config.yaml.
+
+## Prohibited Patterns
+
+1. **No hardcoded repository names** — Never reference `curl`, `nmap`, `redis`, `ffmpeg`,
+   or any specific repo name in executable code (imports, conditionals, paths, field names).
+   - Comments/docstrings may use repo names as illustrative examples (e.g. `"e.g. curl"`)
+   - Test fixtures may reference repo names when testing specific scenarios
+   - config.yaml entries are expected to have repo names as keys
+
+2. **No repo-specific logic** — Never write `if repo_name == "curl"` or similar
+   conditional branches for specific repositories. All behavior must be driven by
+   config.yaml fields (language, build_steps, output_binaries, vendored_dirs, etc.)
+
+3. **No hardcoded paths to repo files** — Never construct paths like
+   `repos/curl/include/curl/curlver.h`. Use generic version detection strategies
+   that work across all repos.
+
+4. **No legacy field names tied to specific repos** — Field names like `curl_version`
+   that embed a repo name must be renamed to generic equivalents (e.g. `repo_version`).
+
+5. **No hardcoded defaults in `__main__` blocks** — If a script has a standalone
+   `__main__`, use argparse with required arguments or sensible generic defaults,
+   never repo-specific paths.
+
+## Required Patterns
+
+- **Config-driven behavior** — Language-specific logic branches on `lang_subdir()`
+  values (`c-cpp`, `go`, `rust`, `java`), never on repo names.
+- **Strategy/detector patterns** — Use generic detection strategies (e.g.,
+  VendoredVersionDetector's 10 ordered strategies) that work across all repos.
+- **DRY pipeline steps** — Common logic shared across language pipelines must be
+  extracted into reusable methods, not copy-pasted with minor variations.

--- a/app/analyze.py
+++ b/app/analyze.py
@@ -63,6 +63,7 @@ from app.pipeline.runners import (                             # noqa: F401
     _run_c_cpp_pipeline,
     _run_rust_pipeline,
     _run_go_pipeline,
+    _validate_syft_spdx,
 )
 
 

--- a/app/collect_dynamic_libs.py
+++ b/app/collect_dynamic_libs.py
@@ -11,7 +11,6 @@ import json
 import os
 import re
 import subprocess
-import sys
 
 
 def main(binary_path, out_dir):
@@ -155,36 +154,11 @@ def main(binary_path, out_dir):
             f"{len(project_built_libs)}"
         )
 
-    # Also analyze libcurl.so NEEDED
-    libcurl_needed = []
-    libcurl_path = os.path.join(
-        os.path.dirname(os.path.dirname(binary_path)),
-        "lib", ".libs", "libcurl.so",
-    )
-    if os.path.exists(libcurl_path):
-        try:
-            re_out = subprocess.check_output(
-                ["readelf", "-d", libcurl_path],
-                text=True,
-            )
-            for line in re_out.splitlines():
-                m = re.search(
-                    r"NEEDED.*\[(.+)\]", line
-                )
-                if m:
-                    libcurl_needed.append(m.group(1))
-            print(
-                f"\nlibcurl.so NEEDED: {libcurl_needed}"
-            )
-        except Exception as e:
-            print(f"Could not analyze libcurl.so: {e}")
-
     output = {
         "binary": binary_path,
         "direct_needed": sorted(needed),
         "dynamic_libs": results,
         "project_built_libs": project_built_libs,
-        "libcurl_needed": sorted(libcurl_needed),
     }
 
     os.makedirs(out_dir, exist_ok=True)
@@ -195,10 +169,20 @@ def main(binary_path, out_dir):
 
 
 if __name__ == "__main__":
-    binary = sys.argv[1] if len(sys.argv) > 1 else (
-        "/workspace/repos/curl/src/.libs/curl"
+    import argparse
+    ap = argparse.ArgumentParser(
+        description=(
+            "Collect dynamic library dependencies"
+            " from a binary"
+        ),
     )
-    out = sys.argv[2] if len(sys.argv) > 2 else (
-        "/workspace/output/omnibor/curl/metadata"
+    ap.add_argument(
+        "binary",
+        help="Path to the binary to analyze",
     )
-    main(binary, out)
+    ap.add_argument(
+        "out_dir",
+        help="Output directory for dynamic_libs.json",
+    )
+    args = ap.parse_args()
+    main(args.binary, args.out_dir)

--- a/app/collect_metadata.py
+++ b/app/collect_metadata.py
@@ -10,10 +10,42 @@ Outputs component_metadata.json alongside the treedb.
 import json
 import os
 import subprocess
-import sys
+from pathlib import Path
 
 
-def main(treedb_path, repos_dir, out_dir):
+def _detect_repo_version(repo_name, repos_dir):
+    """Detect the repo's own version from its source tree."""
+    try:
+        from spdx.version_detector import (
+            VendoredVersionDetector,
+        )
+    except ImportError:
+        return None
+    repo_dir = Path(repos_dir) / repo_name
+    if not repo_dir.exists():
+        return None
+    # Root-level files only — avoids vendored lib versions
+    files = [
+        str(f) for f in repo_dir.iterdir()
+        if f.is_file()
+    ]
+    # Also include include/ headers (version #defines)
+    include_dir = repo_dir / "include"
+    if include_dir.exists():
+        for f in include_dir.rglob("*.h"):
+            files.append(str(f))
+    # Include src/ headers too
+    src_dir = repo_dir / "src"
+    if src_dir.exists():
+        for f in src_dir.rglob("*.h"):
+            files.append(str(f))
+    if not files:
+        return None
+    detector = VendoredVersionDetector()
+    return detector.detect(repo_name, files)
+
+
+def main(treedb_path, repos_dir, out_dir, repo_name=None):
     treedb = json.load(open(treedb_path))
 
     # Collect all system file paths (not under repos)
@@ -88,19 +120,12 @@ def main(treedb_path, repos_dir, out_dir):
         if pkg:
             treedb_path_to_pkg[fp] = pkg
 
-    # Curl version from curlver.h
-    curl_version = "unknown"
-    curlver = os.path.join(
-        repos_dir, "curl", "include", "curl", "curlver.h"
-    )
-    try:
-        with open(curlver) as f:
-            for line in f:
-                if "LIBCURL_VERSION " in line and '"' in line:
-                    curl_version = line.split('"')[1]
-                    break
-    except Exception:
-        pass
+    # Repo version detection (generic — works for any repo)
+    repo_version = None
+    if repo_name:
+        repo_version = _detect_repo_version(
+            repo_name, repos_dir
+        )
 
     # Distro info
     distro = "unknown"
@@ -128,7 +153,7 @@ def main(treedb_path, repos_dir, out_dir):
     result = {
         "distro": distro,
         "gcc_version": gcc_version,
-        "curl_version": curl_version,
+        "repo_version": repo_version,
         "pkg_metadata": pkg_metadata,
         "file_to_pkg": treedb_path_to_pkg,
         "unresolved_files": failed,
@@ -142,19 +167,25 @@ def main(treedb_path, repos_dir, out_dir):
     print(f"\nWrote: {out_path}")
     print(f"Distro: {distro}")
     print(f"GCC: {gcc_version}")
-    print(f"Curl: {curl_version}")
+    if repo_version:
+        print(f"Repo version: {repo_version}")
     print(f"Packages with metadata: {len(pkg_metadata)}")
 
 
 if __name__ == "__main__":
-    treedb = sys.argv[1] if len(sys.argv) > 1 else (
-        "/workspace/output/omnibor/curl/metadata"
-        "/bomsh/bomsh_omnibor_treedb"
+    import argparse
+    ap = argparse.ArgumentParser(
+        description="Collect dpkg metadata for treedb system files",
     )
-    repos = sys.argv[2] if len(sys.argv) > 2 else (
-        "/workspace/repos"
+    ap.add_argument("treedb", help="Path to bomsh_omnibor_treedb")
+    ap.add_argument("repos_dir", help="Path to repos directory")
+    ap.add_argument(
+        "out_dir",
+        help="Output directory for metadata JSON",
     )
-    out = sys.argv[3] if len(sys.argv) > 3 else (
-        "/workspace/output/omnibor/curl/metadata"
+    ap.add_argument(
+        "--repo-name", default=None,
+        help="Repo name for version detection",
     )
-    main(treedb, repos, out)
+    args = ap.parse_args()
+    main(args.treedb, args.repos_dir, args.out_dir, repo_name=args.repo_name)

--- a/app/pipeline/doc_writer.py
+++ b/app/pipeline/doc_writer.py
@@ -18,7 +18,8 @@ class DocWriter:
     def write_build_doc(
         repo_name, repo_cfg,
         paths_cfg, success, duration_sec,
-        run_ts=None,
+        run_ts=None, tracer=None,
+        raw_logfile=None,
     ):
         """Write build log to docs/<lang>/<repo>/<ts>/."""
         ts = run_ts or timestamp()
@@ -51,37 +52,16 @@ class DocWriter:
         ):
             content += f"{i}. `{step}`\n"
 
-        lang = lang_subdir(repo_cfg)
-        if lang == "c-cpp":
-            content += (
-                "\n## Instrumentation\n\n"
-                "- **Tracer:** bomtrace3\n"
-                "- **Raw logfile:** "
-                "/tmp/bomsh_hook_raw_logfile"
-                ".sha1\n"
-            )
-        elif lang == "rust":
-            content += (
-                "\n## Instrumentation\n\n"
-                "- **Tracer:** bomtrace2 "
-                "(default conf)\n"
-                "- **Raw logfile:** "
-                "/tmp/bomsh_hook_raw_logfile"
-                ".sha1\n"
-                "- **Watched tools:** "
-                "rustc\n"
-            )
-        else:
-            content += (
-                "\n## Instrumentation\n\n"
-                "- **Tracer:** bomtrace2 "
-                "(Go-specific conf)\n"
-                "- **Raw logfile:** "
-                "/tmp/bomsh_hook_raw_logfile"
-                ".sha1\n"
-                "- **Watched tools:** "
-                "compile, link\n"
-            )
+        tracer_name = tracer or "unknown"
+        logfile = (
+            raw_logfile
+            or "/tmp/bomsh_hook_raw_logfile.sha1"
+        )
+        content += (
+            "\n## Instrumentation\n\n"
+            f"- **Tracer:** {tracer_name}\n"
+            f"- **Raw logfile:** {logfile}\n"
+        )
 
         content += (
             "\n## Output Binaries\n\n"
@@ -103,7 +83,7 @@ class DocWriter:
     def write_runtime_doc(
         repo_name, repo_cfg, paths_cfg,
         duration_sec, baseline_sec=None,
-        run_ts=None,
+        run_ts=None, tracer=None,
     ):
         """Write runtime performance metrics."""
         ts = run_ts or timestamp()
@@ -130,35 +110,18 @@ class DocWriter:
                 f"{pct:.1f}%"
             )
 
-        if lang == "c-cpp":
-            build_label = "Instrumented build time"
-            notes = (
-                "- Measured wall-clock time for the "
-                "instrumented `make` step only\n"
-                "- Baseline (uninstrumented) build "
-                "time should be recorded separately "
-                "for comparison\n"
-            )
-        elif lang == "rust":
-            build_label = "Instrumented build time"
-            notes = (
-                "- Measured wall-clock time for "
-                "bomtrace2-instrumented "
-                "`cargo build --release`\n"
-                "- OmniBOR ADG + SPDX generated "
-                "from build interception\n"
-            )
-        else:
-            build_label = "Instrumented build time"
-            notes = (
-                "- Measured wall-clock time for "
-                "bomtrace2-instrumented "
-                "`go build -a`\n"
-                "- OmniBOR ADG + SPDX generated "
-                "from build interception\n"
-                "- Syft manifest SBOM also "
-                "generated from go.mod/go.sum\n"
-            )
+        build_cmd = repo_cfg.get(
+            "build_steps", ["unknown"]
+        )[-1]
+        tracer_name = tracer or "unknown"
+        build_label = "Instrumented build time"
+        notes = (
+            f"- Measured wall-clock time for "
+            f"{tracer_name}-instrumented "
+            f"`{build_cmd}`\n"
+            "- OmniBOR ADG + SPDX generated "
+            "from build interception\n"
+        )
 
         content = (
             f"# Runtime Metrics — {repo_name}\n\n"

--- a/app/pipeline/metadata_collector.py
+++ b/app/pipeline/metadata_collector.py
@@ -74,6 +74,7 @@ class MetadataCollector:
                     str(treedb_path),
                     repos_dir,
                     str(meta_dir),
+                    repo_name=repo_name,
                 )
             except Exception as e:
                 print(

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -70,7 +70,19 @@ def main():
 
     repo_cfg = config["repos"][args.repo]
     paths_cfg = config["paths"]
-    omnibor_cfg = config["omnibor"]
+
+    # Language-aware omnibor config lookup
+    lang_omnibor_keys = {
+        "c-cpp": "omnibor",
+        "rust": "omnibor_rust",
+        "java": "omnibor_java",
+        "go": "omnibor_go",
+    }
+    lang = lang_subdir(repo_cfg)
+    omnibor_key = lang_omnibor_keys.get(
+        lang, "omnibor_go"
+    )
+    omnibor_cfg = config[omnibor_key]
 
     # Single timestamp for the entire run — all
     # output folders use this consistently:
@@ -86,8 +98,6 @@ def main():
     desc = repo_cfg.get("description", "")
     print(f"  {desc}")
     print(f"{'#'*60}\n")
-
-    lang = lang_subdir(repo_cfg)
 
     # Step 1: Clone
     if not args.skip_clone:
@@ -118,33 +128,40 @@ def main():
             paths_cfg, omnibor_cfg, run_ts,
         )
     elif lang == "rust":
-        omnibor_rust_cfg = config["omnibor_rust"]
         success, duration = _run_rust_pipeline(
             pipeline, args.repo, repo_cfg,
-            paths_cfg, omnibor_rust_cfg, run_ts,
+            paths_cfg, omnibor_cfg, run_ts,
         )
     elif lang == "java":
-        omnibor_java_cfg = config["omnibor_java"]
         success, duration = _run_java_pipeline(
             pipeline, args.repo, repo_cfg,
-            paths_cfg, omnibor_java_cfg, run_ts,
+            paths_cfg, omnibor_cfg, run_ts,
         )
     else:
-        omnibor_go_cfg = config["omnibor_go"]
         success, duration = _run_go_pipeline(
             pipeline, args.repo, repo_cfg,
-            paths_cfg, omnibor_go_cfg, run_ts,
+            paths_cfg, omnibor_cfg, run_ts,
         )
 
+    # Step 7b: Validate Syft SPDX (all languages)
+    _validate_syft_spdx(
+        pipeline, args.repo, repo_cfg,
+        paths_cfg, run_ts,
+    )
+
     # Step 8: Write docs (all languages)
+    tracer = omnibor_cfg.get("tracer")
+    raw_logfile = omnibor_cfg.get("raw_logfile")
     pipeline.docs.write_build_doc(
         args.repo, repo_cfg, paths_cfg,
         success, duration,
-        run_ts=run_ts,
+        run_ts=run_ts, tracer=tracer,
+        raw_logfile=raw_logfile,
     )
     pipeline.docs.write_runtime_doc(
         args.repo, repo_cfg, paths_cfg,
         duration, run_ts=run_ts,
+        tracer=tracer,
     )
 
     status = "COMPLETE" if success else "FAILED"
@@ -152,6 +169,23 @@ def main():
     print(f"  Analysis {status}: {args.repo}")
     print(f"  Duration: {duration:.1f}s")
     print(f"{'#'*60}\n")
+
+
+def _validate_syft_spdx(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, run_ts,
+):
+    """Validate Syft SPDX if it exists (all languages)."""
+    lang = lang_subdir(repo_cfg)
+    syft_spdx = (
+        Path(paths_cfg["output_dir"])
+        / "spdx" / lang / repo_name / run_ts
+        / f"{repo_name}_syft.spdx.json"
+    )
+    if syft_spdx.exists():
+        pipeline.spdx_validator.validate(
+            str(syft_spdx)
+        )
 
 
 def _run_c_cpp_pipeline(
@@ -283,18 +317,6 @@ def _run_rust_pipeline(
     for adg_file in adg_files:
         pipeline.spdx_validator.validate(adg_file)
 
-    # Also validate Syft SPDX
-    lang = lang_subdir(repo_cfg)
-    syft_spdx = (
-        Path(paths_cfg["output_dir"])
-        / "spdx" / lang / repo_name / run_ts
-        / f"{repo_name}_syft.spdx.json"
-    )
-    if syft_spdx.exists():
-        pipeline.spdx_validator.validate(
-            str(syft_spdx)
-        )
-
     # Step 7: Collect output binaries
     if success:
         pipeline.binary_collector.collect(
@@ -361,18 +383,6 @@ def _run_java_pipeline(
         pipeline.spdx_validator.validate(spdx_file)
     for adg_file in adg_files:
         pipeline.spdx_validator.validate(adg_file)
-
-    # Also validate Syft SPDX
-    lang = lang_subdir(repo_cfg)
-    syft_spdx = (
-        Path(paths_cfg["output_dir"])
-        / "spdx" / lang / repo_name / run_ts
-        / f"{repo_name}_syft.spdx.json"
-    )
-    if syft_spdx.exists():
-        pipeline.spdx_validator.validate(
-            str(syft_spdx)
-        )
 
     # Step 7: Collect output JARs
     if success:
@@ -504,18 +514,6 @@ def _run_go_pipeline(
         pipeline.spdx_validator.validate(spdx_file)
     for adg_file in adg_files:
         pipeline.spdx_validator.validate(adg_file)
-
-    # Also validate Syft SPDX
-    lang = lang_subdir(repo_cfg)
-    syft_spdx = (
-        Path(paths_cfg["output_dir"])
-        / "spdx" / lang / repo_name / run_ts
-        / f"{repo_name}_syft.spdx.json"
-    )
-    if syft_spdx.exists():
-        pipeline.spdx_validator.validate(
-            str(syft_spdx)
-        )
 
     # Step 7: Collect output binaries
     if success:

--- a/app/spdx/generator.py
+++ b/app/spdx/generator.py
@@ -136,7 +136,7 @@ class AdgSpdxGenerator:
         # Emit SPDX
         emitter = SpdxEmitter(
             repo_name=self.repo_name,
-            repo_version=resolver.curl_version,
+            repo_version=resolver.repo_version,
             distro=resolver.distro,
             gcc_version=resolver.gcc_version,
             bomtrace_version=self.bomtrace_version,

--- a/app/spdx/resolver.py
+++ b/app/spdx/resolver.py
@@ -45,10 +45,9 @@ class ComponentResolver:
         )
 
     @property
-    def curl_version(self):
-        return self.metadata.get(
-            "curl_version", "unknown"
-        )
+    def repo_version(self):
+        """Return repo's own version, or None."""
+        return self.metadata.get("repo_version")
 
     def load_dynamic_libs(self, path):
         """Load dynamic_libs.json."""

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -23,6 +23,7 @@ from analyze import (
     AnalysisPipeline, load_config, timestamp,
     _run_go_pipeline,
     _run_rust_pipeline,
+    _validate_syft_spdx,
 )
 
 
@@ -1848,10 +1849,10 @@ class TestDocWriter(unittest.TestCase):
                 result = DocWriter.write_build_doc(
                     "fzf", cfg, paths,
                     True, 10.0,
+                    tracer="bomtrace2",
                 )
             content = Path(result).read_text()
             self.assertIn("bomtrace2", content)
-            self.assertIn("compile, link", content)
             self.assertNotIn(
                 "**Tracer:** bomtrace3", content
             )
@@ -1860,10 +1861,14 @@ class TestDocWriter(unittest.TestCase):
     def test_write_runtime_doc_go(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             paths = {"docs_dir": tmpdir}
-            repo_cfg = {"language": "go"}
+            repo_cfg = {
+                "language": "go",
+                "build_steps": ["go build -a -o fzf ."],
+            }
             with patch("builtins.print"):
                 result = DocWriter.write_runtime_doc(
                     "fzf", repo_cfg, paths, 10.0,
+                    tracer="bomtrace2",
                 )
             content = Path(result).read_text()
             self.assertIn(
@@ -1891,20 +1896,25 @@ class TestDocWriter(unittest.TestCase):
                 result = DocWriter.write_build_doc(
                     "oxipng", cfg, paths,
                     True, 15.0,
+                    tracer="bomtrace2",
                 )
             content = Path(result).read_text()
             self.assertIn("bomtrace2", content)
-            self.assertIn("rustc", content)
-            self.assertIn("default conf", content)
             self.assertIn("oxipng", content)
 
     def test_write_runtime_doc_rust(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             paths = {"docs_dir": tmpdir}
-            repo_cfg = {"language": "rust"}
+            repo_cfg = {
+                "language": "rust",
+                "build_steps": [
+                    "cargo build --release",
+                ],
+            }
             with patch("builtins.print"):
                 result = DocWriter.write_runtime_doc(
                     "oxipng", repo_cfg, paths, 15.0,
+                    tracer="bomtrace2",
                 )
             content = Path(result).read_text()
             self.assertIn(
@@ -1929,6 +1939,7 @@ class TestDocWriter(unittest.TestCase):
                 result = DocWriter.write_build_doc(
                     "myrepo", cfg, paths,
                     True, 42.5,
+                    tracer="bomtrace3",
                 )
             content = Path(result).read_text()
             self.assertIn("bomtrace3", content)
@@ -2352,9 +2363,9 @@ class TestRunGoPipeline(unittest.TestCase):
             .assert_not_called()
 
     def test_validates_syft_spdx(self):
+        """Syft validation is now in _validate_syft_spdx."""
         with tempfile.TemporaryDirectory() as td:
             p = _mock_pipeline()
-            p.builder.build.return_value = True
             repo_cfg = {"language": "go"}
             paths_cfg = {"output_dir": td}
 
@@ -2367,14 +2378,11 @@ class TestRunGoPipeline(unittest.TestCase):
                 spdx_dir / "fzf_syft.spdx.json"
             ).write_text("{}")
 
-            with patch("builtins.print"):
-                _run_go_pipeline(
-                    p, "fzf", repo_cfg,
-                    paths_cfg, self.GO_OMNIBOR_CFG,
-                    "2026-03-04_1200",
-                )
+            _validate_syft_spdx(
+                p, "fzf", repo_cfg,
+                paths_cfg, "2026-03-04_1200",
+            )
 
-            # validator called for Syft SPDX
             v = p.spdx_validator.validate
             calls = [
                 str(c) for c in v.call_args_list
@@ -2464,9 +2472,9 @@ class TestRunRustPipeline(unittest.TestCase):
             .assert_not_called()
 
     def test_validates_syft_spdx(self):
+        """Syft validation is now in _validate_syft_spdx."""
         with tempfile.TemporaryDirectory() as td:
             p = _mock_pipeline()
-            p.builder.build.return_value = True
             repo_cfg = {"language": "rust"}
             paths_cfg = {"output_dir": td}
 
@@ -2479,12 +2487,10 @@ class TestRunRustPipeline(unittest.TestCase):
                 spdx_dir / "oxipng_syft.spdx.json"
             ).write_text("{}")
 
-            with patch("builtins.print"):
-                _run_rust_pipeline(
-                    p, "oxipng", repo_cfg,
-                    paths_cfg, self.RUST_OMNIBOR_CFG,
-                    "2026-03-05_1200",
-                )
+            _validate_syft_spdx(
+                p, "oxipng", repo_cfg,
+                paths_cfg, "2026-03-05_1200",
+            )
 
             v = p.spdx_validator.validate
             calls = [
@@ -2928,7 +2934,10 @@ class TestMetadataCollector(unittest.TestCase):
                 "builtins.print",
             ):
                 # Simulate collect_metadata writing file
-                def write_meta(treedb_p, repos, out):
+                def write_meta(
+                    treedb_p, repos, out,
+                    repo_name=None,
+                ):
                     Path(out).mkdir(
                         parents=True, exist_ok=True,
                     )

--- a/tests/test_java_pipeline.py
+++ b/tests/test_java_pipeline.py
@@ -75,10 +75,12 @@ class TestRunJavaPipeline(unittest.TestCase):
             pipeline.metadata_collector.collect.assert_called_once()
             mock_adg.assert_called_once()
             pipeline.binary_collector.collect.assert_called_once()
-            # spdx_validator called for spdx + adg + syft
+            # spdx_validator called for spdx + adg
+            # (Syft validation is now in main via
+            # _validate_syft_spdx)
             self.assertEqual(
                 pipeline.spdx_validator.validate.call_count,
-                3,
+                2,
             )
 
     @patch(

--- a/tests/test_spdx_from_adg.py
+++ b/tests/test_spdx_from_adg.py
@@ -217,7 +217,7 @@ class TestComponentResolver(unittest.TestCase):
         return {
             "distro": "Ubuntu 22.04.5 LTS",
             "gcc_version": "gcc (Ubuntu 11.4.0) 11.4.0",
-            "curl_version": "8.19.0-DEV",
+            "repo_version": "8.19.0-DEV",
             "pkg_metadata": {},
             "file_to_pkg": {},
             "unresolved_files": [],
@@ -1641,7 +1641,7 @@ class TestComponentResolverEdgeCases(
             meta = {
                 "distro": "Debian GNU/Linux 12",
                 "gcc_version": "gcc 12",
-                "curl_version": "8.0",
+                "repo_version": "8.0",
                 "pkg_metadata": {},
                 "file_to_pkg": {},
                 "unresolved_files": [],
@@ -1682,7 +1682,7 @@ class TestAdgSpdxGenerator(unittest.TestCase):
         comp_meta = {
             "distro": "Ubuntu 22.04",
             "gcc_version": "gcc 11.4.0",
-            "curl_version": "8.19.0",
+            "repo_version": "8.19.0",
             "pkg_metadata": {},
             "file_to_pkg": {},
             "unresolved_files": [],
@@ -1866,7 +1866,7 @@ class TestCli(unittest.TestCase):
             comp_meta = {
                 "distro": "Ubuntu 22.04",
                 "gcc_version": "gcc 11.4.0",
-                "curl_version": "8.19.0",
+                "repo_version": "8.19.0",
                 "pkg_metadata": {},
                 "file_to_pkg": {},
                 "unresolved_files": [],
@@ -1949,7 +1949,7 @@ class TestProjectBuiltLibs(unittest.TestCase):
         return {
             "distro": "Ubuntu 22.04.5 LTS",
             "gcc_version": "gcc (Ubuntu 11.4.0) 11.4.0",
-            "curl_version": "8.19.0-DEV",
+            "repo_version": "8.19.0-DEV",
             "pkg_metadata": {},
             "file_to_pkg": {},
             "unresolved_files": [],
@@ -2317,7 +2317,7 @@ class TestGenerateMissingDynlibs(unittest.TestCase):
             comp_meta = {
                 "distro": "Ubuntu 22.04",
                 "gcc_version": "gcc 11.4.0",
-                "curl_version": "8.19.0",
+                "repo_version": "8.19.0",
                 "pkg_metadata": {},
                 "file_to_pkg": {},
                 "unresolved_files": [],
@@ -2373,7 +2373,7 @@ class TestVisualizationFailure(unittest.TestCase):
             comp_meta = {
                 "distro": "Ubuntu 22.04",
                 "gcc_version": "gcc 11.4.0",
-                "curl_version": "8.19.0",
+                "repo_version": "8.19.0",
                 "pkg_metadata": {},
                 "file_to_pkg": {},
                 "unresolved_files": [],


### PR DESCRIPTION
Remove all curl-specific and repo-specific hardcoded logic. Use generic VendoredVersionDetector for version detection, config-driven tracer info in doc_writer, DRY omnibor config lookup and shared Syft validation in runners. All 608 tests pass.