### PR TITLE
fix: prevent zoomToFit from resetting viewport after node drag

### DIFF
--- a/app/viz/js_interaction.py
+++ b/app/viz/js_interaction.py
@@ -170,8 +170,12 @@ simulation.on('tick', () => {
   node.attr('transform', d => 'translate(' + d.x + ',' + d.y + ')');
 });
 
+let initialFitDone = false;
 simulation.on('end', () => {
-  zoomToFit(0);
+  if (!initialFitDone) {
+    initialFitDone = true;
+    zoomToFit(0);
+  }
 });
 
 function dragstarted(event, d) {


### PR DESCRIPTION
## Problem

Dragging a node and releasing it caused the entire visualization to snap back to the initial auto-zoom position, losing the user's current zoom/pan state.

## Root Cause

`simulation.on('end')` called `zoomToFit(0)` unconditionally. When a drag starts, `dragstarted` calls `simulation.alphaTarget(0.01).restart()`, which re-fires the simulation. When it settles after release, the `end` event fires again and `zoomToFit` resets the viewport.

## Fix

Added an `initialFitDone` flag so `zoomToFit` only runs once on the first simulation end (initial layout), not after drag-triggered restarts.

## Testing

- 670 tests pass
- Regenerated all 54 latest HTML visualizations locally and verified drag no longer resets zoom
