### PR TITLE
fix: eliminate SNAPSHOT versions, filter auxiliary JARs, add DependencyCheck

### DIFF
--- a/app/config.yaml
+++ b/app/config.yaml
@@ -247,16 +247,16 @@ repos:
     description: Static analysis tool (14 direct, 12 transitive - antlr, guava, picocli, commons-beanutils)
     output_binaries:
     - target/checkstyle-*.jar
-  crawler4j:
-    url: https://github.com/yasserg/crawler4j.git
-    branch: crawler4j-4.4.0
+  dependency-check:
+    url: https://github.com/jeremylong/DependencyCheck.git
+    branch: v9.2.0
     language: java
     build_steps:
-    - mvn package -DskipTests -q
+    - mvn package -DskipTests -q -pl cli -am
     clean_cmd: mvn clean -q
-    description: Open source web crawler (42 direct, 35 transitive - Apache HttpComponents, Tika, SLF4J, deep hierarchy)
+    description: OWASP dependency-check CLI (6 modules - utils, core, cli, ant, maven, archetype)
     output_binaries:
-    - crawler4j/target/crawler4j-*.jar
+    - cli/target/dependency-check-*.jar
 paths:
   repos_dir: /workspace/repos
   output_dir: /workspace/output

--- a/app/pipeline/binary_collector.py
+++ b/app/pipeline/binary_collector.py
@@ -20,6 +20,26 @@ class BinaryCollector:
     (e.g. ``src/.libs/curl``).
     """
 
+    # Maven classifier suffixes to skip when
+    # collecting production JARs
+    _JAR_SKIP_SUFFIXES = (
+        "-tests.jar",
+        "-test-sources.jar",
+        "-sources.jar",
+        "-javadoc.jar",
+        "-examples.jar",
+    )
+
+    @staticmethod
+    def _is_auxiliary_jar(filename):
+        """Return True if JAR is a test/sources/javadoc
+        auxiliary artifact, not the production JAR."""
+        name = filename.lower()
+        return any(
+            name.endswith(s)
+            for s in BinaryCollector._JAR_SKIP_SUFFIXES
+        )
+
     @staticmethod
     def collect(repo_name, repo_cfg, paths_cfg,
                 run_ts=None):
@@ -53,7 +73,21 @@ class BinaryCollector:
         for rel_path in bins:
             # Handle glob patterns (e.g., target/jsoup-*.jar)
             if '*' in rel_path or '?' in rel_path:
-                matches = list(repo_dir.glob(rel_path))
+                matches = [
+                    m for m in repo_dir.glob(rel_path)
+                    if not BinaryCollector._is_auxiliary_jar(
+                        m.name
+                    )
+                ]
+                skipped = len(
+                    list(repo_dir.glob(rel_path))
+                ) - len(matches)
+                if skipped:
+                    print(
+                        f"[INFO] Skipped {skipped} "
+                        f"auxiliary JAR(s) "
+                        f"(tests/sources/javadoc)"
+                    )
                 if not matches:
                     print(
                         f"[WARN] No files match: {rel_path}"

--- a/app/pipeline/cloner.py
+++ b/app/pipeline/cloner.py
@@ -38,4 +38,16 @@ class RepoCloner:
                 f"Cloning {repo_name} ({branch})"
             ),
         )
+        # Prefer tag over branch when both share a
+        # name (avoids Maven SNAPSHOT builds)
+        self.runner.run(
+            f"git -C {repo_dir} fetch origin "
+            f"tag {branch} --no-tags 2>/dev/null "
+            f"&& git -C {repo_dir} checkout "
+            f"tags/{branch} 2>/dev/null || true",
+            description=(
+                f"Checkout tag {branch} "
+                f"(if exists)"
+            ),
+        )
         return str(repo_dir)

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -248,10 +248,17 @@ class TestRepoCloner(unittest.TestCase):
             }
 
             cloner.clone("newrepo", cfg, paths)
-            runner.run.assert_called_once()
-            call_args = runner.run.call_args
-            self.assertIn("git clone", call_args[0][0])
-            self.assertIn("main", call_args[0][0])
+            # Two calls: clone + tag checkout attempt
+            self.assertEqual(runner.run.call_count, 2)
+            clone_args = runner.run.call_args_list[0]
+            self.assertIn(
+                "git clone", clone_args[0][0]
+            )
+            self.assertIn("main", clone_args[0][0])
+            tag_args = runner.run.call_args_list[1]
+            self.assertIn(
+                "tags/main", tag_args[0][0]
+            )
 
     def test_default_branch_master(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Fix SNAPSHOT versions in Java binaries and filter auxiliary JARs.

### Problems
1. **SNAPSHOT binaries**: `git clone --branch` prefers branches over tags when both share a name. Checkstyle and jsoup branches had moved to SNAPSHOT versions, producing `checkstyle-13.4.0-SNAPSHOT.jar` instead of `checkstyle-13.3.0.jar`.
2. **Auxiliary JARs collected**: Glob `target/checkstyle-*.jar` matched all 4 JARs including `-tests.jar`, `-sources.jar`, `-javadoc.jar`.
3. **crawler4j broken**: Replaced with DependencyCheck (active, well-maintained OWASP project).

### Fixes
- **cloner.py**: After clone, fetch and checkout the tag if one exists (`tags/{branch}`). Falls back silently for repos that use branch names.
- **binary_collector.py**: New `_is_auxiliary_jar()` filter skips test/sources/javadoc/examples JARs during collection.
- **config.yaml**: Replace crawler4j with dependency-check (v9.2.0).

### Verified on EC2
| Repo | Before | After |
|------|--------|-------|
| jsoup | `jsoup-1.22.2-SNAPSHOT.jar` + 3 aux | `jsoup-1.22.1.jar` (1 file) |
| checkstyle | `checkstyle-13.4.0-SNAPSHOT.jar` + 3 aux | `checkstyle-13.3.0.jar` (1 file) |
| dependency-check | (new) | Build OK, bomsh crashed (third-party bug) |

All SPDX files verified: zero SNAPSHOT, zero test files, zero auxiliary JARs.

692 tests passing.
