### PR TITLE
fix: disable sibling filtering for _build visualizations

### DIFF
--- a/app/spdx_visualize.py
+++ b/app/spdx_visualize.py
@@ -78,7 +78,10 @@ def _build_conditional_legends(type_counts):
 
 def generate_html(doc, output_path):
     """Generate standalone HTML visualization."""
-    nodes, edges = extract_graph(doc)
+    # For _build SPDX, show all deps (no sibling filtering)
+    # For _analyzed SPDX, filter deps only reachable via siblings
+    filter_siblings = "_build" not in str(output_path)
+    nodes, edges = extract_graph(doc, filter_siblings=filter_siblings)
 
     doc_name = doc.get("name", "SPDX Document")
     created = doc.get(

--- a/app/viz/extract.py
+++ b/app/viz/extract.py
@@ -6,8 +6,14 @@ BFS depth from the root package.
 """
 
 
-def extract_graph(doc):
+def extract_graph(doc, filter_siblings=True):
     """Extract nodes and edges from SPDX document.
+
+    Args:
+        doc: SPDX document dict
+        filter_siblings: If True, filter out deps only reachable via
+            sibling modules (for _analyzed SPDX). If False, show all
+            deps (for _build SPDX).
 
     Returns:
         nodes: list of {id, name, version, purpose, group, fileCount}
@@ -229,32 +235,41 @@ def extract_graph(doc):
         if info.get("sibling", False)
     }
 
-    # Find all nodes reachable ONLY through sibling nodes
-    # These should be hidden from the visualization
-    sibling_transitive = set()
-    for r in rels:
-        rt = r["relationshipType"]
-        if rt in ("DEPENDS_ON", "STATIC_LINK"):
-            src = r["spdxElementId"]
-            tgt = r["relatedSpdxElement"]
-            if src in sibling_ids and tgt in pkg_map:
-                sibling_transitive.add(tgt)
-
-    # BFS to find all transitive deps of siblings
-    queue = list(sibling_transitive)
+    # Find nodes reachable from root WITHOUT going through siblings
+    # These should be kept even if also reachable from siblings
+    reachable_from_root = set(root_ids)
+    queue = list(root_ids)
     while queue:
         current = queue.pop(0)
-        for r in rels:
-            if r["spdxElementId"] == current:
-                rt = r["relationshipType"]
-                if rt in ("DEPENDS_ON", "STATIC_LINK"):
-                    tgt = r["relatedSpdxElement"]
-                    if tgt in pkg_map and tgt not in sibling_transitive:
-                        sibling_transitive.add(tgt)
-                        queue.append(tgt)
+        for child in children_of.get(current, []):
+            if child not in reachable_from_root:
+                # Don't traverse through siblings
+                if child not in sibling_ids:
+                    reachable_from_root.add(child)
+                    queue.append(child)
+                else:
+                    # Add sibling itself but don't traverse
+                    reachable_from_root.add(child)
 
-    # Filter nodes to exclude sibling transitive deps
-    nodes = [n for n in nodes if n["id"] not in sibling_transitive]
+    # Find all nodes reachable from siblings (their transitive deps)
+    sibling_reachable = set()
+    for sid in sibling_ids:
+        queue = [sid]
+        while queue:
+            current = queue.pop(0)
+            for child in children_of.get(current, []):
+                if child not in sibling_reachable:
+                    if child not in sibling_ids:
+                        sibling_reachable.add(child)
+                        queue.append(child)
+
+    # Only filter nodes ONLY reachable via siblings
+    # (not also reachable from root via non-sibling paths)
+    # Skip filtering for _build SPDX (filter_siblings=False)
+    sibling_only = set()
+    if filter_siblings:
+        sibling_only = sibling_reachable - reachable_from_root
+        nodes = [n for n in nodes if n["id"] not in sibling_only]
 
     edges = []
     for r in rels:
@@ -266,12 +281,14 @@ def extract_graph(doc):
             "BUILD_TOOL_OF", "DEPENDS_ON",
         ):
             if src in pkg_map and tgt in pkg_map:
-                # Skip edges FROM sibling nodes
-                if src in sibling_ids:
-                    continue
-                # Skip edges TO sibling transitive deps
-                if tgt in sibling_transitive:
-                    continue
+                # Only filter edges when filter_siblings=True
+                if filter_siblings:
+                    # Skip edges FROM sibling nodes
+                    if src in sibling_ids:
+                        continue
+                    # Skip edges TO sibling-only deps
+                    if tgt in sibling_only:
+                        continue
                 edges.append({
                     "source": src,
                     "target": tgt,

--- a/tests/test_spdx_visualize.py
+++ b/tests/test_spdx_visualize.py
@@ -264,6 +264,103 @@ class TestExtractGraph(unittest.TestCase):
         )
 
 
+class TestSiblingFiltering(unittest.TestCase):
+    """Regression tests for _analyzed vs _build sibling filtering.
+
+    _analyzed SPDX: filter deps only reachable via sibling modules
+    _build SPDX: show ALL deps (no filtering)
+
+    This prevents the bug where _build visualizations showed only
+    11 packages when the SPDX JSON contained 81 packages.
+    """
+
+    def _sibling_pkg(self, spdx_id, name):
+        """Create a sibling module package."""
+        return {
+            "SPDXID": spdx_id,
+            "name": name,
+            "versionInfo": "1.0",
+            "primaryPackagePurpose": "LIBRARY",
+            "comment": "Sibling module. See: other.spdx.json",
+        }
+
+    def _make_sibling_doc(self):
+        """Create doc with root -> sibling -> transitive deps."""
+        return _make_doc(
+            packages=[
+                _root_pkg("SPDXRef-Root"),
+                _lib_pkg("SPDXRef-Direct", "direct-dep"),
+                self._sibling_pkg("SPDXRef-Sibling", "sibling-mod"),
+                _lib_pkg("SPDXRef-SibDep1", "sibling-dep-1"),
+                _lib_pkg("SPDXRef-SibDep2", "sibling-dep-2"),
+            ],
+            relationships=[
+                _rel("SPDXRef-DOCUMENT", "DESCRIBES", "SPDXRef-Root"),
+                _rel("SPDXRef-Root", "DEPENDS_ON", "SPDXRef-Direct"),
+                _rel("SPDXRef-Root", "DEPENDS_ON", "SPDXRef-Sibling"),
+                _rel("SPDXRef-Sibling", "DEPENDS_ON", "SPDXRef-SibDep1"),
+                _rel("SPDXRef-SibDep1", "DEPENDS_ON", "SPDXRef-SibDep2"),
+            ],
+        )
+
+    def test_analyzed_filters_sibling_only_deps(self):
+        """_analyzed SPDX filters deps only reachable via siblings."""
+        doc = self._make_sibling_doc()
+        # filter_siblings=True (default for _analyzed)
+        nodes, edges = extract_graph(doc, filter_siblings=True)
+        node_names = {n["name"] for n in nodes}
+        # Should have: root, direct-dep, sibling-mod
+        # Should NOT have: sibling-dep-1, sibling-dep-2
+        self.assertIn("myapp", node_names)
+        self.assertIn("direct-dep", node_names)
+        self.assertIn("sibling-mod", node_names)
+        self.assertNotIn("sibling-dep-1", node_names)
+        self.assertNotIn("sibling-dep-2", node_names)
+
+    def test_build_shows_all_deps(self):
+        """_build SPDX shows ALL deps including sibling transitive."""
+        doc = self._make_sibling_doc()
+        # filter_siblings=False (for _build)
+        nodes, edges = extract_graph(doc, filter_siblings=False)
+        node_names = {n["name"] for n in nodes}
+        # Should have ALL 5 packages
+        self.assertIn("myapp", node_names)
+        self.assertIn("direct-dep", node_names)
+        self.assertIn("sibling-mod", node_names)
+        self.assertIn("sibling-dep-1", node_names)
+        self.assertIn("sibling-dep-2", node_names)
+        self.assertEqual(len(nodes), 5)
+        # Should have ALL edges including from sibling
+        self.assertEqual(len(edges), 4)  # 4 DEPENDS_ON edges
+        edge_pairs = {(e["source"], e["target"]) for e in edges}
+        self.assertIn(
+            ("SPDXRef-Sibling", "SPDXRef-SibDep1"), edge_pairs
+        )
+
+    def test_generate_html_uses_build_flag_from_path(self):
+        """generate_html disables sibling filter for _build paths."""
+        doc = self._make_sibling_doc()
+        with tempfile.TemporaryDirectory() as td:
+            # _build path should show all 5 packages
+            build_out = Path(td) / "test_build.spdx.html"
+            generate_html(doc, str(build_out))
+            content = build_out.read_text()
+            self.assertIn("sibling-dep-1", content)
+            self.assertIn("sibling-dep-2", content)
+
+    def test_generate_html_filters_for_analyzed_path(self):
+        """generate_html enables sibling filter for _analyzed paths."""
+        doc = self._make_sibling_doc()
+        with tempfile.TemporaryDirectory() as td:
+            # _analyzed path should filter sibling deps
+            analyzed_out = Path(td) / "test_analyzed.spdx.html"
+            generate_html(doc, str(analyzed_out))
+            content = analyzed_out.read_text()
+            # Sibling-only deps should NOT be in the graph data
+            self.assertNotIn('"sibling-dep-1"', content)
+            self.assertNotIn('"sibling-dep-2"', content)
+
+
 class TestGenerateHtml(unittest.TestCase):
     """Tests for generate_html."""
 


### PR DESCRIPTION
## Problem
`_build` SPDX visualizations were only showing 11 packages when the SPDX JSON contained 81 packages. The sibling filtering logic was hiding all transitive dependencies reachable through sibling modules.

## Root Cause
The sibling filtering was designed for `_analyzed` SPDX (what's compiled into THIS specific binary). For `_build` SPDX, we want the **full dependency graph** including all transitive deps.

## Fix
- Add `filter_siblings` parameter to `extract_graph()` (default `True`)
- Set `filter_siblings=False` when output path contains `_build`
- `_analyzed` SPDX still filters sibling-only deps (correct behavior)

## Before/After
| File | Before | After |
|------|--------|-------|
| dependency-check-9.2.0_build.spdx.html | 11 packages | 81 packages |
