### PR TITLE
fix: vendored false positives for Rust build output and non-vendored C/C++ libs

### DIFF
--- a/app/spdx/emitter.py
+++ b/app/spdx/emitter.py
@@ -420,6 +420,15 @@ class SpdxEmitter:
             # (e.g. /libnetutil/../nbase/x.h -> /nbase/x.h)
             fp = str(Path(art["file_path"]).resolve())
             matched = False
+            # Skip Rust build output directories —
+            # target/release/deps/ and target/debug/deps/
+            # contain .rlib intermediates that falsely
+            # match the /deps/ vendored pattern.
+            if "/target/release/" in fp or (
+                "/target/debug/" in fp
+            ):
+                own.append(art)
+                continue
             # Try Rust crate from Cargo registry first
             crate_name, _ = (
                 self._rust_crate_from_registry_path(fp)
@@ -1223,9 +1232,18 @@ class SpdxEmitter:
             #   DEPENDS_ON (transitive)
             # - C/C++ vendored: STATIC_LINK +
             #   CONTAINS (source tree containment)
+            # A package is vendored only if its
+            # source files actually reside under a
+            # vendored directory pattern (not just
+            # because it's non-Go / non-Rust).
             is_vendored = (
                 not is_go_module
                 and not is_rust_crate
+                and any(
+                    vd in fp_
+                    for fp_ in file_paths
+                    for vd in self._vendored_dirs
+                )
             )
             if is_go_module:
                 rel_type = "DEPENDS_ON"

--- a/tests/test_spdx_from_adg.py
+++ b/tests/test_spdx_from_adg.py
@@ -1002,6 +1002,56 @@ class TestSpdxEmitterVendored(unittest.TestCase):
         ]
         self.assertEqual(len(root_contains), 2)
 
+    def test_rust_build_output_not_vendored(self):
+        """Rust target/release/deps/ must not match
+        vendored /deps/ pattern."""
+        emitter = self._emitter()
+        files = [
+            # Rust build intermediate in target/
+            {"sha1": "r1", "file_path":
+                "/repos/dura/target/release/deps/"
+                "libadler-0ae352ee44010592.rlib"},
+            # Project own source
+            {"sha1": "r2", "file_path":
+                "/repos/dura/src/main.rs"},
+        ]
+        vendored, own = (
+            emitter._detect_vendored_groups(files)
+        )
+        # .rlib should NOT be in vendored dict
+        self.assertEqual(len(vendored), 0)
+        # Both files should be in own
+        self.assertEqual(len(own), 2)
+
+    def test_is_vendored_requires_vendored_dir_match(
+        self,
+    ):
+        """CONTAINS only emitted when files actually
+        reside under a vendored directory pattern."""
+        emitter = self._emitter()
+        # File NOT in any vendored dir
+        files = [
+            {"sha1": "x1", "file_path":
+                "/repos/redis/src/server.c"},
+            {"sha1": "x2", "file_path":
+                "/repos/redis/src/networking.c"},
+        ]
+        doc = emitter.emit(
+            components=[], project_files=files,
+            doc_mapping={}, logfile_hashes={},
+        )
+        contains_rels = [
+            r for r in doc["relationships"]
+            if r["relationshipType"] == "CONTAINS"
+            and r["relatedSpdxElement"].startswith(
+                "SPDXRef-Package-"
+            )
+            and r["relatedSpdxElement"]
+            != "SPDXRef-Package-root"
+        ]
+        # No package-level CONTAINS (only file CONTAINS)
+        self.assertEqual(len(contains_rels), 0)
+
     def test_no_vendored_files_no_extra_packages(self):
         """No vendored dirs means no extra packages."""
         emitter = self._emitter()


### PR DESCRIPTION
## Fix: Vendored False Positives

Two bugs caused non-vendored packages to be incorrectly marked as vendored in SPDX output.

### Bug 1: Rust build output matched `/deps/` pattern
`VENDORED_DIRS` includes `/deps/` for C/C++ vendored libs (e.g., `redis/deps/lua/`). This also matched Rust's `target/release/deps/` directory, causing `.rlib` build intermediates to be treated as vendored C/C++ libraries with ugly names like `libadler-0ae352ee44010592.rlib`.

**Fix**: Skip files containing `/target/release/` or `/target/debug/` in `_detect_vendored_groups` before checking vendored dir patterns.

### Bug 2: `is_vendored` flag too broad
`is_vendored` was set to `not is_go_module and not is_rust_crate`, marking ALL non-Go/Rust packages as vendored regardless of whether their files actually resided in a vendored directory.

**Fix**: `is_vendored` now checks that at least one of the package's source file paths matches a `_vendored_dirs` pattern.

### Impact
| Repo | Before | After |
|------|--------|-------|
| dura (Rust) | 94 vendored / 191 pkgs | 0 vendored |
| oxipng (Rust) | 46 vendored / 94 pkgs | 0 vendored |
| nmap (C/C++) | 7 vendored | 7 vendored (unchanged, correct) |
| redis (C/C++) | 8 vendored | 8 vendored (unchanged, correct) |
| node (C/C++) | 19 vendored | 19 vendored (unchanged, correct) |

### Tests
- 2 new regression tests added (665 total, all passing)
- `test_rust_build_output_not_vendored`: verifies `.rlib` in `target/release/deps/` is excluded
- `test_is_vendored_requires_vendored_dir_match`: verifies CONTAINS only emitted for actual vendored dirs
