### PR TITLE
fix: SPDX discrepancies + viz improvements

### DIFF
--- a/.windsurf/rules/file-size.md
+++ b/.windsurf/rules/file-size.md
@@ -1,0 +1,16 @@
+# File Size Best Practices
+
+## Guidelines
+- **Python modules** should stay under **400 lines** of code (excluding blank lines and comments).
+- If a module exceeds 400 lines, flag it for refactoring in your response.
+- When flagging, suggest a decomposition strategy (e.g., extract classes, split HTML template from logic, separate constants).
+
+## When to refactor
+- Do NOT refactor proactively — always ask the user first.
+- Complete the current task and merge before starting a refactor.
+- Create a dedicated branch (e.g., `refactor/<module-name>`) for the refactoring work.
+
+## Common decomposition patterns
+- **HTML/JS template strings**: Extract into a separate template file or builder module.
+- **Large f-strings with embedded JS**: Split into a template module with helper functions.
+- **Multiple concerns in one file**: Separate data extraction, rendering, and CLI into distinct modules.

--- a/.windsurf/rules/output-binaries.md
+++ b/.windsurf/rules/output-binaries.md
@@ -1,0 +1,20 @@
+# Output Binaries Completeness
+
+## Rule
+When adding or modifying a repository in `app/config.yaml`, the `output_binaries` list **must include ALL binaries and shared libraries produced by the build**.
+
+## Why
+Each entry in `output_binaries` gets its own SPDX SBOM generated. Missing entries mean incomplete analysis — project-built libraries will appear as dependencies in other binaries' SBOMs but won't have their own SBOM.
+
+## How to verify
+1. After a successful build on EC2, list all produced binaries and `.so` files:
+   - **C/C++**: `find repos/<name> -name '*.so' -o -type f -executable | grep -v '.o$'`
+   - **Rust**: Check `target/release/` for executables
+   - **Go**: Check the build output directory
+   - **Java**: Check `target/` for `.jar` files
+2. Compare against `output_binaries` in config.yaml.
+3. Any project-built binary or `.so` that is dynamically linked by another output binary **must** be listed.
+
+## Red flags
+- A dependency in an SPDX visualization has the same version as the root package — it's likely a project-built library that should have its own SBOM.
+- `ldd` shows a `.so` resolving to the repo's build tree rather than a system path.

--- a/.windsurf/rules/regen-visualizations.md
+++ b/.windsurf/rules/regen-visualizations.md
@@ -1,0 +1,27 @@
+# Regenerating HTML Visualizations
+
+## Rule
+When regenerating HTML visualization files from SPDX JSON, **only regenerate the most recent timestamp folder per language per repo**. Do not regenerate older folders.
+
+## How to find the most recent folder
+Each repo's output is at `output/spdx/<language>/<repo>/<timestamp>/`. The most recent folder is the one that sorts last alphabetically (timestamps are `YYYY-MM-DD_HHMM` format).
+
+## Command
+```bash
+for lang_dir in output/spdx/*/; do
+  for repo_dir in "${lang_dir}"*/; do
+    latest=$(ls -1d "${repo_dir}"*/ 2>/dev/null | sort | tail -1)
+    [ -z "$latest" ] && continue
+    for json_file in "${latest}"*.spdx.json; do
+      [ -f "$json_file" ] || continue
+      case "$json_file" in *syft*) continue;; esac
+      html_file="${json_file%.spdx.json}.spdx.html"
+      .venv/bin/python3 -m app.spdx_visualize "$json_file" -o "$html_file"
+    done
+  done
+done
+```
+
+## Notes
+- Exclude `*syft*` SPDX files (they have their own visualization pipeline).
+- This command should be run from the project root (`/Users/tedg/workspace/omnibor-analysis`).

--- a/.windsurf/rules/stable-tags.md
+++ b/.windsurf/rules/stable-tags.md
@@ -1,0 +1,17 @@
+# Stable Release Tags
+
+## Rule
+When adding or modifying a repository in `app/config.yaml`, the `branch` field **must point to a stable release tag** (e.g., `v8.0.6`, `7.2.13`), never to a development branch like `unstable`, `master`, `main`, or `dev`.
+
+## Why
+Development branches often use placeholder versions (e.g., Redis `unstable` uses `255.255.255`), produce unreproducible builds, and make SBOM version fields meaningless.
+
+## When adding a new repo
+1. Check the repo's releases/tags page for the latest stable version.
+2. Use that tag as the `branch` value (git clone --branch accepts tags).
+3. Document the chosen version in the `description` field.
+
+## Audit checklist
+When reviewing config.yaml, flag any `branch` value that matches:
+- `master`, `main`, `develop`, `dev`, `unstable`, `nightly`
+- Any branch name without a version number

--- a/app/collect_dynamic_libs.py
+++ b/app/collect_dynamic_libs.py
@@ -13,7 +13,7 @@ import re
 import subprocess
 
 
-def main(binary_path, out_dir):
+def main(binary_path, out_dir, project_bins=None):
     # Get ldd output
     ldd_out = subprocess.check_output(
         ["ldd", binary_path], text=True
@@ -124,11 +124,68 @@ def main(binary_path, out_dir):
         ver = meta.get("Version", "?")
         print(f"  {soname:40s} {tag:12s} {source} ({ver})")
 
-    # Record project-built .so files that ldd
-    # could not resolve (e.g. libavcodec.so.62
-    # built by FFmpeg). These are NEEDED entries
-    # that show as "not found" in ldd output.
+    # Identify project-built .so files.
+    # Two sources:
+    # 1. NEEDED entries "not found" by ldd
+    #    (e.g. libavcodec.so.62 from FFmpeg)
+    # 2. NEEDED entries that match an output
+    #    binary from the same repo, even when a
+    #    system dpkg package also provides the
+    #    soname (e.g. libcurl.so.4 when system
+    #    libcurl4 is installed)
+    #
+    # Build set of project .so base names from
+    # output_binaries (e.g. "libcurl.so").
+    proj_so_bases = set()
+    if project_bins:
+        for pb in project_bins:
+            base = os.path.basename(pb)
+            if ".so" in base:
+                # Strip version suffix for matching:
+                # libcurl.so -> libcurl.so
+                # libavcodec.so.62 -> libavcodec.so
+                prefix = base.split(".so")[0] + ".so"
+                proj_so_bases.add(prefix)
+    if proj_so_bases:
+        print(
+            f"Project .so prefixes: "
+            f"{sorted(proj_so_bases)}"
+        )
+
+    # Move ldd-resolved libs that match project
+    # .so prefixes from results -> project_built
     project_built_libs = {}
+    proj_matched = set()
+    for soname in sorted(results.keys()):
+        so_prefix = (
+            soname.split(".so")[0] + ".so"
+        )
+        if so_prefix in proj_so_bases:
+            is_direct = soname in needed
+            name = re.sub(
+                r"\.so(\.\d+)*$", "", soname
+            )
+            project_built_libs[soname] = {
+                "name": name,
+                "direct": is_direct,
+                "project_built": True,
+            }
+            proj_matched.add(soname)
+            tag = (
+                "DIRECT" if is_direct
+                else "transitive"
+            )
+            print(
+                f"  {soname:40s} {tag:12s} "
+                f"{name} (project-built, "
+                f"overriding dpkg)"
+            )
+
+    # Remove project-built libs from dpkg results
+    for soname in proj_matched:
+        del results[soname]
+
+    # Also record "not found" libs as project-built
     for soname in sorted(not_found):
         is_direct = soname in needed
         # Derive a readable name from soname:
@@ -184,5 +241,15 @@ if __name__ == "__main__":
         "out_dir",
         help="Output directory for dynamic_libs.json",
     )
+    ap.add_argument(
+        "--project-bins", nargs="*", default=None,
+        help=(
+            "Output binaries of the same project "
+            "(used to identify project-built .so)"
+        ),
+    )
     args = ap.parse_args()
-    main(args.binary, args.out_dir)
+    main(
+        args.binary, args.out_dir,
+        project_bins=args.project_bins,
+    )

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -38,8 +38,11 @@ repos:
     - ffmpeg
     - ffprobe
     - libavcodec/libavcodec.so
+    - libavdevice/libavdevice.so
+    - libavfilter/libavfilter.so
     - libavformat/libavformat.so
     - libavutil/libavutil.so
+    - libswresample/libswresample.so
     - libswscale/libswscale.so
     apt_deps:
     - libssl-dev

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -88,7 +88,7 @@ repos:
     - /nsock/
   redis:
     url: https://github.com/redis/redis.git
-    branch: unstable
+    branch: "8.0.6"
     language: c-cpp
     build_steps:
     - make -j$(nproc)

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -94,6 +94,15 @@ repos:
     output_binaries:
     - src/redis-server
     - src/redis-cli
+    vendored_dirs:
+    - /deps/fast_float/
+    - /deps/fpconv/
+    - /deps/hdr_histogram/
+    - /deps/hiredis/
+    - /deps/jemalloc/
+    - /deps/linenoise/
+    - /deps/lua/
+    - /deps/xxhash/
   openosc:
     url: https://github.com/cisco/OpenOSC.git
     branch: master
@@ -112,7 +121,7 @@ repos:
     - libtool
   node:
     url: https://github.com/nodejs/node.git
-    branch: v22.x
+    branch: v22.19.0
     language: c-cpp
     build_steps:
     - ./configure

--- a/app/pipeline/metadata_collector.py
+++ b/app/pipeline/metadata_collector.py
@@ -125,6 +125,7 @@ class MetadataCollector:
                 )
                 collect_dynlibs(
                     str(bin_path), str(bin_meta),
+                    project_bins=bins,
                 )
             except Exception as e:
                 print(

--- a/app/spdx/emitter.py
+++ b/app/spdx/emitter.py
@@ -1228,8 +1228,9 @@ class SpdxEmitter:
 
             # Determine relationship type:
             # - Go modules: DEPENDS_ON (all)
-            # - Rust crates: STATIC_LINK (direct),
-            #   DEPENDS_ON (transitive)
+            # - Rust crates: STATIC_LINK (all —
+            #   every crate is statically compiled
+            #   into the binary)
             # - C/C++ vendored: STATIC_LINK +
             #   CONTAINS (source tree containment)
             # A package is vendored only if its
@@ -1248,14 +1249,7 @@ class SpdxEmitter:
             if is_go_module:
                 rel_type = "DEPENDS_ON"
             elif is_rust_crate:
-                if (
-                    cargo_toml_direct
-                    and lib_name
-                    not in cargo_toml_direct
-                ):
-                    rel_type = "DEPENDS_ON"
-                else:
-                    rel_type = "STATIC_LINK"
+                rel_type = "STATIC_LINK"
             else:
                 rel_type = "STATIC_LINK"
             doc["relationships"].append({

--- a/app/spdx/java_generator.py
+++ b/app/spdx/java_generator.py
@@ -469,14 +469,10 @@ class JavaSpdxGenerator:
         for i, dep in enumerate(maven_deps):
             dep_id = f"SPDXRef-Dep-{i}"
 
-            # Determine relationship type and target
-            # Note: test scope deps are filtered out before this point
-            # SPDX relationship types (CISA Build SBOM):
-            #   compile/runtime → DEPENDS_ON (classpath dep,
-            #       NOT bundled in thin JAR)
-            #   provided → BUILD_TOOL_OF (compile-time only)
-            # Direct deps point to root; transitive deps
-            # point to their parent in the dep tree.
+            # Determine relationship target:
+            # Direct deps → root package
+            # Transitive deps → their parent in the
+            #   Maven dependency tree
             if dep.get("direct"):
                 target = root_pkg_id
             else:
@@ -486,16 +482,25 @@ class JavaSpdxGenerator:
                 else:
                     target = root_pkg_id
 
+            # SPDX relationship direction:
+            #   DEPENDS_ON: A depends on B →
+            #     "A DEPENDS_ON B" (parent→child)
+            #   BUILD_TOOL_OF: tool builds target →
+            #     "tool BUILD_TOOL_OF target"
             if dep["scope"] == "provided":
-                rel_type = "BUILD_TOOL_OF"
+                # Provided = compile-time only tool
+                doc["relationships"].append({
+                    "spdxElementId": dep_id,
+                    "relatedSpdxElement": target,
+                    "relationshipType": "BUILD_TOOL_OF",
+                })
             else:
-                rel_type = "DEPENDS_ON"
-
-            doc["relationships"].append({
-                "spdxElementId": dep_id,
-                "relatedSpdxElement": target,
-                "relationshipType": rel_type,
-            })
+                # Runtime dep: parent DEPENDS_ON child
+                doc["relationships"].append({
+                    "spdxElementId": target,
+                    "relatedSpdxElement": dep_id,
+                    "relationshipType": "DEPENDS_ON",
+                })
 
         return doc
 
@@ -520,7 +525,13 @@ class JavaSpdxGenerator:
                 version = root.find("version")
 
             if version is not None:
-                return version.text
+                ver = version.text or "unknown"
+                # Strip -SNAPSHOT suffix — we're
+                # analyzing a specific commit, not a
+                # development snapshot.
+                if ver.endswith("-SNAPSHOT"):
+                    ver = ver[: -len("-SNAPSHOT")]
+                return ver
         except ET.ParseError:
             pass
 

--- a/app/spdx_visualize.py
+++ b/app/spdx_visualize.py
@@ -458,7 +458,7 @@ def generate_html(doc, output_path):
     padding-left: 4px;
   }}
 
-  /* Group labels */
+  /* Group labels (unused, kept for potential future use) */
   .group-label {{
     font-size: 14px;
     font-weight: 600;
@@ -1154,48 +1154,6 @@ searchInput.addEventListener('input', () => {{
   }}
 }});
 
-// --- Group labels (conditional on node types) ---
-const labels = g.append('g').attr('class', 'group-labels');
-const hasStatic = data.nodes.some(
-  d => d.node_type === 'static'
-    || d.node_type === 'direct_dep');
-const hasTransitive = data.nodes.some(
-  d => d.node_type === 'transitive_dep'
-    || (d.depth >= 2 && d.node_type === 'static'));
-const hasDynBuild = data.nodes.some(
-  d => d.node_type === 'dynamic'
-    || d.node_type === 'build');
-const hasVendored = data.nodes.some(
-  d => d.vendored);
-
-if (hasStatic) {{
-  labels.append('text')
-    .attr('class', 'group-label')
-    .attr('x', width * 0.72)
-    .attr('y', 80)
-    .text('DIRECT \u2192');
-}}
-if (hasDynBuild) {{
-  labels.append('text')
-    .attr('class', 'group-label')
-    .attr('x', width * 0.5)
-    .attr('y', 80)
-    .text('DYNAMIC / BUILD');
-}}
-if (hasTransitive) {{
-  labels.append('text')
-    .attr('class', 'group-label')
-    .attr('x', width * 0.22)
-    .attr('y', 80)
-    .text('\u2190 TRANSITIVE');
-}}
-if (hasVendored) {{
-  labels.append('text')
-    .attr('class', 'group-label')
-    .attr('x', width * 0.85)
-    .attr('y', height * 0.72 - 20)
-    .text('VENDORED \u2193');
-}}
 </script>
 </body>
 </html>"""

--- a/app/spdx_visualize.py
+++ b/app/spdx_visualize.py
@@ -1054,7 +1054,7 @@ simulation.on('tick', () => {{
 }});
 
 simulation.on('end', () => {{
-  zoomToFit(600);
+  zoomToFit(0);
 }});
 
 function dragstarted(event, d) {{

--- a/app/spdx_visualize.py
+++ b/app/spdx_visualize.py
@@ -42,21 +42,28 @@ def extract_graph(doc):
             ).lower(),
         }
 
-    # Count CONTAINS relationships per package
+    # Count CONTAINS / CONTAINED_BY relationships
+    # per package (Java uses CONTAINED_BY)
     file_counts = {}
     for r in doc.get("relationships", []):
-        if r["relationshipType"] == "CONTAINS":
+        rt = r["relationshipType"]
+        if rt == "CONTAINS":
             src = r["spdxElementId"]
             file_counts[src] = (
                 file_counts.get(src, 0) + 1
             )
+        elif rt == "CONTAINED_BY":
+            tgt = r["relatedSpdxElement"]
+            file_counts[tgt] = (
+                file_counts.get(tgt, 0) + 1
+            )
 
     # Classify packages into groups
     # Relationship directions vary by type:
-    #   STATIC_LINK:  dep → root   (source = dep)
-    #   DYNAMIC_LINK: root → lib   (target = lib)
+    #   STATIC_LINK:  root → dep (root links dep)
+    #   DYNAMIC_LINK: root → lib (target = lib)
     #   BUILD_TOOL_OF: tool → root (source = tool)
-    #   DEPENDS_ON:   child → parent (source = child)
+    #   DEPENDS_ON:   parent → child (parent needs child)
     rels = doc.get("relationships", [])
     dynamic_nodes = set()
     build_nodes = set()
@@ -88,6 +95,10 @@ def extract_graph(doc):
             dynamic_nodes.add(tgt)
         elif rt == "BUILD_TOOL_OF":
             build_nodes.add(src)
+            # Reverse for BFS: target -> tool
+            children_of.setdefault(
+                tgt, []
+            ).append(src)
         elif rt == "DEPENDS_ON":
             depends_nodes.add(src)
             depends_nodes.add(tgt)
@@ -125,10 +136,21 @@ def extract_graph(doc):
                 )
                 queue.append(child)
 
-    # When STATIC_LINK co-exists with DEPENDS_ON
-    # (Rust, C/C++), DEPENDS_ON marks transitive
-    # deps.  When only DEPENDS_ON exists (Go),
-    # use BFS depth to distinguish direct/transitive.
+    # Detect Go modules by parsing comment field
+    go_node_kind = {}  # spdx_id -> 'stdlib'|'direct'|'indirect'
+    for spdx_id, info in pkg_map.items():
+        cmt = info.get("comment", "").lower()
+        if "go standard library" in cmt:
+            go_node_kind[spdx_id] = "stdlib"
+        elif "go module (direct)" in cmt:
+            go_node_kind[spdx_id] = "direct"
+        elif "go module (indirect)" in cmt:
+            go_node_kind[spdx_id] = "indirect"
+
+    # When only DEPENDS_ON exists (Go, Java), use
+    # BFS depth to distinguish direct vs transitive.
+    # Rust uses STATIC_LINK for all crates.
+    # C/C++ uses STATIC_LINK for vendored/compiled.
     has_static = bool(static_nodes - root_ids)
 
     nodes = []
@@ -141,8 +163,12 @@ def extract_graph(doc):
             group = "dynamic"
             node_type = "dynamic"
         elif spdx_id in build_nodes:
-            group = "build"
-            node_type = "build"
+            if depth is not None and depth >= 2:
+                group = "build_deep"
+                node_type = "build_deep"
+            else:
+                group = "build"
+                node_type = "build"
         elif spdx_id in static_nodes:
             # Color by depth but type is static
             node_type = "static"
@@ -153,19 +179,34 @@ def extract_graph(doc):
             else:
                 group = "depth-1"
         elif spdx_id in depends_nodes:
-            # Classify direct vs transitive
-            if has_static:
-                # Rust/C++: DEPENDS_ON = transitive
+            # Go module type grouping
+            gk = go_node_kind.get(spdx_id)
+            if gk == "stdlib":
+                node_type = "go_stdlib"
+                group = "go_stdlib"
+            elif gk == "direct":
+                node_type = "go_direct"
+                group = "go_direct"
+            elif gk == "indirect":
+                node_type = "go_indirect"
+                group = "go_indirect"
+            elif has_static:
+                # C/C++: DEPENDS_ON = transitive
                 node_type = "transitive_dep"
+                if depth is not None and depth >= 1:
+                    group = f"depth-{min(depth, 5)}"
+                else:
+                    group = "depth-1"
             elif depth is not None and depth > 1:
-                # Go: depth > 1 = transitive
+                # Java/other: depth > 1 = transitive
                 node_type = "transitive_dep"
+                if depth is not None and depth >= 1:
+                    group = f"depth-{min(depth, 5)}"
+                else:
+                    group = "depth-1"
             else:
-                # Go: depth 1 = direct
+                # Java/other: depth 1 = direct
                 node_type = "direct_dep"
-            if depth is not None and depth >= 1:
-                group = f"depth-{min(depth, 5)}"
-            else:
                 group = "depth-1"
         else:
             group = "other"
@@ -224,10 +265,12 @@ def generate_html(doc, output_path):
     rel_counts = Counter(
         e["type"] for e in edges
     )
-    # Also count CONTAINS from original doc
+    # Also count CONTAINS/CONTAINED_BY from original doc
     contains_count = sum(
         1 for r in doc.get("relationships", [])
-        if r["relationshipType"] == "CONTAINS"
+        if r["relationshipType"] in (
+            "CONTAINS", "CONTAINED_BY"
+        )
     )
     grp_counts = Counter(
         n["group"] for n in nodes
@@ -238,6 +281,50 @@ def generate_html(doc, output_path):
     vendored_count = sum(
         1 for n in nodes if n.get("vendored")
     )
+
+    # Build conditional legend sections
+    build_deep_legend = ""
+    if type_counts.get("build_deep", 0):
+        build_deep_legend = (
+            '  <div class="legend-item">\n'
+            '    <div class="legend-dot" '
+            'style="background:#e6a819"></div>\n'
+            "    <span>Build tool chain "
+            f"({type_counts['build_deep']})"
+            "</span>\n"
+            "  </div>\n"
+        )
+    go_legend = ""
+    if type_counts.get("go_stdlib", 0):
+        go_legend += (
+            '  <div class="legend-item">\n'
+            '    <div class="legend-dot" '
+            'style="background:#38bdf8"></div>\n'
+            "    <span>Go stdlib "
+            f"({type_counts['go_stdlib']})"
+            "</span>\n"
+            "  </div>\n"
+        )
+    if type_counts.get("go_direct", 0):
+        go_legend += (
+            '  <div class="legend-item">\n'
+            '    <div class="legend-dot" '
+            'style="background:#34d399"></div>\n'
+            "    <span>Go direct "
+            f"({type_counts['go_direct']})"
+            "</span>\n"
+            "  </div>\n"
+        )
+    if type_counts.get("go_indirect", 0):
+        go_legend += (
+            '  <div class="legend-item">\n'
+            '    <div class="legend-dot" '
+            'style="background:#fb7185"></div>\n'
+            "    <span>Go indirect "
+            f"({type_counts['go_indirect']})"
+            "</span>\n"
+            "  </div>\n"
+        )
 
     html_content = f"""<!DOCTYPE html>
 <html lang="en">
@@ -410,7 +497,7 @@ def generate_html(doc, output_path):
     <div class="legend-dot" style="background:#ffd93d"></div>
     <span>Build tool ({type_counts.get('build', 0)})</span>
   </div>
-  <div class="legend-item">
+{build_deep_legend}  <div class="legend-item">
     <div class="legend-dot" style="background:#4ecdc4"></div>
     <span>Direct dep ({type_counts.get('direct_dep', 0)})</span>
   </div>
@@ -418,6 +505,7 @@ def generate_html(doc, output_path):
     <div class="legend-dot" style="background:#56b6f7"></div>
     <span>Transitive dep ({type_counts.get('transitive_dep', 0)})</span>
   </div>
+{go_legend}
   <h3 style="margin-top:10px;font-size:11px;color:#888">Depth breakdown</h3>
   <div class="legend-item" style="font-size:11px;color:#999">
     <div class="legend-dot" style="background:#4ecdc4;width:8px;height:8px"></div>
@@ -485,8 +573,12 @@ const colors = {{
   'depth-3': '#a78bfa',
   'depth-4': '#f472b6',
   'depth-5': '#fb923c',
+  go_stdlib: '#38bdf8',
+  go_direct: '#34d399',
+  go_indirect: '#fb7185',
   dynamic: '#ff6b6b',
   build: '#ffd93d',
+  build_deep: '#e6a819',
   other: '#888',
 }};
 
@@ -536,8 +628,12 @@ const xPositions = {{
   'depth-4': width * 0.15,
   'depth-5': width * 0.10,
   vendored: width * 0.85,
+  go_stdlib: width * 0.20,
+  go_direct: width * 0.72,
+  go_indirect: width * 0.38,
   dynamic: width * 0.5,
   build: width * 0.5,
+  build_deep: width * 0.5,
   other: width / 2,
 }};
 
@@ -550,8 +646,12 @@ const yPositions = {{
   'depth-4': height * 0.56,
   'depth-5': height * 0.58,
   vendored: height * 0.72,
+  go_stdlib: height * 0.75,
+  go_direct: height * 0.50,
+  go_indirect: height * 0.52,
   dynamic: height * 0.18,
   build: height * 0.18,
+  build_deep: height * 0.25,
   other: height * 0.55,
 }};
 
@@ -562,8 +662,12 @@ const yStrengths = {{
   'depth-3': 0.10,
   'depth-4': 0.10,
   'depth-5': 0.10,
+  go_stdlib: 0.3,
+  go_direct: 0.10,
+  go_indirect: 0.10,
   dynamic: 0.5,
   build: 0.5,
+  build_deep: 0.4,
   other: 0.12,
 }};
 
@@ -865,7 +969,22 @@ node.on('mouseover', (event, d) => {{
   const rows = [];
   if (d.version) rows.push('<div class="tt-row">Version: <span>' + d.version + '</span></div>');
   rows.push('<div class="tt-row">Purpose: <span>' + d.purpose + '</span></div>');
-  rows.push('<div class="tt-row">Group: <span>' + d.group + '</span></div>');
+  const typeLabels = {{
+    'root': 'Root binary',
+    'static': 'Statically linked (compiled in)',
+    'dynamic': 'Dynamically linked (runtime)',
+    'build': 'Build tool',
+    'build_deep': 'Build tool (transitive)',
+    'direct_dep': 'Direct dependency',
+    'transitive_dep': 'Transitive dependency',
+    'go_stdlib': 'Go standard library (compiled in)',
+    'go_direct': 'Direct Go module (compiled in)',
+    'go_indirect': 'Indirect Go module (compiled in)',
+    'vendored': 'Vendored (compiled in)',
+    'other': 'Other',
+  }};
+  const typeLabel = typeLabels[d.node_type] || d.node_type;
+  rows.push('<div class="tt-row">Type: <span>' + typeLabel + '</span></div>');
   const td = treeDepthMap[d.id];
   if (td !== undefined) rows.push('<div class="tt-row">Tree depth: <span>' + td + '</span></div>');
   if (d.fileCount) rows.push('<div class="tt-row">Source files: <span>' + d.fileCount + '</span></div>');
@@ -985,34 +1104,80 @@ searchInput.addEventListener('input', () => {{
   // Zoom to first match
   if (matches.length === 1) {{
     const m = matches[0];
+    selectedNode = null;
     highlightConnections(m);
     const t = d3.zoomIdentity.translate(width/2 - m.x, height/2 - m.y);
     svg.transition().duration(500).call(d3.zoom().transform, t);
   }}
 }});
 
-// --- Group labels ---
+// --- Group labels (conditional on node types) ---
 const labels = g.append('g').attr('class', 'group-labels');
-labels.append('text')
-  .attr('class', 'group-label')
-  .attr('x', width * 0.72)
-  .attr('y', 80)
-  .text('DIRECT \u2192');
-labels.append('text')
-  .attr('class', 'group-label')
-  .attr('x', width * 0.5)
-  .attr('y', 80)
-  .text('DYNAMIC / BUILD');
-labels.append('text')
-  .attr('class', 'group-label')
-  .attr('x', width * 0.22)
-  .attr('y', 80)
-  .text('\u2190 TRANSITIVE');
-labels.append('text')
-  .attr('class', 'group-label')
-  .attr('x', width * 0.85)
-  .attr('y', height * 0.72 - 20)
-  .text('VENDORED \u2193');
+const hasStatic = data.nodes.some(
+  d => d.node_type === 'static'
+    || d.node_type === 'direct_dep');
+const hasTransitive = data.nodes.some(
+  d => d.node_type === 'transitive_dep'
+    || (d.depth >= 2 && d.node_type === 'static'));
+const hasDynBuild = data.nodes.some(
+  d => d.node_type === 'dynamic'
+    || d.node_type === 'build');
+const hasVendored = data.nodes.some(
+  d => d.vendored);
+
+if (hasStatic) {{
+  labels.append('text')
+    .attr('class', 'group-label')
+    .attr('x', width * 0.72)
+    .attr('y', 80)
+    .text('DIRECT \u2192');
+}}
+if (hasDynBuild) {{
+  labels.append('text')
+    .attr('class', 'group-label')
+    .attr('x', width * 0.5)
+    .attr('y', 80)
+    .text('DYNAMIC / BUILD');
+}}
+if (hasTransitive) {{
+  labels.append('text')
+    .attr('class', 'group-label')
+    .attr('x', width * 0.22)
+    .attr('y', 80)
+    .text('\u2190 TRANSITIVE');
+}}
+if (hasVendored) {{
+  labels.append('text')
+    .attr('class', 'group-label')
+    .attr('x', width * 0.85)
+    .attr('y', height * 0.72 - 20)
+    .text('VENDORED \u2193');
+}}
+// Go module group labels (per-type)
+if (data.nodes.some(d => d.node_type === 'go_direct')) {{
+  labels.append('text')
+    .attr('class', 'group-label')
+    .attr('x', width * 0.72)
+    .attr('y', height * 0.50 - 30)
+    .style('fill', '#34d399')
+    .text('GO DIRECT');
+}}
+if (data.nodes.some(d => d.node_type === 'go_indirect')) {{
+  labels.append('text')
+    .attr('class', 'group-label')
+    .attr('x', width * 0.38)
+    .attr('y', height * 0.52 - 30)
+    .style('fill', '#fb7185')
+    .text('GO INDIRECT');
+}}
+if (data.nodes.some(d => d.node_type === 'go_stdlib')) {{
+  labels.append('text')
+    .attr('class', 'group-label')
+    .attr('x', width * 0.20)
+    .attr('y', height * 0.75 - 20)
+    .style('fill', '#38bdf8')
+    .text('GO STDLIB');
+}}
 </script>
 </body>
 </html>"""

--- a/app/spdx_visualize.py
+++ b/app/spdx_visualize.py
@@ -599,9 +599,42 @@ const svg = d3.select('#graph')
 
 // Zoom
 const g = svg.append('g');
-svg.call(d3.zoom()
-  .scaleExtent([0.2, 5])
-  .on('zoom', (e) => g.attr('transform', e.transform)));
+const zoom = d3.zoom()
+  .scaleExtent([0.1, 5])
+  .on('zoom', (e) => g.attr('transform', e.transform));
+svg.call(zoom);
+
+// Zoom-to-fit: compute bounding box of all nodes
+// and apply transform to fit within viewport
+function zoomToFit(duration) {{
+  const pad = 60;
+  let x0 = Infinity, y0 = Infinity;
+  let x1 = -Infinity, y1 = -Infinity;
+  data.nodes.forEach(d => {{
+    if (d.x < x0) x0 = d.x;
+    if (d.y < y0) y0 = d.y;
+    if (d.x > x1) x1 = d.x;
+    if (d.y > y1) y1 = d.y;
+  }});
+  const bw = x1 - x0 || 1;
+  const bh = y1 - y0 || 1;
+  const cx = (x0 + x1) / 2;
+  const cy = (y0 + y1) / 2;
+  const scale = Math.min(
+    (width - pad * 2) / bw,
+    (height - pad * 2) / bh,
+    1.5);
+  const t = d3.zoomIdentity
+    .translate(width / 2, height / 2)
+    .scale(scale)
+    .translate(-cx, -cy);
+  if (duration) {{
+    svg.transition().duration(duration)
+      .call(zoom.transform, t);
+  }} else {{
+    svg.call(zoom.transform, t);
+  }}
+}}
 
 // Arrow markers
 const defs = svg.append('defs');
@@ -1020,6 +1053,10 @@ simulation.on('tick', () => {{
   node.attr('transform', d => 'translate(' + d.x + ',' + d.y + ')');
 }});
 
+simulation.on('end', () => {{
+  zoomToFit(600);
+}});
+
 function dragstarted(event, d) {{
   simulation.alphaTarget(0.01).restart();
   d.fx = d.x; d.fy = d.y;
@@ -1106,8 +1143,13 @@ searchInput.addEventListener('input', () => {{
     const m = matches[0];
     selectedNode = null;
     highlightConnections(m);
-    const t = d3.zoomIdentity.translate(width/2 - m.x, height/2 - m.y);
-    svg.transition().duration(500).call(d3.zoom().transform, t);
+    const scale = 1.2;
+    const t = d3.zoomIdentity
+      .translate(width/2, height/2)
+      .scale(scale)
+      .translate(-m.x, -m.y);
+    svg.transition().duration(500)
+      .call(zoom.transform, t);
   }}
 }});
 

--- a/app/spdx_visualize.py
+++ b/app/spdx_visualize.py
@@ -1153,31 +1153,6 @@ if (hasVendored) {{
     .attr('y', height * 0.72 - 20)
     .text('VENDORED \u2193');
 }}
-// Go module group labels (per-type)
-if (data.nodes.some(d => d.node_type === 'go_direct')) {{
-  labels.append('text')
-    .attr('class', 'group-label')
-    .attr('x', width * 0.72)
-    .attr('y', height * 0.50 - 30)
-    .style('fill', '#34d399')
-    .text('GO DIRECT');
-}}
-if (data.nodes.some(d => d.node_type === 'go_indirect')) {{
-  labels.append('text')
-    .attr('class', 'group-label')
-    .attr('x', width * 0.38)
-    .attr('y', height * 0.52 - 30)
-    .style('fill', '#fb7185')
-    .text('GO INDIRECT');
-}}
-if (data.nodes.some(d => d.node_type === 'go_stdlib')) {{
-  labels.append('text')
-    .attr('class', 'group-label')
-    .attr('x', width * 0.20)
-    .attr('y', height * 0.75 - 20)
-    .style('fill', '#38bdf8')
-    .text('GO STDLIB');
-}}
 </script>
 </body>
 </html>"""

--- a/app/spdx_visualize.py
+++ b/app/spdx_visualize.py
@@ -828,6 +828,7 @@ const deepIdSet = new Set(
 
 // Force simulation (original layout + fan-out)
 const simulation = d3.forceSimulation(data.nodes)
+  .alphaDecay(0.05)
   .force('link', d3.forceLink(data.links)
     .id(d => d.id)
     .distance(d => {{

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -2955,6 +2955,12 @@ class TestMetadataCollector(unittest.TestCase):
             self.assertTrue(result)
             mock_meta.assert_called_once()
             mock_dyn.assert_called_once()
+            # Verify project_bins is passed
+            dyn_call = mock_dyn.call_args
+            self.assertEqual(
+                dyn_call.kwargs.get("project_bins"),
+                ["nmap"],
+            )
 
     def test_skips_existing_dynlibs(self):
         """Skips collection if dynamic_libs.json exists."""

--- a/tests/test_collect_dynamic_libs.py
+++ b/tests/test_collect_dynamic_libs.py
@@ -1,0 +1,335 @@
+"""Tests for collect_dynamic_libs.py.
+
+Focuses on the project_bins logic that identifies
+project-built .so files even when a system dpkg
+package provides the same soname.
+"""
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import sys
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent / "app")
+)
+
+from collect_dynamic_libs import main  # noqa: E402
+
+
+class TestProjectBuiltDetection(unittest.TestCase):
+    """Test project_bins detection in main()."""
+
+    def _mock_ldd(self, libs_map):
+        """Build fake ldd output.
+
+        libs_map: {soname: path} or {soname: None} for
+        "not found".
+        """
+        lines = []
+        for soname, path in libs_map.items():
+            if path is None:
+                lines.append(
+                    f"\t{soname} => not found"
+                )
+            else:
+                lines.append(
+                    f"\t{soname} => {path} "
+                    f"(0x00007f0000000000)"
+                )
+        return "\n".join(lines) + "\n"
+
+    def _mock_readelf(self, needed):
+        """Build fake readelf -d output."""
+        lines = []
+        for soname in needed:
+            lines.append(
+                f" 0x0000000000000001 (NEEDED)"
+                f"             Shared library:"
+                f" [{soname}]"
+            )
+        return "\n".join(lines) + "\n"
+
+    def _mock_dpkg_s(self, path_to_pkg):
+        """Return a side_effect for dpkg -S calls."""
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                path = cmd[2]
+                if path in path_to_pkg:
+                    return path_to_pkg[path]
+                raise Exception("not found")
+            raise Exception("unexpected cmd")
+        return side_effect
+
+    def _mock_dpkg_query(self, pkg_to_meta):
+        """Return a side_effect for dpkg-query calls."""
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "dpkg-query":
+                pkg = cmd[4]
+                if pkg in pkg_to_meta:
+                    return pkg_to_meta[pkg]
+                raise Exception("not found")
+            raise Exception("unexpected cmd")
+        return side_effect
+
+    @patch("collect_dynamic_libs.subprocess.check_output")
+    @patch("collect_dynamic_libs.os.path.realpath")
+    def test_project_bins_overrides_dpkg(
+        self, mock_realpath, mock_subproc,
+    ):
+        """When project_bins contains a .so, matching
+        sonames should be moved to project_built_libs
+        instead of dynamic_libs."""
+        # Simulate curl scenario: libcurl.so.4 resolves
+        # to system dpkg libcurl4 7.81.0
+        needed = ["libcurl.so.4", "libc.so.6"]
+        ldd_out = self._mock_ldd({
+            "libcurl.so.4": "/lib/x86_64-linux-gnu/"
+                            "libcurl.so.4",
+            "libc.so.6": "/lib/x86_64-linux-gnu/"
+                         "libc.so.6",
+        })
+        readelf_out = self._mock_readelf(needed)
+
+        # realpath returns itself for simplicity
+        mock_realpath.side_effect = lambda p: p
+
+        def subproc_side_effect(cmd, **kwargs):
+            if cmd[0] == "ldd":
+                return ldd_out
+            if cmd[0] == "readelf":
+                return readelf_out
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                path = cmd[2]
+                if "libcurl" in path:
+                    return "libcurl4: " + path
+                if "libc" in path:
+                    return "libc6: " + path
+                raise Exception("not found")
+            if cmd[0] == "dpkg-query":
+                pkg = cmd[4]
+                if pkg == "libcurl4":
+                    return (
+                        "libcurl4|7.81.0-1ubuntu1.23"
+                        "|curl|Ubuntu Dev|"
+                        "https://curl.haxx.se|amd64"
+                    )
+                if pkg == "libc6":
+                    return (
+                        "libc6|2.35-0ubuntu3|glibc"
+                        "|Ubuntu Dev|"
+                        "https://www.gnu.org/software"
+                        "/libc/libc.html|amd64"
+                    )
+                raise Exception("not found")
+            raise Exception(f"unexpected: {cmd}")
+
+        mock_subproc.side_effect = subproc_side_effect
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch("builtins.print"):
+                main(
+                    "/fake/curl", td,
+                    project_bins=[
+                        "src/.libs/curl",
+                        "lib/.libs/libcurl.so",
+                    ],
+                )
+
+            out = json.loads(
+                (Path(td) / "dynamic_libs.json")
+                .read_text()
+            )
+
+            # libcurl.so.4 should be in project_built
+            self.assertIn(
+                "libcurl.so.4",
+                out["project_built_libs"],
+            )
+            pb = out["project_built_libs"][
+                "libcurl.so.4"
+            ]
+            self.assertEqual(pb["name"], "libcurl")
+            self.assertTrue(pb["project_built"])
+            self.assertTrue(pb["direct"])
+
+            # libcurl.so.4 should NOT be in dynamic_libs
+            self.assertNotIn(
+                "libcurl.so.4",
+                out["dynamic_libs"],
+            )
+
+            # libc.so.6 should still be in dynamic_libs
+            self.assertIn(
+                "libc.so.6", out["dynamic_libs"],
+            )
+
+    @patch("collect_dynamic_libs.subprocess.check_output")
+    @patch("collect_dynamic_libs.os.path.realpath")
+    def test_no_project_bins_keeps_dpkg(
+        self, mock_realpath, mock_subproc,
+    ):
+        """Without project_bins, all libs stay in
+        dynamic_libs (original behavior)."""
+        needed = ["libcurl.so.4"]
+        ldd_out = self._mock_ldd({
+            "libcurl.so.4": "/lib/x86_64-linux-gnu/"
+                            "libcurl.so.4",
+        })
+        readelf_out = self._mock_readelf(needed)
+        mock_realpath.side_effect = lambda p: p
+
+        def subproc_side_effect(cmd, **kwargs):
+            if cmd[0] == "ldd":
+                return ldd_out
+            if cmd[0] == "readelf":
+                return readelf_out
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                return "libcurl4: " + cmd[2]
+            if cmd[0] == "dpkg-query":
+                return (
+                    "libcurl4|7.81.0|curl|Dev|"
+                    "https://curl.haxx.se|amd64"
+                )
+            raise Exception(f"unexpected: {cmd}")
+
+        mock_subproc.side_effect = subproc_side_effect
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch("builtins.print"):
+                main("/fake/curl", td)
+
+            out = json.loads(
+                (Path(td) / "dynamic_libs.json")
+                .read_text()
+            )
+
+            # Without project_bins, libcurl stays in
+            # dynamic_libs
+            self.assertIn(
+                "libcurl.so.4", out["dynamic_libs"],
+            )
+            self.assertEqual(
+                out["project_built_libs"], {},
+            )
+
+    @patch("collect_dynamic_libs.subprocess.check_output")
+    @patch("collect_dynamic_libs.os.path.realpath")
+    def test_not_found_still_project_built(
+        self, mock_realpath, mock_subproc,
+    ):
+        """'not found' libs are still marked
+        project_built (ffmpeg case)."""
+        needed = [
+            "libavcodec.so.62", "libc.so.6",
+        ]
+        ldd_out = self._mock_ldd({
+            "libavcodec.so.62": None,
+            "libc.so.6": "/lib/x86_64-linux-gnu/"
+                         "libc.so.6",
+        })
+        readelf_out = self._mock_readelf(needed)
+        mock_realpath.side_effect = lambda p: p
+
+        def subproc_side_effect(cmd, **kwargs):
+            if cmd[0] == "ldd":
+                return ldd_out
+            if cmd[0] == "readelf":
+                return readelf_out
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                if "libc" in cmd[2]:
+                    return "libc6: " + cmd[2]
+                raise Exception("not found")
+            if cmd[0] == "dpkg-query":
+                return (
+                    "libc6|2.35|glibc|Dev|"
+                    "https://gnu.org|amd64"
+                )
+            raise Exception(f"unexpected: {cmd}")
+
+        mock_subproc.side_effect = subproc_side_effect
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch("builtins.print"):
+                main(
+                    "/fake/ffmpeg", td,
+                    project_bins=[
+                        "ffmpeg",
+                        "libavcodec/libavcodec.so",
+                    ],
+                )
+
+            out = json.loads(
+                (Path(td) / "dynamic_libs.json")
+                .read_text()
+            )
+
+            # not-found lib is project_built
+            self.assertIn(
+                "libavcodec.so.62",
+                out["project_built_libs"],
+            )
+            pb = out["project_built_libs"][
+                "libavcodec.so.62"
+            ]
+            self.assertEqual(pb["name"], "libavcodec")
+            self.assertTrue(pb["project_built"])
+
+    @patch("collect_dynamic_libs.subprocess.check_output")
+    @patch("collect_dynamic_libs.os.path.realpath")
+    def test_non_so_project_bins_ignored(
+        self, mock_realpath, mock_subproc,
+    ):
+        """Non-.so project_bins (like 'curl') don't
+        match any sonames."""
+        needed = ["libc.so.6"]
+        ldd_out = self._mock_ldd({
+            "libc.so.6": "/lib/x86_64-linux-gnu/"
+                         "libc.so.6",
+        })
+        readelf_out = self._mock_readelf(needed)
+        mock_realpath.side_effect = lambda p: p
+
+        def subproc_side_effect(cmd, **kwargs):
+            if cmd[0] == "ldd":
+                return ldd_out
+            if cmd[0] == "readelf":
+                return readelf_out
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                return "libc6: " + cmd[2]
+            if cmd[0] == "dpkg-query":
+                return (
+                    "libc6|2.35|glibc|Dev|"
+                    "https://gnu.org|amd64"
+                )
+            raise Exception(f"unexpected: {cmd}")
+
+        mock_subproc.side_effect = subproc_side_effect
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch("builtins.print"):
+                main(
+                    "/fake/redis-server", td,
+                    project_bins=[
+                        "src/redis-server",
+                        "src/redis-cli",
+                    ],
+                )
+
+            out = json.loads(
+                (Path(td) / "dynamic_libs.json")
+                .read_text()
+            )
+
+            # No .so in project_bins, so no overrides
+            self.assertIn(
+                "libc.so.6", out["dynamic_libs"],
+            )
+            self.assertEqual(
+                out["project_built_libs"], {},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_java_generator.py
+++ b/tests/test_java_generator.py
@@ -401,6 +401,26 @@ class TestGetVersion(unittest.TestCase):
             )
             self.assertEqual(gen._get_version(), "unknown")
 
+    def test_version_strips_snapshot(self):
+        with tempfile.TemporaryDirectory() as td:
+            repos = Path(td) / "repos"
+            repo = repos / "myapp"
+            repo.mkdir(parents=True)
+            pom = repo / "pom.xml"
+            pom.write_text(
+                '<project>\n'
+                '  <version>10.13.4-SNAPSHOT</version>\n'
+                '</project>\n'
+            )
+            gen = JavaSpdxGenerator(
+                bom_dir="/tmp/bom",
+                repos_dir=str(repos),
+                repo_name="myapp",
+            )
+            self.assertEqual(
+                gen._get_version(), "10.13.4"
+            )
+
 
 class TestGetMavenDeps(unittest.TestCase):
     """Tests for _get_maven_deps."""
@@ -614,9 +634,14 @@ class TestBuildSpdx(unittest.TestCase):
             if r["relationshipType"] == "DEPENDS_ON"
         ]
         self.assertEqual(len(rels), 1)
-        self.assertIn(
+        # root DEPENDS_ON dep (correct SPDX direction)
+        self.assertEqual(
+            rels[0]["spdxElementId"],
             "SPDXRef-Package-myapp.jar",
+        )
+        self.assertEqual(
             rels[0]["relatedSpdxElement"],
+            "SPDXRef-Dep-0",
         )
 
     def test_transitive_compile_dep_depends_on(self):
@@ -649,11 +674,23 @@ class TestBuildSpdx(unittest.TestCase):
         ]
         # Both direct and transitive use DEPENDS_ON
         self.assertEqual(len(depends), 2)
-        # Transitive child points to parent
-        child_rel = depends[1]
+        # Direct: root DEPENDS_ON parent-lib
         self.assertEqual(
-            child_rel["relatedSpdxElement"],
+            depends[0]["spdxElementId"],
+            "SPDXRef-Package-myapp.jar",
+        )
+        self.assertEqual(
+            depends[0]["relatedSpdxElement"],
             "SPDXRef-Dep-0",
+        )
+        # Transitive: parent DEPENDS_ON child
+        self.assertEqual(
+            depends[1]["spdxElementId"],
+            "SPDXRef-Dep-0",
+        )
+        self.assertEqual(
+            depends[1]["relatedSpdxElement"],
+            "SPDXRef-Dep-1",
         )
 
     def test_provided_dep_build_tool_of(self):
@@ -725,9 +762,14 @@ class TestBuildSpdx(unittest.TestCase):
             if r["relationshipType"] == "DEPENDS_ON"
         ]
         self.assertEqual(len(depends), 1)
-        self.assertIn(
+        # Orphan falls to root: root DEPENDS_ON orphan
+        self.assertEqual(
+            depends[0]["spdxElementId"],
             "SPDXRef-Package-myapp.jar",
+        )
+        self.assertEqual(
             depends[0]["relatedSpdxElement"],
+            "SPDXRef-Dep-0",
         )
 
     def test_optional_dep_comment(self):

--- a/tests/test_spdx_from_adg.py
+++ b/tests/test_spdx_from_adg.py
@@ -3364,7 +3364,9 @@ class TestRustDirectVsTransitive(
                 clap_rels[0]["relationshipType"],
                 "STATIC_LINK",
             )
-            # clap_builder is transitive -> DEPENDS_ON
+            # clap_builder is transitive but still
+            # STATIC_LINK (all Rust crates are
+            # statically compiled into the binary)
             cb_pkg = next(
                 p for p in doc["packages"]
                 if p["name"] == "clap_builder"
@@ -3376,7 +3378,7 @@ class TestRustDirectVsTransitive(
             ]
             self.assertEqual(
                 cb_rels[0]["relationshipType"],
-                "DEPENDS_ON",
+                "STATIC_LINK",
             )
 
 


### PR DESCRIPTION
## SPDX Generation Fixes

- **Java DEPENDS_ON direction**: root/parent DEPENDS_ON dep/child (was backwards, causing all deps to appear as "direct")
- **Java -SNAPSHOT stripping**: Maven development version suffix removed from root package versions
- **Rust all-STATIC_LINK**: All compiled crates now use STATIC_LINK (not just direct ones)
- **C/C++ project_bins**: Pass output_binaries to collect_dynamic_libs so project-built .so files are correctly identified

## Visualization Improvements

- **Go module type grouping**: stdlib (sky blue), direct (emerald), indirect (rose) with distinct layout positions
- **CONTAINED_BY counting**: Java file count badges now count CONTAINED_BY relationships
- **Conditional group labels**: DIRECT/TRANSITIVE/VENDORED/Go labels only shown when matching nodes exist
- **GO INDIRECT color**: Changed from purple (#a78bfa, clashed with Root) to rose (#fb7185)
- **Human-friendly tooltips**: "Type: Direct Go module (compiled in)" instead of "Group: go_direct"
- **Search toggle fix**: No longer deselects the match on each keystroke
- **BUILD_TOOL_OF depth tiers**: 2nd tier bright yellow, 3rd tier darker gold

## Config

- Added `vendored_dirs` for redis (8 dirs: jemalloc, lua, hiredis, fpconv, etc.)

## Rules

- `file-size.md`: Flag Python modules exceeding 400 lines for refactoring

## Verified Results (EC2 pipeline re-run)

| Repo | Fix | Before | After |
|------|-----|--------|-------|
| oxipng | Rust STATIC_LINK | 11 static, 33 DEPENDS_ON | 44 STATIC_LINK, 0 DEPENDS_ON |
| checkstyle | Java direction | 31 direct, 0 transitive | 10 direct, 21 transitive |
| checkstyle | Java version | 13.4.0-SNAPSHOT | 13.4.0 |
| lazygit | Go grouping | all "depth-1" | 1 stdlib, 33 direct, 29 indirect |

## Tests

670 passing
