### PR TITLE
fix: update stale doc paths in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `jsonschema==4.23.0` and `spdx-tools==0.8.2` added to `requirements.txt`
 - DigitalOcean droplet (`omnibor-build`) for native x86_64 bomtrace3 builds — replaces local Docker
 - Droplet shutdown reminder rule (`.windsurf/rules/droplet-shutdown.md`)
-- bomtrace3 QEMU/Rosetta debug findings documented (`docs/bomtrace3-qemu-debug.md`)
-- GitHub Issue draft for omnibor/bomsh QEMU bugs (`docs/github-issue-bomsh-qemu.md`)
+- bomtrace3 QEMU/Rosetta debug findings documented (`docs/issues/bomtrace3-qemu-debug.md`)
+- GitHub Issue draft for omnibor/bomsh QEMU bugs (`docs/issues/github-issue-bomsh-qemu.md`)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project instruments C/C++, Rust, Go, and Java open-source builds with [Omni
 
 ### What is Build Interception?
 
-Build interception hooks into the compiler and linker during a software build to observe exactly which source files are compiled into which output artifacts. [OmniBOR's Bomtrace](https://github.com/omnibor/bomsh) uses `strace` to intercept these calls and produce an **Artifact Dependency Graph (ADG)** — a cryptographically verifiable record of what was built from what. C/C++ builds use bomtrace3; Rust and Go builds use bomtrace2. Java uses strace-based post-build analysis. See [Go Language Support](docs/go-language-support.md), [Analyzed vs Build SBOMs](docs/analyzed-vs-build-sboms.md), and [Stable Tag Pinning](docs/stable-tag-pinning.md) for details.
+Build interception hooks into the compiler and linker during a software build to observe exactly which source files are compiled into which output artifacts. [OmniBOR's Bomtrace](https://github.com/omnibor/bomsh) uses `strace` to intercept these calls and produce an **Artifact Dependency Graph (ADG)** — a cryptographically verifiable record of what was built from what. C/C++ builds use bomtrace3; Rust and Go builds use bomtrace2. Java uses strace-based post-build analysis. See [Go Language Support](docs/features/go-language-support.md), [Analyzed vs Build SBOMs](docs/architecture/analyzed-vs-build-sboms.md), and [Stable Tag Pinning](docs/features/stable-tag-pinning.md) for details.
 
 ## Project Structure
 
@@ -45,8 +45,15 @@ omnibor-analysis/
 │   ├── repo_discovery/    Auto-discover and configure repos from GitHub
 │   └── templates/         Report templates
 ├── docker/                Docker environment (Linux + gcc + Rust + Go + Maven + bomtrace)
-├── docs/                  Timestamped results, reports, and methodology
-│   └── summary/           Cross-repo findings and architecture docs
+├── docs/                  Documentation and reports
+│   ├── architecture/      System design, overview, drawio diagram
+│   ├── build-logs/        Timestamped build logs ({lang}/{repo}/{ts}/)
+│   ├── features/          Feature documentation
+│   ├── guides/            Contributing, onboarding, setup guides
+│   ├── infrastructure/    Cloud migration recommendations
+│   ├── issues/            Upstream issue tracking
+│   ├── runtime/           Build performance metrics ({lang}/{repo}/{ts}/)
+│   └── summary/           Cross-repo findings and methodology
 ├── terraform/             AWS EC2 infrastructure as code
 ├── tests/                 Unit tests (670 tests)
 ├── repos/                 Cloned target repositories (gitignored)
@@ -157,7 +164,7 @@ All Rust crates use STATIC_LINK (compiled into the binary). Each crate gets a `p
 | [dive](https://github.com/wagoodman/dive) | ~15-20 | ~25 | Docker image explorer |
 | [gdu](https://github.com/dundee/gdu) | ~10-15 | ~15-20 | Disk usage analyzer |
 
-Go modules are classified as direct or indirect from `go.mod`. Each gets a `pkg:golang` PURL. For details, see [Go Language Support](docs/go-language-support.md).
+Go modules are classified as direct or indirect from `go.mod`. Each gets a `pkg:golang` PURL. For details, see [Go Language Support](docs/features/go-language-support.md).
 
 ### Java (strace + post-build analysis)
 
@@ -169,7 +176,7 @@ Go modules are classified as direct or indirect from `go.mod`. Each gets a `pkg:
 
 Java uses strace-based post-build analysis instead of bomtrace. Maven dependencies are classified as direct (depth 1) or transitive (depth 2+) via BFS.
 
-To add a new target repository, see [CONTRIBUTING.md](docs/CONTRIBUTING.md#adding-a-new-target-repository).
+To add a new target repository, see [CONTRIBUTING.md](docs/guides/CONTRIBUTING.md#adding-a-new-target-repository).
 
 ## Output and Reports
 
@@ -183,7 +190,7 @@ Each analysis run produces SPDX files per output binary:
 | `<binary>_build.spdx.json` | Build | Full dependency graph: static + dynamic + build tools + transitive deps. For build reproducibility and supply chain audit. |
 | `<binary>_omnibor.spdx.json` | — | OmniBOR artifact identity. Cryptographic hashes for provenance tracking. No dependency relationships (by design). |
 
-Each `.spdx.json` has a corresponding `.spdx.html` interactive D3.js visualization. See [Analyzed vs Build SBOMs](docs/analyzed-vs-build-sboms.md) for the rationale behind the two-file approach.
+Each `.spdx.json` has a corresponding `.spdx.html` interactive D3.js visualization. See [Analyzed vs Build SBOMs](docs/architecture/analyzed-vs-build-sboms.md) for the rationale behind the two-file approach.
 
 ### Artifacts (not tracked in git)
 
@@ -197,7 +204,7 @@ Each `.spdx.json` has a corresponding `.spdx.html` interactive D3.js visualizati
 
 | Path | Contents |
 |------|----------|
-| `docs/{lang}/{repo}/{ts}/build.md` | Build log, environment snapshot |
+| `docs/build-logs/{lang}/{repo}/{ts}/build.md` | Build log, environment snapshot |
 | `docs/runtime/{lang}/{repo}/{ts}/runtime.md` | Build time and performance metrics |
 | `docs/summary/` | Cross-repo findings and methodology |
 
@@ -205,7 +212,7 @@ Each `.spdx.json` has a corresponding `.spdx.html` interactive D3.js visualizati
 
 ## Contributing
 
-See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for guidelines on:
+See [CONTRIBUTING.md](docs/guides/CONTRIBUTING.md) for guidelines on:
 - Branch naming and PR workflow
 - Adding new target repositories
 - Code style and testing

--- a/docs/features/go-language-support.md
+++ b/docs/features/go-language-support.md
@@ -59,7 +59,7 @@ The upstream `bomsh_hook2.py` function `is_golang_prog()` only
 matches Go tools under `/usr/lib/go-*` and `/usr/lib/golang/`.
 The official Go installer (go.dev/dl) installs to
 `/usr/local/go/`, which is not matched. Our patch adds
-`"local/go"` to the path check. See `docs/upstream-changes.md`
+`"local/go"` to the path check. See `docs/issues/upstream-changes.md`
 for details on proposing this fix upstream.
 
 ## Go Module Resolution in ADG SPDX
@@ -165,8 +165,8 @@ contain underscores (e.g., `jibber_jabber` → `jibber-jabber`).
 |------|---------|
 | `docker/bomtrace_go.conf` | Go-specific bomtrace2 configuration |
 | `docker/patches/bomsh_hook2_golang_path.patch` | Upstream fix for `is_golang_prog()` |
-| `docs/go-language-support.md` | This document |
-| `docs/upstream-changes.md` | Tracking upstream bomsh issues |
+| `docs/features/go-language-support.md` | This document |
+| `docs/issues/upstream-changes.md` | Tracking upstream bomsh issues |
 
 ### Modified files
 

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -198,7 +198,7 @@ docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
 
 ## Documentation
 
-- All analysis results go in `docs/{lang}/{repo}/{ts}/` (e.g., `docs/rust/oxipng/2026-03-06_2235/build.md`)
+- All analysis results go in `docs/build-logs/{lang}/{repo}/{ts}/` (e.g., `docs/build-logs/rust/oxipng/2026-03-06_2235/build.md`)
 - Cross-repo summaries go in `docs/summary/`
 - Runtime/performance metrics go in `docs/runtime/{lang}/{repo}/{ts}/`
 - `{lang}` is `c-cpp`, `rust`, `go`, or `java`. `{ts}` is `YYYY-MM-DD_HHMM`.

--- a/docs/guides/ONBOARDING.md
+++ b/docs/guides/ONBOARDING.md
@@ -80,7 +80,7 @@ This takes 10-20 minutes on first build (compiles bomtrace3 from source).
 
 Follow the comprehensive setup guide:
 
-**[docs/aws-setup-guide.md](docs/aws-setup-guide.md)**
+**[docs/guides/aws-setup-guide.md](docs/guides/aws-setup-guide.md)**
 
 This covers Cisco Duo SSO authentication, Terraform provisioning, and
 everything needed to go from zero to running builds. The guide handles:
@@ -224,8 +224,8 @@ omnibor-analysis/
 
 ## Further Reading
 
-- `docs/aws-setup-guide.md` — **Greenfield AWS EC2 setup (Cisco Duo SSO + Terraform)**
-- `docs/aws-ec2-migration-recommendation.md` — Instance sizing and cost comparison
+- `docs/guides/aws-setup-guide.md` — **Greenfield AWS EC2 setup (Cisco Duo SSO + Terraform)**
+- `docs/infrastructure/aws-ec2-migration-recommendation.md` — Instance sizing and cost comparison
 - `docs/summary/spdx-generation-deep-dive.md` — Full technical pipeline documentation
 - `docs/summary/workflow-guide.md` — Detailed workflow descriptions
 - `docs/summary/nmap-target-vendored-dirs.md` — Vendored directory detection explained

--- a/docs/summary/windsurf-configuration.md
+++ b/docs/summary/windsurf-configuration.md
@@ -74,7 +74,7 @@ Output locations:
 - ADG: `output/omnibor/{lang}/{repo}/{ts}/`
 - SPDX: `output/spdx/{lang}/{repo}/{ts}/<binary>_adg.spdx.json`
 - HTML: `output/spdx/{lang}/{repo}/{ts}/<binary>_adg.spdx.html`
-- Build log: `docs/{lang}/{repo}/{ts}/build.md`
+- Build log: `docs/build-logs/{lang}/{repo}/{ts}/build.md`
 - Runtime metrics: `docs/runtime/{lang}/{repo}/{ts}/runtime.md`
 
 `{lang}` is `c-cpp`, `rust`, or `go`. `{ts}` is `YYYY-MM-DD_HHMM`.

--- a/docs/summary/workflow-guide.md
+++ b/docs/summary/workflow-guide.md
@@ -112,13 +112,13 @@ docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
 | SPDX SBOM (OmniBOR) | `output/spdx/<repo>/<repo>_omnibor_<timestamp>.spdx.json` |
 | ADG SPDX (per binary) | `output/spdx/<repo>/<binary>_adg.spdx.json` |
 | Visualization (per binary) | `output/spdx/<repo>/<binary>_adg.spdx.html` |
-| Build log | `docs/<repo>/<timestamp>_build.md` |
-| Runtime metrics | `docs/runtime/<timestamp>_<repo>_runtime.md` |
+| Build log | `docs/build-logs/{lang}/<repo>/{ts}/build.md` |
+| Runtime metrics | `docs/runtime/{lang}/<repo>/{ts}/runtime.md` |
 
 ### Recommendations
 
 - **Use `--skip-clone` for re-runs** — avoids re-downloading the repo each time
-- **Check build logs** — if the SBOM looks incomplete, review `docs/<repo>/<timestamp>_build.md` for build warnings or missing deps
+- **Check build logs** — if the SBOM looks incomplete, review `docs/build-logs/{lang}/<repo>/{ts}/build.md` for build warnings or missing deps
 - **Review SPDX output** — the primary output is `<binary>_adg.spdx.json` with full build-time dependency data
 - **Build times** — curl ~5 min, FFmpeg ~20+ min (under QEMU on Apple Silicon, roughly double)
 
@@ -154,7 +154,7 @@ docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
     --binary-file /workspace/output/binary-scan/curl/bdba_export.spdx.json
 ```
 
-### Report contents (`docs/<repo>/<timestamp>_comparison.md`)
+### Report contents (`docs/build-logs/{lang}/<repo>/{ts}_comparison.md`)
 
 - **Summary table** — package counts, overlap percentage, version agreement
 - **Common packages** — detected by both methods, with version match/mismatch
@@ -200,5 +200,5 @@ docker-compose -f docker/docker-compose.yml run --rm omnibor-env \
 # 5. Review results
 ls output/spdx/curl/          # SPDX SBOMs
 ls output/omnibor/curl/        # OmniBOR ADG
-ls docs/curl/                  # Build logs and comparison reports
+ls docs/build-logs/c-cpp/curl/  # Build logs and comparison reports
 ```


### PR DESCRIPTION
Fix 7 stale document paths in README.md after the docs/ reorganization in PR #51.

### Path fixes
- `docs/go-language-support.md` → `docs/features/` (×2)
- `docs/analyzed-vs-build-sboms.md` → `docs/architecture/` (×2)
- `docs/stable-tag-pinning.md` → `docs/features/`
- `docs/CONTRIBUTING.md` → `docs/guides/` (×2)
- `docs/{lang}/…/build.md` → `docs/build-logs/{lang}/…/build.md`

### Also updated
- Project structure tree to show new docs/ subfolder layout
