### PR TITLE
docs: add app-architecture.md — call graph and file dependencies

### DIFF
--- a/docs/app-architecture.md
+++ b/docs/app-architecture.md
@@ -1,0 +1,391 @@
+# App Architecture and Call Graph
+
+This document maps every file under `app/`, shows how they call each
+other, and traces the execution flow from entry points to leaf modules.
+Use this as a guide to understand how the OmniBOR analysis pipeline
+works end to end.
+
+---
+
+## Table of Contents
+
+1. [Entry Points](#1-entry-points)
+2. [Pipeline Workflow (analyze.py)](#2-pipeline-workflow-analyzepy)
+3. [SPDX Generation (spdx_from_adg.py)](#3-spdx-generation-spdx_from_adgpy)
+4. [Visualization (spdx_visualize.py)](#4-visualization-spdx_visualizepy)
+5. [SBOM Comparison (compare.py)](#5-sbom-comparison-comparepy)
+6. [Repo Discovery (add_repo.py)](#6-repo-discovery-add_repopy)
+7. [Shared Utilities](#7-shared-utilities)
+8. [Full Dependency Map](#8-full-dependency-map)
+9. [Package Summaries](#9-package-summaries)
+
+---
+
+## 1. Entry Points
+
+There are five independent CLI entry points. Each can be run as
+`python3 -m app.<module>` or directly inside the Docker container.
+
+| Entry Point | Purpose | Where it runs |
+|-------------|---------|---------------|
+| `app/analyze.py` | Full pipeline: clone → build → instrument → SPDX → validate → collect | Docker container (EC2) |
+| `app/spdx_from_adg.py` | Standalone ADG-to-SPDX generation (per-binary) | Docker container |
+| `app/spdx_visualize.py` | Generate HTML visualization from SPDX JSON | Local or container |
+| `app/compare.py` | Compare OmniBOR SBOM vs. proprietary scan SBOM | Local |
+| `app/add_repo.py` | Auto-discover and add a new repo to config.yaml | Local |
+
+## 2. Pipeline Workflow (analyze.py)
+
+`analyze.py` is the main orchestrator. It reads `config.yaml`, creates
+an `AnalysisPipeline` facade, and dispatches to a language-specific
+runner. Here is the call sequence for a typical `--repo curl` run:
+
+```
+analyze.py
+ └─ main()                              # CLI argument parsing
+     ├─ config.load_config()            # Load app/config.yaml
+     ├─ AnalysisPipeline()              # Create facade (composes all steps)
+     │   ├─ CommandRunner()             # Shell command executor
+     │   ├─ DependencyValidator()       # Check apt deps are installed
+     │   ├─ RepoCloner()               # git clone --branch <tag>
+     │   ├─ BomtraceBuilder()          # Instrumented build (bomtrace2/3)
+     │   ├─ SpdxGenerator()            # bomsh_sbom.py → OmniBOR SPDX
+     │   ├─ SpdxValidator()            # JSON schema + semantic checks
+     │   ├─ SyftGenerator()            # Syft manifest-based SBOM
+     │   ├─ MetadataCollector()        # collect_metadata + collect_dynamic_libs
+     │   ├─ AdgSpdxStep()             # Per-binary analyzed + build SBOMs
+     │   ├─ BinaryCollector()          # Copy output binaries to output/
+     │   └─ DocWriter()                # Write build.md + runtime.md
+     │
+     └─ _run_{language}_pipeline()      # Language-specific step sequence
+```
+
+### Language-specific pipelines
+
+Each language follows the same pattern but with different tools:
+
+```
+Step 1: Clone           RepoCloner.clone()
+Step 2: Syft SBOM       SyftGenerator.generate()
+Step 3: Validate deps   DependencyValidator.validate()     [C/C++ only]
+Step 4: Build           BomtraceBuilder.build()            [or build_java()]
+Step 5a: OmniBOR SPDX   SpdxGenerator.generate()           [or generate_java()]
+Step 5b: Metadata        MetadataCollector.collect()
+Step 5c: ADG SPDX        AdgSpdxStep.generate()            [or _generate_java_adg_spdx()]
+Step 6: Validate         SpdxValidator.validate()
+Step 7: Collect          BinaryCollector.collect()
+Step 8: Docs             DocWriter.write_build_doc() + write_runtime_doc()
+```
+
+| Language | Tracer | ADG SPDX Generator | Notes |
+|----------|--------|-------------------|-------|
+| C/C++ | bomtrace3 | `AdgSpdxStep` → `AdgSpdxGenerator` | apt deps validated first |
+| Rust | bomtrace2 | `AdgSpdxStep` → `AdgSpdxGenerator` | Same as C/C++ but bomtrace2 |
+| Go | bomtrace2 + `bomtrace_go.conf` | `AdgSpdxStep` → `AdgSpdxGenerator` | Needs `-a` flag, openat tracing |
+| Java | strace + `bomsh_create_bom_java.py` | `_generate_java_adg_spdx()` → `JavaSpdxGenerator` | No dynamic libs |
+
+### Pipeline file dependencies
+
+```
+app/pipeline/runners.py          # CLI main() + language-specific runners
+ ├─ app/config.py                # load_config(), timestamp(), lang_subdir()
+ └─ app/pipeline/facade.py       # AnalysisPipeline (composes all steps below)
+     ├─ app/runner.py             # CommandRunner (subprocess wrapper)
+     ├─ app/pipeline/validator.py        # DependencyValidator
+     │   └─ app/runner.py
+     ├─ app/pipeline/cloner.py           # RepoCloner
+     │   └─ app/runner.py
+     ├─ app/pipeline/builder.py          # BomtraceBuilder
+     │   ├─ app/config.py
+     │   └─ app/runner.py
+     ├─ app/pipeline/spdx_generator.py   # SpdxGenerator (bomsh_sbom.py wrapper)
+     │   ├─ app/config.py
+     │   └─ app/runner.py
+     ├─ app/pipeline/spdx_validator.py   # SpdxValidator
+     ├─ app/pipeline/syft.py             # SyftGenerator
+     │   ├─ app/config.py
+     │   └─ app/runner.py
+     ├─ app/pipeline/metadata_collector.py  # MetadataCollector
+     │   ├─ app/config.py
+     │   └─ app/runner.py
+     ├─ app/pipeline/adg_spdx.py         # AdgSpdxStep
+     │   ├─ app/config.py
+     │   └─ app/spdx_from_adg.py  [lazy import inside generate()]
+     ├─ app/pipeline/binary_collector.py  # BinaryCollector
+     │   └─ app/config.py
+     └─ app/pipeline/doc_writer.py       # DocWriter
+         └─ app/config.py
+```
+
+## 3. SPDX Generation (spdx_from_adg.py)
+
+`spdx_from_adg.py` is a backward-compatibility **shim** that re-exports
+everything from the refactored `app/spdx/` package. New code should
+import directly from `app.spdx.*`.
+
+### Call graph: ADG → SPDX JSON → HTML
+
+```
+spdx_from_adg.py (shim)
+ └─ re-exports from app/spdx/
+
+app/spdx/cli.py                  # Standalone CLI entry point
+ └─ AdgSpdxGenerator.generate()
+
+app/spdx/generator.py            # AdgSpdxGenerator (facade)
+ ├─ app/spdx/parser.py           # AdgParser — reads bomsh treedb, classifies artifacts
+ ├─ app/spdx/resolver.py         # ComponentResolver — maps artifacts to packages
+ ├─ app/spdx/emitter.py          # SpdxEmitter — produces SPDX 2.3 JSON
+ │   └─ app/version_detection/   # VendoredVersionDetector (12 strategies)
+ │       ├─ detector.py           # Orchestrates strategies in priority order
+ │       ├─ strategies.py         # 12 version detection strategies
+ │       └─ patterns.py           # Regex patterns and file name constants
+ └─ app/spdx_visualize.py        # generate_html() [called at end of generate()]
+     └─ app/viz/                  # Visualization sub-package (see §4)
+```
+
+### Java-specific path
+
+Java does not use `AdgSpdxGenerator`. It has its own generator:
+
+```
+app/pipeline/runners.py
+ └─ _generate_java_adg_spdx()
+     └─ app/spdx/java_generator.py    # JavaSpdxGenerator
+         ├─ app/spdx/parser.py         # AdgParser (shared with native langs)
+         ├─ mvn dependency:tree         # Maven CLI for transitive deps
+         └─ pom.xml parsing             # XML for project metadata
+```
+
+### The spdx/ package at a glance
+
+| File | Class | Responsibility |
+|------|-------|----------------|
+| `parser.py` | `AdgParser` | Read bomsh treedb, classify artifacts (system_lib, project_source, go_stdlib, etc.) |
+| `resolver.py` | `ComponentResolver` | Load `component_metadata.json` and `dynamic_libs.json`, map files to dpkg packages |
+| `emitter.py` | `SpdxEmitter` | Build SPDX 2.3 JSON: packages, files, relationships, PURLs, ExternalRefs |
+| `generator.py` | `AdgSpdxGenerator` | Facade: compose parser → resolver → emitter → write JSON → generate HTML |
+| `java_generator.py` | `JavaSpdxGenerator` | Java-specific: treedb + Maven deps instead of dynamic libs |
+| `cli.py` | `main()` | Standalone CLI for `python3 -m app.spdx_from_adg` |
+| `version_detector.py` | — | Backward-compat shim → `app.version_detection` |
+
+## 4. Visualization (spdx_visualize.py)
+
+`spdx_visualize.py` is the **orchestrator** that reads an SPDX JSON
+document and assembles a standalone HTML file from modular parts in
+`app/viz/`.
+
+### Call graph
+
+```
+app/spdx_visualize.py             # Orchestrator + CLI
+ ├─ generate_html(doc, path)       # Main function
+ │   ├─ app/viz/extract.py         # extract_graph() — parse SPDX JSON into nodes/edges
+ │   ├─ app/viz/styles.py          # get_css() — all CSS as a Python string
+ │   ├─ app/viz/html_parts.py      # get_header_html(), get_legend_html(), get_ui_html()
+ │   ├─ app/viz/js_simulation.py   # get_js_simulation() — D3 force layout, BFS tree, fanout
+ │   └─ app/viz/js_interaction.py  # get_js_interaction() — rendering, tooltips, drag, search
+ └─ main()                         # CLI: argparse → load JSON → generate_html()
+```
+
+### How the HTML is assembled
+
+```python
+parts = [
+    "<!DOCTYPE html>",
+    "<head>",
+    "  <style>",        get_css(),           "</style>",
+    "</head>",
+    "<body>",
+    get_header_html(),                       # Title bar
+    get_legend_html(),                       # Relationship/type counts
+    get_ui_html(),                           # Tooltip + search box
+    "<script src='d3.v7.min.js'></script>",
+    "<script>",
+    "  const data = {graph_data};",          # Inline JSON
+    get_js_simulation(),                     # Force simulation setup
+    get_js_interaction(),                    # Node/link rendering + events
+    "</script>",
+    "</body></html>",
+]
+```
+
+### The viz/ package at a glance
+
+| File | Function | Lines | Responsibility |
+|------|----------|-------|----------------|
+| `extract.py` | `extract_graph(doc)` | 234 | Parse SPDX relationships → nodes/edges with groups, types, colors |
+| `styles.py` | `get_css()` | 140 | Complete CSS for the visualization page |
+| `html_parts.py` | `get_header_html()`, `get_legend_html()`, `get_ui_html()` | 126 | HTML fragments for header, legend, tooltip, search |
+| `js_simulation.py` | `get_js_simulation()` | 336 | D3 force simulation: layout, BFS tree, xPositions, yPositions, fanout |
+| `js_interaction.py` | `get_js_interaction()` | 272 | D3 rendering: nodes, links, tooltips, drag, click highlight, search |
+| `__init__.py` | — | 3 | Re-exports `extract_graph` |
+
+### Who calls the visualizer?
+
+The visualizer is called in two places:
+
+1. **`app/spdx/generator.py`** line 180 — automatically after generating
+   each SPDX JSON (`from spdx_visualize import generate_html`)
+2. **`scripts/regen_html.sh`** — batch regeneration of all HTML files
+   from existing SPDX JSON files
+
+## 5. SBOM Comparison (compare.py)
+
+`compare.py` is a standalone tool that compares an OmniBOR-generated
+SPDX against a proprietary binary scan SPDX. It is self-contained
+(does not import from `app/spdx/` or `app/pipeline/`).
+
+```
+app/compare.py
+ ├─ SpdxLoader          # Load SPDX JSON files
+ ├─ PackageExtractor    # Normalize package names/versions
+ ├─ SbomComparator      # Set intersection/difference
+ ├─ ReportGenerator     # Markdown comparison report
+ └─ ComparisonPipeline  # Facade orchestrating the above
+```
+
+## 6. Repo Discovery (add_repo.py)
+
+`add_repo.py` auto-discovers build system, dependencies, and output
+binaries for a GitHub repository and generates a `config.yaml` entry.
+
+```
+app/add_repo.py (shim)
+ └─ re-exports from app/repo_discovery/
+
+app/repo_discovery/cli.py              # CLI entry point
+ └─ app/repo_discovery/facade.py       # RepoDiscovery (facade)
+     ├─ app/data_loader.py             # Repology API + cached JSON data
+     ├─ app/repo_discovery/github_client.py        # GitHub API via gh CLI
+     ├─ app/repo_discovery/build_system_detector.py # Detect Makefile/CMake/etc.
+     ├─ app/repo_discovery/dependency_analyzer.py   # Parse configure flags
+     │   └─ github_client.py
+     ├─ app/repo_discovery/binary_detector.py       # Find output binary paths
+     │   └─ github_client.py
+     ├─ app/repo_discovery/build_step_generator.py  # Generate build commands
+     └─ app/repo_discovery/config_generator.py      # Write config.yaml entry
+```
+
+## 7. Shared Utilities
+
+These files are imported by multiple parts of the codebase:
+
+| File | What it provides | Used by |
+|------|-----------------|---------|
+| `app/config.py` | `load_config()`, `timestamp()`, `lang_subdir()` | pipeline/*, runners.py |
+| `app/runner.py` | `CommandRunner` (subprocess wrapper with logging) | pipeline/facade.py and 6 pipeline steps |
+| `app/config.yaml` | All repo definitions, paths, omnibor settings | config.py, runners.py |
+| `app/data_loader.py` | `DataLoader` (Repology API, JSON cache) | repo_discovery/facade.py |
+
+### Container-only utilities
+
+These run inside the Docker container during pipeline execution:
+
+| File | Purpose | Called by |
+|------|---------|----------|
+| `app/collect_metadata.py` | dpkg metadata for system files → `component_metadata.json` | `MetadataCollector` |
+| `app/collect_dynamic_libs.py` | ldd/readelf → `dynamic_libs.json` per binary | `MetadataCollector` |
+| `app/apply_qemu_fallback.py` | Patch bomsh for QEMU/Apple Silicon compatibility | Dockerfile |
+
+## 8. Full Dependency Map
+
+Every `app/*.py` file and what it imports from within the project:
+
+```
+analyze.py
+ ├── app.config (load_config, timestamp, lang_subdir)
+ ├── app.runner (CommandRunner)
+ └── app.pipeline.* (all 10 pipeline steps + facade + runners)
+
+spdx_from_adg.py [shim]
+ ├── app.spdx.parser (AdgParser)
+ ├── app.spdx.resolver (ComponentResolver)
+ ├── app.spdx.emitter (SpdxEmitter)
+ ├── app.spdx.generator (AdgSpdxGenerator)
+ ├── app.spdx.cli (main)
+ └── app.version_detection (VendoredVersionDetector)
+
+spdx_visualize.py
+ ├── app.viz.extract (extract_graph)
+ ├── app.viz.styles (get_css)
+ ├── app.viz.html_parts (get_header_html, get_legend_html, get_ui_html)
+ ├── app.viz.js_simulation (get_js_simulation)
+ └── app.viz.js_interaction (get_js_interaction)
+
+compare.py
+ └── (self-contained — no app.* imports)
+
+add_repo.py [shim]
+ ├── data_loader (DataLoader)
+ └── app.repo_discovery.* (all 6 discovery modules + facade + cli)
+
+app/spdx/emitter.py
+ └── app.version_detection (VendoredVersionDetector)
+
+app/spdx/generator.py
+ ├── app.spdx.parser
+ ├── app.spdx.resolver
+ ├── app.spdx.emitter
+ └── spdx_visualize (generate_html) [lazy import at end]
+
+app/spdx/java_generator.py
+ └── app.spdx.parser (AdgParser)
+
+app/pipeline/adg_spdx.py
+ ├── app.config
+ └── spdx_from_adg (AdgSpdxGenerator) [lazy import]
+
+app/pipeline/facade.py
+ ├── app.runner
+ └── app.pipeline.{validator,cloner,builder,spdx_generator,
+     spdx_validator,syft,metadata_collector,adg_spdx,
+     binary_collector,doc_writer}
+
+app/pipeline/runners.py
+ ├── app.config
+ ├── app.pipeline.facade
+ └── app.spdx.java_generator [lazy import in _generate_java_adg_spdx]
+
+app/collect_metadata.py
+ └── app.version_detection (VendoredVersionDetector) [lazy import]
+```
+
+## 9. Package Summaries
+
+### `app/pipeline/` — Build orchestration (10 step classes + facade + runners)
+
+Manages the full lifecycle: clone, build with bomtrace instrumentation,
+generate SPDX, validate, collect artifacts, write docs. Each step is a
+small class (30-80 lines) that depends only on `app.config` and
+`app.runner`.
+
+### `app/spdx/` — SPDX generation (parser → resolver → emitter)
+
+Three-stage pipeline: parse bomsh treedb → resolve artifacts to named
+packages → emit SPDX 2.3 JSON. The `AdgSpdxGenerator` facade composes
+all three. `JavaSpdxGenerator` handles Java-specific Maven dependency
+resolution.
+
+### `app/viz/` — D3.js visualization (6 modules)
+
+Modular HTML generation for interactive dependency graphs. The
+orchestrator (`spdx_visualize.py`) assembles CSS, HTML fragments, and
+JS code from dedicated modules. Each module is under 340 lines.
+
+### `app/version_detection/` — Vendored library version detection (3 modules)
+
+12 ordered strategies for detecting versions from source trees
+(VERSION files, CMakeLists.txt, configure.ac, package.json, Cargo.toml,
+Makefile variables, etc.). Used by `SpdxEmitter` to set `versionInfo`
+on vendored packages.
+
+### `app/repo_discovery/` — Auto-discover repos (6 modules)
+
+GitHub API client, build system detection, dependency analysis, binary
+path detection, build step generation, and config.yaml writing. Used by
+`add_repo.py` to onboard new target repositories.
+
+---
+
+*Last updated: March 20, 2026*


### PR DESCRIPTION
## docs: add app-architecture.md

New onboarding document for contributors that maps the entire `app/` directory — call graphs, execution flow, and inter-file dependencies.

### Contents

1. **Entry Points** — 5 CLI entry points (analyze, spdx_from_adg, spdx_visualize, compare, add_repo)
2. **Pipeline Workflow** — full call sequence from `analyze.py` through the `AnalysisPipeline` facade and all 10 pipeline steps, with language-specific variations (C/C++, Rust, Go, Java)
3. **SPDX Generation** — 3-stage pipeline (parser → resolver → emitter) with Java-specific path
4. **Visualization** — how `spdx_visualize.py` orchestrates the `app/viz/` package to assemble HTML
5. **SBOM Comparison** — self-contained comparison tool
6. **Repo Discovery** — auto-onboarding via GitHub API
7. **Shared Utilities** — config.py, runner.py, container-only scripts
8. **Full Dependency Map** — every `app/*.py` file and what it imports
9. **Package Summaries** — one-paragraph overview of each sub-package

ASCII call trees throughout for quick reference.
