### PR TITLE
chore: add cascade rules for minimize-terminals and golden-file-approval

### DIFF
--- a/.windsurf/rules/cascade/golden-file-approval.md
+++ b/.windsurf/rules/cascade/golden-file-approval.md
@@ -1,0 +1,41 @@
+---
+description: NEVER update golden files or dismiss differences without explicit user approval
+trigger: always_on
+priority: critical
+---
+
+# Golden File Approval — MANDATORY
+
+## Rule: ALL differences require user review
+
+When comparing new analysis output against golden SPDX files or previous runs:
+
+1. **Report EVERY difference** — no matter how small (package counts, relationship
+   counts, names, versions, relationship types, any structural change)
+2. **Do NOT assume** any difference is benign, expected, or caused by upstream changes
+3. **Do NOT update golden files** until the user has reviewed all diffs and explicitly approved
+4. **Do NOT dismiss** differences with phrases like "likely upstream" or "within tolerance"
+
+## What to report
+
+For each SPDX file compared, provide:
+
+- Exact package count (old → new)
+- Exact relationship count (old → new)
+- Any added/removed/changed package names
+- Any added/removed/changed relationship types
+- Any changed versions, checksums, or metadata
+- Side-by-side summary of what specifically changed
+
+## Workflow
+
+1. Run regression tests
+2. If tests pass with zero diffs → report "identical, no changes"
+3. If ANY diffs exist → **STOP and report all diffs to user**
+4. Wait for explicit user approval before updating golden files
+5. Only after approval: copy new output to golden folder and re-run tests
+
+## Violations
+
+Updating golden files without user approval is a **critical violation**.
+Dismissing or minimizing differences without investigation is a **critical violation**.

--- a/.windsurf/rules/cascade/minimize-terminals.md
+++ b/.windsurf/rules/cascade/minimize-terminals.md
@@ -1,0 +1,18 @@
+---
+description: Minimize terminal window usage — user views terminals during work
+trigger: always_on
+priority: high
+---
+
+# Minimize Terminal Windows
+
+The user actively views terminal windows while Cascade works. Opening many
+parallel terminals clutters the workspace and makes it hard to follow.
+
+## Rules
+
+1. **Run commands sequentially** in one terminal, not in parallel across many
+2. **Prefer built-in tools** (read_file, grep_search, find_by_name, list_dir)
+   over terminal commands — they produce zero terminal windows
+3. **Batch related checks** into a single command with `&&` when safe and short
+4. Only use a second terminal if the first is occupied by a long-running process

--- a/.windsurf/rules/infrastructure/active-profile.md
+++ b/.windsurf/rules/infrastructure/active-profile.md
@@ -12,7 +12,7 @@ description: Active infrastructure profile — tedg's AWS EC2 instance
 | **Instance Name** | `omnibor-build` |
 | **SSH alias** | `omnibor-build` |
 | **IP** | `54.215.15.253` (Elastic IP) |
-| **Instance ID** | `i-0c93cd60e3e27ebe9` |
+| **Instance ID** | `i-02ef4bf118d6bae90` |
 | **Region** | `us-west-1` |
 | **Instance Type** | `c6i.4xlarge` (16 vCPU, 32 GB RAM) |
 | **OS** | Ubuntu 22.04 x86_64 |


### PR DESCRIPTION
## Summary

Add two new Cascade rules created during new laptop setup session:

### New Rules

- **`minimize-terminals.md`** (high priority): Run commands sequentially in one terminal, prefer built-in tools over terminal commands, batch related checks with `&&`
- **`golden-file-approval.md`** (critical priority): NEVER update golden SPDX files without explicit user review and approval of ALL differences

### Updated

- **`active-profile.md`**: Updated EC2 instance ID from `i-0c93cd60e3e27ebe9` to `i-02ef4bf118d6bae90` (instance was recreated, Elastic IP unchanged)
