### PR TITLE
fix: filter sibling transitive deps from Java SPDX JSON

### DIFF
--- a/app/spdx/java_generator.py
+++ b/app/spdx/java_generator.py
@@ -466,7 +466,24 @@ class JavaSpdxGenerator:
         artifact_to_spdx = {}
         project_group_id = self._get_project_group_id()
 
-        for i, dep in enumerate(maven_deps):
+        # First pass: identify sibling artifacts
+        sibling_artifacts = set()
+        for dep in maven_deps:
+            if (project_group_id is not None
+                    and dep["groupId"] == project_group_id):
+                sibling_artifacts.add(dep["artifactId"])
+
+        # Filter deps: exclude transitive deps of siblings
+        # (they belong in the sibling's own SPDX file)
+        filtered_deps = []
+        for dep in maven_deps:
+            parent = dep.get("parent")
+            if parent and parent in sibling_artifacts:
+                # This dep's parent is a sibling - skip it
+                continue
+            filtered_deps.append(dep)
+
+        for i, dep in enumerate(filtered_deps):
             dep_id = f"SPDXRef-Dep-{i}"
             artifact_to_spdx[dep["artifactId"]] = dep_id
 
@@ -534,7 +551,7 @@ class JavaSpdxGenerator:
             doc["packages"].append(pkg)
 
         # Add relationships for dependencies
-        for i, dep in enumerate(maven_deps):
+        for i, dep in enumerate(filtered_deps):
             dep_id = f"SPDXRef-Dep-{i}"
 
             # Determine relationship target:


### PR DESCRIPTION
## Problem
Java SPDX JSON files included transitive deps of sibling modules when they should only be in the sibling's own SPDX file.

Example: `dependency-check-9.2.0_build.spdx.json` had 81 packages when it should have ~10 (direct deps + siblings only).

## Root Cause
The Java SPDX generator was adding ALL Maven dependencies to the JSON, including deps whose parent was a sibling module.

## Fix
- First pass: identify sibling artifacts (same groupId as project)
- Filter out deps whose parent is a sibling before adding to SPDX
- Sibling modules themselves are still included (with "Sibling module" comment)
- Their transitive deps are NOT included (they're in the sibling's own SPDX)

## Testing
- 720 tests passing
- Need to re-run Java repos on EC2 to regenerate SPDX files
