### PR TITLE
feat: add pocketbase Go repo, fix crawler4j build

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ All Rust crates use STATIC_LINK (compiled into the binary). Each crate gets a `p
 |------|-------------|---------------|----------|
 | [fzf](https://github.com/junegunn/fzf) | 7 | 4 | Small Go project, fuzzy finder |
 | [lazygit](https://github.com/jesseduffield/lazygit) | 33 | 29 | Rich Go dependency graph |
+| [pocketbase](https://github.com/pocketbase/pocketbase) | ~50 | ~100 | Backend with SQLite, REST API, auth |
 | [croc](https://github.com/schollz/croc) | ~10-15 | ~15 | Secure file transfer |
 | [dive](https://github.com/wagoodman/dive) | ~15-20 | ~25 | Docker image explorer |
 | [gdu](https://github.com/dundee/gdu) | ~10-15 | ~15-20 | Disk usage analyzer |
@@ -186,7 +187,8 @@ Go modules are classified as direct or indirect from `go.mod`. Each gets a `pkg:
 |------|-------------|-----------------|----------|
 | [checkstyle](https://github.com/checkstyle/checkstyle) | 10 | 21 | Static analysis, deep Maven tree |
 | [jsoup](https://github.com/jhy/jsoup) | 0 | 0 | HTML parser, zero runtime deps |
-| [crawler4j](https://github.com/yasserg/crawler4j) | ~42 | ~35 | Web crawler, deep hierarchy |
+| [crawler4j](https://github.com/yasserg/crawler4j) | 6 | 16 | Web crawler, Apache HttpComponents |
+| [dependency-check](https://github.com/jeremylong/DependencyCheck) | ~20 | ~80 | OWASP vulnerability scanner, multi-module |
 
 Java uses strace-based post-build analysis instead of bomtrace. Maven dependencies are classified as direct (depth 1) or transitive (depth 2+) via BFS.
 

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -207,6 +207,16 @@ repos:
     description: Fast disk usage analyzer with TUI (~10-15 direct + 15-20 indirect Go deps)
     output_binaries:
     - gdu
+  pocketbase:
+    url: https://github.com/pocketbase/pocketbase.git
+    branch: v0.25.9
+    language: go
+    build_steps:
+    - 'go build -a -trimpath -ldflags="-s -w" -o pocketbase ./examples/base'
+    clean_cmd: rm -f pocketbase
+    description: Open source backend (Go, SQLite, REST API, auth, realtime subscriptions)
+    output_binaries:
+    - pocketbase
   oxipng:
     url: https://github.com/oxipng/oxipng.git
     branch: v10.1.0
@@ -252,7 +262,7 @@ repos:
     branch: crawler4j-4.4.0
     language: java
     build_steps:
-    - mvn package -DskipTests -q
+    - mvn package -DskipTests -q -pl crawler4j
     clean_cmd: mvn clean -q
     description: Open source web crawler (42 direct, 35 transitive - Apache HttpComponents, Tika, SLF4J, deep hierarchy)
     output_binaries:

--- a/docs/architecture/build-time-impact-analysis.md
+++ b/docs/architecture/build-time-impact-analysis.md
@@ -41,6 +41,7 @@ The omnibor-analysis post-processing (SPDX generation, visualization) adds **<5 
 |------------|-------------------|---------|--------|---------------|
 | **fzf** | 47.5s | 11 | bomtrace2 | `go build -a` |
 | **lazygit** | 115.8s (1.9 min) | 63 | bomtrace2 | `go build -a` |
+| **pocketbase** | 140.6s (2.3 min) | ~150 | bomtrace2 | `go build -a` |
 
 ### Java Projects (strace + post-build analysis)
 

--- a/docs/features/stable-tag-pinning.md
+++ b/docs/features/stable-tag-pinning.md
@@ -115,6 +115,7 @@ All repositories in `config.yaml` as of March 2026:
 | node | c-cpp | `v22.19.0` | GitHub Release |
 | fzf | go | `v0.70.0` | GitHub Release |
 | lazygit | go | `v0.60.0` | GitHub Release |
+| pocketbase | go | `v0.25.9` | GitHub Release |
 | croc | go | `v10.4.2` | GitHub Release |
 | dive | go | `v0.13.1` | GitHub Release |
 | gdu | go | `v5.34.1` | GitHub Release |
@@ -123,6 +124,7 @@ All repositories in `config.yaml` as of March 2026:
 | jsoup | java | `jsoup-1.22.1` | GitHub Release |
 | checkstyle | java | `checkstyle-13.3.0` | GitHub Release |
 | crawler4j | java | `crawler4j-4.4.0` | GitHub Release |
+| dependency-check | java | `v9.2.0` | GitHub Release |
 
 ## 5. How Tags Were Selected
 

--- a/scripts/regen_html.sh
+++ b/scripts/regen_html.sh
@@ -9,8 +9,8 @@ cd "$SCRIPT_DIR"
 COUNT=0
 ERRORS=0
 
-# Find all *_analyzed.spdx.json and *_adg.spdx.json files
-find output/spdx -name '*_analyzed.spdx.json' -o -name '*_adg.spdx.json' | sort | while read -r json_file; do
+# Find all *_analyzed.spdx.json, *_build.spdx.json, and *_adg.spdx.json files
+find output/spdx \( -name '*_analyzed.spdx.json' -o -name '*_build.spdx.json' -o -name '*_adg.spdx.json' \) | sort | while read -r json_file; do
     html_file="${json_file%.spdx.json}.spdx.html"
     echo "  $json_file -> $(basename "$html_file")"
     if .venv/bin/python3 -m app.spdx_visualize "$json_file" -o "$html_file" 2>&1; then


### PR DESCRIPTION
## Summary
- Add **pocketbase** to config.yaml (Go backend with SQLite, REST API, auth, realtime)
- Fix **crawler4j** build: use `-pl crawler4j` to skip examples with dead bintray dependencies
- Update `regen_html.sh` to include `*_build.spdx.json` files (was missing)

## Changes
- `app/config.yaml`: Added pocketbase Go repo config
- `app/config.yaml`: Changed crawler4j build from `mvn package` to `mvn package -pl crawler4j`
- `scripts/regen_html.sh`: Added `*_build.spdx.json` to find pattern

## Testing
- pocketbase analysis completed successfully (140.6s)
- crawler4j analysis completed successfully (105.0s)
- Both have analyzed + build SPDX with zoomToFit visualizations
