### PR TITLE
fix: update stale doc paths in .windsurf workflows and rules

### DIFF
--- a/.windsurf/rules/project/project-context.md
+++ b/.windsurf/rules/project/project-context.md
@@ -19,8 +19,16 @@ and completeness.
   - **app/config.py** — Shared config loading, timestamp, lang_subdir
   - **app/runner.py** — CommandRunner utility
 - **docker/** — Linux container environment (Ubuntu 22.04) with gcc, bomtrace3, syft
-- **tests/** — Unit tests (427+ tests, 99% coverage)
-- **docs/** — Timestamped results and summary documentation, organized by language (`c-cpp/`, `go/`, `rust/`)
+- **tests/** — Unit tests (670+ tests, 97%+ coverage)
+- **docs/** — Documentation and reports
+  - **docs/architecture/** — System design, overview, drawio diagram
+  - **docs/build-logs/** — Timestamped build logs (`{lang}/{repo}/{ts}/`)
+  - **docs/features/** — Feature documentation
+  - **docs/guides/** — Contributing, onboarding, setup guides
+  - **docs/infrastructure/** — Cloud migration recommendations
+  - **docs/issues/** — Upstream issue tracking
+  - **docs/runtime/** — Build performance metrics (`{lang}/{repo}/{ts}/`)
+  - **docs/summary/** — Cross-repo findings and methodology
 - **repos/** — Cloned target repositories (gitignored)
 - **output/** — Generated artifacts organized by language: `output/{category}/{lang}/{repo}/{ts}/` (gitignored)
 - **.windsurf/** — Cascade AI rules and workflows

--- a/.windsurf/workflows/run-comparison.md
+++ b/.windsurf/workflows/run-comparison.md
@@ -36,7 +36,7 @@ docker-compose -f docker/docker-compose.yml run --rm omnibor-env python3 /worksp
 
 ## 3. Review the comparison report
 
-The report is written to `docs/<repo>/<timestamp>_comparison.md` and includes:
+The report is written to `docs/build-logs/{lang}/<repo>/{ts}/` and includes:
 
 - **Summary table** — package counts, overlap percentage, version agreement
 - **Common packages** — detected by both methods, with version match/mismatch


### PR DESCRIPTION
Fix stale doc references in `.windsurf/` after the docs/ reorganization (PR #51).

### Fixes
- `run-comparison.md`: `docs/<repo>/<timestamp>_comparison.md` → `docs/build-logs/{lang}/<repo>/{ts}/`
- `project-context.md`: Updated docs/ directory description to list all 8 subfolders, updated test count 427→670
