### PR TITLE
feat: release build policy — classify, verify, and document production builds

### DIFF
--- a/.windsurf/rules/project/release-builds.md
+++ b/.windsurf/rules/project/release-builds.md
@@ -1,0 +1,82 @@
+---
+description: All builds must produce release/production binaries, not debug builds
+trigger: always_on
+---
+
+# Release Build Policy
+
+All OmniBOR analysis builds MUST target **release/production binaries**.
+SPDX SBOMs must reflect what ships to customers, not debug or development artifacts.
+
+## Language-Specific Requirements
+
+### C/C++ (autoconf/make)
+
+- `./configure` without `--enable-debug` or `CFLAGS="-g -O0"`
+- `make` with default optimization (typically `-O2`)
+- Never pass `DEBUG=1`, `ASAN=1`, or sanitizer flags
+- Verify: output binaries should NOT be in a `debug/` directory
+
+### Rust
+
+- Always `cargo build --release` (never plain `cargo build`)
+- Output path must be `target/release/`, not `target/debug/`
+
+### Go
+
+- Always include `-trimpath -ldflags="-s -w"` in `go build`
+- `-trimpath` strips local filesystem paths from the binary
+- `-ldflags="-s -w"` strips symbol table and DWARF debug info
+- `-a` is still required for bomtrace2 cache bypass
+- Full pattern: `go build -a -trimpath -ldflags="-s -w" -o <binary> .`
+
+### Java (Maven)
+
+- Always `mvn package -DskipTests` (skip test execution)
+- Standard Maven JAR packaging only includes `target/classes/` (main sources)
+- Test classes (`target/test-classes/`) are NOT in the production JAR
+- SPDX generation must exclude `test`-scope dependencies
+- If a project's build plugins (shade, assembly) include test artifacts
+  in the production JAR, annotate those packages in the SPDX `comment` field
+
+## SPDX Comment Annotations
+
+When a dependency is test-scope but appears in the production binary
+(e.g., via shade plugin), add to the SPDX package `comment` field:
+
+```
+Test-scope dependency included in production JAR via <plugin>.
+```
+
+When test-scope dependencies are excluded (standard behavior), the
+build doc should note: "N test-scope dependencies excluded from SPDX."
+
+## Build Documentation
+
+Every build doc (`docs/build-logs/{lang}/{repo}/{ts}/build.md`) must include
+a **Release Build Verification** section reporting:
+
+- Whether the build is classified as release or debug
+- Language-specific flags that confirm release mode
+- Any warnings (e.g., missing optimization flags)
+- For Java: count of test-scope dependencies excluded
+
+## Console Output
+
+The pipeline must print release-build classification to the console
+before the build starts, e.g.:
+
+```
+[RELEASE] curl: release build confirmed (./configure + make, no debug flags)
+[RELEASE] oxipng: release build confirmed (cargo build --release)
+[WARNING] fzf: missing -trimpath -ldflags="-s -w" in go build
+```
+
+## Adding New Repos
+
+When adding a new target repository (via `/add-repo` or manually):
+
+1. Verify the build steps produce release binaries
+2. Check for debug/development flags and remove them
+3. For Java: confirm the JAR does not bundle test classes
+4. Run analysis and verify the SPDX reflects production components only

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -162,7 +162,7 @@ repos:
     branch: v0.70.0
     language: go
     build_steps:
-    - go build -a -o fzf .
+    - 'go build -a -trimpath -ldflags="-s -w" -o fzf .'
     clean_cmd: rm -f fzf
     description: Fuzzy finder CLI (~7 direct + 4 indirect Go deps)
     output_binaries:
@@ -172,7 +172,7 @@ repos:
     branch: v0.60.0
     language: go
     build_steps:
-    - go build -a -o lazygit .
+    - 'go build -a -trimpath -ldflags="-s -w" -o lazygit .'
     clean_cmd: rm -f lazygit
     description: Terminal UI for git (~15-20 direct + 20-30 indirect Go deps)
     output_binaries:
@@ -182,7 +182,7 @@ repos:
     branch: v10.4.2
     language: go
     build_steps:
-    - go build -a -o croc .
+    - 'go build -a -trimpath -ldflags="-s -w" -o croc .'
     clean_cmd: rm -f croc
     description: Secure file transfer tool (~10-15 direct + 15 indirect Go deps)
     output_binaries:
@@ -192,7 +192,7 @@ repos:
     branch: v0.13.1
     language: go
     build_steps:
-    - go build -a -o dive .
+    - 'go build -a -trimpath -ldflags="-s -w" -o dive .'
     clean_cmd: rm -f dive
     description: Docker image layer explorer (~15-20 direct + 25 indirect Go deps)
     output_binaries:
@@ -202,7 +202,7 @@ repos:
     branch: v5.34.1
     language: go
     build_steps:
-    - go build -a -o gdu ./cmd/gdu
+    - 'go build -a -trimpath -ldflags="-s -w" -o gdu ./cmd/gdu'
     clean_cmd: rm -f gdu
     description: Fast disk usage analyzer with TUI (~10-15 direct + 15-20 indirect Go deps)
     output_binaries:

--- a/app/pipeline/doc_writer.py
+++ b/app/pipeline/doc_writer.py
@@ -15,6 +15,80 @@ class DocWriter:
     """Writes build logs and runtime metrics."""
 
     @staticmethod
+    def classify_release_build(repo_cfg):
+        """Classify build as release or debug.
+
+        Returns dict with keys:
+          is_release: bool
+          label: str  (e.g. 'RELEASE' or 'WARNING')
+          reason: str (human-readable explanation)
+          warnings: list[str]
+        """
+        lang = repo_cfg.get("language", "c-cpp")
+        steps = repo_cfg.get("build_steps", [])
+        joined = " ".join(steps)
+        warnings = []
+
+        if lang == "c-cpp":
+            debug_flags = [
+                "--enable-debug", "CFLAGS=\"-g",
+                "-O0", "DEBUG=1", "ASAN=1",
+            ]
+            for flag in debug_flags:
+                if flag in joined:
+                    warnings.append(
+                        f"Debug flag detected: {flag}"
+                    )
+            reason = (
+                "./configure + make, no debug flags"
+                if "./configure" in joined
+                else "make with default optimization"
+            )
+
+        elif lang == "rust":
+            if "--release" not in joined:
+                warnings.append(
+                    "Missing --release flag in "
+                    "cargo build"
+                )
+            reason = "cargo build --release"
+
+        elif lang == "go":
+            if "-trimpath" not in joined:
+                warnings.append(
+                    "Missing -trimpath in go build"
+                )
+            if '-ldflags' not in joined:
+                warnings.append(
+                    'Missing -ldflags="-s -w" '
+                    "in go build"
+                )
+            reason = (
+                "go build with -trimpath "
+                '-ldflags="-s -w"'
+            )
+
+        elif lang == "java":
+            if "-DskipTests" not in joined:
+                warnings.append(
+                    "Missing -DskipTests in "
+                    "mvn package"
+                )
+            reason = "mvn package -DskipTests"
+
+        else:
+            reason = "unknown language"
+
+        is_release = len(warnings) == 0
+        label = "RELEASE" if is_release else "WARNING"
+        return {
+            "is_release": is_release,
+            "label": label,
+            "reason": reason,
+            "warnings": warnings,
+        }
+
+    @staticmethod
     def write_build_doc(
         repo_name, repo_cfg,
         paths_cfg, success, duration_sec,
@@ -70,6 +144,30 @@ class DocWriter:
             "output_binaries", []
         ):
             content += f"- `{binary}`\n"
+
+        # Release Build Verification section
+        rb = DocWriter.classify_release_build(
+            repo_cfg
+        )
+        status_icon = (
+            "RELEASE" if rb["is_release"]
+            else "WARNING"
+        )
+        content += (
+            "\n## Release Build Verification\n\n"
+            f"**Classification:** {status_icon}\n"
+            f"**Reason:** {rb['reason']}\n"
+        )
+        if rb["warnings"]:
+            content += "\n**Warnings:**\n\n"
+            for w in rb["warnings"]:
+                content += f"- {w}\n"
+        else:
+            content += (
+                "\nNo debug or development flags "
+                "detected. Build targets "
+                "production/release binaries.\n"
+            )
 
         with open(
             doc_path, "w", encoding="utf-8"

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -99,6 +99,21 @@ def main():
     print(f"  {desc}")
     print(f"{'#'*60}\n")
 
+    # Release build verification (console)
+    from app.pipeline.doc_writer import DocWriter
+    rb = DocWriter.classify_release_build(repo_cfg)
+    status_msg = (
+        "release build confirmed"
+        if rb["is_release"]
+        else "release build issue"
+    )
+    print(
+        f"[{rb['label']}] {args.repo}: "
+        f"{status_msg} ({rb['reason']})"
+    )
+    for w in rb["warnings"]:
+        print(f"[WARNING] {args.repo}: {w}")
+
     # Step 1: Clone
     if not args.skip_clone:
         pipeline.cloner.clone(

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1945,6 +1945,166 @@ class TestDocWriter(unittest.TestCase):
             self.assertIn("bomtrace3", content)
             self.assertNotIn("bomtrace2", content)
 
+    def test_write_build_doc_has_release_section(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = {"docs_dir": tmpdir}
+            cfg = {
+                "url": "https://github.com/x/y.git",
+                "branch": "main",
+                "build_steps": [
+                    "./configure", "make",
+                ],
+                "output_binaries": ["bin/app"],
+                "language": "c-cpp",
+            }
+            with patch("builtins.print"):
+                result = DocWriter.write_build_doc(
+                    "myrepo", cfg, paths,
+                    True, 10.0,
+                )
+            content = Path(result).read_text()
+            self.assertIn(
+                "Release Build Verification", content
+            )
+            self.assertIn("RELEASE", content)
+
+
+class TestClassifyReleaseBuild(unittest.TestCase):
+    """Tests for DocWriter.classify_release_build."""
+
+    def test_c_cpp_release(self):
+        cfg = {
+            "language": "c-cpp",
+            "build_steps": [
+                "./configure --with-openssl",
+                "make -j$(nproc)",
+            ],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertTrue(rb["is_release"])
+        self.assertEqual(rb["label"], "RELEASE")
+        self.assertEqual(rb["warnings"], [])
+        self.assertIn("configure", rb["reason"])
+
+    def test_c_cpp_make_only(self):
+        cfg = {
+            "language": "c-cpp",
+            "build_steps": ["make -j$(nproc)"],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertTrue(rb["is_release"])
+        self.assertIn("default optimization", rb["reason"])
+
+    def test_c_cpp_debug_flag(self):
+        cfg = {
+            "language": "c-cpp",
+            "build_steps": [
+                "./configure --enable-debug",
+                "make",
+            ],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertFalse(rb["is_release"])
+        self.assertEqual(rb["label"], "WARNING")
+        self.assertEqual(len(rb["warnings"]), 1)
+        self.assertIn("--enable-debug", rb["warnings"][0])
+
+    def test_c_cpp_asan(self):
+        cfg = {
+            "language": "c-cpp",
+            "build_steps": ["make ASAN=1"],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertFalse(rb["is_release"])
+        self.assertIn("ASAN=1", rb["warnings"][0])
+
+    def test_rust_release(self):
+        cfg = {
+            "language": "rust",
+            "build_steps": ["cargo build --release"],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertTrue(rb["is_release"])
+        self.assertEqual(rb["label"], "RELEASE")
+
+    def test_rust_debug(self):
+        cfg = {
+            "language": "rust",
+            "build_steps": ["cargo build"],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertFalse(rb["is_release"])
+        self.assertIn("--release", rb["warnings"][0])
+
+    def test_go_release(self):
+        cfg = {
+            "language": "go",
+            "build_steps": [
+                'go build -a -trimpath '
+                '-ldflags="-s -w" -o app .',
+            ],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertTrue(rb["is_release"])
+        self.assertEqual(rb["label"], "RELEASE")
+
+    def test_go_missing_trimpath(self):
+        cfg = {
+            "language": "go",
+            "build_steps": ["go build -a -o app ."],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertFalse(rb["is_release"])
+        self.assertEqual(len(rb["warnings"]), 2)
+
+    def test_go_partial_flags(self):
+        cfg = {
+            "language": "go",
+            "build_steps": [
+                "go build -a -trimpath -o app .",
+            ],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertFalse(rb["is_release"])
+        self.assertEqual(len(rb["warnings"]), 1)
+        self.assertIn("ldflags", rb["warnings"][0])
+
+    def test_java_release(self):
+        cfg = {
+            "language": "java",
+            "build_steps": [
+                "mvn package -DskipTests -q",
+            ],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertTrue(rb["is_release"])
+
+    def test_java_missing_skip_tests(self):
+        cfg = {
+            "language": "java",
+            "build_steps": ["mvn package -q"],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertFalse(rb["is_release"])
+        self.assertIn(
+            "-DskipTests", rb["warnings"][0]
+        )
+
+    def test_unknown_language(self):
+        cfg = {
+            "language": "python",
+            "build_steps": ["pip install ."],
+        }
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertTrue(rb["is_release"])
+        self.assertIn("unknown", rb["reason"])
+
+    def test_default_language(self):
+        cfg = {"build_steps": ["make"]}
+        rb = DocWriter.classify_release_build(cfg)
+        self.assertTrue(rb["is_release"])
+        self.assertIn("optimization", rb["reason"])
+
 
 # ============================================================
 # AnalysisPipeline


### PR DESCRIPTION
Enforce release/production builds across all languages. SPDX SBOMs must reflect what ships to customers, not debug/dev artifacts.

### Changes

**Rule**: `.windsurf/rules/project/release-builds.md`
- Language-specific requirements (C/C++, Rust, Go, Java)
- SPDX comment annotation policy for test-scope deps
- Build doc and console output requirements

**Go build flags** (config.yaml):
- All 5 Go repos now use `-trimpath -ldflags="-s -w"` for release binaries
- `-trimpath` strips local filesystem paths; `-ldflags="-s -w"` strips debug symbols

**Release-build verification** (doc_writer.py):
- New `classify_release_build()` classifies builds per language
- Build docs now include "Release Build Verification" section
- Console prints `[RELEASE]` or `[WARNING]` before each build

**Java** (already correct):
- `java_generator.py` already filters test-scope deps (compile/runtime/provided only)
- Logs count of excluded test-scope dependencies

**14 new tests** for classify_release_build: C/C++ (4), Rust (2), Go (3), Java (2), edge cases (3)

684 total tests passing.
