### PR TITLE
chore: update curl golden SPDX files to curl-8_19_0 tag build

### DIFF
--- a/tests/golden/spdx/c-cpp/curl/curl_analyzed.spdx.json
+++ b/tests/golden/spdx/c-cpp/curl/curl_analyzed.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "curl",
-  "documentNamespace": "https://omnibor.io/omnibor-analysis/curl-bd63b5a4-85d0-4f65-a550-26d7b0feef8a",
+  "documentNamespace": "https://omnibor.io/omnibor-analysis/curl-5b58162c-f52c-4dba-9208-60d7a2197ebe",
   "creationInfo": {
-    "created": "2026-03-12T21:58:56Z",
+    "created": "2026-04-02T21:39:27Z",
     "creators": [
       "Tool: bomtrace3-unknown",
       "Tool: bomsh-unknown",
@@ -20,98 +20,118 @@
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": true,
       "primaryPackagePurpose": "APPLICATION",
-      "builtDate": "2026-03-12T21:58:56Z",
+      "builtDate": "2026-04-02T21:39:27Z",
       "externalRefs": [
         {
           "referenceCategory": "PERSISTENT-ID",
           "referenceType": "gitoid",
-          "referenceLocator": "gitoid:blob:sha1:74fd43a1b975341cb3dea18e2340a5129bc55a34"
+          "referenceLocator": "gitoid:blob:sha1:d41e267c4ad22aa1ab48051e4378f7f423ccaf88"
         }
       ],
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5c0ce10201c3366cf243f6507e635317f0bc2260"
+          "checksumValue": "9ceebafa1b1f3cfbd1d31552976b51c3c5d62900"
         }
       ],
       "comment": "Built on Ubuntu 22.04.5 LTS with gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
-      "versionInfo": "8.19.0-DEV"
+      "versionInfo": "8.19.0"
     }
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-File-idn.c-2",
-      "fileName": "repos/curl/lib/idn.c",
+      "SPDXID": "SPDXRef-File-smb.c-2",
+      "fileName": "repos/curl/lib/smb.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "00e2fc6e4cb6dcd2036b24331adc2672a4f9bcd3"
+          "checksumValue": "00297adee7f2116f0ec521167ee5ec3ac411b404"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-scache.c-3",
-      "fileName": "repos/curl/lib/vtls/vtls_scache.c",
+      "SPDXID": "SPDXRef-File-cf-socket.h-3",
+      "fileName": "repos/curl/lib/cf-socket.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0149b51869d7b42c41bfed6c81f6bc5d32921445"
+          "checksumValue": "014f5f7881728246f7f7c0aebda9e5fbe3746325"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-ip-happy.c-4",
-      "fileName": "repos/curl/lib/cf-ip-happy.c",
+      "SPDXID": "SPDXRef-File-keylog.c-4",
+      "fileName": "repos/curl/lib/vtls/keylog.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "01ddd9f3d890ee06d6f1227b06b40546d54f033e"
+          "checksumValue": "0206e32cf8fd21e90cb5d1d8079243472dd6dee8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multiif.h-5",
-      "fileName": "repos/curl/lib/vtls/../multiif.h",
+      "SPDXID": "SPDXRef-File-hmac.c-5",
+      "fileName": "repos/curl/lib/hmac.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0252b2dfd978b5626cc3f8e1e196440ab735c6f6"
+          "checksumValue": "028b476c77a3bdeb67176c058410c5f8220463d5"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rustls.c-6",
-      "fileName": "repos/curl/lib/vtls/rustls.c",
+      "SPDXID": "SPDXRef-File-inet-pton.h-6",
+      "fileName": "repos/curl/lib/curlx/inet_pton.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "02a6b7d5aa8d0237724a487be0dea89c32c98a42"
+          "checksumValue": "02ae7f2269dd1c7131bb833c56a63453fac1c8d1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.h-7",
-      "fileName": "repos/curl/lib/vauth/../rand.h",
+      "SPDXID": "SPDXRef-File-multiif.h-7",
+      "fileName": "repos/curl/lib/multiif.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c69a0df460f64a88df44a55b3cc44d31c28d7c"
+          "checksumValue": "039db269e001d28f6e41b3b2ea010c4d566c19a6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ldap.c-8",
-      "fileName": "repos/curl/lib/ldap.c",
+      "SPDXID": "SPDXRef-File-hsts.c-8",
+      "fileName": "repos/curl/lib/hsts.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "046fcd48e885273cf6cb49d2f6c94ec01024b056"
+          "checksumValue": "03f51f8109d4900c7a287fe297f138fd7aedb13a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transfer.h-9",
-      "fileName": "repos/curl/lib/vtls/../transfer.h",
+      "SPDXID": "SPDXRef-File-curl-md5.h-9",
+      "fileName": "repos/curl/lib/curl_md5.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "042c5f59ae5ecbb33a26f980be5da064629b370d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-imap.c-10",
+      "fileName": "repos/curl/lib/imap.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0546595f8998214cdd0b77784d9d25cd4e52f051"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-transfer.h-11",
+      "fileName": "repos/curl/lib/transfer.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -120,7 +140,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-md4.h-10",
+      "SPDXID": "SPDXRef-File-curl-md4.h-12",
       "fileName": "repos/curl/lib/curl_md4.h",
       "checksums": [
         {
@@ -130,8 +150,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ntfy.h-11",
-      "fileName": "repos/curl/lib/vauth/../multi_ntfy.h",
+      "SPDXID": "SPDXRef-File-multi-ntfy.h-13",
+      "fileName": "repos/curl/lib/multi_ntfy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -140,7 +160,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-if2ip.c-12",
+      "SPDXID": "SPDXRef-File-if2ip.c-14",
       "fileName": "repos/curl/lib/if2ip.c",
       "checksums": [
         {
@@ -150,17 +170,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-typecheck-gcc.h-13",
-      "fileName": "repos/curl/lib/../include/curl/typecheck-gcc.h",
+      "SPDXID": "SPDXRef-File-rustls.c-15",
+      "fileName": "repos/curl/lib/vtls/rustls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0642afd91ed2f07c171ecbf34c69107c6c800748"
+          "checksumValue": "061b444bcefd9b963287da7d1bee1ed3aab1069b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-rea.h-14",
+      "SPDXID": "SPDXRef-File-netrc.h-16",
+      "fileName": "repos/curl/lib/netrc.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "061e1e438b9c956e8e794347492286b9783a60f0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-system.h-17",
+      "fileName": "repos/curl/lib/../include/curl/system.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "064833d6e1e72385ed9e493513c1a2d8219c6443"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-rea.h-18",
       "fileName": "repos/curl/src/tool_cb_rea.h",
       "checksums": [
         {
@@ -170,17 +210,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-range.c-15",
-      "fileName": "repos/curl/lib/curl_range.c",
+      "SPDXID": "SPDXRef-File-connect.h-19",
+      "fileName": "repos/curl/lib/connect.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "070dee428980cd6bacb36dec17a698e98c42a163"
+          "checksumValue": "071b4329c1154c5ce0d97125e23479ca0cec9225"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-addrinfo.h-16",
+      "SPDXID": "SPDXRef-File-fake-addrinfo.h-20",
       "fileName": "repos/curl/lib/fake_addrinfo.h",
       "checksums": [
         {
@@ -190,7 +230,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getpass.h-17",
+      "SPDXID": "SPDXRef-File-llist.h-21",
+      "fileName": "repos/curl/lib/llist.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "09c695d3cfaef70dba17fb05724803c65c3265b9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-getpass.h-22",
       "fileName": "repos/curl/src/tool_getpass.h",
       "checksums": [
         {
@@ -200,7 +250,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlinfo.c-18",
+      "SPDXID": "SPDXRef-File-curlinfo.c-23",
       "fileName": "repos/curl/src/curlinfo.c",
       "checksums": [
         {
@@ -210,7 +260,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-macos.h-19",
+      "SPDXID": "SPDXRef-File-macos.h-24",
       "fileName": "repos/curl/lib/macos.h",
       "checksums": [
         {
@@ -220,82 +270,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sha256.h-20",
-      "fileName": "repos/curl/lib/vauth/../curl_sha256.h",
+      "SPDXID": "SPDXRef-File-tool-filetime.c-25",
+      "fileName": "repos/curl/src/tool_filetime.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0aaa4126f4e3f07fa78d9883b0fada4a3ba07efc"
+          "checksumValue": "0b6cd7b38f397dfb12161399505c507badda253a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-ntop.c-21",
-      "fileName": "repos/curl/lib/curlx/inet_ntop.c",
+      "SPDXID": "SPDXRef-File-easy.h-26",
+      "fileName": "repos/curl/lib/../include/curl/easy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0b10e8a7f63087853c342313f6fe0e57670dd7f8"
+          "checksumValue": "0be6915d92bb21f42dacb2d3cb981af3710437ec"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.c-22",
-      "fileName": "repos/curl/lib/hash.c",
+      "SPDXID": "SPDXRef-File-strdup.h-27",
+      "fileName": "repos/curl/lib/curlx/strdup.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0b6ecc48f7d52d388c7fce4dda3e85ef3055084e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-dbg.c-23",
-      "fileName": "repos/curl/src/tool_cb_dbg.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0c8568ff62ff8a6c0931089b3d96e0762455612a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cram.c-24",
-      "fileName": "repos/curl/lib/vauth/cram.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0d061ebbb029aba5ba5656b285f4e7d161b83655"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-doh.h-25",
-      "fileName": "repos/curl/lib/doh.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0dc6a3f2a490024225e76806399b8d715a094d28"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-setopt.h-26",
-      "fileName": "repos/curl/lib/vtls/../setopt.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0dd60c785f939b50563a053d5286b19f150c9a7c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-smb.c-27",
-      "fileName": "repos/curl/lib/smb.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0ddb167e61514f5376ea17ee5132dff8c84f4219"
+          "checksumValue": "0c4b14161e98dbcd6694358eeb6d424d3ff07358"
         }
       ]
     },
@@ -311,7 +311,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-curl-threads.h-29",
-      "fileName": "repos/curl/lib/vauth/../curl_threads.h",
+      "fileName": "repos/curl/lib/curl_threads.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -320,17 +320,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-thrdd.c-30",
-      "fileName": "repos/curl/lib/asyn-thrdd.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0e06db22ca0cab9e291e14a85eb3a005b863ad5e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-llist.c-31",
+      "SPDXID": "SPDXRef-File-llist.c-30",
       "fileName": "repos/curl/lib/llist.c",
       "checksums": [
         {
@@ -340,22 +330,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base64.c-32",
-      "fileName": "repos/curl/lib/curlx/base64.c",
+      "SPDXID": "SPDXRef-File-netrc.c-31",
+      "fileName": "repos/curl/lib/netrc.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0e44eae7faf3634cb181e6c735aac7f3f876fdba"
+          "checksumValue": "1073cc53656f0bd71017f906c1f4c82fbdb3c222"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-formparse.c-33",
-      "fileName": "repos/curl/src/tool_formparse.c",
+      "SPDXID": "SPDXRef-File-timediff.h-32",
+      "fileName": "repos/curl/lib/../lib/curlx/timediff.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0ec434e2def65be84c10bd3341c07023bd8aedd4"
+          "checksumValue": "1081c75d1c9644a3c47b124e50861ffaf6a1b332"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-rtsp.c-33",
+      "fileName": "repos/curl/lib/rtsp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "11848c82820470ebd6e7617084fca138e4da29e3"
         }
       ]
     },
@@ -370,37 +370,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http1.h-35",
-      "fileName": "repos/curl/lib/http1.h",
+      "SPDXID": "SPDXRef-File-ntlm-sspi.c-35",
+      "fileName": "repos/curl/lib/vauth/ntlm_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "124d32e373cb497fbb2a0e752a18979be32ac614"
+          "checksumValue": "12cf32b8945979d680ff1274f90614952c407ead"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-spnego-sspi.c-36",
-      "fileName": "repos/curl/lib/vauth/spnego_sspi.c",
+      "SPDXID": "SPDXRef-File-tool-time.c-36",
+      "fileName": "repos/curl/src/toolx/tool_time.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "12bdc3afd798ee9c792debd1024ad279de2de4e9"
+          "checksumValue": "12eaea9fe4eed120187b2036408527e57fb692d0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn.h-37",
-      "fileName": "repos/curl/lib/vauth/../asyn.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "12d3e1c33883c850d535b97807806c8901760b68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-if2ip.h-38",
+      "SPDXID": "SPDXRef-File-if2ip.h-37",
       "fileName": "repos/curl/lib/if2ip.h",
       "checksums": [
         {
@@ -410,7 +400,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ntfy.c-39",
+      "SPDXID": "SPDXRef-File-multi-ntfy.c-38",
       "fileName": "repos/curl/lib/multi_ntfy.c",
       "checksums": [
         {
@@ -420,28 +410,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noproxy.c-40",
-      "fileName": "repos/curl/lib/noproxy.c",
+      "SPDXID": "SPDXRef-File-strparse.c-39",
+      "fileName": "repos/curl/lib/curlx/strparse.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1421fb114de2950ba9306090a7145e6f663318d9"
+          "checksumValue": "138b3df1255328b71f6f352d6aa78ae3195c2f6f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sendf.h-41",
-      "fileName": "repos/curl/lib/vssh/../sendf.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1521ccb0f86614d0f2e1a948c988df6026514e8e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-ctype.h-42",
-      "fileName": "repos/curl/lib/vauth/../curl_ctype.h",
+      "SPDXID": "SPDXRef-File-curl-ctype.h-40",
+      "fileName": "repos/curl/lib/curl_ctype.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -450,7 +430,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-time.h-43",
+      "SPDXID": "SPDXRef-File-tool-time.h-41",
       "fileName": "repos/curl/src/toolx/tool_time.h",
       "checksums": [
         {
@@ -460,37 +440,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libssh2.c-44",
-      "fileName": "repos/curl/lib/vssh/libssh2.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "15b7c056dd54a23a08432aaf4d5e4dd836e4a7ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hsts.c-45",
-      "fileName": "repos/curl/lib/hsts.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "15d4207548d319fc021423e1150e50a95ae71f22"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-md5.h-46",
-      "fileName": "repos/curl/lib/vauth/../curl_md5.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "16272c759105bbdd91edef6100c8f9d0a3a4a599"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-httpsrr.c-47",
+      "SPDXID": "SPDXRef-File-httpsrr.c-42",
       "fileName": "repos/curl/lib/httpsrr.c",
       "checksums": [
         {
@@ -500,77 +450,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-pton.c-48",
-      "fileName": "repos/curl/lib/curlx/inet_pton.c",
+      "SPDXID": "SPDXRef-File-http.c-43",
+      "fileName": "repos/curl/lib/http.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1767bf19af715657ff5a393ae84eaad8e95cd995"
+          "checksumValue": "188da5fd832edc887ba50e8aad4d79750dbdbcff"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-msgs.c-49",
-      "fileName": "repos/curl/src/tool_msgs.c",
+      "SPDXID": "SPDXRef-File-md4.c-44",
+      "fileName": "repos/curl/lib/md4.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "18e014950df5f52f71acb18808086f3b6f29fc97"
+          "checksumValue": "1ac6ef1c5b7befa694333d5c363ad77d178ded35"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-paramhlp.h-50",
-      "fileName": "repos/curl/src/tool_paramhlp.h",
+      "SPDXID": "SPDXRef-File-ssh.h-45",
+      "fileName": "repos/curl/lib/vssh/ssh.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "192d242d181d2495bc836f17b572fdd5a24dccd0"
+          "checksumValue": "1afb1e8643d99a8dd4ab35d17df32acb866628e0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-doswin.c-51",
-      "fileName": "repos/curl/src/tool_doswin.c",
+      "SPDXID": "SPDXRef-File-system-win32.c-46",
+      "fileName": "repos/curl/lib/system_win32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "193446cba3869353d81dea0b34b14b7e2aee9c89"
+          "checksumValue": "1b052357b5dd4f7b41117bae8e6e2df05d9603f6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cookie.c-52",
-      "fileName": "repos/curl/lib/cookie.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "19d8fc85474cf205be8439b3574c901253cd7a40"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ratelimit.c-53",
-      "fileName": "repos/curl/lib/ratelimit.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1b1fb6ccedc3e04fa5ad3445bdac113830ef71b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-vquic.c-54",
-      "fileName": "repos/curl/lib/vquic/vquic.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1b7dc1d3aacf071aed30977c1e853cb3ff49ef99"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file.c-55",
+      "SPDXID": "SPDXRef-File-file.c-47",
       "fileName": "repos/curl/lib/file.c",
       "checksums": [
         {
@@ -580,7 +500,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sspi.c-56",
+      "SPDXID": "SPDXRef-File-tool-cb-wrt.c-48",
+      "fileName": "repos/curl/src/tool_cb_wrt.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1d2b81ea7cacb6e3bb09260687f50d464465cb66"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sspi.c-49",
       "fileName": "repos/curl/lib/curl_sspi.c",
       "checksums": [
         {
@@ -590,37 +520,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-llist.h-57",
-      "fileName": "repos/curl/lib/vauth/../llist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1d73db1719da962379938387032ac1b38f0d1052"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-url.h-58",
-      "fileName": "repos/curl/lib/vauth/../url.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e44ebe43bb0d94309e27a15486fc1d040dab958"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strdup.h-59",
-      "fileName": "repos/curl/lib/vauth/../curlx/strdup.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e6bc1981429b9e4055bccd0448e9256a4dd1b41"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strerror.c-60",
+      "SPDXID": "SPDXRef-File-strerror.c-50",
       "fileName": "repos/curl/lib/strerror.c",
       "checksums": [
         {
@@ -630,47 +530,77 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ngtcp2.h-61",
-      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.h",
+      "SPDXID": "SPDXRef-File-vquic.c-51",
+      "fileName": "repos/curl/lib/vquic/vquic.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1e9868e0f7f6d1b2f68b40856824000187affb61"
+          "checksumValue": "1eaabb95f5d47769af808a81fbdfba037ab073c2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlx.h-62",
-      "fileName": "repos/curl/src/../lib/curlx/curlx.h",
+      "SPDXID": "SPDXRef-File-spnego-sspi.c-52",
+      "fileName": "repos/curl/lib/vauth/spnego_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1ee35fa1a029667d290f599fbdcc57264d3b4a0f"
+          "checksumValue": "1f73123a0d79e03637c05d2ef695f7d260fa770c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-spack.c-63",
-      "fileName": "repos/curl/lib/vtls/vtls_spack.c",
+      "SPDXID": "SPDXRef-File-cipher-suite.c-53",
+      "fileName": "repos/curl/lib/vtls/cipher_suite.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2026fe3ed57d0fd96748720ea486b3dddfbf3e63"
+          "checksumValue": "1fc6e9f8c6f909e02c1cacdbd409d0067b63fd5b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-printf.h-64",
-      "fileName": "repos/curl/lib/curlx/../curl_printf.h",
+      "SPDXID": "SPDXRef-File-curl.h-54",
+      "fileName": "repos/curl/lib/../include/curl/curl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "207ba7125d62ab9a358a5644c3adbdc31abd6cef"
+          "checksumValue": "209716b334da52a7260b50fada5785870e431322"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyif.h-65",
+      "SPDXID": "SPDXRef-File-ftp.h-55",
+      "fileName": "repos/curl/lib/ftp.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20b360033e05dfddf23b5eaec31f7b7847cd660b"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-config2setopts.c-56",
+      "fileName": "repos/curl/src/config2setopts.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20d87a070ab54f77784e0cfb4953f20b4af78fa6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-formparse.c-57",
+      "fileName": "repos/curl/src/tool_formparse.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20f7e366a000e2a2cfab633d0a31355cd78f0d34"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easyif.h-58",
       "fileName": "repos/curl/lib/easyif.h",
       "checksums": [
         {
@@ -680,17 +610,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks-gssapi.c-66",
-      "fileName": "repos/curl/lib/socks_gssapi.c",
+      "SPDXID": "SPDXRef-File-tool-writeout.c-59",
+      "fileName": "repos/curl/src/tool_writeout.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "21722f072016b083a86e3cd50c8f85f8f04cf106"
+          "checksumValue": "22c83efd03089b3ef1d43e6a297c86292bb18fcf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ssls.c-67",
+      "SPDXID": "SPDXRef-File-tool-ssls.c-60",
       "fileName": "repos/curl/src/tool_ssls.c",
       "checksums": [
         {
@@ -700,28 +630,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-rea.c-68",
-      "fileName": "repos/curl/src/tool_cb_rea.c",
+      "SPDXID": "SPDXRef-File-uint-hash.c-61",
+      "fileName": "repos/curl/lib/uint-hash.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2343d04a133a5a52cc8eeffbf3b0e4ee5a08c4c5"
+          "checksumValue": "2377840200141e225c72298a18b74addd28192f8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-smtp.c-69",
-      "fileName": "repos/curl/lib/smtp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "23590398f949e6fafb513264d7f0c2823bb2bcd6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-memrchr.h-70",
-      "fileName": "repos/curl/lib/vtls/../curl_memrchr.h",
+      "SPDXID": "SPDXRef-File-curl-memrchr.h-62",
+      "fileName": "repos/curl/lib/curl_memrchr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -730,17 +650,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-pause.c-71",
-      "fileName": "repos/curl/lib/cw-pause.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2489a330a03ba8fc94808f4b142ea54f43723272"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-aws-sigv4.h-72",
+      "SPDXID": "SPDXRef-File-http-aws-sigv4.h-63",
       "fileName": "repos/curl/lib/http_aws_sigv4.h",
       "checksums": [
         {
@@ -750,17 +660,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-snprintf.h-73",
-      "fileName": "repos/curl/lib/curlx/snprintf.h",
+      "SPDXID": "SPDXRef-File-hash.h-64",
+      "fileName": "repos/curl/lib/hash.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "266ea137fae6eb76466219d69ec828facf4edc58"
+          "checksumValue": "267f91d1ae43cc3d9493df25b215d1d4e136ef37"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easygetopt.c-74",
+      "SPDXID": "SPDXRef-File-easygetopt.c-65",
       "fileName": "repos/curl/lib/easygetopt.c",
       "checksums": [
         {
@@ -770,37 +680,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-select.h-75",
-      "fileName": "repos/curl/lib/vtls/../select.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "268ae7cecfd4f9a1e806f506f240448adaeb6017"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-multibyte.h-76",
-      "fileName": "repos/curl/lib/vauth/../curlx/multibyte.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "26da0f0843e09509b3a3f41db92b8fc149caa3a6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-writeout.c-77",
-      "fileName": "repos/curl/src/tool_writeout.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2700abfa44385e8cc290ed158b5ce01fc69935ef"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-findfile.c-78",
+      "SPDXID": "SPDXRef-File-tool-findfile.c-66",
       "fileName": "repos/curl/src/tool_findfile.c",
       "checksums": [
         {
@@ -810,68 +690,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basename.c-79",
-      "fileName": "repos/curl/lib/curlx/basename.c",
+      "SPDXID": "SPDXRef-File-cfilters.c-67",
+      "fileName": "repos/curl/lib/cfilters.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "27c29f3c00aace71a0a9f9194c11dc580c530429"
+          "checksumValue": "27b0306180cf80071b421289dc794578492a3ee3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basename.h-80",
-      "fileName": "repos/curl/lib/curlx/basename.h",
+      "SPDXID": "SPDXRef-File-altsvc.h-68",
+      "fileName": "repos/curl/lib/altsvc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "287a14aa14aef0d2aae54a56a5a4520ba5ad402f"
+          "checksumValue": "2931af452bef3a61b90fc7e502bc646048e19675"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-socket.h-81",
-      "fileName": "repos/curl/lib/vauth/../cf-socket.h",
+      "SPDXID": "SPDXRef-File-version-win32.c-69",
+      "fileName": "repos/curl/lib/curlx/version_win32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "298ced926996b3b35f54a084a73c7352cd3f9c52"
+          "checksumValue": "296a38d9247b176476cd5613ca6c7d1859bd1875"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-helpers.c-82",
-      "fileName": "repos/curl/src/tool_helpers.c",
+      "SPDXID": "SPDXRef-File-urlapi-int.h-70",
+      "fileName": "repos/curl/lib/urlapi-int.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2a84accf2c508f000bf3eab280a7e87cb562cf5d"
+          "checksumValue": "29d4fe5f39a0ee84d7fae0239209ccee9452881b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-scache.h-83",
-      "fileName": "repos/curl/lib/vtls/vtls_scache.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a99e779e5285dee6adcbb396988d374c00489ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-wait.c-84",
-      "fileName": "repos/curl/lib/curlx/wait.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a9f54bb3e4eb8655ce48a1c4ff4cdc7ce9e08ce"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socketpair.h-85",
-      "fileName": "repos/curl/lib/vauth/../socketpair.h",
+      "SPDXID": "SPDXRef-File-socketpair.h-71",
+      "fileName": "repos/curl/lib/socketpair.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -880,8 +740,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockaddr.h-86",
-      "fileName": "repos/curl/lib/vauth/../sockaddr.h",
+      "SPDXID": "SPDXRef-File-sockaddr.h-72",
+      "fileName": "repos/curl/lib/sockaddr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -890,38 +750,58 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-prg.c-87",
-      "fileName": "repos/curl/src/tool_cb_prg.c",
+      "SPDXID": "SPDXRef-File-mbedtls.c-73",
+      "fileName": "repos/curl/lib/vtls/mbedtls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2b9e6d63112b864e7ada0c956dd664e98c16116f"
+          "checksumValue": "2bac406c359b21ed33a7e1d16a548409f522745a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynhds.h-88",
-      "fileName": "repos/curl/lib/vauth/../dynhds.h",
+      "SPDXID": "SPDXRef-File-timediff.c-74",
+      "fileName": "repos/curl/lib/curlx/timediff.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2cfa290571201bfbed02112326973f7e5ffe3b73"
+          "checksumValue": "2bf786941d080ba5d552ac28be9089c0abe1ae4d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rustls.h-89",
-      "fileName": "repos/curl/lib/vtls/rustls.h",
+      "SPDXID": "SPDXRef-File-ratelimit.c-75",
+      "fileName": "repos/curl/lib/ratelimit.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2d3b0bb11f1daff419f2b8a37ce0673717b0ec1a"
+          "checksumValue": "2d88cdd7c94428a1cddbb7cd8554d7123e33fabe"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base64.h-90",
-      "fileName": "repos/curl/lib/vauth/../curlx/base64.h",
+      "SPDXID": "SPDXRef-File-idn.c-76",
+      "fileName": "repos/curl/lib/idn.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2db4f6d79e2edfec2afdb5019c0d925017f077ab"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-inet-ntop.h-77",
+      "fileName": "repos/curl/lib/curlx/inet_ntop.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2e3419f02be577ee15228e20f63052c5d81a5b46"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-base64.h-78",
+      "fileName": "repos/curl/lib/curlx/base64.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -930,67 +810,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-escape.h-91",
-      "fileName": "repos/curl/lib/vtls/../escape.h",
+      "SPDXID": "SPDXRef-File-cf-socket.c-79",
+      "fileName": "repos/curl/lib/cf-socket.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2ea06c444fd32f164769906430cef2da8829a137"
+          "checksumValue": "2ebbe4df4da503e272cac2a73db28652867793b4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ntlm-core.c-92",
-      "fileName": "repos/curl/lib/curl_ntlm_core.c",
+      "SPDXID": "SPDXRef-File-cshutdn.c-80",
+      "fileName": "repos/curl/lib/cshutdn.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2edc7b07ce5a1e3f48b304a6cea451867abe8d2f"
+          "checksumValue": "308f2aaa82dfb5f3f389ada7aa8a6320056e7a7a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-system-win32.c-93",
-      "fileName": "repos/curl/lib/system_win32.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2f24fe5c0ccec9c72477a785086e073a8cfd9e51"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-setopt.c-94",
-      "fileName": "repos/curl/src/tool_setopt.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2ffcd1076b978b354dfd80d972f70973d9746daa"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-var.c-95",
-      "fileName": "repos/curl/src/var.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "306ed1b02bcbec022ec8f11da63ca3898a908932"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-vauth.h-96",
-      "fileName": "repos/curl/lib/vauth/vauth.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "312bd8da5ad474c66012fc26fe9d36bcea8ec894"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cf-h2-proxy.h-97",
+      "SPDXID": "SPDXRef-File-cf-h2-proxy.h-81",
       "fileName": "repos/curl/lib/cf-h2-proxy.h",
       "checksums": [
         {
@@ -1000,7 +840,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-writeout-json.c-98",
+      "SPDXID": "SPDXRef-File-tool-writeout-json.c-82",
       "fileName": "repos/curl/src/tool_writeout_json.c",
       "checksums": [
         {
@@ -1010,27 +850,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-arpa-telnet.h-99",
-      "fileName": "repos/curl/lib/arpa_telnet.h",
+      "SPDXID": "SPDXRef-File-slist-wc.h-83",
+      "fileName": "repos/curl/src/slist_wc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "329f4bcd1c5414f5c28b7767725e1cbd3e98aaae"
+          "checksumValue": "328d6b00f5ba7e1be00a0c48fe62d50087098e40"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transfer.c-100",
-      "fileName": "repos/curl/lib/transfer.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "32c31c6e9378298bd25affb9b90244128710ceed"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-macos.c-101",
+      "SPDXID": "SPDXRef-File-macos.c-84",
       "fileName": "repos/curl/lib/macos.c",
       "checksums": [
         {
@@ -1040,18 +870,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic-tls.c-102",
-      "fileName": "repos/curl/lib/vquic/vquic-tls.c",
+      "SPDXID": "SPDXRef-File-curl-share.c-85",
+      "fileName": "repos/curl/lib/curl_share.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3391d98074088f646498adafd8d3ee74b6fcb76c"
+          "checksumValue": "338727a4fab265303d41853ee4b169cb4e567666"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pingpong.h-103",
-      "fileName": "repos/curl/lib/vauth/../pingpong.h",
+      "SPDXID": "SPDXRef-File-pingpong.h-86",
+      "fileName": "repos/curl/lib/pingpong.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1060,7 +890,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fileinfo.c-104",
+      "SPDXID": "SPDXRef-File-formdata.h-87",
+      "fileName": "repos/curl/lib/formdata.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "33d7d0ae33d540bfb7f734f6c367fd3c4cf1245d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fileinfo.c-88",
       "fileName": "repos/curl/lib/fileinfo.c",
       "checksums": [
         {
@@ -1070,17 +910,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcase.h-105",
-      "fileName": "repos/curl/lib/vtls/../strcase.h",
+      "SPDXID": "SPDXRef-File-winapi.c-89",
+      "fileName": "repos/curl/lib/curlx/winapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "35f726c3eecef87a51ef1a576514266feed7253f"
+          "checksumValue": "3417df269e056282d37ab70a4432bca5fdc1c951"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-hdr.h-106",
+      "SPDXID": "SPDXRef-File-altsvc.c-90",
+      "fileName": "repos/curl/lib/altsvc.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "34da3e1ac86d083a31afb81d71ea3da74e8b5297"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-hugehelp.c-91",
+      "fileName": "repos/curl/src/tool_hugehelp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "374cf39809682272c1c8034d1d803c7783186357"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-formdata.c-92",
+      "fileName": "repos/curl/lib/formdata.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3770d28b18ec9f8bfc0cfea4b7be2a79239437a2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-hdr.h-93",
       "fileName": "repos/curl/src/tool_cb_hdr.h",
       "checksums": [
         {
@@ -1090,37 +960,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mbedtls.h-107",
-      "fileName": "repos/curl/lib/vtls/mbedtls.h",
+      "SPDXID": "SPDXRef-File-mime.c-94",
+      "fileName": "repos/curl/lib/mime.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3876fe36fc5d82a56c1022c67aac4446f6cc036c"
+          "checksumValue": "37ea514e4f8715557562aea4bd1cc3e4342e195e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-request.h-108",
-      "fileName": "repos/curl/lib/vauth/../request.h",
+      "SPDXID": "SPDXRef-File-uint-table.h-95",
+      "fileName": "repos/curl/lib/uint-table.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "389ae4d8b1f8d7d6db078637f29304f6e5cf36a7"
+          "checksumValue": "398a26a64843389caffdbe0359d2e35e91e7065c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http.c-109",
-      "fileName": "repos/curl/lib/http.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "39f0a0d194056356c3f6339497e141bdba3ebca4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-smtp.h-110",
+      "SPDXID": "SPDXRef-File-smtp.h-96",
       "fileName": "repos/curl/lib/smtp.h",
       "checksums": [
         {
@@ -1130,7 +990,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config2setopts.h-111",
+      "SPDXID": "SPDXRef-File-libssh.c-97",
+      "fileName": "repos/curl/lib/vssh/libssh.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3a2a52e1f84fb57a17a2081375efbff799ea8b13"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-printf.h-98",
+      "fileName": "repos/curl/lib/curl_printf.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3b1a5af3b4593f544383faee11c07d8618a9d8ea"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strdup.c-99",
+      "fileName": "repos/curl/lib/curlx/strdup.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3c967dbe0a5d144dc4c77ad8e9ffac848d3c6d22"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-config2setopts.h-100",
       "fileName": "repos/curl/src/config2setopts.h",
       "checksums": [
         {
@@ -1140,37 +1030,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ipfs.c-112",
-      "fileName": "repos/curl/src/tool_ipfs.c",
+      "SPDXID": "SPDXRef-File-warnless.h-101",
+      "fileName": "repos/curl/lib/curlx/warnless.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3d2d5dea8424432dfe85fb138e171135c563643c"
+          "checksumValue": "3d0341e418a51614a644704a617f934681d0518e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-socket.c-113",
-      "fileName": "repos/curl/lib/cf-socket.c",
+      "SPDXID": "SPDXRef-File-vauth.h-102",
+      "fileName": "repos/curl/lib/vauth/vauth.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3e47a98722fc435f72915441868f473955a8c64c"
+          "checksumValue": "3e66c89cb5199edc6d792df91c9df50ccf6434a9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mbedtls.c-114",
-      "fileName": "repos/curl/lib/vtls/mbedtls.c",
+      "SPDXID": "SPDXRef-File-doh.h-103",
+      "fileName": "repos/curl/lib/doh.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3f5654ea0be7078ddafb2ec50407b663b7eb539d"
+          "checksumValue": "3eba4df26e29f5fe3b6065b2a4a8392f0c618cc0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-dirhie.c-115",
+      "SPDXID": "SPDXRef-File-tool-dirhie.c-104",
       "fileName": "repos/curl/src/tool_dirhie.c",
       "checksums": [
         {
@@ -1180,7 +1070,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cfgable.c-116",
+      "SPDXID": "SPDXRef-File-tool-cfgable.c-105",
       "fileName": "repos/curl/src/tool_cfgable.c",
       "checksums": [
         {
@@ -1190,37 +1080,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-table.h-117",
-      "fileName": "repos/curl/lib/vauth/../uint-table.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3fc7e34ef436e9c53ce465f736b8cdd550cace9f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-share.h-118",
-      "fileName": "repos/curl/lib/vtls/../curl_share.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3fcaaecd4ad64586c5db922a04a1c4ceb7f92783"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-share.c-119",
-      "fileName": "repos/curl/lib/curl_share.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3ff27556845f3f8ae0b1e31de45b7007310437f0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-writeout.h-120",
+      "SPDXID": "SPDXRef-File-tool-writeout.h-106",
       "fileName": "repos/curl/src/tool_writeout.h",
       "checksums": [
         {
@@ -1230,7 +1090,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-websockets.h-121",
+      "SPDXID": "SPDXRef-File-websockets.h-107",
       "fileName": "repos/curl/lib/../include/curl/websockets.h",
       "checksums": [
         {
@@ -1240,27 +1100,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-imap.c-122",
-      "fileName": "repos/curl/lib/imap.c",
+      "SPDXID": "SPDXRef-File-schannel-verify.c-108",
+      "fileName": "repos/curl/lib/vtls/schannel_verify.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "414ee32466d374da767cfc38ac55da587d6770be"
+          "checksumValue": "414b2e915aaaf7086002f5217db5f2cfda0b2881"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-idn.h-123",
-      "fileName": "repos/curl/lib/idn.h",
+      "SPDXID": "SPDXRef-File-rand.c-109",
+      "fileName": "repos/curl/lib/rand.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "42613af5096c058f000c2a8809e88d0f6c6844a2"
+          "checksumValue": "4232e819e17bbf101bfd7cd7593b9c72f28465ee"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ssls.h-124",
+      "SPDXID": "SPDXRef-File-cf-h2-proxy.c-110",
+      "fileName": "repos/curl/lib/cf-h2-proxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4275e1ef5aef37f4d1a5d7ef716d38c41e413272"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-ssls.h-111",
       "fileName": "repos/curl/src/tool_ssls.h",
       "checksums": [
         {
@@ -1270,8 +1140,28 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerr.h-125",
-      "fileName": "repos/curl/lib/vtls/../curlx/strerr.h",
+      "SPDXID": "SPDXRef-File-timeval.c-112",
+      "fileName": "repos/curl/lib/curlx/timeval.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "435804c2996b90f81c25c073a55e00ec67b1a8a1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-addrinfo.c-113",
+      "fileName": "repos/curl/lib/curl_addrinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "43d398d119216ea4ea4e53e25873807dafe949f3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strerr.h-114",
+      "fileName": "repos/curl/lib/curlx/strerr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1280,68 +1170,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mqtt.c-126",
-      "fileName": "repos/curl/lib/mqtt.c",
+      "SPDXID": "SPDXRef-File-vtls-spack.h-115",
+      "fileName": "repos/curl/lib/../lib/vtls/vtls_spack.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "446918cc44886a99b297d41aa1437c8d8e9ac702"
+          "checksumValue": "4479384de978cac1836eb55288466211663e1d0e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-filetime.c-127",
-      "fileName": "repos/curl/src/tool_filetime.c",
+      "SPDXID": "SPDXRef-File-doh.c-116",
+      "fileName": "repos/curl/lib/doh.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "45598413cd487828115d35fa1dae7912994a9b52"
+          "checksumValue": "4488d422b12cd93b8824cc689ef7ab75be8f80f9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-memdebug.c-128",
-      "fileName": "repos/curl/lib/memdebug.c",
+      "SPDXID": "SPDXRef-File-asyn-base.c-117",
+      "fileName": "repos/curl/lib/asyn-base.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "457034ebdae2227ed453e777681031b6de84b77f"
+          "checksumValue": "44bf98c8e4f912a7f2903f8f320d7db8f1d8a668"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-ntop.h-129",
-      "fileName": "repos/curl/lib/curlx/inet_ntop.h",
+      "SPDXID": "SPDXRef-File-oauth2.c-118",
+      "fileName": "repos/curl/lib/vauth/oauth2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "45b63d97a5958b327e288e0baed020b5bf5a8387"
+          "checksumValue": "4541d1d551bb94f687eab71dff4658cade41d6ae"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http2.c-130",
-      "fileName": "repos/curl/lib/http2.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "45f82192b024a77bc48bcc6b0a0f4b78c2334f64"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-hmac.h-131",
-      "fileName": "repos/curl/lib/vauth/../curl_hmac.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4759ff6ec6626e91f728ade60137ba5e573ff9e4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist.h-132",
-      "fileName": "repos/curl/lib/vtls/../slist.h",
+      "SPDXID": "SPDXRef-File-slist.h-119",
+      "fileName": "repos/curl/lib/slist.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1350,7 +1220,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-stderr.h-133",
+      "SPDXID": "SPDXRef-File-tool-stderr.h-120",
       "fileName": "repos/curl/src/tool_stderr.h",
       "checksums": [
         {
@@ -1360,18 +1230,58 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timeval.h-134",
-      "fileName": "repos/curl/lib/vauth/../curlx/timeval.h",
+      "SPDXID": "SPDXRef-File-curl-ngtcp2.c-121",
+      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4aab17519d8bfe74a78f1dfd761fc4ed760b627a"
+          "checksumValue": "48905d3e201780d2dde1742d7db4a6b4140b3b76"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-spbset.h-135",
-      "fileName": "repos/curl/lib/vauth/../uint-spbset.h",
+      "SPDXID": "SPDXRef-File-vssh.h-122",
+      "fileName": "repos/curl/lib/vssh/vssh.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "492108fbd7663d1629f6fcefe9ac7b13f0eee1c0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-aws-sigv4.c-123",
+      "fileName": "repos/curl/lib/http_aws_sigv4.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "492be1ab58634f8f6ef5773a21c6d54753fa7a5e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-ntlm-core.c-124",
+      "fileName": "repos/curl/lib/curl_ntlm_core.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4a9433b2936771dadc46831804ba91815606ffea"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cfgable.h-125",
+      "fileName": "repos/curl/src/tool_cfgable.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4af31b802e7b0012a9fd82e341ad19a049708c4d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-uint-spbset.h-126",
+      "fileName": "repos/curl/lib/uint-spbset.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1380,17 +1290,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connect.c-136",
-      "fileName": "repos/curl/lib/connect.c",
+      "SPDXID": "SPDXRef-File-curl-trc.c-127",
+      "fileName": "repos/curl/lib/curl_trc.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4b363ebe31b04b79f6c4b780a8471c211a60918a"
+          "checksumValue": "4b8734a7e9d50ef4f44ff0b3ecb8ffa039735e54"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerror.h-137",
+      "SPDXID": "SPDXRef-File-strerror.h-128",
       "fileName": "repos/curl/lib/strerror.h",
       "checksums": [
         {
@@ -1400,7 +1310,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyoptions.c-138",
+      "SPDXID": "SPDXRef-File-easyoptions.c-129",
       "fileName": "repos/curl/lib/easyoptions.c",
       "checksums": [
         {
@@ -1410,37 +1320,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-urlglob.c-139",
-      "fileName": "repos/curl/src/tool_urlglob.c",
+      "SPDXID": "SPDXRef-File-asyn-ares.c-130",
+      "fileName": "repos/curl/lib/asyn-ares.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4c5973875b2ef5a5a828220bd2d9f1c19549449f"
+          "checksumValue": "4d063d9f26574d5a93a402e497053703c93fa828"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getparam.h-140",
-      "fileName": "repos/curl/src/tool_getparam.h",
+      "SPDXID": "SPDXRef-File-cookie.c-131",
+      "fileName": "repos/curl/lib/cookie.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4d345413931debbcd76798ac0eac7b15793ddf04"
+          "checksumValue": "4d53cc460cb82b2df44a86a829f454423b3c62b2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vssh.h-141",
-      "fileName": "repos/curl/lib/vssh/vssh.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4d5b7ad24e98046a6ef2ca2e88073cf5b678b188"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-ca-embed.c-142",
+      "SPDXID": "SPDXRef-File-tool-ca-embed.c-132",
       "fileName": "repos/curl/src/tool_ca_embed.c",
       "checksums": [
         {
@@ -1450,17 +1350,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config2setopts.c-143",
-      "fileName": "repos/curl/src/config2setopts.c",
+      "SPDXID": "SPDXRef-File-pingpong.c-133",
+      "fileName": "repos/curl/lib/pingpong.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4ea65f453c24faee45d9bba96233bfd95f13cec1"
+          "checksumValue": "4ede0a5985db595d164eaf8993b4efd5b23702c2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufref.c-144",
+      "SPDXID": "SPDXRef-File-curl-setup.h-134",
+      "fileName": "repos/curl/lib/curl_setup.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4f8d65af8b5d8c3c13720f28a4edf36bfe021bcd"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-openssl.c-135",
+      "fileName": "repos/curl/lib/vtls/openssl.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50bf1e04766e90ef5d7744a35fff0ed2f79093e5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-help.c-136",
+      "fileName": "repos/curl/src/tool_help.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50cca527057333b3dfcfd0e3f8bdea076f7a59df"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-bufref.c-137",
       "fileName": "repos/curl/lib/bufref.c",
       "checksums": [
         {
@@ -1470,27 +1400,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ftp.c-145",
-      "fileName": "repos/curl/lib/ftp.c",
+      "SPDXID": "SPDXRef-File-strparse.h-138",
+      "fileName": "repos/curl/lib/curlx/strparse.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5110ee1397e14ba4e61b127a584822719e11bf40"
+          "checksumValue": "514203dc92fad6a5f39c9428d243e06a37ff249b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel-verify.c-146",
-      "fileName": "repos/curl/lib/vtls/schannel_verify.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5129b8b04d33871489166eee0bf87b6186fb097f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socks.h-147",
+      "SPDXID": "SPDXRef-File-socks.h-139",
       "fileName": "repos/curl/lib/socks.h",
       "checksums": [
         {
@@ -1500,47 +1420,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-paramhlp.c-148",
-      "fileName": "repos/curl/src/tool_paramhlp.c",
+      "SPDXID": "SPDXRef-File-wait.c-140",
+      "fileName": "repos/curl/lib/curlx/wait.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "523b52629c93e5083ab4f940cf7b37961aba5b57"
+          "checksumValue": "52784269ef51fabb405b91e12a02682fc56a0e9f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multibyte.c-149",
-      "fileName": "repos/curl/lib/curlx/multibyte.c",
+      "SPDXID": "SPDXRef-File-vquic.h-141",
+      "fileName": "repos/curl/lib/vquic/vquic.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "529091ad92d6ae8ceb5fbc8a9b79c6becddb6ede"
+          "checksumValue": "528e18476d48d0b565c8fdc8bf95505a46396fc4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.h-150",
-      "fileName": "repos/curl/lib/../include/curl/multi.h",
+      "SPDXID": "SPDXRef-File-request.h-142",
+      "fileName": "repos/curl/lib/request.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "531c1a954a955b9f4c42f64a87be1ca9918f601c"
+          "checksumValue": "5332d48538d9e519ddfda5cc86edb4dc0e92c97d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doh.c-151",
-      "fileName": "repos/curl/lib/doh.c",
+      "SPDXID": "SPDXRef-File-tool-sdecls.h-143",
+      "fileName": "repos/curl/src/tool_sdecls.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5401256bf895aff995b26184bac2d436dcae2694"
+          "checksumValue": "5350b71a3714bc38f04f045180bfb82dd535d11c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-pause.h-152",
+      "SPDXID": "SPDXRef-File-strcase.h-144",
+      "fileName": "repos/curl/lib/strcase.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "54299812beaed5ac5d98f210c997982572824fa0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostip.c-145",
+      "fileName": "repos/curl/lib/hostip.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "542b655b113d14d1fbdd29985ab32ca1e92a03fd"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cw-pause.h-146",
       "fileName": "repos/curl/lib/cw-pause.h",
       "checksums": [
         {
@@ -1550,7 +1490,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-wrt.h-153",
+      "SPDXID": "SPDXRef-File-cw-out.c-147",
+      "fileName": "repos/curl/lib/cw-out.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "554c32e84ecdd31de8d70669ce9c5e389745c5db"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-wrt.h-148",
       "fileName": "repos/curl/src/tool_cb_wrt.h",
       "checksums": [
         {
@@ -1560,27 +1510,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-setup.h-154",
-      "fileName": "repos/curl/lib/vauth/../curl_setup.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "559f586b7859f561f1067a1d976ed2667c0a4665"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cipher-suite.c-155",
-      "fileName": "repos/curl/lib/vtls/cipher_suite.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "562a3477355d7764c16550460966d9563df18b8f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-hash.h-156",
+      "SPDXID": "SPDXRef-File-uint-hash.h-149",
       "fileName": "repos/curl/lib/uint-hash.h",
       "checksums": [
         {
@@ -1590,7 +1520,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amigaos.h-157",
+      "SPDXID": "SPDXRef-File-amigaos.h-150",
       "fileName": "repos/curl/lib/amigaos.h",
       "checksums": [
         {
@@ -1600,17 +1530,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-trc.h-158",
-      "fileName": "repos/curl/lib/vauth/../curl_trc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "58903844acf1c8f5063ed79980bfe7acfcd3013d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-spbset.c-159",
+      "SPDXID": "SPDXRef-File-uint-spbset.c-151",
       "fileName": "repos/curl/lib/uint-spbset.c",
       "checksums": [
         {
@@ -1620,7 +1540,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-memrchr.c-160",
+      "SPDXID": "SPDXRef-File-curl-memrchr.c-152",
       "fileName": "repos/curl/lib/curl_memrchr.c",
       "checksums": [
         {
@@ -1630,7 +1550,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-headers.c-161",
+      "SPDXID": "SPDXRef-File-headers.c-153",
       "fileName": "repos/curl/lib/headers.c",
       "checksums": [
         {
@@ -1640,7 +1560,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-easysrc.c-162",
+      "SPDXID": "SPDXRef-File-urldata.h-154",
+      "fileName": "repos/curl/lib/urldata.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5ae148054baf7c04c0b38a585af0baaa0be11cef"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-easysrc.c-155",
       "fileName": "repos/curl/src/tool_easysrc.c",
       "checksums": [
         {
@@ -1650,27 +1580,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy.h-163",
-      "fileName": "repos/curl/lib/../include/curl/easy.h",
+      "SPDXID": "SPDXRef-File-digest.h-156",
+      "fileName": "repos/curl/lib/../lib/vauth/digest.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5b3cdbd64e805870cf8a30193cb945ef99e446d8"
+          "checksumValue": "5b8f3ae7675f4d45d7b6b83ec953c5e97530297e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x509asn1.c-164",
-      "fileName": "repos/curl/lib/vtls/x509asn1.c",
+      "SPDXID": "SPDXRef-File-telnet.c-157",
+      "fileName": "repos/curl/lib/telnet.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5c3a727e63c47edcf846dc58b6649937887935e3"
+          "checksumValue": "5bae99e1fcca877fd0919424f6f9ea5359d99441"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlver.h-165",
+      "SPDXID": "SPDXRef-File-curlver.h-158",
       "fileName": "repos/curl/lib/../include/curl/curlver.h",
       "checksums": [
         {
@@ -1680,8 +1610,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufref.h-166",
-      "fileName": "repos/curl/lib/vauth/../bufref.h",
+      "SPDXID": "SPDXRef-File-bufref.h-159",
+      "fileName": "repos/curl/lib/bufref.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1690,17 +1620,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-quiche.c-167",
-      "fileName": "repos/curl/lib/vquic/curl_quiche.c",
+      "SPDXID": "SPDXRef-File-ftplistparser.h-160",
+      "fileName": "repos/curl/lib/ftplistparser.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5d981cb2e6bf35f7a7257e698f90fca6de26c30c"
+          "checksumValue": "5d7aa492ba4eda791a2bc74a342ba088f0a28d59"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-version.h-168",
+      "SPDXID": "SPDXRef-File-tool-version.h-161",
       "fileName": "repos/curl/src/tool_version.h",
       "checksums": [
         {
@@ -1710,37 +1640,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-splay.c-169",
-      "fileName": "repos/curl/lib/splay.c",
+      "SPDXID": "SPDXRef-File-curl-share.h-162",
+      "fileName": "repos/curl/lib/curl_share.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5e4cd54d27babe055c6bfed9b11af06f016d128e"
+          "checksumValue": "5e3f82aa56b2b2835daf1de4e65de75be47b6821"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http2.h-170",
-      "fileName": "repos/curl/lib/http2.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5e545b234900946021d14c443a6259326af621f6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-mime.h-171",
-      "fileName": "repos/curl/lib/vauth/../mime.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5ef05506a4be35e593b92d8070bdbd40fca85f47"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-bset.c-172",
+      "SPDXID": "SPDXRef-File-uint-bset.c-163",
       "fileName": "repos/curl/lib/uint-bset.c",
       "checksums": [
         {
@@ -1750,7 +1660,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-digest.h-173",
+      "SPDXID": "SPDXRef-File-http-digest.h-164",
       "fileName": "repos/curl/lib/http_digest.h",
       "checksums": [
         {
@@ -1760,7 +1670,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-util.c-174",
+      "SPDXID": "SPDXRef-File-warnless.c-165",
+      "fileName": "repos/curl/lib/curlx/warnless.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5fc36ac9a8762103e3688a6dd5e31236ff7b176c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-ws.c-166",
+      "fileName": "repos/curl/lib/ws.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60465611bb74ce21cb20f715e418d4de253f5f11"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-ftp.c-167",
+      "fileName": "repos/curl/lib/ftp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6047759e7850a78de48e9e983ea4a3a38fb68222"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-smtp.c-168",
+      "fileName": "repos/curl/lib/smtp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60889858d3e2756869d1e903581ad352ecd4382c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http1.c-169",
+      "fileName": "repos/curl/lib/http1.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60ad32ce89b95832a753d01baa75303aac013b7b"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-util.c-170",
       "fileName": "repos/curl/src/tool_util.c",
       "checksums": [
         {
@@ -1770,17 +1730,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operate.c-175",
-      "fileName": "repos/curl/src/tool_operate.c",
+      "SPDXID": "SPDXRef-File-multi.c-171",
+      "fileName": "repos/curl/lib/multi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "618508aca49f4e6f662ed558a1657821613096ac"
+          "checksumValue": "6133736525778b122b1b3e615388b5c622296d9e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fnmatch.h-176",
+      "SPDXID": "SPDXRef-File-curl-fnmatch.h-172",
       "fileName": "repos/curl/lib/curl_fnmatch.h",
       "checksums": [
         {
@@ -1790,7 +1750,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-libinfo.c-177",
+      "SPDXID": "SPDXRef-File-tool-libinfo.c-173",
       "fileName": "repos/curl/src/tool_libinfo.c",
       "checksums": [
         {
@@ -1800,7 +1760,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-findfile.h-178",
+      "SPDXID": "SPDXRef-File-tool-findfile.h-174",
       "fileName": "repos/curl/src/tool_findfile.h",
       "checksums": [
         {
@@ -1810,17 +1770,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-addrinfo.h-179",
-      "fileName": "repos/curl/lib/vauth/../curl_addrinfo.h",
+      "SPDXID": "SPDXRef-File-libssh2.c-175",
+      "fileName": "repos/curl/lib/vssh/libssh2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "63d3f7a2442c75c48ab232cabb28f92ecf475bd6"
+          "checksumValue": "63f5735b835b38017b0544993e1ca2253d3fdefc"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-progress.c-180",
+      "SPDXID": "SPDXRef-File-tool-progress.c-176",
       "fileName": "repos/curl/src/tool_progress.c",
       "checksums": [
         {
@@ -1830,27 +1790,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-altsvc.c-181",
-      "fileName": "repos/curl/lib/altsvc.c",
+      "SPDXID": "SPDXRef-File-curl-sha512-256.c-177",
+      "fileName": "repos/curl/lib/curl_sha512_256.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "64bfec420bd518583f9c696df156affc2ffb5c93"
+          "checksumValue": "648e3e38e960be028a92a3b48a576f41bbc6a0ac"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ngtcp2.c-182",
-      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.c",
+      "SPDXID": "SPDXRef-File-schannel.c-178",
+      "fileName": "repos/curl/lib/vtls/schannel.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "65c78e68485b63468465175893f00cc8eff04c1b"
+          "checksumValue": "650a0e38ca8bf04eee4aba3b40d089a1b7e1d530"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-xattr.h-183",
+      "SPDXID": "SPDXRef-File-cf-h1-proxy.h-179",
+      "fileName": "repos/curl/lib/cf-h1-proxy.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6544ec58d026839cdbe1117bea42e77ed0a10c3f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-request.c-180",
+      "fileName": "repos/curl/lib/request.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "66077530d72637f0bc4af84dcd96163ae6b9c269"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-vtls-int.h-181",
+      "fileName": "repos/curl/lib/../lib/vtls/vtls_int.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6700ee74cbe163fbf45d378e898cabe0b1e6a6b4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-xattr.h-182",
       "fileName": "repos/curl/src/tool_xattr.h",
       "checksums": [
         {
@@ -1860,8 +1850,18 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-File-vtls-scache.c-183",
+      "fileName": "repos/curl/lib/vtls/vtls_scache.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "673abcfe0dbf7c1699fdc7e7b050e508e460165f"
+        }
+      ]
+    },
+    {
       "SPDXID": "SPDXRef-File-mqtt.h-184",
-      "fileName": "repos/curl/lib/vauth/../mqtt.h",
+      "fileName": "repos/curl/lib/mqtt.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1870,52 +1870,52 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks.c-185",
-      "fileName": "repos/curl/lib/socks.c",
+      "SPDXID": "SPDXRef-File-asyn.h-185",
+      "fileName": "repos/curl/lib/asyn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "67e9c9b3c7cf132efbeb936148d8da2f3a1094ad"
+          "checksumValue": "68628f90c007f0a27b26c1f8d2ee4588d91c761b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version.c-186",
-      "fileName": "repos/curl/lib/version.c",
+      "SPDXID": "SPDXRef-File-tool-getpass.c-186",
+      "fileName": "repos/curl/src/tool_getpass.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6949278f47d31d540ba01f5471e4dbff0b8eab3b"
+          "checksumValue": "68a16cab3e611bab75a18399525db1e622bb2c85"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timediff.c-187",
-      "fileName": "repos/curl/lib/curlx/timediff.c",
+      "SPDXID": "SPDXRef-File-multi-ev.c-187",
+      "fileName": "repos/curl/lib/multi_ev.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "694c8d83520673b844cdeb2d67f3b125b74ecb9a"
+          "checksumValue": "696a012ebff74fbf31ece59b5f45d99175f7ab18"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-help.h-188",
+      "SPDXID": "SPDXRef-File-cf-h1-proxy.c-188",
+      "fileName": "repos/curl/lib/cf-h1-proxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "69e050b9d63ee3f61e70a07f6652daa5f373bd70"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-help.h-189",
       "fileName": "repos/curl/src/tool_help.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "6a2ecdb0622e90fa34dcd01a74aa3354e0bcc670"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-krb5-gssapi.c-189",
-      "fileName": "repos/curl/lib/vauth/krb5_gssapi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6a9f182864c034b0b8c9fd8e40fb87942c45b898"
         }
       ]
     },
@@ -1930,17 +1930,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-quiche.h-191",
-      "fileName": "repos/curl/lib/vquic/curl_quiche.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6c0fb9ee1ee695f4780d34a45c050575ff8501ce"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-negotiate.h-192",
+      "SPDXID": "SPDXRef-File-http-negotiate.h-191",
       "fileName": "repos/curl/lib/http_negotiate.h",
       "checksums": [
         {
@@ -1950,7 +1940,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-haproxy.h-193",
+      "SPDXID": "SPDXRef-File-tool-cb-prg.c-192",
+      "fileName": "repos/curl/src/tool_cb_prg.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c3a366fa632b9c967f8d47fc57bfcc8c1cec4bc"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostip.h-193",
+      "fileName": "repos/curl/lib/hostip.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c7f1291b261c01dde04ab5ae190ab83df38e404"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-progress.c-194",
+      "fileName": "repos/curl/lib/progress.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6cde5678be84f4e430035912d4341da6ec6633a3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fopen.c-195",
+      "fileName": "repos/curl/lib/curlx/fopen.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6d0ef7e683564b162fd4ab8c1c2e342a32b6c2a9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-haproxy.h-196",
       "fileName": "repos/curl/lib/cf-haproxy.h",
       "checksums": [
         {
@@ -1960,28 +1990,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ws.c-194",
-      "fileName": "repos/curl/lib/ws.c",
+      "SPDXID": "SPDXRef-File-transfer.c-197",
+      "fileName": "repos/curl/lib/transfer.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6ed417185e1d927ffaf85a51c0a5af3b413667fd"
+          "checksumValue": "6dd2f52fe572801b4f48d7f0b25c19057cdc6c12"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http.h-195",
-      "fileName": "repos/curl/lib/vauth/../http.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6ef391af60200b7b3b86df2e1655cacdfae88d93"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dynbuf.h-196",
-      "fileName": "repos/curl/lib/vauth/../curlx/dynbuf.h",
+      "SPDXID": "SPDXRef-File-dynbuf.h-198",
+      "fileName": "repos/curl/lib/curlx/dynbuf.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1990,37 +2010,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-config.h-197",
-      "fileName": "repos/curl/lib/vauth/../curl_config.h",
+      "SPDXID": "SPDXRef-File-nonblock.c-199",
+      "fileName": "repos/curl/lib/curlx/nonblock.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6f16a673ffc1baa4164b57425e4515fd3253185c"
+          "checksumValue": "6f6458f2b3427985ec0c3cb4ba4e8b93bb4f178d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-content-encoding.c-198",
-      "fileName": "repos/curl/lib/content_encoding.c",
+      "SPDXID": "SPDXRef-File-dynbuf.c-200",
+      "fileName": "repos/curl/lib/curlx/dynbuf.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6f58054bb29557117890f53a973c3ecae58c404b"
+          "checksumValue": "7045a1f2940b9047cb299bf41d547925a783c7f4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-vms.c-199",
-      "fileName": "repos/curl/src/tool_vms.c",
+      "SPDXID": "SPDXRef-File-multibyte.c-201",
+      "fileName": "repos/curl/lib/curlx/multibyte.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "71606f3d66c5e20a20d88523e2ad4129596f2686"
+          "checksumValue": "715d2b8dc20d7600e3769773a2b7ec90781919e4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noproxy.h-200",
+      "SPDXID": "SPDXRef-File-noproxy.h-202",
       "fileName": "repos/curl/lib/noproxy.h",
       "checksums": [
         {
@@ -2030,17 +2050,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urldata.h-201",
-      "fileName": "repos/curl/lib/vauth/../urldata.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "71e5d6f4a11a9e69119c56d48f108bc17fff5f01"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cf-ip-happy.h-202",
+      "SPDXID": "SPDXRef-File-cf-ip-happy.h-203",
       "fileName": "repos/curl/lib/cf-ip-happy.h",
       "checksums": [
         {
@@ -2050,7 +2060,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gopher.c-203",
+      "SPDXID": "SPDXRef-File-gopher.c-204",
       "fileName": "repos/curl/lib/gopher.c",
       "checksums": [
         {
@@ -2060,7 +2070,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-writeout-json.h-204",
+      "SPDXID": "SPDXRef-File-tool-writeout-json.h-205",
       "fileName": "repos/curl/src/tool_writeout_json.h",
       "checksums": [
         {
@@ -2070,27 +2080,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timeval.c-205",
-      "fileName": "repos/curl/lib/curlx/timeval.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "734b784c04f04b4b2258106dad2ba52a7551f951"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-wolfssl.h-206",
-      "fileName": "repos/curl/lib/vtls/wolfssl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "736da9a1a6a205ca918de6e47d61a9fdc5772d68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fileinfo.h-207",
+      "SPDXID": "SPDXRef-File-fileinfo.h-206",
       "fileName": "repos/curl/lib/fileinfo.h",
       "checksums": [
         {
@@ -2100,7 +2090,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynhds.c-208",
+      "SPDXID": "SPDXRef-File-dynhds.c-207",
       "fileName": "repos/curl/lib/dynhds.c",
       "checksums": [
         {
@@ -2110,12 +2100,22 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-bset.h-209",
-      "fileName": "repos/curl/lib/vauth/../uint-bset.h",
+      "SPDXID": "SPDXRef-File-uint-bset.h-208",
+      "fileName": "repos/curl/lib/uint-bset.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "7455c427df94f3a624cb820c92ff61a9044e06d5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-vms.c-209",
+      "fileName": "repos/curl/src/tool_vms.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "74eb210ab54658fed417d735f49933ff09e485f6"
         }
       ]
     },
@@ -2131,7 +2131,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-ratelimit.h-211",
-      "fileName": "repos/curl/lib/vauth/../ratelimit.h",
+      "fileName": "repos/curl/lib/ratelimit.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2150,7 +2150,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-rtmp.c-213",
+      "SPDXID": "SPDXRef-File-ws.h-213",
+      "fileName": "repos/curl/lib/ws.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "757eae0f0f69f898821ad80a622be2fdd4aa4b90"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-rtmp.c-214",
       "fileName": "repos/curl/lib/curl_rtmp.c",
       "checksums": [
         {
@@ -2160,17 +2170,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strdup.c-214",
-      "fileName": "repos/curl/lib/curlx/strdup.c",
+      "SPDXID": "SPDXRef-File-sendf.h-215",
+      "fileName": "repos/curl/lib/sendf.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "75e088fe4ce605e7ce7f0706265533caecae2ebc"
+          "checksumValue": "75c6e248ea473f8a94f819186cad0aaeb6efb020"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pop3.h-215",
+      "SPDXID": "SPDXRef-File-socketpair.c-216",
+      "fileName": "repos/curl/lib/socketpair.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "76b959dd4afc698252290be068b482940a041b5e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-pop3.h-217",
       "fileName": "repos/curl/lib/pop3.h",
       "checksums": [
         {
@@ -2180,7 +2200,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-haproxy.c-216",
+      "SPDXID": "SPDXRef-File-curl-config.h-218",
+      "fileName": "repos/curl/lib/curl_config.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "780ceae0a2f299041c7085c2d564f097e4eab5a3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-haproxy.c-219",
       "fileName": "repos/curl/lib/cf-haproxy.c",
       "checksums": [
         {
@@ -2190,38 +2220,38 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tftp.c-217",
-      "fileName": "repos/curl/lib/tftp.c",
+      "SPDXID": "SPDXRef-File-connect.c-220",
+      "fileName": "repos/curl/lib/connect.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "782cb1959a8e186e219b076b9a1455ad9176d066"
+          "checksumValue": "78c9370804824d6626e4540ad593ee4863b24a88"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ssh.h-218",
-      "fileName": "repos/curl/lib/vssh/ssh.h",
+      "SPDXID": "SPDXRef-File-cleartext.c-221",
+      "fileName": "repos/curl/lib/vauth/cleartext.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "78889bf60e6b96c85d6683afb4ed07aa75f2df07"
+          "checksumValue": "7976adec9c8fec28baaa8a9c42684677e7d20f28"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cshutdn.h-219",
-      "fileName": "repos/curl/lib/vauth/../cshutdn.h",
+      "SPDXID": "SPDXRef-File-curlx.h-222",
+      "fileName": "repos/curl/src/../lib/curlx/curlx.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "79c95cca5917d8d3a8d56707707aa34c955cd696"
+          "checksumValue": "79cffc8f6dbcd2df6ff7499164ae2b601103f41a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multihandle.h-220",
-      "fileName": "repos/curl/lib/vauth/../multihandle.h",
+      "SPDXID": "SPDXRef-File-multihandle.h-223",
+      "fileName": "repos/curl/lib/multihandle.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2230,27 +2260,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-krb5-sspi.c-221",
-      "fileName": "repos/curl/lib/vauth/krb5_sspi.c",
+      "SPDXID": "SPDXRef-File-sha256.c-224",
+      "fileName": "repos/curl/lib/sha256.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7aad4badfab4d9d3430ed6407489e46c6aa056fd"
+          "checksumValue": "7b063659be03511b73c247291d5f8f6bd49119d9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slist-wc.h-222",
-      "fileName": "repos/curl/src/slist_wc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7bf76257a49c9bfe351708f3325b9dc81292c81b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-ldap.h-223",
+      "SPDXID": "SPDXRef-File-curl-ldap.h-225",
       "fileName": "repos/curl/lib/curl_ldap.h",
       "checksums": [
         {
@@ -2260,27 +2280,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apple.c-224",
-      "fileName": "repos/curl/lib/vtls/apple.c",
+      "SPDXID": "SPDXRef-File-version.c-226",
+      "fileName": "repos/curl/lib/version.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7c2ea4989f89f3fb71c3c192480cb7570353c1a8"
+          "checksumValue": "7ccd875dc8e3dc039ecea4d7377b154e2bd04100"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-progress.c-225",
-      "fileName": "repos/curl/lib/progress.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7daa4b4b3efd690d97d055dbb0e268b573dd2e74"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cw-out.h-226",
+      "SPDXID": "SPDXRef-File-cw-out.h-227",
       "fileName": "repos/curl/lib/cw-out.h",
       "checksums": [
         {
@@ -2290,47 +2300,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel.c-227",
-      "fileName": "repos/curl/lib/vtls/schannel.c",
+      "SPDXID": "SPDXRef-File-keylog.h-228",
+      "fileName": "repos/curl/lib/../lib/vtls/keylog.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7eba7843684c2375fefa90bbe583542d2073fc8d"
+          "checksumValue": "7e741b964d596dea3606dd4aec0978752d7f836b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mime.c-228",
-      "fileName": "repos/curl/lib/mime.c",
+      "SPDXID": "SPDXRef-File-tool-operate.h-229",
+      "fileName": "repos/curl/src/tool_operate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7f350ae7e0475d2f196cea6d54f01d08586fa8cc"
+          "checksumValue": "7e886f6ef043017edf50686626c1c0adcde55f6c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socketpair.c-229",
-      "fileName": "repos/curl/lib/socketpair.c",
+      "SPDXID": "SPDXRef-File-parsedate.c-230",
+      "fileName": "repos/curl/lib/parsedate.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7fd7e30bbab8271c2ff28ebd5d217375371c0d0d"
+          "checksumValue": "7efedec7d2452959e80c23647608d48859015d3d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-ares.c-230",
-      "fileName": "repos/curl/lib/asyn-ares.c",
+      "SPDXID": "SPDXRef-File-var.c-231",
+      "fileName": "repos/curl/src/var.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "80126ce056d5aafd41d5e154bf2a133690155578"
+          "checksumValue": "7fb51d656e38279bc603aa06a776af6a64444a23"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-doswin.h-231",
+      "SPDXID": "SPDXRef-File-inet-ntop.c-232",
+      "fileName": "repos/curl/lib/curlx/inet_ntop.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "803b9887ac91c638e0f34a614a97aab8e42b5793"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hash.c-233",
+      "fileName": "repos/curl/lib/hash.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8095ca2e450748cde390aaa07cebb4f2da1f0e5c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-doswin.h-234",
       "fileName": "repos/curl/src/tool_doswin.h",
       "checksums": [
         {
@@ -2340,7 +2370,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options.h-232",
+      "SPDXID": "SPDXRef-File-options.h-235",
       "fileName": "repos/curl/lib/../include/curl/options.h",
       "checksums": [
         {
@@ -2350,27 +2380,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-openldap.c-233",
-      "fileName": "repos/curl/lib/openldap.c",
+      "SPDXID": "SPDXRef-File-setopt.c-236",
+      "fileName": "repos/curl/lib/setopt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "83ae013593d8ab56826d5ad7e1d933dcddcacc3b"
+          "checksumValue": "84f3e02b7b1584191d15844bad6470eaa16fc8ad"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sasl.h-234",
-      "fileName": "repos/curl/lib/curl_sasl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8432d261ecc8386f1af3f18993984ff070a6251f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-dirhie.h-235",
+      "SPDXID": "SPDXRef-File-tool-dirhie.h-237",
       "fileName": "repos/curl/src/tool_dirhie.h",
       "checksums": [
         {
@@ -2380,17 +2400,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cshutdn.c-236",
-      "fileName": "repos/curl/lib/cshutdn.c",
+      "SPDXID": "SPDXRef-File-headers.h-238",
+      "fileName": "repos/curl/lib/headers.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "85863ef93051dd62fd01a46cc251a1f829d4bc49"
+          "checksumValue": "85905e5141dc96e820eb886135e6caee4c39121c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-get-line.c-237",
+      "SPDXID": "SPDXRef-File-curl-get-line.c-239",
       "fileName": "repos/curl/lib/curl_get_line.c",
       "checksums": [
         {
@@ -2400,17 +2420,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-altsvc.h-238",
-      "fileName": "repos/curl/lib/altsvc.h",
+      "SPDXID": "SPDXRef-File-header.h-240",
+      "fileName": "repos/curl/lib/../include/curl/header.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "85da8cceb91ce31062a51388be33bb31cb595ea6"
+          "checksumValue": "85c10c8d7833211bab237dac62a21fdc7f91cff9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-parsecfg.h-239",
+      "SPDXID": "SPDXRef-File-tool-parsecfg.h-241",
       "fileName": "repos/curl/src/tool_parsecfg.h",
       "checksums": [
         {
@@ -2420,7 +2440,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-listhelp.c-240",
+      "SPDXID": "SPDXRef-File-tool-listhelp.c-242",
       "fileName": "repos/curl/src/tool_listhelp.c",
       "checksums": [
         {
@@ -2430,7 +2450,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-endian.c-241",
+      "SPDXID": "SPDXRef-File-curl-endian.c-243",
       "fileName": "repos/curl/lib/curl_endian.c",
       "checksums": [
         {
@@ -2440,62 +2460,42 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-spack.h-242",
-      "fileName": "repos/curl/lib/vtls/vtls_spack.h",
+      "SPDXID": "SPDXRef-File-rand.h-244",
+      "fileName": "repos/curl/lib/rand.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86796ee62ed6ca3f2ecb1ea7cb7ec2b71ce4cda1"
+          "checksumValue": "86765806f90894e0069733a2688e6122bf448064"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conncache.c-243",
-      "fileName": "repos/curl/lib/conncache.c",
+      "SPDXID": "SPDXRef-File-multibyte.h-245",
+      "fileName": "repos/curl/lib/../lib/curlx/multibyte.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "869af4215e457f74df665dbd044884758634ec36"
+          "checksumValue": "8863fb024990faa22fcdaca761cbefa3edbb051e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getparam.c-244",
-      "fileName": "repos/curl/src/tool_getparam.c",
+      "SPDXID": "SPDXRef-File-functypes.h-246",
+      "fileName": "repos/curl/lib/functypes.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86ebed13e8a4e9a1ee673edfe126f998e710b8bd"
+          "checksumValue": "887c2612ef94d83ce89e7fa8a019c3f78d804cbb"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest-sspi.c-245",
-      "fileName": "repos/curl/lib/vauth/digest_sspi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "893838d2cdd5cedd92a6df5de70a342eaf48b6e5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-hugehelp.h-246",
+      "SPDXID": "SPDXRef-File-tool-hugehelp.h-247",
       "fileName": "repos/curl/src/tool_hugehelp.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "89df96ce5fe9a12e0b21bf143c67eaa57ad21614"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-vms.h-247",
-      "fileName": "repos/curl/src/tool_vms.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "89ea31ee1583277ab18498d5fa8ea3f634106c05"
         }
       ]
     },
@@ -2510,12 +2510,12 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnless.h-249",
-      "fileName": "repos/curl/lib/vauth/../curlx/warnless.h",
+      "SPDXID": "SPDXRef-File-curl-sasl.h-249",
+      "fileName": "repos/curl/lib/curl_sasl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8a62ccf6a70b0416582f9b6e893270e7e5a6db7d"
+          "checksumValue": "8a97f52adcff1c1730743e90575565aebd024431"
         }
       ]
     },
@@ -2540,58 +2540,28 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.h-252",
-      "fileName": "repos/curl/lib/vauth/../hash.h",
+      "SPDXID": "SPDXRef-File-bufq.h-252",
+      "fileName": "repos/curl/lib/bufq.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8bf47ccf753dd8043f001ad47f545893cd424ef8"
+          "checksumValue": "8dd186f505535c53e1242b652f6008a9086e3edf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnless.c-253",
-      "fileName": "repos/curl/lib/curlx/warnless.c",
+      "SPDXID": "SPDXRef-File-tool-ipfs.c-253",
+      "fileName": "repos/curl/src/tool_ipfs.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8c1be2d589c8751c353b40254348b0ffd6d3155d"
+          "checksumValue": "8e762b8cf0326b1eaab2dd9506ccc592acde9d78"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls.c-254",
-      "fileName": "repos/curl/lib/vtls/vtls.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8c87dd3d9cd6fe1b4ed3d9a5337783622bd409df"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-fnmatch.c-255",
-      "fileName": "repos/curl/lib/curl_fnmatch.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8e35edeed6306f7484153a169f451c194c7af545"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-mprintf.c-256",
-      "fileName": "repos/curl/lib/mprintf.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8f81f033dcb0c7125beab6183168a1fab87a9f08"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-httpsrr.h-257",
-      "fileName": "repos/curl/lib/vtls/../httpsrr.h",
+      "SPDXID": "SPDXRef-File-httpsrr.h-254",
+      "fileName": "repos/curl/lib/httpsrr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2600,37 +2570,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest.h-258",
-      "fileName": "repos/curl/lib/vauth/digest.h",
+      "SPDXID": "SPDXRef-File-cshutdn.h-255",
+      "fileName": "repos/curl/lib/cshutdn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "902ffab153a8ccfb7c0b73ff6690f5a55db35042"
+          "checksumValue": "9030474032b49953229cb633aae68341978c5570"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-sdecls.h-259",
-      "fileName": "repos/curl/src/tool_sdecls.h",
+      "SPDXID": "SPDXRef-File-idn.h-256",
+      "fileName": "repos/curl/lib/idn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9058233a688e183df4edc2d69812d513ebdd4c5a"
+          "checksumValue": "90d8e811b1a6128e0bafec2b6006ca0cbcfe46be"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hmac.c-260",
-      "fileName": "repos/curl/lib/hmac.c",
+      "SPDXID": "SPDXRef-File-strerr.c-257",
+      "fileName": "repos/curl/lib/curlx/strerr.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9080588341da6efd0262f244873d5b993c9b273f"
+          "checksumValue": "91a329e91502c28ae79cb6d0498a0807a22c6505"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tftp.h-261",
+      "SPDXID": "SPDXRef-File-tftp.h-258",
       "fileName": "repos/curl/lib/tftp.h",
       "checksums": [
         {
@@ -2640,7 +2610,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mprintf.h-262",
+      "SPDXID": "SPDXRef-File-mprintf.h-259",
       "fileName": "repos/curl/lib/../include/curl/mprintf.h",
       "checksums": [
         {
@@ -2650,7 +2620,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-gethostname.h-263",
+      "SPDXID": "SPDXRef-File-curl-gethostname.h-260",
       "fileName": "repos/curl/lib/curl_gethostname.h",
       "checksums": [
         {
@@ -2660,7 +2630,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rtsp.h-264",
+      "SPDXID": "SPDXRef-File-rtsp.h-261",
       "fileName": "repos/curl/lib/rtsp.h",
       "checksums": [
         {
@@ -2670,47 +2640,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operate.h-265",
-      "fileName": "repos/curl/src/tool_operate.h",
+      "SPDXID": "SPDXRef-File-sendf.c-262",
+      "fileName": "repos/curl/lib/sendf.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "93c87e10e65936f2c08b8d4cf8043e50a65d6760"
+          "checksumValue": "92e77b482aeaf049d048dcec2013c44c98d95082"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.c-266",
-      "fileName": "repos/curl/lib/multi.c",
+      "SPDXID": "SPDXRef-File-gsasl.c-263",
+      "fileName": "repos/curl/lib/vauth/gsasl.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9420e3f940b116af32ab383c91043c9c359867c7"
+          "checksumValue": "958f4ffab746546fdb526ca82d6ade0589072d8d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock.c-267",
-      "fileName": "repos/curl/lib/curlx/nonblock.c",
+      "SPDXID": "SPDXRef-File-openldap.c-264",
+      "fileName": "repos/curl/lib/openldap.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "96bf3db64ec8c9f1163e45e0ffba018e99402479"
+          "checksumValue": "95f7681caa8bcd4dbb3e27178e8af9245018dfed"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostcheck.c-268",
-      "fileName": "repos/curl/lib/vtls/hostcheck.c",
+      "SPDXID": "SPDXRef-File-digest.c-265",
+      "fileName": "repos/curl/lib/vauth/digest.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9706336735c210b8d453efe1ff2f837a2285eaa6"
+          "checksumValue": "96093903871fc1215753d6bde0db7ae590b07798"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-range.h-269",
+      "SPDXID": "SPDXRef-File-socks-gssapi.c-266",
+      "fileName": "repos/curl/lib/socks_gssapi.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "962fcd05b2a6db214d86a469cf05460e7850ddab"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-paramhlp.c-267",
+      "fileName": "repos/curl/src/tool_paramhlp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "970d42192adac3e9363d56a4cc980c4485984acb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-range.h-268",
       "fileName": "repos/curl/lib/curl_range.h",
       "checksums": [
         {
@@ -2720,8 +2710,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-psl.h-270",
-      "fileName": "repos/curl/lib/vauth/../psl.h",
+      "SPDXID": "SPDXRef-File-psl.h-269",
+      "fileName": "repos/curl/lib/psl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2730,87 +2720,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strequal.c-271",
-      "fileName": "repos/curl/lib/strequal.c",
+      "SPDXID": "SPDXRef-File-tool-setup.h-270",
+      "fileName": "repos/curl/src/tool_setup.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "98cecdc244d4d3724cee85a0a3c856cf1415de11"
+          "checksumValue": "9860a0b96244562446673af2565ee7ed820b61c1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-netrc.h-272",
-      "fileName": "repos/curl/lib/vauth/../netrc.h",
+      "SPDXID": "SPDXRef-File-select.c-271",
+      "fileName": "repos/curl/lib/select.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "99ddc6253e08da0840eeadec71d9879d43b4acec"
+          "checksumValue": "9a11924976ac384288176a5bf58c06351e318692"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getpass.c-273",
-      "fileName": "repos/curl/src/tool_getpass.c",
+      "SPDXID": "SPDXRef-File-tool-operate.c-272",
+      "fileName": "repos/curl/src/tool_operate.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "99ded8f4c5b57b40fa83aa65eb0c786dc53700fe"
+          "checksumValue": "9a29b8e34c01055915e24e86abde466c7b062750"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedate.c-274",
-      "fileName": "repos/curl/lib/parsedate.c",
+      "SPDXID": "SPDXRef-File-wait.h-273",
+      "fileName": "repos/curl/lib/curlx/wait.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9a3060bd50be97332fd44af19bc34df264bd0fc3"
+          "checksumValue": "9b9c27386e92150fd85c701d3c4f8394316f6c9f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-chunks.c-275",
-      "fileName": "repos/curl/lib/http_chunks.c",
+      "SPDXID": "SPDXRef-File-curl-range.c-274",
+      "fileName": "repos/curl/lib/curl_range.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9b38a3780cae1ea9c372fb94de428570150d2b87"
+          "checksumValue": "9bbafa40cfc38e04c61d69c4814f1c23e6cfc25f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conncache.h-276",
-      "fileName": "repos/curl/lib/vauth/../conncache.h",
+      "SPDXID": "SPDXRef-File-tool-msgs.c-275",
+      "fileName": "repos/curl/src/tool_msgs.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9b392af05ccd2d6f794ca2db680bbd9bfc7475fb"
+          "checksumValue": "9bc8ca18f12f92c64fca976a1bb4112d01b178b3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cfgable.h-277",
-      "fileName": "repos/curl/src/tool_cfgable.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9bd1f59bc9863d1ce68436e7149c8300ae43ca9f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist.c-278",
-      "fileName": "repos/curl/lib/slist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9bfd08ae2ce138477d75f003fca9740537fdd4fc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-prg.h-279",
+      "SPDXID": "SPDXRef-File-tool-cb-prg.h-276",
       "fileName": "repos/curl/src/tool_cb_prg.h",
       "checksums": [
         {
@@ -2820,8 +2790,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-progress.h-280",
-      "fileName": "repos/curl/lib/vtls/../progress.h",
+      "SPDXID": "SPDXRef-File-progress.h-277",
+      "fileName": "repos/curl/lib/progress.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2830,27 +2800,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http1.c-281",
-      "fileName": "repos/curl/lib/http1.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9e584248bedd5532edd81a09267a4770304769c5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-splay.h-282",
-      "fileName": "repos/curl/lib/vauth/../splay.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9ed96f63e4eae5a81731506731b724eb25237c12"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strcase.c-283",
+      "SPDXID": "SPDXRef-File-strcase.c-278",
       "fileName": "repos/curl/lib/strcase.c",
       "checksums": [
         {
@@ -2860,47 +2810,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cfilters.h-284",
-      "fileName": "repos/curl/lib/vtls/../cfilters.h",
+      "SPDXID": "SPDXRef-File-escape.h-279",
+      "fileName": "repos/curl/lib/escape.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9faf01de755d092998b002b5732ef86104f66ba5"
+          "checksumValue": "9f9a89e4022bcdbfb7ebf816492b9f67ea318c28"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.c-285",
-      "fileName": "repos/curl/lib/rand.c",
+      "SPDXID": "SPDXRef-File-vauth.c-280",
+      "fileName": "repos/curl/lib/vauth/vauth.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a02338f206a56bb7be5d4939c2f4ede34a67b020"
+          "checksumValue": "a00078fce1939ececb86458c39e37e3cac80318e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-see.c-286",
-      "fileName": "repos/curl/src/tool_cb_see.c",
+      "SPDXID": "SPDXRef-File-gtls.c-281",
+      "fileName": "repos/curl/lib/vtls/gtls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a1983b94cc5b35179c6b44c36305e26077837d08"
+          "checksumValue": "a0a465c3607ca86322972c16166089cd429cea55"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pingpong.c-287",
-      "fileName": "repos/curl/lib/pingpong.c",
+      "SPDXID": "SPDXRef-File-http2.h-282",
+      "fileName": "repos/curl/lib/http2.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a2ca05ae4767e3649f3f1160688da8e71e2bea82"
+          "checksumValue": "a14c8485cc884baddaaecf3a9d22bef7c2091d1c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.h-288",
+      "SPDXID": "SPDXRef-File-tool-helpers.c-283",
+      "fileName": "repos/curl/src/tool_helpers.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a23c3a80e75b29cc4f9ff2bd08a107d211bb1048"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-file.h-284",
       "fileName": "repos/curl/lib/file.h",
       "checksums": [
         {
@@ -2910,67 +2870,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ev.c-289",
-      "fileName": "repos/curl/lib/multi_ev.c",
+      "SPDXID": "SPDXRef-File-strequal.c-285",
+      "fileName": "repos/curl/lib/strequal.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a399e3f4cbce975b58e07875cbc25ed9254ad327"
+          "checksumValue": "a352fda70b246728660d097bcd4f2e9ae81b13de"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-select.c-290",
-      "fileName": "repos/curl/lib/select.c",
+      "SPDXID": "SPDXRef-File-urlapi.c-286",
+      "fileName": "repos/curl/lib/urlapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a3d77145ce14e8a0f590aea3e0485a8a815951d9"
+          "checksumValue": "a4b82f31bd74f345e0959630fef59469022f66da"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-system.h-291",
-      "fileName": "repos/curl/lib/../include/curl/system.h",
+      "SPDXID": "SPDXRef-File-gtls.h-287",
+      "fileName": "repos/curl/lib/../lib/vtls/gtls.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a5b3e9eba79a055c4c300b1d5d516678e5fbe693"
+          "checksumValue": "a5e55cd4f9f8e7c6489c21af1cfb9e636421f1b9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libssh.c-292",
-      "fileName": "repos/curl/lib/vssh/libssh.c",
+      "SPDXID": "SPDXRef-File-apple.c-288",
+      "fileName": "repos/curl/lib/vtls/apple.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a5d58ec731ba1d7cbaaea991499d9bd54461b8b1"
+          "checksumValue": "a6a5ba01f026f95abab3315a1518e56b4cf80f13"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-win32.h-293",
-      "fileName": "repos/curl/lib/curlx/version_win32.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a5fb8ff3c23fa8a82c1f747f13d005d246dcf949"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-openssl.c-294",
-      "fileName": "repos/curl/lib/vtls/openssl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a632e80943f23feecf144c3580408e24d8622c77"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-negotiate.c-295",
+      "SPDXID": "SPDXRef-File-http-negotiate.c-289",
       "fileName": "repos/curl/lib/http_negotiate.c",
       "checksums": [
         {
@@ -2980,47 +2920,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedate.h-296",
-      "fileName": "repos/curl/lib/vssh/../parsedate.h",
+      "SPDXID": "SPDXRef-File-base64.c-290",
+      "fileName": "repos/curl/lib/curlx/base64.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a6ee43a5d487c425b744c3451cc2dbbf26e55466"
+          "checksumValue": "a7a6703099128d30c29c92c7c837ca546906a87a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-oauth2.c-297",
-      "fileName": "repos/curl/lib/vauth/oauth2.c",
+      "SPDXID": "SPDXRef-File-curl-trc.h-291",
+      "fileName": "repos/curl/lib/curl_trc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a7a061337fa9abd1783da7863346523b2a446e89"
+          "checksumValue": "a82c945e5f9b7e1f0fbfc113c3ea929a7fac1fe7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h1-proxy.c-298",
-      "fileName": "repos/curl/lib/cf-h1-proxy.c",
+      "SPDXID": "SPDXRef-File-conncache.c-292",
+      "fileName": "repos/curl/lib/conncache.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a85cd1d5a6fc0809a1b9f8ad149a72712fff1605"
+          "checksumValue": "a865959709b7c07d30e9a44066b60c68a80d7b5f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sigpipe.h-299",
-      "fileName": "repos/curl/lib/sigpipe.h",
+      "SPDXID": "SPDXRef-File-http-proxy.c-293",
+      "fileName": "repos/curl/lib/http_proxy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a906b27037498037864017c36d8e91e5e4b58900"
+          "checksumValue": "a9521c92dab64ccd604ddd440f0f8a08d4d83bc7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getenv.c-300",
+      "SPDXID": "SPDXRef-File-getenv.c-294",
       "fileName": "repos/curl/lib/getenv.c",
       "checksums": [
         {
@@ -3030,47 +2970,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynbuf.c-301",
-      "fileName": "repos/curl/lib/curlx/dynbuf.c",
+      "SPDXID": "SPDXRef-File-content-encoding.c-295",
+      "fileName": "repos/curl/lib/content_encoding.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a96b2a5974c59a19df2d39058784bdda019ff8bb"
+          "checksumValue": "aa35da840b23251fc37882dbce411b81cdd80f2f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-win32.c-302",
-      "fileName": "repos/curl/lib/curlx/version_win32.c",
+      "SPDXID": "SPDXRef-File-wolfssl.c-296",
+      "fileName": "repos/curl/lib/vtls/wolfssl.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a9a4ee38f9293d5f876b37fff4b74d20ec9e6174"
+          "checksumValue": "aa841a754a944cdaf678460f3618899777692e95"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-out.c-303",
-      "fileName": "repos/curl/lib/cw-out.c",
+      "SPDXID": "SPDXRef-File-tool-doswin.c-297",
+      "fileName": "repos/curl/src/tool_doswin.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ab38109ad900dbec31e3e7a58ec78ad078c662e3"
+          "checksumValue": "ad0386555dbd8c4778c82ef14ea5f8167f831420"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keylog.c-304",
-      "fileName": "repos/curl/lib/vtls/keylog.c",
+      "SPDXID": "SPDXRef-File-hostcheck.c-298",
+      "fileName": "repos/curl/lib/vtls/hostcheck.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ace9cab1ae2b7ffa706695986c9239bbb555f971"
+          "checksumValue": "ad09b8319413891c9065116c7bb8a2d871a8caa5"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-urlglob.h-305",
+      "SPDXID": "SPDXRef-File-tool-urlglob.h-299",
       "fileName": "repos/curl/src/tool_urlglob.h",
       "checksums": [
         {
@@ -3080,97 +3020,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-headers.h-306",
-      "fileName": "repos/curl/lib/headers.h",
+      "SPDXID": "SPDXRef-File-multi.h-300",
+      "fileName": "repos/curl/lib/../include/curl/multi.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "adb03af75b5e1fecf3713fcfb51dcd74fe4f98ff"
+          "checksumValue": "ad6f53f3e2c44a99e7b55f230a0ce9a2b60ab674"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-https-connect.c-307",
-      "fileName": "repos/curl/lib/cf-https-connect.c",
+      "SPDXID": "SPDXRef-File-tool-paramhlp.h-301",
+      "fileName": "repos/curl/src/tool_paramhlp.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ae6721bd41258205ed29170ff8f45d5927e512ad"
+          "checksumValue": "af40f10591b50e3120b6e22e1fd1daf20ccd6091"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strparse.h-308",
-      "fileName": "repos/curl/lib/vauth/../curlx/strparse.h",
+      "SPDXID": "SPDXRef-File-memdebug.c-302",
+      "fileName": "repos/curl/lib/memdebug.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ae8fd19d955e2b53d01b8b81458a849f7e467313"
+          "checksumValue": "af4fc9d6c107cdea99bbac619dc19efe82595f74"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-request.c-309",
-      "fileName": "repos/curl/lib/request.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aed9c7eb3b1608262ff4c4670df52bb919b1672b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-openssl.h-310",
-      "fileName": "repos/curl/lib/vtls/openssl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aeeb8dd805b0fd0e5ad8c0adf27cf127f88fe044"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ftplistparser.h-311",
-      "fileName": "repos/curl/lib/vauth/../ftplistparser.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "afb90dee4cada77f126f9a85461f8ffd814981a2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-escape.c-312",
-      "fileName": "repos/curl/lib/escape.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "afdf18c1b4d91ed7c4c800fc7269615190d6917a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-time.c-313",
-      "fileName": "repos/curl/src/toolx/tool_time.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "affcd7a16730ba0d553468c144f19f2874c6cc74"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-spnego-gssapi.c-314",
+      "SPDXID": "SPDXRef-File-spnego-gssapi.c-303",
       "fileName": "repos/curl/lib/vauth/spnego_gssapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b1ec37cb31686f30197fa9f647b4bd6dc9d54688"
+          "checksumValue": "af8498bad3b942a2ed7b25b63f19c2b2de6a0d14"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sasl.c-315",
+      "SPDXID": "SPDXRef-File-wolfssl.h-304",
+      "fileName": "repos/curl/lib/../lib/vtls/wolfssl.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b097b60b78b72ac6c77b48bce978048c674772d7"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sasl.c-305",
       "fileName": "repos/curl/lib/curl_sasl.c",
       "checksums": [
         {
@@ -3180,47 +3080,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy.c-316",
-      "fileName": "repos/curl/lib/easy.c",
+      "SPDXID": "SPDXRef-File-tool-vms.h-306",
+      "fileName": "repos/curl/src/tool_vms.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b30ce2ace41f926c9cb7cc1ec2fedb53850c770b"
+          "checksumValue": "b459a25ee8a1a8d5917ee2ae1fef3d3bf5070993"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-parsecfg.c-317",
-      "fileName": "repos/curl/src/tool_parsecfg.c",
+      "SPDXID": "SPDXRef-File-sigpipe.h-307",
+      "fileName": "repos/curl/lib/sigpipe.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b36d113232315488f02352660ad0412151f6320f"
+          "checksumValue": "b4897969538a5199c7ab8a5350950bde4b51ed57"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vssh.c-318",
-      "fileName": "repos/curl/lib/vssh/vssh.c",
+      "SPDXID": "SPDXRef-File-ntlm.c-308",
+      "fileName": "repos/curl/lib/vauth/ntlm.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b52b09b696e9beff92e6a27234a4ea59446fd3d5"
+          "checksumValue": "b50cfdd6812903dbe2ddc557138fa57f1fefccad"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-formdata.c-319",
-      "fileName": "repos/curl/lib/formdata.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b5bd1206f1068e46acb8677b8eb55772faa95047"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.h-320",
+      "SPDXID": "SPDXRef-File-dict.h-309",
       "fileName": "repos/curl/lib/dict.h",
       "checksums": [
         {
@@ -3230,17 +3120,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fopen.c-321",
-      "fileName": "repos/curl/lib/curlx/fopen.c",
+      "SPDXID": "SPDXRef-File-arpa-telnet.h-310",
+      "fileName": "repos/curl/lib/arpa_telnet.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b73d4f94a1123767332467e73908a5362a0df06c"
+          "checksumValue": "b5faab419c26d84c0eb713e0e3b666eb7f4d13fd"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fopen.c-322",
+      "SPDXID": "SPDXRef-File-x509asn1.c-311",
+      "fileName": "repos/curl/lib/vtls/x509asn1.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b687a60193d28268d90cc04d4da9b08d2e2fd196"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-rustls.h-312",
+      "fileName": "repos/curl/lib/../lib/vtls/rustls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b6ddbd1b7e012ec04b5c7de6d299c1c51caa3780"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-fopen.c-313",
       "fileName": "repos/curl/lib/curl_fopen.c",
       "checksums": [
         {
@@ -3250,17 +3160,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gsasl.c-323",
-      "fileName": "repos/curl/lib/vauth/gsasl.c",
+      "SPDXID": "SPDXRef-File-socks.c-314",
+      "fileName": "repos/curl/lib/socks.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b95d6e3f0a8e47f7fa5f29bb7b080b242b54ace5"
+          "checksumValue": "b7c3bd61463d76779a8bf53d8eee87762cdb7757"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-table.c-324",
+      "SPDXID": "SPDXRef-File-vtls.h-315",
+      "fileName": "repos/curl/lib/vtls/vtls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b9335bbf18598bb2af2ed387734e11381a2132ff"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-uint-table.c-316",
       "fileName": "repos/curl/lib/uint-table.c",
       "checksums": [
         {
@@ -3270,17 +3190,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-netrc.c-325",
-      "fileName": "repos/curl/lib/netrc.c",
+      "SPDXID": "SPDXRef-File-vtls-scache.h-317",
+      "fileName": "repos/curl/lib/vtls/vtls_scache.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "baabe917a75ab4a1c33f053fdcc90ae604d99f7f"
+          "checksumValue": "b9db0f19b36c4beab5a10080ed6a2526dcbc960f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-main.c-326",
+      "SPDXID": "SPDXRef-File-curl-hmac.h-318",
+      "fileName": "repos/curl/lib/curl_hmac.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b9f218fac930074434dd50816ddbf4a2f2c29e1d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-main.c-319",
       "fileName": "repos/curl/src/tool_main.c",
       "checksums": [
         {
@@ -3290,7 +3220,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-var.h-327",
+      "SPDXID": "SPDXRef-File-var.h-320",
       "fileName": "repos/curl/src/var.h",
       "checksums": [
         {
@@ -3300,17 +3230,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-trc.c-328",
-      "fileName": "repos/curl/lib/curl_trc.c",
+      "SPDXID": "SPDXRef-File-http.h-321",
+      "fileName": "repos/curl/lib/http.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bbec332f99d04b483abf3eac84d10c6c6d71916b"
+          "checksumValue": "bb535955d1f016a272982689f8a24ab4706c4c79"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gopher.h-329",
+      "SPDXID": "SPDXRef-File-tool-setopt.h-322",
+      "fileName": "repos/curl/src/tool_setopt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bb85ae7088bdbb123c2e615312cfe01fa76d6634"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sha256.h-323",
+      "fileName": "repos/curl/lib/curl_sha256.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bc1512e6e8c20dd91e53c29704564ac7fb802091"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-gopher.h-324",
       "fileName": "repos/curl/lib/gopher.h",
       "checksums": [
         {
@@ -3320,17 +3270,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufq.h-330",
-      "fileName": "repos/curl/lib/vauth/../bufq.h",
+      "SPDXID": "SPDXRef-File-tool-setopt.c-325",
+      "fileName": "repos/curl/src/tool_setopt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bcd7df2ab9ddd45a5f321254de43694f9caa642e"
+          "checksumValue": "bd24e4b411e3b522327b8fe0195a6b8f8e467e3a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fopen.h-331",
+      "SPDXID": "SPDXRef-File-curl-fopen.h-326",
       "fileName": "repos/curl/lib/curl_fopen.h",
       "checksums": [
         {
@@ -3340,67 +3290,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vauth.c-332",
-      "fileName": "repos/curl/lib/vauth/vauth.c",
+      "SPDXID": "SPDXRef-File-escape.c-327",
+      "fileName": "repos/curl/lib/escape.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bdf194b99562b3a8abda275fc77d1d9808992c52"
+          "checksumValue": "be44e971569e4da3fc94eecd419f91940c47e1bf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls.h-333",
-      "fileName": "repos/curl/lib/vtls/vtls.h",
+      "SPDXID": "SPDXRef-File-timeval.h-328",
+      "fileName": "repos/curl/lib/curlx/timeval.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bf19572fc62536679010b45a9efb08fdb31ac0f9"
+          "checksumValue": "c01f95d87df0d53dad4ac60cba387449eb5b4d39"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-addrinfo.c-334",
-      "fileName": "repos/curl/lib/fake_addrinfo.c",
+      "SPDXID": "SPDXRef-File-krb5-sspi.c-329",
+      "fileName": "repos/curl/lib/vauth/krb5_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bf5a44892c5d2be4ab1414c34b7922218a7d4aaa"
+          "checksumValue": "c08b6a4c3a5a2d6dac17e825adb23bc7aa2b1c0a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-hugehelp.c-335",
-      "fileName": "repos/curl/src/tool_hugehelp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c0323e2f4dbf1e990d8603fb770362d99079b49a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sha256.c-336",
-      "fileName": "repos/curl/lib/sha256.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c042c1bb0cb70a39877914e86bbd2ce7a5c447e4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-winapi.c-337",
-      "fileName": "repos/curl/lib/curlx/winapi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c0d6b7f861c4308c1fe3acf0edbb5968fb371dbf"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-gssapi.c-338",
+      "SPDXID": "SPDXRef-File-curl-gssapi.c-330",
       "fileName": "repos/curl/lib/curl_gssapi.c",
       "checksums": [
         {
@@ -3410,7 +3330,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-telnet.h-339",
+      "SPDXID": "SPDXRef-File-telnet.h-331",
       "fileName": "repos/curl/lib/telnet.h",
       "checksums": [
         {
@@ -3420,17 +3340,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wait.h-340",
-      "fileName": "repos/curl/lib/curlx/wait.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c140194a8c2dfae9fa8c9393027e1f9ea5dfbe04"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-proxy.h-341",
+      "SPDXID": "SPDXRef-File-http-proxy.h-332",
       "fileName": "repos/curl/lib/http_proxy.h",
       "checksums": [
         {
@@ -3440,17 +3350,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-int.h-342",
-      "fileName": "repos/curl/lib/vtls/vtls_int.h",
+      "SPDXID": "SPDXRef-File-http1.h-333",
+      "fileName": "repos/curl/lib/http1.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c2a44a3a33b1e79bbdd986fd8339b7390ef23394"
+          "checksumValue": "c2894613de7fe48116816174f0dce2aa0decfe47"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-ntlm.c-343",
+      "SPDXID": "SPDXRef-File-md5.c-334",
+      "fileName": "repos/curl/lib/md5.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c2bd176dc96f6a2d3c7681f51323c401767e5fb9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-asyn-thrdd.c-335",
+      "fileName": "repos/curl/lib/asyn-thrdd.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c3ed8eacaaf13be9fc72478a5da4ba9282df0af6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-setopt.h-336",
+      "fileName": "repos/curl/lib/setopt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c421f5c5e5bce7570f4ecefcf7168b9a8f0345d5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-version-win32.h-337",
+      "fileName": "repos/curl/lib/curlx/version_win32.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4a1c0f7586b7aca8c0e82abab2378af96c92706"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-url.h-338",
+      "fileName": "repos/curl/lib/url.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4cd762fb85948a9fb75cd73f6943f59e0915a0e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-ntlm.c-339",
       "fileName": "repos/curl/lib/http_ntlm.c",
       "checksums": [
         {
@@ -3460,17 +3420,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel.h-344",
-      "fileName": "repos/curl/lib/vtls/schannel.h",
+      "SPDXID": "SPDXRef-File-splay.h-340",
+      "fileName": "repos/curl/lib/splay.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c617233e0883e1bae73d9adb5a85e96c85a94c14"
+          "checksumValue": "c6623f2ef0c45d4b324bb8af5cd167f0511f1a00"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ipfs.h-345",
+      "SPDXID": "SPDXRef-File-mprintf.c-341",
+      "fileName": "repos/curl/lib/mprintf.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6a4a494292294c5223b856aad1d95ffb484dc0a"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-slist.c-342",
+      "fileName": "repos/curl/lib/slist.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6dcdc1af0ef4c7041473a7cfb7c36bb1bdf73f0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-snprintf.c-343",
+      "fileName": "repos/curl/lib/curlx/snprintf.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7332520e7a2ddc148cc608f6d0713e2affd4c40"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cfilters.h-344",
+      "fileName": "repos/curl/lib/cfilters.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7546344af42253bf95afcfc9b3f97137b9f58eb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-dbg.c-345",
+      "fileName": "repos/curl/src/tool_cb_dbg.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c9c14e6d131100686fa2ad100a04cc36387ddfb9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-ipfs.h-346",
       "fileName": "repos/curl/src/tool_ipfs.h",
       "checksums": [
         {
@@ -3480,17 +3490,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cookie.h-346",
-      "fileName": "repos/curl/lib/vauth/../cookie.h",
+      "SPDXID": "SPDXRef-File-cf-https-connect.c-347",
+      "fileName": "repos/curl/lib/cf-https-connect.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cbc7b748fc2bdd54a8ca181de38a588092d627b6"
+          "checksumValue": "cabc6ab14b91b06716a3aff500006926c888754d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-helpers.h-347",
+      "SPDXID": "SPDXRef-File-tool-helpers.h-348",
       "fileName": "repos/curl/src/tool_helpers.h",
       "checksums": [
         {
@@ -3500,22 +3510,12 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-xattr.c-348",
-      "fileName": "repos/curl/src/tool_xattr.c",
+      "SPDXID": "SPDXRef-File-tftp.c-349",
+      "fileName": "repos/curl/lib/tftp.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cdf8296307a514ddc2b02fa330fa20e9959f3890"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-formdata.h-349",
-      "fileName": "repos/curl/lib/vauth/../formdata.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ce592a8fd9d02510d89a62834f9a155c37046873"
+          "checksumValue": "cc0769bbb3b540403cabba673445e372d182dd3e"
         }
       ]
     },
@@ -3525,12 +3525,22 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cec410fe6073b96d1f3b6b9dad1290cfeb700055"
+          "checksumValue": "cc0e04388714b1bfdd546682c0c62c2cdf3e305a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy-lock.h-351",
+      "SPDXID": "SPDXRef-File-tool-xattr.c-351",
+      "fileName": "repos/curl/src/tool_xattr.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cdf8296307a514ddc2b02fa330fa20e9959f3890"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easy-lock.h-352",
       "fileName": "repos/curl/lib/easy_lock.h",
       "checksums": [
         {
@@ -3540,57 +3550,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostip.c-352",
-      "fileName": "repos/curl/lib/hostip.c",
+      "SPDXID": "SPDXRef-File-openssl.h-353",
+      "fileName": "repos/curl/lib/../lib/vtls/openssl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cfa7995dbac607c486a1a678abeb0dafd7858bfc"
+          "checksumValue": "cfffe9df1b6846b4dff5ed069d2ac98ca1274fdc"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-wrt.c-353",
-      "fileName": "repos/curl/src/tool_cb_wrt.c",
+      "SPDXID": "SPDXRef-File-easy.c-354",
+      "fileName": "repos/curl/lib/easy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cfeb06d5a47539c94fb2aa9ad85ed0a6da285cae"
+          "checksumValue": "d05674e81959f74c083fb3a88b404c571d262ac8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wolfssl.c-354",
-      "fileName": "repos/curl/lib/vtls/wolfssl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0311facb9ad9d21e18c1ba98fa79465cf328eb6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ntlm.c-355",
-      "fileName": "repos/curl/lib/vauth/ntlm.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0aae81b80e4e18879d6e8f0f1ccedcf5b60a801"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rtsp.c-356",
-      "fileName": "repos/curl/lib/rtsp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0e5cf43e39d5069d19c6221b0e7b21d3df3c2d5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-terminal.c-357",
+      "SPDXID": "SPDXRef-File-terminal.c-355",
       "fileName": "repos/curl/src/terminal.c",
       "checksums": [
         {
@@ -3600,17 +3580,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-telnet.c-358",
-      "fileName": "repos/curl/lib/telnet.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d1b1d8fc5ea795e8ded96c492535f6ae70cd8b8d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-formparse.h-359",
+      "SPDXID": "SPDXRef-File-tool-formparse.h-356",
       "fileName": "repos/curl/src/tool_formparse.h",
       "checksums": [
         {
@@ -3620,17 +3590,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fopen.h-360",
-      "fileName": "repos/curl/lib/vtls/../curlx/fopen.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d23dc82445ddbf6573da449f58917ac77f55ef6e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-filetime.h-361",
+      "SPDXID": "SPDXRef-File-tool-filetime.h-357",
       "fileName": "repos/curl/src/tool_filetime.h",
       "checksums": [
         {
@@ -3640,7 +3600,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amigaos.c-362",
+      "SPDXID": "SPDXRef-File-amigaos.c-358",
       "fileName": "repos/curl/lib/amigaos.c",
       "checksums": [
         {
@@ -3650,7 +3610,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-progress.h-363",
+      "SPDXID": "SPDXRef-File-basename.c-359",
+      "fileName": "repos/curl/lib/curlx/basename.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d2fd160ff224360b5ee05b3190ec97b3aeb9b69f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-progress.h-360",
       "fileName": "repos/curl/src/tool_progress.h",
       "checksums": [
         {
@@ -3660,7 +3630,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-winapi.h-364",
+      "SPDXID": "SPDXRef-File-winapi.h-361",
       "fileName": "repos/curl/lib/curlx/winapi.h",
       "checksums": [
         {
@@ -3670,8 +3640,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-smb.h-365",
-      "fileName": "repos/curl/lib/vauth/../smb.h",
+      "SPDXID": "SPDXRef-File-smb.h-362",
+      "fileName": "repos/curl/lib/smb.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3680,38 +3650,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ws.h-366",
-      "fileName": "repos/curl/lib/ws.h",
+      "SPDXID": "SPDXRef-File-inet-pton.c-363",
+      "fileName": "repos/curl/lib/curlx/inet_pton.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d4d6d46f3a51d788c3b51343508fa7ede68bebef"
+          "checksumValue": "d3c53fb5791610415e125f5495d255a9b86671a6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gtls.c-367",
-      "fileName": "repos/curl/lib/vtls/gtls.c",
+      "SPDXID": "SPDXRef-File-cram.c-364",
+      "fileName": "repos/curl/lib/vauth/cram.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d6093cfe3063138c5105273359da38c73f08f31e"
+          "checksumValue": "d3f2d137b779607e37d9cc3453f7cb0bb2ffa8d3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostcheck.h-368",
-      "fileName": "repos/curl/lib/vtls/hostcheck.h",
+      "SPDXID": "SPDXRef-File-vssh.c-365",
+      "fileName": "repos/curl/lib/vssh/vssh.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d62c721352af1874753e9671e2dc424a9bc99f8f"
+          "checksumValue": "d499a633af4bdff71738d7d1905639c2accdae99"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcopy.h-369",
-      "fileName": "repos/curl/lib/vtls/../curlx/strcopy.h",
+      "SPDXID": "SPDXRef-File-snprintf.h-366",
+      "fileName": "repos/curl/lib/curlx/snprintf.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d6260e4e3931cd4cb8b59bd9407537f1d11d5620"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strcopy.h-367",
+      "fileName": "repos/curl/lib/curlx/strcopy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3720,37 +3700,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi.c-370",
-      "fileName": "repos/curl/lib/urlapi.c",
+      "SPDXID": "SPDXRef-File-krb5-gssapi.c-368",
+      "fileName": "repos/curl/lib/vauth/krb5_gssapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d6a790b06e5b6ede34788e685d54f72cb096200a"
+          "checksumValue": "d6af18f40b5b67d685354937f144eac932a7d66a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcopy.c-371",
-      "fileName": "repos/curl/lib/curlx/strcopy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d6bff15330e9c8f81cb403f0d9ccbeeabb96d279"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-help.c-372",
-      "fileName": "repos/curl/src/tool_help.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d743fe395344a5d8094d9afb1401cf747491ef34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-dbg.h-373",
+      "SPDXID": "SPDXRef-File-tool-cb-dbg.h-369",
       "fileName": "repos/curl/src/tool_cb_dbg.h",
       "checksums": [
         {
@@ -3760,17 +3720,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-md4.c-374",
-      "fileName": "repos/curl/lib/md4.c",
+      "SPDXID": "SPDXRef-File-conncache.h-370",
+      "fileName": "repos/curl/lib/conncache.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d78f84282305ae7c46d2efa0083c2e16d6c13567"
+          "checksumValue": "d8626ae6928c49a828b18e660546491356083190"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyoptions.h-375",
+      "SPDXID": "SPDXRef-File-apple.h-371",
+      "fileName": "repos/curl/lib/../lib/vtls/apple.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d86a56b1f9320ec8e83818d402a0ed2a259c9ff2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easyoptions.h-372",
       "fileName": "repos/curl/lib/easyoptions.h",
       "checksums": [
         {
@@ -3780,8 +3750,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-chunks.h-376",
-      "fileName": "repos/curl/lib/vauth/../http_chunks.h",
+      "SPDXID": "SPDXRef-File-fopen.h-373",
+      "fileName": "repos/curl/lib/curlx/fopen.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d89830edd30eea66d9f5ca00d757c81d2a0f6aa6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-mbedtls.h-374",
+      "fileName": "repos/curl/lib/../lib/vtls/mbedtls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8a0a06eb6aac22289e2b91fcad3a7164b77f9ae"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fake-addrinfo.c-375",
+      "fileName": "repos/curl/lib/fake_addrinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8b139830b83af600dfee6cb4d9b519e898bb221"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostcheck.h-376",
+      "fileName": "repos/curl/lib/../lib/vtls/hostcheck.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8e1a52377129c86dedf7a2252f59b400631adfa"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-chunks.h-377",
+      "fileName": "repos/curl/lib/http_chunks.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3790,47 +3800,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h2-proxy.c-377",
-      "fileName": "repos/curl/lib/cf-h2-proxy.c",
+      "SPDXID": "SPDXRef-File-curl-quiche.c-378",
+      "fileName": "repos/curl/lib/vquic/curl_quiche.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d95716eaff9a5acdd1b25f40ad3d4511bbf7cffe"
+          "checksumValue": "d8e6b30f84bc2997e95705a1b22c66c79dc90ac7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerr.c-378",
-      "fileName": "repos/curl/lib/curlx/strerr.c",
+      "SPDXID": "SPDXRef-File-vtls-spack.c-379",
+      "fileName": "repos/curl/lib/vtls/vtls_spack.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d9c1686e443928c9eef4908414a6f1b554baac5f"
+          "checksumValue": "d96f4e41bd720d08ef2ffc476cb41c5e2324c736"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi.h-379",
-      "fileName": "repos/curl/lib/../include/curl/urlapi.h",
+      "SPDXID": "SPDXRef-File-typecheck-gcc.h-380",
+      "fileName": "repos/curl/lib/../include/curl/typecheck-gcc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "dabe44a47d0d3f73dda0ed97c09c21b0668b825f"
+          "checksumValue": "d9a672ea0b782448bc795a1bc5fdf2524f572442"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cfilters.c-380",
-      "fileName": "repos/curl/lib/cfilters.c",
+      "SPDXID": "SPDXRef-File-strcopy.c-381",
+      "fileName": "repos/curl/lib/curlx/strcopy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "db8efcf2fe867dea43f16d24d30fd3c2c9f1b649"
+          "checksumValue": "da137c3f92cf39033c1d3b053408ec375eb829d3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal.h-381",
+      "SPDXID": "SPDXRef-File-http-chunks.c-382",
+      "fileName": "repos/curl/lib/http_chunks.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "db650b1e1e645b6e0a68dd08e362af7ed5c95b62"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-terminal.h-383",
       "fileName": "repos/curl/src/terminal.h",
       "checksums": [
         {
@@ -3840,28 +3860,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic-int.h-382",
-      "fileName": "repos/curl/lib/vquic/vquic_int.h",
+      "SPDXID": "SPDXRef-File-splay.c-384",
+      "fileName": "repos/curl/lib/splay.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "dbe1fca777a1295aa077a413e8374d389977d550"
+          "checksumValue": "ddab7a4d6e2cfabc69e686311b9784921a814f24"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apple.h-383",
-      "fileName": "repos/curl/lib/vtls/apple.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "dd1b5db357658b0dae9cc6956dd3c1b5af62a760"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-sha512-256.h-384",
-      "fileName": "repos/curl/lib/vauth/../curl_sha512_256.h",
+      "SPDXID": "SPDXRef-File-curl-sha512-256.h-385",
+      "fileName": "repos/curl/lib/curl_sha512_256.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3870,8 +3880,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ev.h-385",
-      "fileName": "repos/curl/lib/vauth/../multi_ev.h",
+      "SPDXID": "SPDXRef-File-multi-ev.h-386",
+      "fileName": "repos/curl/lib/multi_ev.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3880,7 +3890,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-libinfo.h-386",
+      "SPDXID": "SPDXRef-File-tool-libinfo.h-387",
       "fileName": "repos/curl/src/tool_libinfo.h",
       "checksums": [
         {
@@ -3890,7 +3900,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-https-connect.h-387",
+      "SPDXID": "SPDXRef-File-curl-fnmatch.c-388",
+      "fileName": "repos/curl/lib/curl_fnmatch.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dde956c3ac2aa213e1d68c3c72a3b679bb0759bb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-pop3.c-389",
+      "fileName": "repos/curl/lib/pop3.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "de704d11e1a9f1c93b0f2d105a0a3a1e8ad33981"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-getinfo.c-390",
+      "fileName": "repos/curl/lib/getinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dedafd382e5dc44a55e5a148d7df3e27a26fcfd2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-https-connect.h-391",
       "fileName": "repos/curl/lib/cf-https-connect.h",
       "checksums": [
         {
@@ -3900,27 +3940,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-functypes.h-388",
-      "fileName": "repos/curl/lib/vauth/../functypes.h",
+      "SPDXID": "SPDXRef-File-cf-ip-happy.c-392",
+      "fileName": "repos/curl/lib/cf-ip-happy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "df3cfd44c88f3f254dfa1907c1673192b326fd8a"
+          "checksumValue": "dfbf4ae183b528a80f73e5a256768b2fefe05ed9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ntlm-sspi.c-389",
-      "fileName": "repos/curl/lib/vauth/ntlm_sspi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e0a0bebec3e0eff4f496092cded290fdc9a8383a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-operhlp.c-390",
+      "SPDXID": "SPDXRef-File-tool-operhlp.c-393",
       "fileName": "repos/curl/src/tool_operhlp.c",
       "checksums": [
         {
@@ -3930,47 +3960,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-setup.h-391",
-      "fileName": "repos/curl/src/tool_setup.h",
+      "SPDXID": "SPDXRef-File-hsts.h-394",
+      "fileName": "repos/curl/lib/hsts.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e113de8ddae2cc41de16a38adb5c835d4addddb1"
+          "checksumValue": "e0f6363bb355072fdc5a92289c48ce806bf60829"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timediff.h-392",
-      "fileName": "repos/curl/lib/vauth/../curlx/timediff.h",
+      "SPDXID": "SPDXRef-File-vquic-tls.c-395",
+      "fileName": "repos/curl/lib/vquic/vquic-tls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e19b0f4403a1138b7b789e612cb7aa9c29b3cfce"
+          "checksumValue": "e135ac517417add98a34ca092f980e5a84e62556"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-hdr.c-393",
-      "fileName": "repos/curl/src/tool_cb_hdr.c",
+      "SPDXID": "SPDXRef-File-http2.c-396",
+      "fileName": "repos/curl/lib/http2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e22c59694cf579f73ef16092da359d8105663ec7"
+          "checksumValue": "e1c57986e81c2c02ca6b7b1f3527892c7a043e00"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-hash.c-394",
-      "fileName": "repos/curl/lib/uint-hash.c",
+      "SPDXID": "SPDXRef-File-tool-cb-see.c-397",
+      "fileName": "repos/curl/src/tool_cb_see.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e23d249d0571390fc6cc988a2c5502b586140c93"
+          "checksumValue": "e1ebd8d99f65b9e5533971b56b2d69c8b1ca5f31"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-psl.c-395",
+      "SPDXID": "SPDXRef-File-ldap.c-398",
+      "fileName": "repos/curl/lib/ldap.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e223078b03701d19b4e53853082321686570e064"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-psl.c-399",
       "fileName": "repos/curl/lib/psl.c",
       "checksums": [
         {
@@ -3980,17 +4020,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hsts.h-396",
-      "fileName": "repos/curl/lib/hsts.h",
+      "SPDXID": "SPDXRef-File-dynhds.h-400",
+      "fileName": "repos/curl/lib/dynhds.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e2c9922f18ef955b590a6c07f9cca35247936ef2"
+          "checksumValue": "e30eb457257d34fb243073e0b8aeea0121da342f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-see.h-397",
+      "SPDXID": "SPDXRef-File-tool-getparam.h-401",
+      "fileName": "repos/curl/src/tool_getparam.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e3cbe5454a6d429232396e87796b0a1f724be220"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-see.h-402",
       "fileName": "repos/curl/src/tool_cb_see.h",
       "checksums": [
         {
@@ -4000,17 +4050,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h1-proxy.h-398",
-      "fileName": "repos/curl/lib/cf-h1-proxy.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e48d827825d3ebeeac1bd65fd9eb305b2e845106"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-rtmp.h-399",
+      "SPDXID": "SPDXRef-File-curl-rtmp.h-403",
       "fileName": "repos/curl/lib/curl_rtmp.h",
       "checksums": [
         {
@@ -4020,47 +4060,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-md5.c-400",
-      "fileName": "repos/curl/lib/md5.c",
+      "SPDXID": "SPDXRef-File-mqtt.c-404",
+      "fileName": "repos/curl/lib/mqtt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e5a4f534c7cf50d0f52497b377077f228124c2df"
+          "checksumValue": "e591cfcf0100533bdba5a8d6bb42d1f96a85922f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-setopt.c-401",
-      "fileName": "repos/curl/lib/setopt.c",
+      "SPDXID": "SPDXRef-File-tool-getparam.c-405",
+      "fileName": "repos/curl/src/tool_getparam.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e6476dfaf30c2413e630ccd8f20714ec81dcf130"
+          "checksumValue": "e6e641923beef9abf9cd6b0db2cda306f95ea244"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostip.h-402",
-      "fileName": "repos/curl/lib/vauth/../hostip.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e70eac841bf2f1181598e9e3fbeaf6602338a086"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-header.h-403",
-      "fileName": "repos/curl/lib/../include/curl/header.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e7334b5a3a4d35f9d23fc47a4d9826370b0dc0c5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-content-encoding.h-404",
+      "SPDXID": "SPDXRef-File-content-encoding.h-406",
       "fileName": "repos/curl/lib/content_encoding.h",
       "checksums": [
         {
@@ -4070,7 +4090,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operhlp.h-405",
+      "SPDXID": "SPDXRef-File-mime.h-407",
+      "fileName": "repos/curl/lib/mime.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e84f04051b534a0230881cfc810d6b2f53cd1988"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-operhlp.h-408",
       "fileName": "repos/curl/src/tool_operhlp.h",
       "checksums": [
         {
@@ -4080,37 +4110,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-setopt.h-406",
-      "fileName": "repos/curl/src/tool_setopt.h",
+      "SPDXID": "SPDXRef-File-parsedate.h-409",
+      "fileName": "repos/curl/lib/parsedate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e990f08a81a3b4624d7280010f2de7f865ff2216"
+          "checksumValue": "ea136bd30158437fe88efbeb88541aceb44099e6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-proxy.c-407",
-      "fileName": "repos/curl/lib/http_proxy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e9dfb8dbb3bd7a583b8744f4ec1d51589ec58971"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-aws-sigv4.c-408",
-      "fileName": "repos/curl/lib/http_aws_sigv4.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ea1a7ff758b2e51a0ccefdc23e8c38adf5403f56"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-msgs.h-409",
+      "SPDXID": "SPDXRef-File-tool-msgs.h-410",
       "fileName": "repos/curl/src/tool_msgs.h",
       "checksums": [
         {
@@ -4120,37 +4130,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest.c-410",
-      "fileName": "repos/curl/lib/vauth/digest.c",
+      "SPDXID": "SPDXRef-File-tool-cb-rea.c-411",
+      "fileName": "repos/curl/src/tool_cb_rea.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ec82564d2c96834058dc2224aee55e9a1fe22e45"
+          "checksumValue": "eb23f9b907be53e106db188288f0025971daa45c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keylog.h-411",
-      "fileName": "repos/curl/lib/vtls/keylog.h",
+      "SPDXID": "SPDXRef-File-url.c-412",
+      "fileName": "repos/curl/lib/url.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ec82abf547f08b9914e4f4a05c353f454f737dd7"
+          "checksumValue": "ec0457bcdd6f2aacbc5f188aa81955f3654a4ab4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gtls.h-412",
-      "fileName": "repos/curl/lib/vtls/gtls.h",
+      "SPDXID": "SPDXRef-File-cw-pause.c-413",
+      "fileName": "repos/curl/lib/cw-pause.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ecdca0a666a5fd27e2ff82e61f0fec3fdfb72ceb"
+          "checksumValue": "ec611879d1e8a2c378e2302259a667004694b6d6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock.h-413",
+      "SPDXID": "SPDXRef-File-noproxy.c-414",
+      "fileName": "repos/curl/lib/noproxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ee03fd35b9f1ae4f60e2d639d51003da71537077"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-nonblock.h-415",
       "fileName": "repos/curl/lib/curlx/nonblock.h",
       "checksums": [
         {
@@ -4160,17 +4180,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ftp.h-414",
-      "fileName": "repos/curl/lib/vauth/../ftp.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ef1aacb40c89e42c2ff0f57ebfdc4888bfe1187f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-soc.h-415",
+      "SPDXID": "SPDXRef-File-tool-cb-soc.h-416",
       "fileName": "repos/curl/src/tool_cb_soc.h",
       "checksums": [
         {
@@ -4180,27 +4190,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strparse.c-416",
-      "fileName": "repos/curl/lib/curlx/strparse.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f11b58b7eee5e24474be34e836a9c79b0533b18e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl.h-417",
-      "fileName": "repos/curl/lib/../include/curl/curl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f14f887261b4af00e74e4b499539a4d2b13639a9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-gethostname.c-418",
+      "SPDXID": "SPDXRef-File-curl-gethostname.c-417",
       "fileName": "repos/curl/lib/curl_gethostname.c",
       "checksums": [
         {
@@ -4210,7 +4200,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-imap.h-419",
+      "SPDXID": "SPDXRef-File-imap.h-418",
       "fileName": "repos/curl/lib/imap.h",
       "checksums": [
         {
@@ -4220,37 +4210,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-addrinfo.c-420",
-      "fileName": "repos/curl/lib/curl_addrinfo.c",
+      "SPDXID": "SPDXRef-File-digest-sspi.c-419",
+      "fileName": "repos/curl/lib/vauth/digest_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f1eaa6bcb604ac242c6504fbba601ca28a170454"
+          "checksumValue": "f29e569cd1801053bc2c72a67599c7be7dc0426a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connect.h-421",
-      "fileName": "repos/curl/lib/vtls/../connect.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f2b9911073b94df6c1a4770977e45fbd9bd228e8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sendf.c-422",
-      "fileName": "repos/curl/lib/sendf.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f2d30a4269a1eb8b78a0fadf0290f248564a8c34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist-wc.c-423",
+      "SPDXID": "SPDXRef-File-slist-wc.c-420",
       "fileName": "repos/curl/src/slist_wc.c",
       "checksums": [
         {
@@ -4260,37 +4230,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-base.c-424",
-      "fileName": "repos/curl/lib/asyn-base.c",
+      "SPDXID": "SPDXRef-File-tool-easysrc.h-421",
+      "fileName": "repos/curl/src/tool_easysrc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f35e1c988c3f683e0eea38fe13ab25c1d2d7b41f"
+          "checksumValue": "f37ce4ba86f556a6b6fc3074d8a1ad4366f9a222"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-url.c-425",
-      "fileName": "repos/curl/lib/url.c",
+      "SPDXID": "SPDXRef-File-curl-addrinfo.h-422",
+      "fileName": "repos/curl/lib/curl_addrinfo.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f3b24c9de24e17eba9e0317f480d91ef8680dd45"
+          "checksumValue": "f464b5ed7898c5264b5833025c6d409e44c7fb4d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic.h-426",
-      "fileName": "repos/curl/lib/vquic/vquic.h",
+      "SPDXID": "SPDXRef-File-tool-parsecfg.c-423",
+      "fileName": "repos/curl/src/tool_parsecfg.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f5392eb04797f7f2d55d4120d6cc4d3c095f0d1e"
+          "checksumValue": "f5910f404e77a43a7f19f862e298e3cce0031e85"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-digest.c-427",
+      "SPDXID": "SPDXRef-File-http-digest.c-424",
       "fileName": "repos/curl/lib/http_digest.c",
       "checksums": [
         {
@@ -4300,7 +4270,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getinfo.h-428",
+      "SPDXID": "SPDXRef-File-getinfo.h-425",
       "fileName": "repos/curl/lib/getinfo.h",
       "checksums": [
         {
@@ -4310,12 +4280,42 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-threads.c-429",
+      "SPDXID": "SPDXRef-File-curl-threads.c-426",
       "fileName": "repos/curl/lib/curl_threads.c",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "f5fea9804693e1eee1faae8c48e1b2625e014730"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-urlglob.c-427",
+      "fileName": "repos/curl/src/tool_urlglob.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f62d9738ec081a16f19fb34d68501aec22817bb2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-vtls.c-428",
+      "fileName": "repos/curl/lib/vtls/vtls.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f7201d18d6507d9f7d076928385d1304bff16dd1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-urlapi.h-429",
+      "fileName": "repos/curl/lib/../include/curl/urlapi.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f7a42b3b9e0f526a36ae326f3ac3fc82a366de08"
         }
       ]
     },
@@ -4341,7 +4341,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-curl-ntlm-core.h-432",
-      "fileName": "repos/curl/lib/vauth/../curl_ntlm_core.h",
+      "fileName": "repos/curl/lib/curl_ntlm_core.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4350,18 +4350,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-easysrc.h-433",
-      "fileName": "repos/curl/src/tool_easysrc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f9ddacfc3779d941303f0c6e8b4fe277ae4858ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-endian.h-434",
-      "fileName": "repos/curl/lib/vauth/../curl_endian.h",
+      "SPDXID": "SPDXRef-File-curl-endian.h-433",
+      "fileName": "repos/curl/lib/curl_endian.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4370,47 +4360,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sha512-256.c-435",
-      "fileName": "repos/curl/lib/curl_sha512_256.c",
+      "SPDXID": "SPDXRef-File-cookie.h-434",
+      "fileName": "repos/curl/lib/cookie.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fa568b6b041ddb9cc2f7150cfdaef906f38c25ab"
+          "checksumValue": "fabd04d3989bb9fdb078ef57321f884ca7c699b4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi-int.h-436",
-      "fileName": "repos/curl/lib/urlapi-int.h",
+      "SPDXID": "SPDXRef-File-basename.h-435",
+      "fileName": "repos/curl/lib/curlx/basename.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fbce1837ff94fb6c74d47847f687a53332edfeca"
+          "checksumValue": "fb79fed8053dac80b2a526801fce9d6e7cec43c1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-pton.h-437",
-      "fileName": "repos/curl/lib/vtls/../curlx/inet_pton.h",
+      "SPDXID": "SPDXRef-File-tool-cb-hdr.c-436",
+      "fileName": "repos/curl/src/tool_cb_hdr.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fc3ae3d2bb2c20dd9beff7fc3c369addd15f9c94"
+          "checksumValue": "fc03cf143b95a8451c20f326fbdd338693833331"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cleartext.c-438",
-      "fileName": "repos/curl/lib/vauth/cleartext.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fc8a6ebd5102516803695f3bdd91cc94100eed3d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.c-439",
+      "SPDXID": "SPDXRef-File-dict.c-437",
       "fileName": "repos/curl/lib/dict.c",
       "checksums": [
         {
@@ -4420,32 +4400,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getinfo.c-440",
-      "fileName": "repos/curl/lib/getinfo.c",
+      "SPDXID": "SPDXRef-File-schannel.h-438",
+      "fileName": "repos/curl/lib/../lib/vtls/schannel.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fd0d483f0a1137a94b0eb6cd5e3bd5043f2a4333"
+          "checksumValue": "fe49e9a9d0fb50eedb38e6873df19d66e1f89634"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pop3.c-441",
-      "fileName": "repos/curl/lib/pop3.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fdb09f232097032e1e1dfab45c98eaa4501065b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-ntlm.h-442",
+      "SPDXID": "SPDXRef-File-http-ntlm.h-439",
       "fileName": "repos/curl/lib/http_ntlm.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "ff5218d89f6cd740ceb878a6cd7c1e21047f2cf9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-select.h-440",
+      "fileName": "repos/curl/lib/select.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ffcd44cfcfc773158bcc47a6d422ddfb962b39c1"
         }
       ]
     }
@@ -4459,132 +4439,132 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idn.c-2"
+      "relatedSpdxElement": "SPDXRef-File-smb.c-2"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-scache.c-3"
+      "relatedSpdxElement": "SPDXRef-File-cf-socket.h-3"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.c-4"
+      "relatedSpdxElement": "SPDXRef-File-keylog.c-4"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multiif.h-5"
+      "relatedSpdxElement": "SPDXRef-File-hmac.c-5"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rustls.c-6"
+      "relatedSpdxElement": "SPDXRef-File-inet-pton.h-6"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.h-7"
+      "relatedSpdxElement": "SPDXRef-File-multiif.h-7"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ldap.c-8"
+      "relatedSpdxElement": "SPDXRef-File-hsts.c-8"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transfer.h-9"
+      "relatedSpdxElement": "SPDXRef-File-curl-md5.h-9"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-md4.h-10"
+      "relatedSpdxElement": "SPDXRef-File-imap.c-10"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.h-11"
+      "relatedSpdxElement": "SPDXRef-File-transfer.h-11"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-if2ip.c-12"
+      "relatedSpdxElement": "SPDXRef-File-curl-md4.h-12"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-typecheck-gcc.h-13"
+      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.h-13"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.h-14"
+      "relatedSpdxElement": "SPDXRef-File-if2ip.c-14"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-range.c-15"
+      "relatedSpdxElement": "SPDXRef-File-rustls.c-15"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.h-16"
+      "relatedSpdxElement": "SPDXRef-File-netrc.h-16"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getpass.h-17"
+      "relatedSpdxElement": "SPDXRef-File-system.h-17"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlinfo.c-18"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.h-18"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-macos.h-19"
+      "relatedSpdxElement": "SPDXRef-File-connect.h-19"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha256.h-20"
+      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.h-20"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-ntop.c-21"
+      "relatedSpdxElement": "SPDXRef-File-llist.h-21"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.c-22"
+      "relatedSpdxElement": "SPDXRef-File-tool-getpass.h-22"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.c-23"
+      "relatedSpdxElement": "SPDXRef-File-curlinfo.c-23"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cram.c-24"
+      "relatedSpdxElement": "SPDXRef-File-macos.h-24"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doh.h-25"
+      "relatedSpdxElement": "SPDXRef-File-tool-filetime.c-25"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setopt.h-26"
+      "relatedSpdxElement": "SPDXRef-File-easy.h-26"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smb.c-27"
+      "relatedSpdxElement": "SPDXRef-File-strdup.h-27"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -4599,22 +4579,22 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-thrdd.c-30"
+      "relatedSpdxElement": "SPDXRef-File-llist.c-30"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llist.c-31"
+      "relatedSpdxElement": "SPDXRef-File-netrc.c-31"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base64.c-32"
+      "relatedSpdxElement": "SPDXRef-File-timediff.h-32"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-formparse.c-33"
+      "relatedSpdxElement": "SPDXRef-File-rtsp.c-33"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -4624,747 +4604,747 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http1.h-35"
+      "relatedSpdxElement": "SPDXRef-File-ntlm-sspi.c-35"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-spnego-sspi.c-36"
+      "relatedSpdxElement": "SPDXRef-File-tool-time.c-36"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn.h-37"
+      "relatedSpdxElement": "SPDXRef-File-if2ip.h-37"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-if2ip.h-38"
+      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.c-38"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.c-39"
+      "relatedSpdxElement": "SPDXRef-File-strparse.c-39"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noproxy.c-40"
+      "relatedSpdxElement": "SPDXRef-File-curl-ctype.h-40"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sendf.h-41"
+      "relatedSpdxElement": "SPDXRef-File-tool-time.h-41"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ctype.h-42"
+      "relatedSpdxElement": "SPDXRef-File-httpsrr.c-42"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-time.h-43"
+      "relatedSpdxElement": "SPDXRef-File-http.c-43"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libssh2.c-44"
+      "relatedSpdxElement": "SPDXRef-File-md4.c-44"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsts.c-45"
+      "relatedSpdxElement": "SPDXRef-File-ssh.h-45"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-md5.h-46"
+      "relatedSpdxElement": "SPDXRef-File-system-win32.c-46"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpsrr.c-47"
+      "relatedSpdxElement": "SPDXRef-File-file.c-47"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-pton.c-48"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.c-48"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-msgs.c-49"
+      "relatedSpdxElement": "SPDXRef-File-curl-sspi.c-49"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.h-50"
+      "relatedSpdxElement": "SPDXRef-File-strerror.c-50"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-doswin.c-51"
+      "relatedSpdxElement": "SPDXRef-File-vquic.c-51"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cookie.c-52"
+      "relatedSpdxElement": "SPDXRef-File-spnego-sspi.c-52"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ratelimit.c-53"
+      "relatedSpdxElement": "SPDXRef-File-cipher-suite.c-53"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic.c-54"
+      "relatedSpdxElement": "SPDXRef-File-curl.h-54"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.c-55"
+      "relatedSpdxElement": "SPDXRef-File-ftp.h-55"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sspi.c-56"
+      "relatedSpdxElement": "SPDXRef-File-config2setopts.c-56"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llist.h-57"
+      "relatedSpdxElement": "SPDXRef-File-tool-formparse.c-57"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.h-58"
+      "relatedSpdxElement": "SPDXRef-File-easyif.h-58"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strdup.h-59"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout.c-59"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerror.c-60"
+      "relatedSpdxElement": "SPDXRef-File-tool-ssls.c-60"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.h-61"
+      "relatedSpdxElement": "SPDXRef-File-uint-hash.c-61"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlx.h-62"
+      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.h-62"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-spack.c-63"
+      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.h-63"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-printf.h-64"
+      "relatedSpdxElement": "SPDXRef-File-hash.h-64"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyif.h-65"
+      "relatedSpdxElement": "SPDXRef-File-easygetopt.c-65"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks-gssapi.c-66"
+      "relatedSpdxElement": "SPDXRef-File-tool-findfile.c-66"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ssls.c-67"
+      "relatedSpdxElement": "SPDXRef-File-cfilters.c-67"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.c-68"
+      "relatedSpdxElement": "SPDXRef-File-altsvc.h-68"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smtp.c-69"
+      "relatedSpdxElement": "SPDXRef-File-version-win32.c-69"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.h-70"
+      "relatedSpdxElement": "SPDXRef-File-urlapi-int.h-70"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-pause.c-71"
+      "relatedSpdxElement": "SPDXRef-File-socketpair.h-71"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.h-72"
+      "relatedSpdxElement": "SPDXRef-File-sockaddr.h-72"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snprintf.h-73"
+      "relatedSpdxElement": "SPDXRef-File-mbedtls.c-73"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easygetopt.c-74"
+      "relatedSpdxElement": "SPDXRef-File-timediff.c-74"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-select.h-75"
+      "relatedSpdxElement": "SPDXRef-File-ratelimit.c-75"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multibyte.h-76"
+      "relatedSpdxElement": "SPDXRef-File-idn.c-76"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout.c-77"
+      "relatedSpdxElement": "SPDXRef-File-inet-ntop.h-77"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-findfile.c-78"
+      "relatedSpdxElement": "SPDXRef-File-base64.h-78"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basename.c-79"
+      "relatedSpdxElement": "SPDXRef-File-cf-socket.c-79"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basename.h-80"
+      "relatedSpdxElement": "SPDXRef-File-cshutdn.c-80"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-socket.h-81"
+      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.h-81"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-helpers.c-82"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.c-82"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-scache.h-83"
+      "relatedSpdxElement": "SPDXRef-File-slist-wc.h-83"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wait.c-84"
+      "relatedSpdxElement": "SPDXRef-File-macos.c-84"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socketpair.h-85"
+      "relatedSpdxElement": "SPDXRef-File-curl-share.c-85"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockaddr.h-86"
+      "relatedSpdxElement": "SPDXRef-File-pingpong.h-86"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.c-87"
+      "relatedSpdxElement": "SPDXRef-File-formdata.h-87"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynhds.h-88"
+      "relatedSpdxElement": "SPDXRef-File-fileinfo.c-88"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rustls.h-89"
+      "relatedSpdxElement": "SPDXRef-File-winapi.c-89"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base64.h-90"
+      "relatedSpdxElement": "SPDXRef-File-altsvc.c-90"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.h-91"
+      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.c-91"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ntlm-core.c-92"
+      "relatedSpdxElement": "SPDXRef-File-formdata.c-92"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-system-win32.c-93"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.h-93"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setopt.c-94"
+      "relatedSpdxElement": "SPDXRef-File-mime.c-94"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-var.c-95"
+      "relatedSpdxElement": "SPDXRef-File-uint-table.h-95"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vauth.h-96"
+      "relatedSpdxElement": "SPDXRef-File-smtp.h-96"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.h-97"
+      "relatedSpdxElement": "SPDXRef-File-libssh.c-97"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.c-98"
+      "relatedSpdxElement": "SPDXRef-File-curl-printf.h-98"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-arpa-telnet.h-99"
+      "relatedSpdxElement": "SPDXRef-File-strdup.c-99"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transfer.c-100"
+      "relatedSpdxElement": "SPDXRef-File-config2setopts.h-100"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-macos.c-101"
+      "relatedSpdxElement": "SPDXRef-File-warnless.h-101"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic-tls.c-102"
+      "relatedSpdxElement": "SPDXRef-File-vauth.h-102"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pingpong.h-103"
+      "relatedSpdxElement": "SPDXRef-File-doh.h-103"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fileinfo.c-104"
+      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.c-104"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcase.h-105"
+      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.c-105"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.h-106"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout.h-106"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mbedtls.h-107"
+      "relatedSpdxElement": "SPDXRef-File-websockets.h-107"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-request.h-108"
+      "relatedSpdxElement": "SPDXRef-File-schannel-verify.c-108"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http.c-109"
+      "relatedSpdxElement": "SPDXRef-File-rand.c-109"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smtp.h-110"
+      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.c-110"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config2setopts.h-111"
+      "relatedSpdxElement": "SPDXRef-File-tool-ssls.h-111"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.c-112"
+      "relatedSpdxElement": "SPDXRef-File-timeval.c-112"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-socket.c-113"
+      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.c-113"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mbedtls.c-114"
+      "relatedSpdxElement": "SPDXRef-File-strerr.h-114"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.c-115"
+      "relatedSpdxElement": "SPDXRef-File-vtls-spack.h-115"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.c-116"
+      "relatedSpdxElement": "SPDXRef-File-doh.c-116"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-table.h-117"
+      "relatedSpdxElement": "SPDXRef-File-asyn-base.c-117"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-share.h-118"
+      "relatedSpdxElement": "SPDXRef-File-oauth2.c-118"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-share.c-119"
+      "relatedSpdxElement": "SPDXRef-File-slist.h-119"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout.h-120"
+      "relatedSpdxElement": "SPDXRef-File-tool-stderr.h-120"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-websockets.h-121"
+      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.c-121"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-imap.c-122"
+      "relatedSpdxElement": "SPDXRef-File-vssh.h-122"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idn.h-123"
+      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.c-123"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ssls.h-124"
+      "relatedSpdxElement": "SPDXRef-File-curl-ntlm-core.c-124"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerr.h-125"
+      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.h-125"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mqtt.c-126"
+      "relatedSpdxElement": "SPDXRef-File-uint-spbset.h-126"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-filetime.c-127"
+      "relatedSpdxElement": "SPDXRef-File-curl-trc.c-127"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memdebug.c-128"
+      "relatedSpdxElement": "SPDXRef-File-strerror.h-128"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-ntop.h-129"
+      "relatedSpdxElement": "SPDXRef-File-easyoptions.c-129"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http2.c-130"
+      "relatedSpdxElement": "SPDXRef-File-asyn-ares.c-130"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-hmac.h-131"
+      "relatedSpdxElement": "SPDXRef-File-cookie.c-131"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist.h-132"
+      "relatedSpdxElement": "SPDXRef-File-tool-ca-embed.c-132"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-stderr.h-133"
+      "relatedSpdxElement": "SPDXRef-File-pingpong.c-133"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeval.h-134"
+      "relatedSpdxElement": "SPDXRef-File-curl-setup.h-134"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-spbset.h-135"
+      "relatedSpdxElement": "SPDXRef-File-openssl.c-135"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connect.c-136"
+      "relatedSpdxElement": "SPDXRef-File-tool-help.c-136"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerror.h-137"
+      "relatedSpdxElement": "SPDXRef-File-bufref.c-137"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyoptions.c-138"
+      "relatedSpdxElement": "SPDXRef-File-strparse.h-138"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.c-139"
+      "relatedSpdxElement": "SPDXRef-File-socks.h-139"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getparam.h-140"
+      "relatedSpdxElement": "SPDXRef-File-wait.c-140"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vssh.h-141"
+      "relatedSpdxElement": "SPDXRef-File-vquic.h-141"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ca-embed.c-142"
+      "relatedSpdxElement": "SPDXRef-File-request.h-142"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config2setopts.c-143"
+      "relatedSpdxElement": "SPDXRef-File-tool-sdecls.h-143"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufref.c-144"
+      "relatedSpdxElement": "SPDXRef-File-strcase.h-144"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftp.c-145"
+      "relatedSpdxElement": "SPDXRef-File-hostip.c-145"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel-verify.c-146"
+      "relatedSpdxElement": "SPDXRef-File-cw-pause.h-146"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.h-147"
+      "relatedSpdxElement": "SPDXRef-File-cw-out.c-147"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.c-148"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.h-148"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multibyte.c-149"
+      "relatedSpdxElement": "SPDXRef-File-uint-hash.h-149"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.h-150"
+      "relatedSpdxElement": "SPDXRef-File-amigaos.h-150"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doh.c-151"
+      "relatedSpdxElement": "SPDXRef-File-uint-spbset.c-151"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-pause.h-152"
+      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.c-152"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.h-153"
+      "relatedSpdxElement": "SPDXRef-File-headers.c-153"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-setup.h-154"
+      "relatedSpdxElement": "SPDXRef-File-urldata.h-154"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher-suite.c-155"
+      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.c-155"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-hash.h-156"
+      "relatedSpdxElement": "SPDXRef-File-digest.h-156"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amigaos.h-157"
+      "relatedSpdxElement": "SPDXRef-File-telnet.c-157"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-trc.h-158"
+      "relatedSpdxElement": "SPDXRef-File-curlver.h-158"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-spbset.c-159"
+      "relatedSpdxElement": "SPDXRef-File-bufref.h-159"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.c-160"
+      "relatedSpdxElement": "SPDXRef-File-ftplistparser.h-160"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-headers.c-161"
+      "relatedSpdxElement": "SPDXRef-File-tool-version.h-161"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.c-162"
+      "relatedSpdxElement": "SPDXRef-File-curl-share.h-162"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy.h-163"
+      "relatedSpdxElement": "SPDXRef-File-uint-bset.c-163"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x509asn1.c-164"
+      "relatedSpdxElement": "SPDXRef-File-http-digest.h-164"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlver.h-165"
+      "relatedSpdxElement": "SPDXRef-File-warnless.c-165"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufref.h-166"
+      "relatedSpdxElement": "SPDXRef-File-ws.c-166"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-quiche.c-167"
+      "relatedSpdxElement": "SPDXRef-File-ftp.c-167"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-version.h-168"
+      "relatedSpdxElement": "SPDXRef-File-smtp.c-168"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-splay.c-169"
+      "relatedSpdxElement": "SPDXRef-File-http1.c-169"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http2.h-170"
+      "relatedSpdxElement": "SPDXRef-File-tool-util.c-170"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mime.h-171"
+      "relatedSpdxElement": "SPDXRef-File-multi.c-171"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-bset.c-172"
+      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.h-172"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-digest.h-173"
+      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.c-173"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-util.c-174"
+      "relatedSpdxElement": "SPDXRef-File-tool-findfile.h-174"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operate.c-175"
+      "relatedSpdxElement": "SPDXRef-File-libssh2.c-175"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.h-176"
+      "relatedSpdxElement": "SPDXRef-File-tool-progress.c-176"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.c-177"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.c-177"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-findfile.h-178"
+      "relatedSpdxElement": "SPDXRef-File-schannel.c-178"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.h-179"
+      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.h-179"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-progress.c-180"
+      "relatedSpdxElement": "SPDXRef-File-request.c-180"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-altsvc.c-181"
+      "relatedSpdxElement": "SPDXRef-File-vtls-int.h-181"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.c-182"
+      "relatedSpdxElement": "SPDXRef-File-tool-xattr.h-182"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-xattr.h-183"
+      "relatedSpdxElement": "SPDXRef-File-vtls-scache.c-183"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5374,27 +5354,27 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.c-185"
+      "relatedSpdxElement": "SPDXRef-File-asyn.h-185"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version.c-186"
+      "relatedSpdxElement": "SPDXRef-File-tool-getpass.c-186"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timediff.c-187"
+      "relatedSpdxElement": "SPDXRef-File-multi-ev.c-187"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-help.h-188"
+      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.c-188"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-krb5-gssapi.c-189"
+      "relatedSpdxElement": "SPDXRef-File-tool-help.h-189"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5404,97 +5384,97 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-quiche.h-191"
+      "relatedSpdxElement": "SPDXRef-File-http-negotiate.h-191"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-negotiate.h-192"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.c-192"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.h-193"
+      "relatedSpdxElement": "SPDXRef-File-hostip.h-193"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ws.c-194"
+      "relatedSpdxElement": "SPDXRef-File-progress.c-194"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http.h-195"
+      "relatedSpdxElement": "SPDXRef-File-fopen.c-195"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynbuf.h-196"
+      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.h-196"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-config.h-197"
+      "relatedSpdxElement": "SPDXRef-File-transfer.c-197"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-content-encoding.c-198"
+      "relatedSpdxElement": "SPDXRef-File-dynbuf.h-198"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-vms.c-199"
+      "relatedSpdxElement": "SPDXRef-File-nonblock.c-199"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noproxy.h-200"
+      "relatedSpdxElement": "SPDXRef-File-dynbuf.c-200"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urldata.h-201"
+      "relatedSpdxElement": "SPDXRef-File-multibyte.c-201"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.h-202"
+      "relatedSpdxElement": "SPDXRef-File-noproxy.h-202"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gopher.c-203"
+      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.h-203"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.h-204"
+      "relatedSpdxElement": "SPDXRef-File-gopher.c-204"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeval.c-205"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.h-205"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wolfssl.h-206"
+      "relatedSpdxElement": "SPDXRef-File-fileinfo.h-206"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fileinfo.h-207"
+      "relatedSpdxElement": "SPDXRef-File-dynhds.c-207"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynhds.c-208"
+      "relatedSpdxElement": "SPDXRef-File-uint-bset.h-208"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-bset.h-209"
+      "relatedSpdxElement": "SPDXRef-File-tool-vms.c-209"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5514,177 +5494,177 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.c-213"
+      "relatedSpdxElement": "SPDXRef-File-ws.h-213"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strdup.c-214"
+      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.c-214"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pop3.h-215"
+      "relatedSpdxElement": "SPDXRef-File-sendf.h-215"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.c-216"
+      "relatedSpdxElement": "SPDXRef-File-socketpair.c-216"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tftp.c-217"
+      "relatedSpdxElement": "SPDXRef-File-pop3.h-217"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ssh.h-218"
+      "relatedSpdxElement": "SPDXRef-File-curl-config.h-218"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cshutdn.h-219"
+      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.c-219"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multihandle.h-220"
+      "relatedSpdxElement": "SPDXRef-File-connect.c-220"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-krb5-sspi.c-221"
+      "relatedSpdxElement": "SPDXRef-File-cleartext.c-221"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist-wc.h-222"
+      "relatedSpdxElement": "SPDXRef-File-curlx.h-222"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ldap.h-223"
+      "relatedSpdxElement": "SPDXRef-File-multihandle.h-223"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apple.c-224"
+      "relatedSpdxElement": "SPDXRef-File-sha256.c-224"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-progress.c-225"
+      "relatedSpdxElement": "SPDXRef-File-curl-ldap.h-225"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-out.h-226"
+      "relatedSpdxElement": "SPDXRef-File-version.c-226"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel.c-227"
+      "relatedSpdxElement": "SPDXRef-File-cw-out.h-227"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mime.c-228"
+      "relatedSpdxElement": "SPDXRef-File-keylog.h-228"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socketpair.c-229"
+      "relatedSpdxElement": "SPDXRef-File-tool-operate.h-229"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-ares.c-230"
+      "relatedSpdxElement": "SPDXRef-File-parsedate.c-230"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-doswin.h-231"
+      "relatedSpdxElement": "SPDXRef-File-var.c-231"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options.h-232"
+      "relatedSpdxElement": "SPDXRef-File-inet-ntop.c-232"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openldap.c-233"
+      "relatedSpdxElement": "SPDXRef-File-hash.c-233"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sasl.h-234"
+      "relatedSpdxElement": "SPDXRef-File-tool-doswin.h-234"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.h-235"
+      "relatedSpdxElement": "SPDXRef-File-options.h-235"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cshutdn.c-236"
+      "relatedSpdxElement": "SPDXRef-File-setopt.c-236"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-get-line.c-237"
+      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.h-237"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-altsvc.h-238"
+      "relatedSpdxElement": "SPDXRef-File-headers.h-238"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.h-239"
+      "relatedSpdxElement": "SPDXRef-File-curl-get-line.c-239"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-listhelp.c-240"
+      "relatedSpdxElement": "SPDXRef-File-header.h-240"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-endian.c-241"
+      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.h-241"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-spack.h-242"
+      "relatedSpdxElement": "SPDXRef-File-tool-listhelp.c-242"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conncache.c-243"
+      "relatedSpdxElement": "SPDXRef-File-curl-endian.c-243"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getparam.c-244"
+      "relatedSpdxElement": "SPDXRef-File-rand.h-244"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest-sspi.c-245"
+      "relatedSpdxElement": "SPDXRef-File-multibyte.h-245"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.h-246"
+      "relatedSpdxElement": "SPDXRef-File-functypes.h-246"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-vms.h-247"
+      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.h-247"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5694,7 +5674,7 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnless.h-249"
+      "relatedSpdxElement": "SPDXRef-File-curl-sasl.h-249"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5709,492 +5689,492 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.h-252"
+      "relatedSpdxElement": "SPDXRef-File-bufq.h-252"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnless.c-253"
+      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.c-253"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls.c-254"
+      "relatedSpdxElement": "SPDXRef-File-httpsrr.h-254"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.c-255"
+      "relatedSpdxElement": "SPDXRef-File-cshutdn.h-255"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mprintf.c-256"
+      "relatedSpdxElement": "SPDXRef-File-idn.h-256"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpsrr.h-257"
+      "relatedSpdxElement": "SPDXRef-File-strerr.c-257"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest.h-258"
+      "relatedSpdxElement": "SPDXRef-File-tftp.h-258"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-sdecls.h-259"
+      "relatedSpdxElement": "SPDXRef-File-mprintf.h-259"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hmac.c-260"
+      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.h-260"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tftp.h-261"
+      "relatedSpdxElement": "SPDXRef-File-rtsp.h-261"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mprintf.h-262"
+      "relatedSpdxElement": "SPDXRef-File-sendf.c-262"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.h-263"
+      "relatedSpdxElement": "SPDXRef-File-gsasl.c-263"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rtsp.h-264"
+      "relatedSpdxElement": "SPDXRef-File-openldap.c-264"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operate.h-265"
+      "relatedSpdxElement": "SPDXRef-File-digest.c-265"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.c-266"
+      "relatedSpdxElement": "SPDXRef-File-socks-gssapi.c-266"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock.c-267"
+      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.c-267"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostcheck.c-268"
+      "relatedSpdxElement": "SPDXRef-File-curl-range.h-268"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-range.h-269"
+      "relatedSpdxElement": "SPDXRef-File-psl.h-269"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-psl.h-270"
+      "relatedSpdxElement": "SPDXRef-File-tool-setup.h-270"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strequal.c-271"
+      "relatedSpdxElement": "SPDXRef-File-select.c-271"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-netrc.h-272"
+      "relatedSpdxElement": "SPDXRef-File-tool-operate.c-272"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getpass.c-273"
+      "relatedSpdxElement": "SPDXRef-File-wait.h-273"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedate.c-274"
+      "relatedSpdxElement": "SPDXRef-File-curl-range.c-274"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-chunks.c-275"
+      "relatedSpdxElement": "SPDXRef-File-tool-msgs.c-275"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conncache.h-276"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.h-276"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.h-277"
+      "relatedSpdxElement": "SPDXRef-File-progress.h-277"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist.c-278"
+      "relatedSpdxElement": "SPDXRef-File-strcase.c-278"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.h-279"
+      "relatedSpdxElement": "SPDXRef-File-escape.h-279"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-progress.h-280"
+      "relatedSpdxElement": "SPDXRef-File-vauth.c-280"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http1.c-281"
+      "relatedSpdxElement": "SPDXRef-File-gtls.c-281"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-splay.h-282"
+      "relatedSpdxElement": "SPDXRef-File-http2.h-282"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcase.c-283"
+      "relatedSpdxElement": "SPDXRef-File-tool-helpers.c-283"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cfilters.h-284"
+      "relatedSpdxElement": "SPDXRef-File-file.h-284"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.c-285"
+      "relatedSpdxElement": "SPDXRef-File-strequal.c-285"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.c-286"
+      "relatedSpdxElement": "SPDXRef-File-urlapi.c-286"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pingpong.c-287"
+      "relatedSpdxElement": "SPDXRef-File-gtls.h-287"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.h-288"
+      "relatedSpdxElement": "SPDXRef-File-apple.c-288"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ev.c-289"
+      "relatedSpdxElement": "SPDXRef-File-http-negotiate.c-289"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-select.c-290"
+      "relatedSpdxElement": "SPDXRef-File-base64.c-290"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-system.h-291"
+      "relatedSpdxElement": "SPDXRef-File-curl-trc.h-291"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libssh.c-292"
+      "relatedSpdxElement": "SPDXRef-File-conncache.c-292"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-win32.h-293"
+      "relatedSpdxElement": "SPDXRef-File-http-proxy.c-293"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openssl.c-294"
+      "relatedSpdxElement": "SPDXRef-File-getenv.c-294"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-negotiate.c-295"
+      "relatedSpdxElement": "SPDXRef-File-content-encoding.c-295"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedate.h-296"
+      "relatedSpdxElement": "SPDXRef-File-wolfssl.c-296"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-oauth2.c-297"
+      "relatedSpdxElement": "SPDXRef-File-tool-doswin.c-297"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.c-298"
+      "relatedSpdxElement": "SPDXRef-File-hostcheck.c-298"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sigpipe.h-299"
+      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.h-299"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getenv.c-300"
+      "relatedSpdxElement": "SPDXRef-File-multi.h-300"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynbuf.c-301"
+      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.h-301"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-win32.c-302"
+      "relatedSpdxElement": "SPDXRef-File-memdebug.c-302"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-out.c-303"
+      "relatedSpdxElement": "SPDXRef-File-spnego-gssapi.c-303"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keylog.c-304"
+      "relatedSpdxElement": "SPDXRef-File-wolfssl.h-304"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.h-305"
+      "relatedSpdxElement": "SPDXRef-File-curl-sasl.c-305"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-headers.h-306"
+      "relatedSpdxElement": "SPDXRef-File-tool-vms.h-306"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.c-307"
+      "relatedSpdxElement": "SPDXRef-File-sigpipe.h-307"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strparse.h-308"
+      "relatedSpdxElement": "SPDXRef-File-ntlm.c-308"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-request.c-309"
+      "relatedSpdxElement": "SPDXRef-File-dict.h-309"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openssl.h-310"
+      "relatedSpdxElement": "SPDXRef-File-arpa-telnet.h-310"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftplistparser.h-311"
+      "relatedSpdxElement": "SPDXRef-File-x509asn1.c-311"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.c-312"
+      "relatedSpdxElement": "SPDXRef-File-rustls.h-312"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-time.c-313"
+      "relatedSpdxElement": "SPDXRef-File-curl-fopen.c-313"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-spnego-gssapi.c-314"
+      "relatedSpdxElement": "SPDXRef-File-socks.c-314"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sasl.c-315"
+      "relatedSpdxElement": "SPDXRef-File-vtls.h-315"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy.c-316"
+      "relatedSpdxElement": "SPDXRef-File-uint-table.c-316"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.c-317"
+      "relatedSpdxElement": "SPDXRef-File-vtls-scache.h-317"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vssh.c-318"
+      "relatedSpdxElement": "SPDXRef-File-curl-hmac.h-318"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formdata.c-319"
+      "relatedSpdxElement": "SPDXRef-File-tool-main.c-319"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.h-320"
+      "relatedSpdxElement": "SPDXRef-File-var.h-320"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fopen.c-321"
+      "relatedSpdxElement": "SPDXRef-File-http.h-321"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fopen.c-322"
+      "relatedSpdxElement": "SPDXRef-File-tool-setopt.h-322"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gsasl.c-323"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha256.h-323"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-table.c-324"
+      "relatedSpdxElement": "SPDXRef-File-gopher.h-324"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-netrc.c-325"
+      "relatedSpdxElement": "SPDXRef-File-tool-setopt.c-325"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-main.c-326"
+      "relatedSpdxElement": "SPDXRef-File-curl-fopen.h-326"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-var.h-327"
+      "relatedSpdxElement": "SPDXRef-File-escape.c-327"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-trc.c-328"
+      "relatedSpdxElement": "SPDXRef-File-timeval.h-328"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gopher.h-329"
+      "relatedSpdxElement": "SPDXRef-File-krb5-sspi.c-329"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufq.h-330"
+      "relatedSpdxElement": "SPDXRef-File-curl-gssapi.c-330"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fopen.h-331"
+      "relatedSpdxElement": "SPDXRef-File-telnet.h-331"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vauth.c-332"
+      "relatedSpdxElement": "SPDXRef-File-http-proxy.h-332"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls.h-333"
+      "relatedSpdxElement": "SPDXRef-File-http1.h-333"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.c-334"
+      "relatedSpdxElement": "SPDXRef-File-md5.c-334"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.c-335"
+      "relatedSpdxElement": "SPDXRef-File-asyn-thrdd.c-335"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha256.c-336"
+      "relatedSpdxElement": "SPDXRef-File-setopt.h-336"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-winapi.c-337"
+      "relatedSpdxElement": "SPDXRef-File-version-win32.h-337"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gssapi.c-338"
+      "relatedSpdxElement": "SPDXRef-File-url.h-338"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-telnet.h-339"
+      "relatedSpdxElement": "SPDXRef-File-http-ntlm.c-339"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wait.h-340"
+      "relatedSpdxElement": "SPDXRef-File-splay.h-340"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-proxy.h-341"
+      "relatedSpdxElement": "SPDXRef-File-mprintf.c-341"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-int.h-342"
+      "relatedSpdxElement": "SPDXRef-File-slist.c-342"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-ntlm.c-343"
+      "relatedSpdxElement": "SPDXRef-File-snprintf.c-343"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel.h-344"
+      "relatedSpdxElement": "SPDXRef-File-cfilters.h-344"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.h-345"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.c-345"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cookie.h-346"
+      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.h-346"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-helpers.h-347"
+      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.c-347"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-xattr.c-348"
+      "relatedSpdxElement": "SPDXRef-File-tool-helpers.h-348"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formdata.h-349"
+      "relatedSpdxElement": "SPDXRef-File-tftp.c-349"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -6204,397 +6184,397 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy-lock.h-351"
+      "relatedSpdxElement": "SPDXRef-File-tool-xattr.c-351"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostip.c-352"
+      "relatedSpdxElement": "SPDXRef-File-easy-lock.h-352"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.c-353"
+      "relatedSpdxElement": "SPDXRef-File-openssl.h-353"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wolfssl.c-354"
+      "relatedSpdxElement": "SPDXRef-File-easy.c-354"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ntlm.c-355"
+      "relatedSpdxElement": "SPDXRef-File-terminal.c-355"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rtsp.c-356"
+      "relatedSpdxElement": "SPDXRef-File-tool-formparse.h-356"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.c-357"
+      "relatedSpdxElement": "SPDXRef-File-tool-filetime.h-357"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-telnet.c-358"
+      "relatedSpdxElement": "SPDXRef-File-amigaos.c-358"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-formparse.h-359"
+      "relatedSpdxElement": "SPDXRef-File-basename.c-359"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fopen.h-360"
+      "relatedSpdxElement": "SPDXRef-File-tool-progress.h-360"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-filetime.h-361"
+      "relatedSpdxElement": "SPDXRef-File-winapi.h-361"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amigaos.c-362"
+      "relatedSpdxElement": "SPDXRef-File-smb.h-362"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-progress.h-363"
+      "relatedSpdxElement": "SPDXRef-File-inet-pton.c-363"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-winapi.h-364"
+      "relatedSpdxElement": "SPDXRef-File-cram.c-364"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smb.h-365"
+      "relatedSpdxElement": "SPDXRef-File-vssh.c-365"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ws.h-366"
+      "relatedSpdxElement": "SPDXRef-File-snprintf.h-366"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gtls.c-367"
+      "relatedSpdxElement": "SPDXRef-File-strcopy.h-367"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostcheck.h-368"
+      "relatedSpdxElement": "SPDXRef-File-krb5-gssapi.c-368"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcopy.h-369"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.h-369"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi.c-370"
+      "relatedSpdxElement": "SPDXRef-File-conncache.h-370"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcopy.c-371"
+      "relatedSpdxElement": "SPDXRef-File-apple.h-371"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-help.c-372"
+      "relatedSpdxElement": "SPDXRef-File-easyoptions.h-372"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.h-373"
+      "relatedSpdxElement": "SPDXRef-File-fopen.h-373"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-md4.c-374"
+      "relatedSpdxElement": "SPDXRef-File-mbedtls.h-374"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyoptions.h-375"
+      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.c-375"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-chunks.h-376"
+      "relatedSpdxElement": "SPDXRef-File-hostcheck.h-376"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.c-377"
+      "relatedSpdxElement": "SPDXRef-File-http-chunks.h-377"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerr.c-378"
+      "relatedSpdxElement": "SPDXRef-File-curl-quiche.c-378"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi.h-379"
+      "relatedSpdxElement": "SPDXRef-File-vtls-spack.c-379"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cfilters.c-380"
+      "relatedSpdxElement": "SPDXRef-File-typecheck-gcc.h-380"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.h-381"
+      "relatedSpdxElement": "SPDXRef-File-strcopy.c-381"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic-int.h-382"
+      "relatedSpdxElement": "SPDXRef-File-http-chunks.c-382"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apple.h-383"
+      "relatedSpdxElement": "SPDXRef-File-terminal.h-383"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.h-384"
+      "relatedSpdxElement": "SPDXRef-File-splay.c-384"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ev.h-385"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.h-385"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.h-386"
+      "relatedSpdxElement": "SPDXRef-File-multi-ev.h-386"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.h-387"
+      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.h-387"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-functypes.h-388"
+      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.c-388"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ntlm-sspi.c-389"
+      "relatedSpdxElement": "SPDXRef-File-pop3.c-389"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.c-390"
+      "relatedSpdxElement": "SPDXRef-File-getinfo.c-390"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setup.h-391"
+      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.h-391"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timediff.h-392"
+      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.c-392"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.c-393"
+      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.c-393"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-hash.c-394"
+      "relatedSpdxElement": "SPDXRef-File-hsts.h-394"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-psl.c-395"
+      "relatedSpdxElement": "SPDXRef-File-vquic-tls.c-395"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsts.h-396"
+      "relatedSpdxElement": "SPDXRef-File-http2.c-396"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.h-397"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.c-397"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.h-398"
+      "relatedSpdxElement": "SPDXRef-File-ldap.c-398"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.h-399"
+      "relatedSpdxElement": "SPDXRef-File-psl.c-399"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-md5.c-400"
+      "relatedSpdxElement": "SPDXRef-File-dynhds.h-400"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setopt.c-401"
+      "relatedSpdxElement": "SPDXRef-File-tool-getparam.h-401"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostip.h-402"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.h-402"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-header.h-403"
+      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.h-403"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-content-encoding.h-404"
+      "relatedSpdxElement": "SPDXRef-File-mqtt.c-404"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.h-405"
+      "relatedSpdxElement": "SPDXRef-File-tool-getparam.c-405"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setopt.h-406"
+      "relatedSpdxElement": "SPDXRef-File-content-encoding.h-406"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-proxy.c-407"
+      "relatedSpdxElement": "SPDXRef-File-mime.h-407"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.c-408"
+      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.h-408"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-msgs.h-409"
+      "relatedSpdxElement": "SPDXRef-File-parsedate.h-409"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest.c-410"
+      "relatedSpdxElement": "SPDXRef-File-tool-msgs.h-410"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keylog.h-411"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.c-411"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gtls.h-412"
+      "relatedSpdxElement": "SPDXRef-File-url.c-412"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock.h-413"
+      "relatedSpdxElement": "SPDXRef-File-cw-pause.c-413"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftp.h-414"
+      "relatedSpdxElement": "SPDXRef-File-noproxy.c-414"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-soc.h-415"
+      "relatedSpdxElement": "SPDXRef-File-nonblock.h-415"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strparse.c-416"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-soc.h-416"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl.h-417"
+      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.c-417"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.c-418"
+      "relatedSpdxElement": "SPDXRef-File-imap.h-418"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-imap.h-419"
+      "relatedSpdxElement": "SPDXRef-File-digest-sspi.c-419"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.c-420"
+      "relatedSpdxElement": "SPDXRef-File-slist-wc.c-420"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connect.h-421"
+      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.h-421"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sendf.c-422"
+      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.h-422"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist-wc.c-423"
+      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.c-423"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-base.c-424"
+      "relatedSpdxElement": "SPDXRef-File-http-digest.c-424"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.c-425"
+      "relatedSpdxElement": "SPDXRef-File-getinfo.h-425"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic.h-426"
+      "relatedSpdxElement": "SPDXRef-File-curl-threads.c-426"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-digest.c-427"
+      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.c-427"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getinfo.h-428"
+      "relatedSpdxElement": "SPDXRef-File-vtls.c-428"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-threads.c-429"
+      "relatedSpdxElement": "SPDXRef-File-urlapi.h-429"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -6614,52 +6594,42 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.h-433"
+      "relatedSpdxElement": "SPDXRef-File-curl-endian.h-433"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-endian.h-434"
+      "relatedSpdxElement": "SPDXRef-File-cookie.h-434"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.c-435"
+      "relatedSpdxElement": "SPDXRef-File-basename.h-435"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi-int.h-436"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.c-436"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-pton.h-437"
+      "relatedSpdxElement": "SPDXRef-File-dict.c-437"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cleartext.c-438"
+      "relatedSpdxElement": "SPDXRef-File-schannel.h-438"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.c-439"
+      "relatedSpdxElement": "SPDXRef-File-http-ntlm.h-439"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getinfo.c-440"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pop3.c-441"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-ntlm.h-442"
+      "relatedSpdxElement": "SPDXRef-File-select.h-440"
     }
   ]
 }

--- a/tests/golden/spdx/c-cpp/curl/curl_build.spdx.json
+++ b/tests/golden/spdx/c-cpp/curl/curl_build.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "curl",
-  "documentNamespace": "https://omnibor.io/omnibor-analysis/curl-06f56b99-71a3-4683-8a6d-f92c5595e503",
+  "documentNamespace": "https://omnibor.io/omnibor-analysis/curl-3570059b-c022-4830-90bc-b707886e8a5a",
   "creationInfo": {
-    "created": "2026-03-12T21:58:56Z",
+    "created": "2026-04-02T21:39:27Z",
     "creators": [
       "Tool: bomtrace3-unknown",
       "Tool: bomsh-unknown",
@@ -20,49 +20,25 @@
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": true,
       "primaryPackagePurpose": "APPLICATION",
-      "builtDate": "2026-03-12T21:58:56Z",
+      "builtDate": "2026-04-02T21:39:27Z",
       "externalRefs": [
         {
           "referenceCategory": "PERSISTENT-ID",
           "referenceType": "gitoid",
-          "referenceLocator": "gitoid:blob:sha1:74fd43a1b975341cb3dea18e2340a5129bc55a34"
+          "referenceLocator": "gitoid:blob:sha1:d41e267c4ad22aa1ab48051e4378f7f423ccaf88"
         }
       ],
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5c0ce10201c3366cf243f6507e635317f0bc2260"
+          "checksumValue": "9ceebafa1b1f3cfbd1d31552976b51c3c5d62900"
         }
       ],
       "comment": "Built on Ubuntu 22.04.5 LTS with gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
-      "versionInfo": "8.19.0-DEV"
+      "versionInfo": "8.19.0"
     },
     {
-      "SPDXID": "SPDXRef-libcurl4-1",
-      "name": "libcurl4",
-      "downloadLocation": "https://curl.haxx.se",
-      "filesAnalyzed": false,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:deb/ubuntu/libcurl4@7.81.0-1ubuntu1.23?arch=amd64&distro=ubuntu-22.04"
-        },
-        {
-          "referenceCategory": "SECURITY",
-          "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:curl:curl:7.81.0:*:*:*:*:*:*:*"
-        }
-      ],
-      "comment": "Dynamically linked (direct). sonames: libcurl.so.4. dpkg: libcurl4 (amd64)",
-      "versionInfo": "7.81.0-1ubuntu1.23",
-      "supplier": "Organization: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
-      "homepage": "https://curl.haxx.se",
-      "packageSourceInfo": "Installed via dpkg package libcurl4 on Ubuntu 22.04.5 LTS."
-    },
-    {
-      "SPDXID": "SPDXRef-libc6-2",
+      "SPDXID": "SPDXRef-libc6-1",
       "name": "libc6",
       "downloadLocation": "https://www.gnu.org/software/libc/libc.html",
       "filesAnalyzed": false,
@@ -86,7 +62,7 @@
       "packageSourceInfo": "Installed via dpkg package libc6 on Ubuntu 22.04.5 LTS."
     },
     {
-      "SPDXID": "SPDXRef-zlib1g-3",
+      "SPDXID": "SPDXRef-zlib1g-2",
       "name": "zlib1g",
       "downloadLocation": "http://zlib.net/",
       "filesAnalyzed": false,
@@ -110,6 +86,17 @@
       "packageSourceInfo": "Installed via dpkg package zlib1g on Ubuntu 22.04.5 LTS."
     },
     {
+      "SPDXID": "SPDXRef-libcurl-3",
+      "name": "libcurl",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "LIBRARY",
+      "externalRefs": [],
+      "comment": "Project-built shared library (direct). sonames: libcurl.so.4",
+      "packageSourceInfo": "Built from project source as part of curl build.",
+      "versionInfo": "8.19.0"
+    },
+    {
       "SPDXID": "SPDXRef-gcc-4",
       "name": "gcc",
       "versionInfo": "11.4.0",
@@ -130,78 +117,98 @@
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-File-idn.c-5",
-      "fileName": "repos/curl/lib/idn.c",
+      "SPDXID": "SPDXRef-File-smb.c-5",
+      "fileName": "repos/curl/lib/smb.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "00e2fc6e4cb6dcd2036b24331adc2672a4f9bcd3"
+          "checksumValue": "00297adee7f2116f0ec521167ee5ec3ac411b404"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-scache.c-6",
-      "fileName": "repos/curl/lib/vtls/vtls_scache.c",
+      "SPDXID": "SPDXRef-File-cf-socket.h-6",
+      "fileName": "repos/curl/lib/cf-socket.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0149b51869d7b42c41bfed6c81f6bc5d32921445"
+          "checksumValue": "014f5f7881728246f7f7c0aebda9e5fbe3746325"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-ip-happy.c-7",
-      "fileName": "repos/curl/lib/cf-ip-happy.c",
+      "SPDXID": "SPDXRef-File-keylog.c-7",
+      "fileName": "repos/curl/lib/vtls/keylog.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "01ddd9f3d890ee06d6f1227b06b40546d54f033e"
+          "checksumValue": "0206e32cf8fd21e90cb5d1d8079243472dd6dee8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multiif.h-8",
-      "fileName": "repos/curl/lib/vtls/../multiif.h",
+      "SPDXID": "SPDXRef-File-hmac.c-8",
+      "fileName": "repos/curl/lib/hmac.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0252b2dfd978b5626cc3f8e1e196440ab735c6f6"
+          "checksumValue": "028b476c77a3bdeb67176c058410c5f8220463d5"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rustls.c-9",
-      "fileName": "repos/curl/lib/vtls/rustls.c",
+      "SPDXID": "SPDXRef-File-inet-pton.h-9",
+      "fileName": "repos/curl/lib/curlx/inet_pton.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "02a6b7d5aa8d0237724a487be0dea89c32c98a42"
+          "checksumValue": "02ae7f2269dd1c7131bb833c56a63453fac1c8d1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.h-10",
-      "fileName": "repos/curl/lib/vauth/../rand.h",
+      "SPDXID": "SPDXRef-File-multiif.h-10",
+      "fileName": "repos/curl/lib/multiif.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c69a0df460f64a88df44a55b3cc44d31c28d7c"
+          "checksumValue": "039db269e001d28f6e41b3b2ea010c4d566c19a6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ldap.c-11",
-      "fileName": "repos/curl/lib/ldap.c",
+      "SPDXID": "SPDXRef-File-hsts.c-11",
+      "fileName": "repos/curl/lib/hsts.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "046fcd48e885273cf6cb49d2f6c94ec01024b056"
+          "checksumValue": "03f51f8109d4900c7a287fe297f138fd7aedb13a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transfer.h-12",
-      "fileName": "repos/curl/lib/vtls/../transfer.h",
+      "SPDXID": "SPDXRef-File-curl-md5.h-12",
+      "fileName": "repos/curl/lib/curl_md5.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "042c5f59ae5ecbb33a26f980be5da064629b370d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-imap.c-13",
+      "fileName": "repos/curl/lib/imap.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0546595f8998214cdd0b77784d9d25cd4e52f051"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-transfer.h-14",
+      "fileName": "repos/curl/lib/transfer.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -210,7 +217,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-md4.h-13",
+      "SPDXID": "SPDXRef-File-curl-md4.h-15",
       "fileName": "repos/curl/lib/curl_md4.h",
       "checksums": [
         {
@@ -220,8 +227,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ntfy.h-14",
-      "fileName": "repos/curl/lib/vauth/../multi_ntfy.h",
+      "SPDXID": "SPDXRef-File-multi-ntfy.h-16",
+      "fileName": "repos/curl/lib/multi_ntfy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -230,7 +237,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-if2ip.c-15",
+      "SPDXID": "SPDXRef-File-if2ip.c-17",
       "fileName": "repos/curl/lib/if2ip.c",
       "checksums": [
         {
@@ -240,17 +247,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-typecheck-gcc.h-16",
-      "fileName": "repos/curl/lib/../include/curl/typecheck-gcc.h",
+      "SPDXID": "SPDXRef-File-rustls.c-18",
+      "fileName": "repos/curl/lib/vtls/rustls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0642afd91ed2f07c171ecbf34c69107c6c800748"
+          "checksumValue": "061b444bcefd9b963287da7d1bee1ed3aab1069b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-rea.h-17",
+      "SPDXID": "SPDXRef-File-netrc.h-19",
+      "fileName": "repos/curl/lib/netrc.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "061e1e438b9c956e8e794347492286b9783a60f0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-system.h-20",
+      "fileName": "repos/curl/lib/../include/curl/system.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "064833d6e1e72385ed9e493513c1a2d8219c6443"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-rea.h-21",
       "fileName": "repos/curl/src/tool_cb_rea.h",
       "checksums": [
         {
@@ -260,17 +287,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-range.c-18",
-      "fileName": "repos/curl/lib/curl_range.c",
+      "SPDXID": "SPDXRef-File-connect.h-22",
+      "fileName": "repos/curl/lib/connect.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "070dee428980cd6bacb36dec17a698e98c42a163"
+          "checksumValue": "071b4329c1154c5ce0d97125e23479ca0cec9225"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-addrinfo.h-19",
+      "SPDXID": "SPDXRef-File-fake-addrinfo.h-23",
       "fileName": "repos/curl/lib/fake_addrinfo.h",
       "checksums": [
         {
@@ -280,7 +307,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getpass.h-20",
+      "SPDXID": "SPDXRef-File-llist.h-24",
+      "fileName": "repos/curl/lib/llist.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "09c695d3cfaef70dba17fb05724803c65c3265b9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-getpass.h-25",
       "fileName": "repos/curl/src/tool_getpass.h",
       "checksums": [
         {
@@ -290,7 +327,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlinfo.c-21",
+      "SPDXID": "SPDXRef-File-curlinfo.c-26",
       "fileName": "repos/curl/src/curlinfo.c",
       "checksums": [
         {
@@ -300,7 +337,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-macos.h-22",
+      "SPDXID": "SPDXRef-File-macos.h-27",
       "fileName": "repos/curl/lib/macos.h",
       "checksums": [
         {
@@ -310,82 +347,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sha256.h-23",
-      "fileName": "repos/curl/lib/vauth/../curl_sha256.h",
+      "SPDXID": "SPDXRef-File-tool-filetime.c-28",
+      "fileName": "repos/curl/src/tool_filetime.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0aaa4126f4e3f07fa78d9883b0fada4a3ba07efc"
+          "checksumValue": "0b6cd7b38f397dfb12161399505c507badda253a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-ntop.c-24",
-      "fileName": "repos/curl/lib/curlx/inet_ntop.c",
+      "SPDXID": "SPDXRef-File-easy.h-29",
+      "fileName": "repos/curl/lib/../include/curl/easy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0b10e8a7f63087853c342313f6fe0e57670dd7f8"
+          "checksumValue": "0be6915d92bb21f42dacb2d3cb981af3710437ec"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.c-25",
-      "fileName": "repos/curl/lib/hash.c",
+      "SPDXID": "SPDXRef-File-strdup.h-30",
+      "fileName": "repos/curl/lib/curlx/strdup.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0b6ecc48f7d52d388c7fce4dda3e85ef3055084e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-dbg.c-26",
-      "fileName": "repos/curl/src/tool_cb_dbg.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0c8568ff62ff8a6c0931089b3d96e0762455612a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cram.c-27",
-      "fileName": "repos/curl/lib/vauth/cram.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0d061ebbb029aba5ba5656b285f4e7d161b83655"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-doh.h-28",
-      "fileName": "repos/curl/lib/doh.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0dc6a3f2a490024225e76806399b8d715a094d28"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-setopt.h-29",
-      "fileName": "repos/curl/lib/vtls/../setopt.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0dd60c785f939b50563a053d5286b19f150c9a7c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-smb.c-30",
-      "fileName": "repos/curl/lib/smb.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0ddb167e61514f5376ea17ee5132dff8c84f4219"
+          "checksumValue": "0c4b14161e98dbcd6694358eeb6d424d3ff07358"
         }
       ]
     },
@@ -401,7 +388,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-curl-threads.h-32",
-      "fileName": "repos/curl/lib/vauth/../curl_threads.h",
+      "fileName": "repos/curl/lib/curl_threads.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -410,17 +397,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-thrdd.c-33",
-      "fileName": "repos/curl/lib/asyn-thrdd.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0e06db22ca0cab9e291e14a85eb3a005b863ad5e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-llist.c-34",
+      "SPDXID": "SPDXRef-File-llist.c-33",
       "fileName": "repos/curl/lib/llist.c",
       "checksums": [
         {
@@ -430,22 +407,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base64.c-35",
-      "fileName": "repos/curl/lib/curlx/base64.c",
+      "SPDXID": "SPDXRef-File-netrc.c-34",
+      "fileName": "repos/curl/lib/netrc.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0e44eae7faf3634cb181e6c735aac7f3f876fdba"
+          "checksumValue": "1073cc53656f0bd71017f906c1f4c82fbdb3c222"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-formparse.c-36",
-      "fileName": "repos/curl/src/tool_formparse.c",
+      "SPDXID": "SPDXRef-File-timediff.h-35",
+      "fileName": "repos/curl/lib/../lib/curlx/timediff.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0ec434e2def65be84c10bd3341c07023bd8aedd4"
+          "checksumValue": "1081c75d1c9644a3c47b124e50861ffaf6a1b332"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-rtsp.c-36",
+      "fileName": "repos/curl/lib/rtsp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "11848c82820470ebd6e7617084fca138e4da29e3"
         }
       ]
     },
@@ -460,37 +447,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http1.h-38",
-      "fileName": "repos/curl/lib/http1.h",
+      "SPDXID": "SPDXRef-File-ntlm-sspi.c-38",
+      "fileName": "repos/curl/lib/vauth/ntlm_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "124d32e373cb497fbb2a0e752a18979be32ac614"
+          "checksumValue": "12cf32b8945979d680ff1274f90614952c407ead"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-spnego-sspi.c-39",
-      "fileName": "repos/curl/lib/vauth/spnego_sspi.c",
+      "SPDXID": "SPDXRef-File-tool-time.c-39",
+      "fileName": "repos/curl/src/toolx/tool_time.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "12bdc3afd798ee9c792debd1024ad279de2de4e9"
+          "checksumValue": "12eaea9fe4eed120187b2036408527e57fb692d0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn.h-40",
-      "fileName": "repos/curl/lib/vauth/../asyn.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "12d3e1c33883c850d535b97807806c8901760b68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-if2ip.h-41",
+      "SPDXID": "SPDXRef-File-if2ip.h-40",
       "fileName": "repos/curl/lib/if2ip.h",
       "checksums": [
         {
@@ -500,7 +477,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ntfy.c-42",
+      "SPDXID": "SPDXRef-File-multi-ntfy.c-41",
       "fileName": "repos/curl/lib/multi_ntfy.c",
       "checksums": [
         {
@@ -510,28 +487,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noproxy.c-43",
-      "fileName": "repos/curl/lib/noproxy.c",
+      "SPDXID": "SPDXRef-File-strparse.c-42",
+      "fileName": "repos/curl/lib/curlx/strparse.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1421fb114de2950ba9306090a7145e6f663318d9"
+          "checksumValue": "138b3df1255328b71f6f352d6aa78ae3195c2f6f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sendf.h-44",
-      "fileName": "repos/curl/lib/vssh/../sendf.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1521ccb0f86614d0f2e1a948c988df6026514e8e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-ctype.h-45",
-      "fileName": "repos/curl/lib/vauth/../curl_ctype.h",
+      "SPDXID": "SPDXRef-File-curl-ctype.h-43",
+      "fileName": "repos/curl/lib/curl_ctype.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -540,7 +507,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-time.h-46",
+      "SPDXID": "SPDXRef-File-tool-time.h-44",
       "fileName": "repos/curl/src/toolx/tool_time.h",
       "checksums": [
         {
@@ -550,37 +517,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libssh2.c-47",
-      "fileName": "repos/curl/lib/vssh/libssh2.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "15b7c056dd54a23a08432aaf4d5e4dd836e4a7ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hsts.c-48",
-      "fileName": "repos/curl/lib/hsts.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "15d4207548d319fc021423e1150e50a95ae71f22"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-md5.h-49",
-      "fileName": "repos/curl/lib/vauth/../curl_md5.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "16272c759105bbdd91edef6100c8f9d0a3a4a599"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-httpsrr.c-50",
+      "SPDXID": "SPDXRef-File-httpsrr.c-45",
       "fileName": "repos/curl/lib/httpsrr.c",
       "checksums": [
         {
@@ -590,77 +527,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-pton.c-51",
-      "fileName": "repos/curl/lib/curlx/inet_pton.c",
+      "SPDXID": "SPDXRef-File-http.c-46",
+      "fileName": "repos/curl/lib/http.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1767bf19af715657ff5a393ae84eaad8e95cd995"
+          "checksumValue": "188da5fd832edc887ba50e8aad4d79750dbdbcff"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-msgs.c-52",
-      "fileName": "repos/curl/src/tool_msgs.c",
+      "SPDXID": "SPDXRef-File-md4.c-47",
+      "fileName": "repos/curl/lib/md4.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "18e014950df5f52f71acb18808086f3b6f29fc97"
+          "checksumValue": "1ac6ef1c5b7befa694333d5c363ad77d178ded35"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-paramhlp.h-53",
-      "fileName": "repos/curl/src/tool_paramhlp.h",
+      "SPDXID": "SPDXRef-File-ssh.h-48",
+      "fileName": "repos/curl/lib/vssh/ssh.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "192d242d181d2495bc836f17b572fdd5a24dccd0"
+          "checksumValue": "1afb1e8643d99a8dd4ab35d17df32acb866628e0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-doswin.c-54",
-      "fileName": "repos/curl/src/tool_doswin.c",
+      "SPDXID": "SPDXRef-File-system-win32.c-49",
+      "fileName": "repos/curl/lib/system_win32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "193446cba3869353d81dea0b34b14b7e2aee9c89"
+          "checksumValue": "1b052357b5dd4f7b41117bae8e6e2df05d9603f6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cookie.c-55",
-      "fileName": "repos/curl/lib/cookie.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "19d8fc85474cf205be8439b3574c901253cd7a40"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ratelimit.c-56",
-      "fileName": "repos/curl/lib/ratelimit.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1b1fb6ccedc3e04fa5ad3445bdac113830ef71b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-vquic.c-57",
-      "fileName": "repos/curl/lib/vquic/vquic.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1b7dc1d3aacf071aed30977c1e853cb3ff49ef99"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file.c-58",
+      "SPDXID": "SPDXRef-File-file.c-50",
       "fileName": "repos/curl/lib/file.c",
       "checksums": [
         {
@@ -670,7 +577,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sspi.c-59",
+      "SPDXID": "SPDXRef-File-tool-cb-wrt.c-51",
+      "fileName": "repos/curl/src/tool_cb_wrt.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1d2b81ea7cacb6e3bb09260687f50d464465cb66"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sspi.c-52",
       "fileName": "repos/curl/lib/curl_sspi.c",
       "checksums": [
         {
@@ -680,37 +597,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-llist.h-60",
-      "fileName": "repos/curl/lib/vauth/../llist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1d73db1719da962379938387032ac1b38f0d1052"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-url.h-61",
-      "fileName": "repos/curl/lib/vauth/../url.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e44ebe43bb0d94309e27a15486fc1d040dab958"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strdup.h-62",
-      "fileName": "repos/curl/lib/vauth/../curlx/strdup.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e6bc1981429b9e4055bccd0448e9256a4dd1b41"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strerror.c-63",
+      "SPDXID": "SPDXRef-File-strerror.c-53",
       "fileName": "repos/curl/lib/strerror.c",
       "checksums": [
         {
@@ -720,47 +607,77 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ngtcp2.h-64",
-      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.h",
+      "SPDXID": "SPDXRef-File-vquic.c-54",
+      "fileName": "repos/curl/lib/vquic/vquic.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1e9868e0f7f6d1b2f68b40856824000187affb61"
+          "checksumValue": "1eaabb95f5d47769af808a81fbdfba037ab073c2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlx.h-65",
-      "fileName": "repos/curl/src/../lib/curlx/curlx.h",
+      "SPDXID": "SPDXRef-File-spnego-sspi.c-55",
+      "fileName": "repos/curl/lib/vauth/spnego_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1ee35fa1a029667d290f599fbdcc57264d3b4a0f"
+          "checksumValue": "1f73123a0d79e03637c05d2ef695f7d260fa770c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-spack.c-66",
-      "fileName": "repos/curl/lib/vtls/vtls_spack.c",
+      "SPDXID": "SPDXRef-File-cipher-suite.c-56",
+      "fileName": "repos/curl/lib/vtls/cipher_suite.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2026fe3ed57d0fd96748720ea486b3dddfbf3e63"
+          "checksumValue": "1fc6e9f8c6f909e02c1cacdbd409d0067b63fd5b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-printf.h-67",
-      "fileName": "repos/curl/lib/curlx/../curl_printf.h",
+      "SPDXID": "SPDXRef-File-curl.h-57",
+      "fileName": "repos/curl/lib/../include/curl/curl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "207ba7125d62ab9a358a5644c3adbdc31abd6cef"
+          "checksumValue": "209716b334da52a7260b50fada5785870e431322"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyif.h-68",
+      "SPDXID": "SPDXRef-File-ftp.h-58",
+      "fileName": "repos/curl/lib/ftp.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20b360033e05dfddf23b5eaec31f7b7847cd660b"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-config2setopts.c-59",
+      "fileName": "repos/curl/src/config2setopts.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20d87a070ab54f77784e0cfb4953f20b4af78fa6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-formparse.c-60",
+      "fileName": "repos/curl/src/tool_formparse.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20f7e366a000e2a2cfab633d0a31355cd78f0d34"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easyif.h-61",
       "fileName": "repos/curl/lib/easyif.h",
       "checksums": [
         {
@@ -770,17 +687,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks-gssapi.c-69",
-      "fileName": "repos/curl/lib/socks_gssapi.c",
+      "SPDXID": "SPDXRef-File-tool-writeout.c-62",
+      "fileName": "repos/curl/src/tool_writeout.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "21722f072016b083a86e3cd50c8f85f8f04cf106"
+          "checksumValue": "22c83efd03089b3ef1d43e6a297c86292bb18fcf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ssls.c-70",
+      "SPDXID": "SPDXRef-File-tool-ssls.c-63",
       "fileName": "repos/curl/src/tool_ssls.c",
       "checksums": [
         {
@@ -790,28 +707,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-rea.c-71",
-      "fileName": "repos/curl/src/tool_cb_rea.c",
+      "SPDXID": "SPDXRef-File-uint-hash.c-64",
+      "fileName": "repos/curl/lib/uint-hash.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2343d04a133a5a52cc8eeffbf3b0e4ee5a08c4c5"
+          "checksumValue": "2377840200141e225c72298a18b74addd28192f8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-smtp.c-72",
-      "fileName": "repos/curl/lib/smtp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "23590398f949e6fafb513264d7f0c2823bb2bcd6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-memrchr.h-73",
-      "fileName": "repos/curl/lib/vtls/../curl_memrchr.h",
+      "SPDXID": "SPDXRef-File-curl-memrchr.h-65",
+      "fileName": "repos/curl/lib/curl_memrchr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -820,17 +727,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-pause.c-74",
-      "fileName": "repos/curl/lib/cw-pause.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2489a330a03ba8fc94808f4b142ea54f43723272"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-aws-sigv4.h-75",
+      "SPDXID": "SPDXRef-File-http-aws-sigv4.h-66",
       "fileName": "repos/curl/lib/http_aws_sigv4.h",
       "checksums": [
         {
@@ -840,17 +737,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-snprintf.h-76",
-      "fileName": "repos/curl/lib/curlx/snprintf.h",
+      "SPDXID": "SPDXRef-File-hash.h-67",
+      "fileName": "repos/curl/lib/hash.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "266ea137fae6eb76466219d69ec828facf4edc58"
+          "checksumValue": "267f91d1ae43cc3d9493df25b215d1d4e136ef37"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easygetopt.c-77",
+      "SPDXID": "SPDXRef-File-easygetopt.c-68",
       "fileName": "repos/curl/lib/easygetopt.c",
       "checksums": [
         {
@@ -860,37 +757,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-select.h-78",
-      "fileName": "repos/curl/lib/vtls/../select.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "268ae7cecfd4f9a1e806f506f240448adaeb6017"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-multibyte.h-79",
-      "fileName": "repos/curl/lib/vauth/../curlx/multibyte.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "26da0f0843e09509b3a3f41db92b8fc149caa3a6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-writeout.c-80",
-      "fileName": "repos/curl/src/tool_writeout.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2700abfa44385e8cc290ed158b5ce01fc69935ef"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-findfile.c-81",
+      "SPDXID": "SPDXRef-File-tool-findfile.c-69",
       "fileName": "repos/curl/src/tool_findfile.c",
       "checksums": [
         {
@@ -900,68 +767,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basename.c-82",
-      "fileName": "repos/curl/lib/curlx/basename.c",
+      "SPDXID": "SPDXRef-File-cfilters.c-70",
+      "fileName": "repos/curl/lib/cfilters.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "27c29f3c00aace71a0a9f9194c11dc580c530429"
+          "checksumValue": "27b0306180cf80071b421289dc794578492a3ee3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basename.h-83",
-      "fileName": "repos/curl/lib/curlx/basename.h",
+      "SPDXID": "SPDXRef-File-altsvc.h-71",
+      "fileName": "repos/curl/lib/altsvc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "287a14aa14aef0d2aae54a56a5a4520ba5ad402f"
+          "checksumValue": "2931af452bef3a61b90fc7e502bc646048e19675"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-socket.h-84",
-      "fileName": "repos/curl/lib/vauth/../cf-socket.h",
+      "SPDXID": "SPDXRef-File-version-win32.c-72",
+      "fileName": "repos/curl/lib/curlx/version_win32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "298ced926996b3b35f54a084a73c7352cd3f9c52"
+          "checksumValue": "296a38d9247b176476cd5613ca6c7d1859bd1875"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-helpers.c-85",
-      "fileName": "repos/curl/src/tool_helpers.c",
+      "SPDXID": "SPDXRef-File-urlapi-int.h-73",
+      "fileName": "repos/curl/lib/urlapi-int.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2a84accf2c508f000bf3eab280a7e87cb562cf5d"
+          "checksumValue": "29d4fe5f39a0ee84d7fae0239209ccee9452881b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-scache.h-86",
-      "fileName": "repos/curl/lib/vtls/vtls_scache.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a99e779e5285dee6adcbb396988d374c00489ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-wait.c-87",
-      "fileName": "repos/curl/lib/curlx/wait.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a9f54bb3e4eb8655ce48a1c4ff4cdc7ce9e08ce"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socketpair.h-88",
-      "fileName": "repos/curl/lib/vauth/../socketpair.h",
+      "SPDXID": "SPDXRef-File-socketpair.h-74",
+      "fileName": "repos/curl/lib/socketpair.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -970,8 +817,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockaddr.h-89",
-      "fileName": "repos/curl/lib/vauth/../sockaddr.h",
+      "SPDXID": "SPDXRef-File-sockaddr.h-75",
+      "fileName": "repos/curl/lib/sockaddr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -980,38 +827,58 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-prg.c-90",
-      "fileName": "repos/curl/src/tool_cb_prg.c",
+      "SPDXID": "SPDXRef-File-mbedtls.c-76",
+      "fileName": "repos/curl/lib/vtls/mbedtls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2b9e6d63112b864e7ada0c956dd664e98c16116f"
+          "checksumValue": "2bac406c359b21ed33a7e1d16a548409f522745a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynhds.h-91",
-      "fileName": "repos/curl/lib/vauth/../dynhds.h",
+      "SPDXID": "SPDXRef-File-timediff.c-77",
+      "fileName": "repos/curl/lib/curlx/timediff.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2cfa290571201bfbed02112326973f7e5ffe3b73"
+          "checksumValue": "2bf786941d080ba5d552ac28be9089c0abe1ae4d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rustls.h-92",
-      "fileName": "repos/curl/lib/vtls/rustls.h",
+      "SPDXID": "SPDXRef-File-ratelimit.c-78",
+      "fileName": "repos/curl/lib/ratelimit.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2d3b0bb11f1daff419f2b8a37ce0673717b0ec1a"
+          "checksumValue": "2d88cdd7c94428a1cddbb7cd8554d7123e33fabe"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base64.h-93",
-      "fileName": "repos/curl/lib/vauth/../curlx/base64.h",
+      "SPDXID": "SPDXRef-File-idn.c-79",
+      "fileName": "repos/curl/lib/idn.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2db4f6d79e2edfec2afdb5019c0d925017f077ab"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-inet-ntop.h-80",
+      "fileName": "repos/curl/lib/curlx/inet_ntop.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2e3419f02be577ee15228e20f63052c5d81a5b46"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-base64.h-81",
+      "fileName": "repos/curl/lib/curlx/base64.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1020,67 +887,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-escape.h-94",
-      "fileName": "repos/curl/lib/vtls/../escape.h",
+      "SPDXID": "SPDXRef-File-cf-socket.c-82",
+      "fileName": "repos/curl/lib/cf-socket.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2ea06c444fd32f164769906430cef2da8829a137"
+          "checksumValue": "2ebbe4df4da503e272cac2a73db28652867793b4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ntlm-core.c-95",
-      "fileName": "repos/curl/lib/curl_ntlm_core.c",
+      "SPDXID": "SPDXRef-File-cshutdn.c-83",
+      "fileName": "repos/curl/lib/cshutdn.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2edc7b07ce5a1e3f48b304a6cea451867abe8d2f"
+          "checksumValue": "308f2aaa82dfb5f3f389ada7aa8a6320056e7a7a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-system-win32.c-96",
-      "fileName": "repos/curl/lib/system_win32.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2f24fe5c0ccec9c72477a785086e073a8cfd9e51"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-setopt.c-97",
-      "fileName": "repos/curl/src/tool_setopt.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2ffcd1076b978b354dfd80d972f70973d9746daa"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-var.c-98",
-      "fileName": "repos/curl/src/var.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "306ed1b02bcbec022ec8f11da63ca3898a908932"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-vauth.h-99",
-      "fileName": "repos/curl/lib/vauth/vauth.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "312bd8da5ad474c66012fc26fe9d36bcea8ec894"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cf-h2-proxy.h-100",
+      "SPDXID": "SPDXRef-File-cf-h2-proxy.h-84",
       "fileName": "repos/curl/lib/cf-h2-proxy.h",
       "checksums": [
         {
@@ -1090,7 +917,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-writeout-json.c-101",
+      "SPDXID": "SPDXRef-File-tool-writeout-json.c-85",
       "fileName": "repos/curl/src/tool_writeout_json.c",
       "checksums": [
         {
@@ -1100,27 +927,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-arpa-telnet.h-102",
-      "fileName": "repos/curl/lib/arpa_telnet.h",
+      "SPDXID": "SPDXRef-File-slist-wc.h-86",
+      "fileName": "repos/curl/src/slist_wc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "329f4bcd1c5414f5c28b7767725e1cbd3e98aaae"
+          "checksumValue": "328d6b00f5ba7e1be00a0c48fe62d50087098e40"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transfer.c-103",
-      "fileName": "repos/curl/lib/transfer.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "32c31c6e9378298bd25affb9b90244128710ceed"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-macos.c-104",
+      "SPDXID": "SPDXRef-File-macos.c-87",
       "fileName": "repos/curl/lib/macos.c",
       "checksums": [
         {
@@ -1130,18 +947,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic-tls.c-105",
-      "fileName": "repos/curl/lib/vquic/vquic-tls.c",
+      "SPDXID": "SPDXRef-File-curl-share.c-88",
+      "fileName": "repos/curl/lib/curl_share.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3391d98074088f646498adafd8d3ee74b6fcb76c"
+          "checksumValue": "338727a4fab265303d41853ee4b169cb4e567666"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pingpong.h-106",
-      "fileName": "repos/curl/lib/vauth/../pingpong.h",
+      "SPDXID": "SPDXRef-File-pingpong.h-89",
+      "fileName": "repos/curl/lib/pingpong.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1150,7 +967,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fileinfo.c-107",
+      "SPDXID": "SPDXRef-File-formdata.h-90",
+      "fileName": "repos/curl/lib/formdata.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "33d7d0ae33d540bfb7f734f6c367fd3c4cf1245d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fileinfo.c-91",
       "fileName": "repos/curl/lib/fileinfo.c",
       "checksums": [
         {
@@ -1160,17 +987,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcase.h-108",
-      "fileName": "repos/curl/lib/vtls/../strcase.h",
+      "SPDXID": "SPDXRef-File-winapi.c-92",
+      "fileName": "repos/curl/lib/curlx/winapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "35f726c3eecef87a51ef1a576514266feed7253f"
+          "checksumValue": "3417df269e056282d37ab70a4432bca5fdc1c951"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-hdr.h-109",
+      "SPDXID": "SPDXRef-File-altsvc.c-93",
+      "fileName": "repos/curl/lib/altsvc.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "34da3e1ac86d083a31afb81d71ea3da74e8b5297"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-hugehelp.c-94",
+      "fileName": "repos/curl/src/tool_hugehelp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "374cf39809682272c1c8034d1d803c7783186357"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-formdata.c-95",
+      "fileName": "repos/curl/lib/formdata.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3770d28b18ec9f8bfc0cfea4b7be2a79239437a2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-hdr.h-96",
       "fileName": "repos/curl/src/tool_cb_hdr.h",
       "checksums": [
         {
@@ -1180,37 +1037,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mbedtls.h-110",
-      "fileName": "repos/curl/lib/vtls/mbedtls.h",
+      "SPDXID": "SPDXRef-File-mime.c-97",
+      "fileName": "repos/curl/lib/mime.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3876fe36fc5d82a56c1022c67aac4446f6cc036c"
+          "checksumValue": "37ea514e4f8715557562aea4bd1cc3e4342e195e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-request.h-111",
-      "fileName": "repos/curl/lib/vauth/../request.h",
+      "SPDXID": "SPDXRef-File-uint-table.h-98",
+      "fileName": "repos/curl/lib/uint-table.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "389ae4d8b1f8d7d6db078637f29304f6e5cf36a7"
+          "checksumValue": "398a26a64843389caffdbe0359d2e35e91e7065c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http.c-112",
-      "fileName": "repos/curl/lib/http.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "39f0a0d194056356c3f6339497e141bdba3ebca4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-smtp.h-113",
+      "SPDXID": "SPDXRef-File-smtp.h-99",
       "fileName": "repos/curl/lib/smtp.h",
       "checksums": [
         {
@@ -1220,7 +1067,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config2setopts.h-114",
+      "SPDXID": "SPDXRef-File-libssh.c-100",
+      "fileName": "repos/curl/lib/vssh/libssh.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3a2a52e1f84fb57a17a2081375efbff799ea8b13"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-printf.h-101",
+      "fileName": "repos/curl/lib/curl_printf.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3b1a5af3b4593f544383faee11c07d8618a9d8ea"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strdup.c-102",
+      "fileName": "repos/curl/lib/curlx/strdup.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3c967dbe0a5d144dc4c77ad8e9ffac848d3c6d22"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-config2setopts.h-103",
       "fileName": "repos/curl/src/config2setopts.h",
       "checksums": [
         {
@@ -1230,37 +1107,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ipfs.c-115",
-      "fileName": "repos/curl/src/tool_ipfs.c",
+      "SPDXID": "SPDXRef-File-warnless.h-104",
+      "fileName": "repos/curl/lib/curlx/warnless.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3d2d5dea8424432dfe85fb138e171135c563643c"
+          "checksumValue": "3d0341e418a51614a644704a617f934681d0518e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-socket.c-116",
-      "fileName": "repos/curl/lib/cf-socket.c",
+      "SPDXID": "SPDXRef-File-vauth.h-105",
+      "fileName": "repos/curl/lib/vauth/vauth.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3e47a98722fc435f72915441868f473955a8c64c"
+          "checksumValue": "3e66c89cb5199edc6d792df91c9df50ccf6434a9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mbedtls.c-117",
-      "fileName": "repos/curl/lib/vtls/mbedtls.c",
+      "SPDXID": "SPDXRef-File-doh.h-106",
+      "fileName": "repos/curl/lib/doh.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3f5654ea0be7078ddafb2ec50407b663b7eb539d"
+          "checksumValue": "3eba4df26e29f5fe3b6065b2a4a8392f0c618cc0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-dirhie.c-118",
+      "SPDXID": "SPDXRef-File-tool-dirhie.c-107",
       "fileName": "repos/curl/src/tool_dirhie.c",
       "checksums": [
         {
@@ -1270,7 +1147,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cfgable.c-119",
+      "SPDXID": "SPDXRef-File-tool-cfgable.c-108",
       "fileName": "repos/curl/src/tool_cfgable.c",
       "checksums": [
         {
@@ -1280,37 +1157,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-table.h-120",
-      "fileName": "repos/curl/lib/vauth/../uint-table.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3fc7e34ef436e9c53ce465f736b8cdd550cace9f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-share.h-121",
-      "fileName": "repos/curl/lib/vtls/../curl_share.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3fcaaecd4ad64586c5db922a04a1c4ceb7f92783"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-share.c-122",
-      "fileName": "repos/curl/lib/curl_share.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3ff27556845f3f8ae0b1e31de45b7007310437f0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-writeout.h-123",
+      "SPDXID": "SPDXRef-File-tool-writeout.h-109",
       "fileName": "repos/curl/src/tool_writeout.h",
       "checksums": [
         {
@@ -1320,7 +1167,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-websockets.h-124",
+      "SPDXID": "SPDXRef-File-websockets.h-110",
       "fileName": "repos/curl/lib/../include/curl/websockets.h",
       "checksums": [
         {
@@ -1330,27 +1177,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-imap.c-125",
-      "fileName": "repos/curl/lib/imap.c",
+      "SPDXID": "SPDXRef-File-schannel-verify.c-111",
+      "fileName": "repos/curl/lib/vtls/schannel_verify.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "414ee32466d374da767cfc38ac55da587d6770be"
+          "checksumValue": "414b2e915aaaf7086002f5217db5f2cfda0b2881"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-idn.h-126",
-      "fileName": "repos/curl/lib/idn.h",
+      "SPDXID": "SPDXRef-File-rand.c-112",
+      "fileName": "repos/curl/lib/rand.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "42613af5096c058f000c2a8809e88d0f6c6844a2"
+          "checksumValue": "4232e819e17bbf101bfd7cd7593b9c72f28465ee"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ssls.h-127",
+      "SPDXID": "SPDXRef-File-cf-h2-proxy.c-113",
+      "fileName": "repos/curl/lib/cf-h2-proxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4275e1ef5aef37f4d1a5d7ef716d38c41e413272"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-ssls.h-114",
       "fileName": "repos/curl/src/tool_ssls.h",
       "checksums": [
         {
@@ -1360,8 +1217,28 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerr.h-128",
-      "fileName": "repos/curl/lib/vtls/../curlx/strerr.h",
+      "SPDXID": "SPDXRef-File-timeval.c-115",
+      "fileName": "repos/curl/lib/curlx/timeval.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "435804c2996b90f81c25c073a55e00ec67b1a8a1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-addrinfo.c-116",
+      "fileName": "repos/curl/lib/curl_addrinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "43d398d119216ea4ea4e53e25873807dafe949f3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strerr.h-117",
+      "fileName": "repos/curl/lib/curlx/strerr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1370,68 +1247,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mqtt.c-129",
-      "fileName": "repos/curl/lib/mqtt.c",
+      "SPDXID": "SPDXRef-File-vtls-spack.h-118",
+      "fileName": "repos/curl/lib/../lib/vtls/vtls_spack.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "446918cc44886a99b297d41aa1437c8d8e9ac702"
+          "checksumValue": "4479384de978cac1836eb55288466211663e1d0e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-filetime.c-130",
-      "fileName": "repos/curl/src/tool_filetime.c",
+      "SPDXID": "SPDXRef-File-doh.c-119",
+      "fileName": "repos/curl/lib/doh.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "45598413cd487828115d35fa1dae7912994a9b52"
+          "checksumValue": "4488d422b12cd93b8824cc689ef7ab75be8f80f9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-memdebug.c-131",
-      "fileName": "repos/curl/lib/memdebug.c",
+      "SPDXID": "SPDXRef-File-asyn-base.c-120",
+      "fileName": "repos/curl/lib/asyn-base.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "457034ebdae2227ed453e777681031b6de84b77f"
+          "checksumValue": "44bf98c8e4f912a7f2903f8f320d7db8f1d8a668"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-ntop.h-132",
-      "fileName": "repos/curl/lib/curlx/inet_ntop.h",
+      "SPDXID": "SPDXRef-File-oauth2.c-121",
+      "fileName": "repos/curl/lib/vauth/oauth2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "45b63d97a5958b327e288e0baed020b5bf5a8387"
+          "checksumValue": "4541d1d551bb94f687eab71dff4658cade41d6ae"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http2.c-133",
-      "fileName": "repos/curl/lib/http2.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "45f82192b024a77bc48bcc6b0a0f4b78c2334f64"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-hmac.h-134",
-      "fileName": "repos/curl/lib/vauth/../curl_hmac.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4759ff6ec6626e91f728ade60137ba5e573ff9e4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist.h-135",
-      "fileName": "repos/curl/lib/vtls/../slist.h",
+      "SPDXID": "SPDXRef-File-slist.h-122",
+      "fileName": "repos/curl/lib/slist.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1440,7 +1297,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-stderr.h-136",
+      "SPDXID": "SPDXRef-File-tool-stderr.h-123",
       "fileName": "repos/curl/src/tool_stderr.h",
       "checksums": [
         {
@@ -1450,18 +1307,58 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timeval.h-137",
-      "fileName": "repos/curl/lib/vauth/../curlx/timeval.h",
+      "SPDXID": "SPDXRef-File-curl-ngtcp2.c-124",
+      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4aab17519d8bfe74a78f1dfd761fc4ed760b627a"
+          "checksumValue": "48905d3e201780d2dde1742d7db4a6b4140b3b76"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-spbset.h-138",
-      "fileName": "repos/curl/lib/vauth/../uint-spbset.h",
+      "SPDXID": "SPDXRef-File-vssh.h-125",
+      "fileName": "repos/curl/lib/vssh/vssh.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "492108fbd7663d1629f6fcefe9ac7b13f0eee1c0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-aws-sigv4.c-126",
+      "fileName": "repos/curl/lib/http_aws_sigv4.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "492be1ab58634f8f6ef5773a21c6d54753fa7a5e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-ntlm-core.c-127",
+      "fileName": "repos/curl/lib/curl_ntlm_core.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4a9433b2936771dadc46831804ba91815606ffea"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cfgable.h-128",
+      "fileName": "repos/curl/src/tool_cfgable.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4af31b802e7b0012a9fd82e341ad19a049708c4d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-uint-spbset.h-129",
+      "fileName": "repos/curl/lib/uint-spbset.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1470,17 +1367,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connect.c-139",
-      "fileName": "repos/curl/lib/connect.c",
+      "SPDXID": "SPDXRef-File-curl-trc.c-130",
+      "fileName": "repos/curl/lib/curl_trc.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4b363ebe31b04b79f6c4b780a8471c211a60918a"
+          "checksumValue": "4b8734a7e9d50ef4f44ff0b3ecb8ffa039735e54"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerror.h-140",
+      "SPDXID": "SPDXRef-File-strerror.h-131",
       "fileName": "repos/curl/lib/strerror.h",
       "checksums": [
         {
@@ -1490,7 +1387,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyoptions.c-141",
+      "SPDXID": "SPDXRef-File-easyoptions.c-132",
       "fileName": "repos/curl/lib/easyoptions.c",
       "checksums": [
         {
@@ -1500,37 +1397,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-urlglob.c-142",
-      "fileName": "repos/curl/src/tool_urlglob.c",
+      "SPDXID": "SPDXRef-File-asyn-ares.c-133",
+      "fileName": "repos/curl/lib/asyn-ares.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4c5973875b2ef5a5a828220bd2d9f1c19549449f"
+          "checksumValue": "4d063d9f26574d5a93a402e497053703c93fa828"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getparam.h-143",
-      "fileName": "repos/curl/src/tool_getparam.h",
+      "SPDXID": "SPDXRef-File-cookie.c-134",
+      "fileName": "repos/curl/lib/cookie.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4d345413931debbcd76798ac0eac7b15793ddf04"
+          "checksumValue": "4d53cc460cb82b2df44a86a829f454423b3c62b2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vssh.h-144",
-      "fileName": "repos/curl/lib/vssh/vssh.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4d5b7ad24e98046a6ef2ca2e88073cf5b678b188"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-ca-embed.c-145",
+      "SPDXID": "SPDXRef-File-tool-ca-embed.c-135",
       "fileName": "repos/curl/src/tool_ca_embed.c",
       "checksums": [
         {
@@ -1540,17 +1427,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config2setopts.c-146",
-      "fileName": "repos/curl/src/config2setopts.c",
+      "SPDXID": "SPDXRef-File-pingpong.c-136",
+      "fileName": "repos/curl/lib/pingpong.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4ea65f453c24faee45d9bba96233bfd95f13cec1"
+          "checksumValue": "4ede0a5985db595d164eaf8993b4efd5b23702c2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufref.c-147",
+      "SPDXID": "SPDXRef-File-curl-setup.h-137",
+      "fileName": "repos/curl/lib/curl_setup.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4f8d65af8b5d8c3c13720f28a4edf36bfe021bcd"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-openssl.c-138",
+      "fileName": "repos/curl/lib/vtls/openssl.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50bf1e04766e90ef5d7744a35fff0ed2f79093e5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-help.c-139",
+      "fileName": "repos/curl/src/tool_help.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50cca527057333b3dfcfd0e3f8bdea076f7a59df"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-bufref.c-140",
       "fileName": "repos/curl/lib/bufref.c",
       "checksums": [
         {
@@ -1560,27 +1477,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ftp.c-148",
-      "fileName": "repos/curl/lib/ftp.c",
+      "SPDXID": "SPDXRef-File-strparse.h-141",
+      "fileName": "repos/curl/lib/curlx/strparse.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5110ee1397e14ba4e61b127a584822719e11bf40"
+          "checksumValue": "514203dc92fad6a5f39c9428d243e06a37ff249b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel-verify.c-149",
-      "fileName": "repos/curl/lib/vtls/schannel_verify.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5129b8b04d33871489166eee0bf87b6186fb097f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socks.h-150",
+      "SPDXID": "SPDXRef-File-socks.h-142",
       "fileName": "repos/curl/lib/socks.h",
       "checksums": [
         {
@@ -1590,47 +1497,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-paramhlp.c-151",
-      "fileName": "repos/curl/src/tool_paramhlp.c",
+      "SPDXID": "SPDXRef-File-wait.c-143",
+      "fileName": "repos/curl/lib/curlx/wait.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "523b52629c93e5083ab4f940cf7b37961aba5b57"
+          "checksumValue": "52784269ef51fabb405b91e12a02682fc56a0e9f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multibyte.c-152",
-      "fileName": "repos/curl/lib/curlx/multibyte.c",
+      "SPDXID": "SPDXRef-File-vquic.h-144",
+      "fileName": "repos/curl/lib/vquic/vquic.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "529091ad92d6ae8ceb5fbc8a9b79c6becddb6ede"
+          "checksumValue": "528e18476d48d0b565c8fdc8bf95505a46396fc4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.h-153",
-      "fileName": "repos/curl/lib/../include/curl/multi.h",
+      "SPDXID": "SPDXRef-File-request.h-145",
+      "fileName": "repos/curl/lib/request.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "531c1a954a955b9f4c42f64a87be1ca9918f601c"
+          "checksumValue": "5332d48538d9e519ddfda5cc86edb4dc0e92c97d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doh.c-154",
-      "fileName": "repos/curl/lib/doh.c",
+      "SPDXID": "SPDXRef-File-tool-sdecls.h-146",
+      "fileName": "repos/curl/src/tool_sdecls.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5401256bf895aff995b26184bac2d436dcae2694"
+          "checksumValue": "5350b71a3714bc38f04f045180bfb82dd535d11c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-pause.h-155",
+      "SPDXID": "SPDXRef-File-strcase.h-147",
+      "fileName": "repos/curl/lib/strcase.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "54299812beaed5ac5d98f210c997982572824fa0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostip.c-148",
+      "fileName": "repos/curl/lib/hostip.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "542b655b113d14d1fbdd29985ab32ca1e92a03fd"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cw-pause.h-149",
       "fileName": "repos/curl/lib/cw-pause.h",
       "checksums": [
         {
@@ -1640,7 +1567,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-wrt.h-156",
+      "SPDXID": "SPDXRef-File-cw-out.c-150",
+      "fileName": "repos/curl/lib/cw-out.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "554c32e84ecdd31de8d70669ce9c5e389745c5db"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-wrt.h-151",
       "fileName": "repos/curl/src/tool_cb_wrt.h",
       "checksums": [
         {
@@ -1650,27 +1587,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-setup.h-157",
-      "fileName": "repos/curl/lib/vauth/../curl_setup.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "559f586b7859f561f1067a1d976ed2667c0a4665"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cipher-suite.c-158",
-      "fileName": "repos/curl/lib/vtls/cipher_suite.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "562a3477355d7764c16550460966d9563df18b8f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-hash.h-159",
+      "SPDXID": "SPDXRef-File-uint-hash.h-152",
       "fileName": "repos/curl/lib/uint-hash.h",
       "checksums": [
         {
@@ -1680,7 +1597,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amigaos.h-160",
+      "SPDXID": "SPDXRef-File-amigaos.h-153",
       "fileName": "repos/curl/lib/amigaos.h",
       "checksums": [
         {
@@ -1690,17 +1607,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-trc.h-161",
-      "fileName": "repos/curl/lib/vauth/../curl_trc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "58903844acf1c8f5063ed79980bfe7acfcd3013d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-spbset.c-162",
+      "SPDXID": "SPDXRef-File-uint-spbset.c-154",
       "fileName": "repos/curl/lib/uint-spbset.c",
       "checksums": [
         {
@@ -1710,7 +1617,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-memrchr.c-163",
+      "SPDXID": "SPDXRef-File-curl-memrchr.c-155",
       "fileName": "repos/curl/lib/curl_memrchr.c",
       "checksums": [
         {
@@ -1720,7 +1627,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-headers.c-164",
+      "SPDXID": "SPDXRef-File-headers.c-156",
       "fileName": "repos/curl/lib/headers.c",
       "checksums": [
         {
@@ -1730,7 +1637,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-easysrc.c-165",
+      "SPDXID": "SPDXRef-File-urldata.h-157",
+      "fileName": "repos/curl/lib/urldata.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5ae148054baf7c04c0b38a585af0baaa0be11cef"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-easysrc.c-158",
       "fileName": "repos/curl/src/tool_easysrc.c",
       "checksums": [
         {
@@ -1740,27 +1657,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy.h-166",
-      "fileName": "repos/curl/lib/../include/curl/easy.h",
+      "SPDXID": "SPDXRef-File-digest.h-159",
+      "fileName": "repos/curl/lib/../lib/vauth/digest.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5b3cdbd64e805870cf8a30193cb945ef99e446d8"
+          "checksumValue": "5b8f3ae7675f4d45d7b6b83ec953c5e97530297e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x509asn1.c-167",
-      "fileName": "repos/curl/lib/vtls/x509asn1.c",
+      "SPDXID": "SPDXRef-File-telnet.c-160",
+      "fileName": "repos/curl/lib/telnet.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5c3a727e63c47edcf846dc58b6649937887935e3"
+          "checksumValue": "5bae99e1fcca877fd0919424f6f9ea5359d99441"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlver.h-168",
+      "SPDXID": "SPDXRef-File-curlver.h-161",
       "fileName": "repos/curl/lib/../include/curl/curlver.h",
       "checksums": [
         {
@@ -1770,8 +1687,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufref.h-169",
-      "fileName": "repos/curl/lib/vauth/../bufref.h",
+      "SPDXID": "SPDXRef-File-bufref.h-162",
+      "fileName": "repos/curl/lib/bufref.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1780,17 +1697,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-quiche.c-170",
-      "fileName": "repos/curl/lib/vquic/curl_quiche.c",
+      "SPDXID": "SPDXRef-File-ftplistparser.h-163",
+      "fileName": "repos/curl/lib/ftplistparser.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5d981cb2e6bf35f7a7257e698f90fca6de26c30c"
+          "checksumValue": "5d7aa492ba4eda791a2bc74a342ba088f0a28d59"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-version.h-171",
+      "SPDXID": "SPDXRef-File-tool-version.h-164",
       "fileName": "repos/curl/src/tool_version.h",
       "checksums": [
         {
@@ -1800,37 +1717,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-splay.c-172",
-      "fileName": "repos/curl/lib/splay.c",
+      "SPDXID": "SPDXRef-File-curl-share.h-165",
+      "fileName": "repos/curl/lib/curl_share.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5e4cd54d27babe055c6bfed9b11af06f016d128e"
+          "checksumValue": "5e3f82aa56b2b2835daf1de4e65de75be47b6821"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http2.h-173",
-      "fileName": "repos/curl/lib/http2.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5e545b234900946021d14c443a6259326af621f6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-mime.h-174",
-      "fileName": "repos/curl/lib/vauth/../mime.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5ef05506a4be35e593b92d8070bdbd40fca85f47"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-bset.c-175",
+      "SPDXID": "SPDXRef-File-uint-bset.c-166",
       "fileName": "repos/curl/lib/uint-bset.c",
       "checksums": [
         {
@@ -1840,7 +1737,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-digest.h-176",
+      "SPDXID": "SPDXRef-File-http-digest.h-167",
       "fileName": "repos/curl/lib/http_digest.h",
       "checksums": [
         {
@@ -1850,7 +1747,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-util.c-177",
+      "SPDXID": "SPDXRef-File-warnless.c-168",
+      "fileName": "repos/curl/lib/curlx/warnless.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5fc36ac9a8762103e3688a6dd5e31236ff7b176c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-ws.c-169",
+      "fileName": "repos/curl/lib/ws.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60465611bb74ce21cb20f715e418d4de253f5f11"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-ftp.c-170",
+      "fileName": "repos/curl/lib/ftp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6047759e7850a78de48e9e983ea4a3a38fb68222"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-smtp.c-171",
+      "fileName": "repos/curl/lib/smtp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60889858d3e2756869d1e903581ad352ecd4382c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http1.c-172",
+      "fileName": "repos/curl/lib/http1.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60ad32ce89b95832a753d01baa75303aac013b7b"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-util.c-173",
       "fileName": "repos/curl/src/tool_util.c",
       "checksums": [
         {
@@ -1860,17 +1807,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operate.c-178",
-      "fileName": "repos/curl/src/tool_operate.c",
+      "SPDXID": "SPDXRef-File-multi.c-174",
+      "fileName": "repos/curl/lib/multi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "618508aca49f4e6f662ed558a1657821613096ac"
+          "checksumValue": "6133736525778b122b1b3e615388b5c622296d9e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fnmatch.h-179",
+      "SPDXID": "SPDXRef-File-curl-fnmatch.h-175",
       "fileName": "repos/curl/lib/curl_fnmatch.h",
       "checksums": [
         {
@@ -1880,7 +1827,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-libinfo.c-180",
+      "SPDXID": "SPDXRef-File-tool-libinfo.c-176",
       "fileName": "repos/curl/src/tool_libinfo.c",
       "checksums": [
         {
@@ -1890,7 +1837,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-findfile.h-181",
+      "SPDXID": "SPDXRef-File-tool-findfile.h-177",
       "fileName": "repos/curl/src/tool_findfile.h",
       "checksums": [
         {
@@ -1900,17 +1847,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-addrinfo.h-182",
-      "fileName": "repos/curl/lib/vauth/../curl_addrinfo.h",
+      "SPDXID": "SPDXRef-File-libssh2.c-178",
+      "fileName": "repos/curl/lib/vssh/libssh2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "63d3f7a2442c75c48ab232cabb28f92ecf475bd6"
+          "checksumValue": "63f5735b835b38017b0544993e1ca2253d3fdefc"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-progress.c-183",
+      "SPDXID": "SPDXRef-File-tool-progress.c-179",
       "fileName": "repos/curl/src/tool_progress.c",
       "checksums": [
         {
@@ -1920,27 +1867,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-altsvc.c-184",
-      "fileName": "repos/curl/lib/altsvc.c",
+      "SPDXID": "SPDXRef-File-curl-sha512-256.c-180",
+      "fileName": "repos/curl/lib/curl_sha512_256.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "64bfec420bd518583f9c696df156affc2ffb5c93"
+          "checksumValue": "648e3e38e960be028a92a3b48a576f41bbc6a0ac"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ngtcp2.c-185",
-      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.c",
+      "SPDXID": "SPDXRef-File-schannel.c-181",
+      "fileName": "repos/curl/lib/vtls/schannel.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "65c78e68485b63468465175893f00cc8eff04c1b"
+          "checksumValue": "650a0e38ca8bf04eee4aba3b40d089a1b7e1d530"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-xattr.h-186",
+      "SPDXID": "SPDXRef-File-cf-h1-proxy.h-182",
+      "fileName": "repos/curl/lib/cf-h1-proxy.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6544ec58d026839cdbe1117bea42e77ed0a10c3f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-request.c-183",
+      "fileName": "repos/curl/lib/request.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "66077530d72637f0bc4af84dcd96163ae6b9c269"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-vtls-int.h-184",
+      "fileName": "repos/curl/lib/../lib/vtls/vtls_int.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6700ee74cbe163fbf45d378e898cabe0b1e6a6b4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-xattr.h-185",
       "fileName": "repos/curl/src/tool_xattr.h",
       "checksums": [
         {
@@ -1950,8 +1927,18 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-File-vtls-scache.c-186",
+      "fileName": "repos/curl/lib/vtls/vtls_scache.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "673abcfe0dbf7c1699fdc7e7b050e508e460165f"
+        }
+      ]
+    },
+    {
       "SPDXID": "SPDXRef-File-mqtt.h-187",
-      "fileName": "repos/curl/lib/vauth/../mqtt.h",
+      "fileName": "repos/curl/lib/mqtt.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1960,52 +1947,52 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks.c-188",
-      "fileName": "repos/curl/lib/socks.c",
+      "SPDXID": "SPDXRef-File-asyn.h-188",
+      "fileName": "repos/curl/lib/asyn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "67e9c9b3c7cf132efbeb936148d8da2f3a1094ad"
+          "checksumValue": "68628f90c007f0a27b26c1f8d2ee4588d91c761b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version.c-189",
-      "fileName": "repos/curl/lib/version.c",
+      "SPDXID": "SPDXRef-File-tool-getpass.c-189",
+      "fileName": "repos/curl/src/tool_getpass.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6949278f47d31d540ba01f5471e4dbff0b8eab3b"
+          "checksumValue": "68a16cab3e611bab75a18399525db1e622bb2c85"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timediff.c-190",
-      "fileName": "repos/curl/lib/curlx/timediff.c",
+      "SPDXID": "SPDXRef-File-multi-ev.c-190",
+      "fileName": "repos/curl/lib/multi_ev.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "694c8d83520673b844cdeb2d67f3b125b74ecb9a"
+          "checksumValue": "696a012ebff74fbf31ece59b5f45d99175f7ab18"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-help.h-191",
+      "SPDXID": "SPDXRef-File-cf-h1-proxy.c-191",
+      "fileName": "repos/curl/lib/cf-h1-proxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "69e050b9d63ee3f61e70a07f6652daa5f373bd70"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-help.h-192",
       "fileName": "repos/curl/src/tool_help.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "6a2ecdb0622e90fa34dcd01a74aa3354e0bcc670"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-krb5-gssapi.c-192",
-      "fileName": "repos/curl/lib/vauth/krb5_gssapi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6a9f182864c034b0b8c9fd8e40fb87942c45b898"
         }
       ]
     },
@@ -2020,17 +2007,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-quiche.h-194",
-      "fileName": "repos/curl/lib/vquic/curl_quiche.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6c0fb9ee1ee695f4780d34a45c050575ff8501ce"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-negotiate.h-195",
+      "SPDXID": "SPDXRef-File-http-negotiate.h-194",
       "fileName": "repos/curl/lib/http_negotiate.h",
       "checksums": [
         {
@@ -2040,7 +2017,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-haproxy.h-196",
+      "SPDXID": "SPDXRef-File-tool-cb-prg.c-195",
+      "fileName": "repos/curl/src/tool_cb_prg.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c3a366fa632b9c967f8d47fc57bfcc8c1cec4bc"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostip.h-196",
+      "fileName": "repos/curl/lib/hostip.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c7f1291b261c01dde04ab5ae190ab83df38e404"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-progress.c-197",
+      "fileName": "repos/curl/lib/progress.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6cde5678be84f4e430035912d4341da6ec6633a3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fopen.c-198",
+      "fileName": "repos/curl/lib/curlx/fopen.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6d0ef7e683564b162fd4ab8c1c2e342a32b6c2a9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-haproxy.h-199",
       "fileName": "repos/curl/lib/cf-haproxy.h",
       "checksums": [
         {
@@ -2050,28 +2067,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ws.c-197",
-      "fileName": "repos/curl/lib/ws.c",
+      "SPDXID": "SPDXRef-File-transfer.c-200",
+      "fileName": "repos/curl/lib/transfer.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6ed417185e1d927ffaf85a51c0a5af3b413667fd"
+          "checksumValue": "6dd2f52fe572801b4f48d7f0b25c19057cdc6c12"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http.h-198",
-      "fileName": "repos/curl/lib/vauth/../http.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6ef391af60200b7b3b86df2e1655cacdfae88d93"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dynbuf.h-199",
-      "fileName": "repos/curl/lib/vauth/../curlx/dynbuf.h",
+      "SPDXID": "SPDXRef-File-dynbuf.h-201",
+      "fileName": "repos/curl/lib/curlx/dynbuf.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2080,37 +2087,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-config.h-200",
-      "fileName": "repos/curl/lib/vauth/../curl_config.h",
+      "SPDXID": "SPDXRef-File-nonblock.c-202",
+      "fileName": "repos/curl/lib/curlx/nonblock.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6f16a673ffc1baa4164b57425e4515fd3253185c"
+          "checksumValue": "6f6458f2b3427985ec0c3cb4ba4e8b93bb4f178d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-content-encoding.c-201",
-      "fileName": "repos/curl/lib/content_encoding.c",
+      "SPDXID": "SPDXRef-File-dynbuf.c-203",
+      "fileName": "repos/curl/lib/curlx/dynbuf.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6f58054bb29557117890f53a973c3ecae58c404b"
+          "checksumValue": "7045a1f2940b9047cb299bf41d547925a783c7f4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-vms.c-202",
-      "fileName": "repos/curl/src/tool_vms.c",
+      "SPDXID": "SPDXRef-File-multibyte.c-204",
+      "fileName": "repos/curl/lib/curlx/multibyte.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "71606f3d66c5e20a20d88523e2ad4129596f2686"
+          "checksumValue": "715d2b8dc20d7600e3769773a2b7ec90781919e4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noproxy.h-203",
+      "SPDXID": "SPDXRef-File-noproxy.h-205",
       "fileName": "repos/curl/lib/noproxy.h",
       "checksums": [
         {
@@ -2120,17 +2127,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urldata.h-204",
-      "fileName": "repos/curl/lib/vauth/../urldata.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "71e5d6f4a11a9e69119c56d48f108bc17fff5f01"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cf-ip-happy.h-205",
+      "SPDXID": "SPDXRef-File-cf-ip-happy.h-206",
       "fileName": "repos/curl/lib/cf-ip-happy.h",
       "checksums": [
         {
@@ -2140,7 +2137,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gopher.c-206",
+      "SPDXID": "SPDXRef-File-gopher.c-207",
       "fileName": "repos/curl/lib/gopher.c",
       "checksums": [
         {
@@ -2150,7 +2147,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-writeout-json.h-207",
+      "SPDXID": "SPDXRef-File-tool-writeout-json.h-208",
       "fileName": "repos/curl/src/tool_writeout_json.h",
       "checksums": [
         {
@@ -2160,27 +2157,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timeval.c-208",
-      "fileName": "repos/curl/lib/curlx/timeval.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "734b784c04f04b4b2258106dad2ba52a7551f951"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-wolfssl.h-209",
-      "fileName": "repos/curl/lib/vtls/wolfssl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "736da9a1a6a205ca918de6e47d61a9fdc5772d68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fileinfo.h-210",
+      "SPDXID": "SPDXRef-File-fileinfo.h-209",
       "fileName": "repos/curl/lib/fileinfo.h",
       "checksums": [
         {
@@ -2190,7 +2167,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynhds.c-211",
+      "SPDXID": "SPDXRef-File-dynhds.c-210",
       "fileName": "repos/curl/lib/dynhds.c",
       "checksums": [
         {
@@ -2200,12 +2177,22 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-bset.h-212",
-      "fileName": "repos/curl/lib/vauth/../uint-bset.h",
+      "SPDXID": "SPDXRef-File-uint-bset.h-211",
+      "fileName": "repos/curl/lib/uint-bset.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "7455c427df94f3a624cb820c92ff61a9044e06d5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-vms.c-212",
+      "fileName": "repos/curl/src/tool_vms.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "74eb210ab54658fed417d735f49933ff09e485f6"
         }
       ]
     },
@@ -2221,7 +2208,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-ratelimit.h-214",
-      "fileName": "repos/curl/lib/vauth/../ratelimit.h",
+      "fileName": "repos/curl/lib/ratelimit.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2240,7 +2227,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-rtmp.c-216",
+      "SPDXID": "SPDXRef-File-ws.h-216",
+      "fileName": "repos/curl/lib/ws.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "757eae0f0f69f898821ad80a622be2fdd4aa4b90"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-rtmp.c-217",
       "fileName": "repos/curl/lib/curl_rtmp.c",
       "checksums": [
         {
@@ -2250,17 +2247,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strdup.c-217",
-      "fileName": "repos/curl/lib/curlx/strdup.c",
+      "SPDXID": "SPDXRef-File-sendf.h-218",
+      "fileName": "repos/curl/lib/sendf.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "75e088fe4ce605e7ce7f0706265533caecae2ebc"
+          "checksumValue": "75c6e248ea473f8a94f819186cad0aaeb6efb020"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pop3.h-218",
+      "SPDXID": "SPDXRef-File-socketpair.c-219",
+      "fileName": "repos/curl/lib/socketpair.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "76b959dd4afc698252290be068b482940a041b5e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-pop3.h-220",
       "fileName": "repos/curl/lib/pop3.h",
       "checksums": [
         {
@@ -2270,7 +2277,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-haproxy.c-219",
+      "SPDXID": "SPDXRef-File-curl-config.h-221",
+      "fileName": "repos/curl/lib/curl_config.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "780ceae0a2f299041c7085c2d564f097e4eab5a3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-haproxy.c-222",
       "fileName": "repos/curl/lib/cf-haproxy.c",
       "checksums": [
         {
@@ -2280,38 +2297,38 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tftp.c-220",
-      "fileName": "repos/curl/lib/tftp.c",
+      "SPDXID": "SPDXRef-File-connect.c-223",
+      "fileName": "repos/curl/lib/connect.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "782cb1959a8e186e219b076b9a1455ad9176d066"
+          "checksumValue": "78c9370804824d6626e4540ad593ee4863b24a88"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ssh.h-221",
-      "fileName": "repos/curl/lib/vssh/ssh.h",
+      "SPDXID": "SPDXRef-File-cleartext.c-224",
+      "fileName": "repos/curl/lib/vauth/cleartext.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "78889bf60e6b96c85d6683afb4ed07aa75f2df07"
+          "checksumValue": "7976adec9c8fec28baaa8a9c42684677e7d20f28"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cshutdn.h-222",
-      "fileName": "repos/curl/lib/vauth/../cshutdn.h",
+      "SPDXID": "SPDXRef-File-curlx.h-225",
+      "fileName": "repos/curl/src/../lib/curlx/curlx.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "79c95cca5917d8d3a8d56707707aa34c955cd696"
+          "checksumValue": "79cffc8f6dbcd2df6ff7499164ae2b601103f41a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multihandle.h-223",
-      "fileName": "repos/curl/lib/vauth/../multihandle.h",
+      "SPDXID": "SPDXRef-File-multihandle.h-226",
+      "fileName": "repos/curl/lib/multihandle.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2320,27 +2337,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-krb5-sspi.c-224",
-      "fileName": "repos/curl/lib/vauth/krb5_sspi.c",
+      "SPDXID": "SPDXRef-File-sha256.c-227",
+      "fileName": "repos/curl/lib/sha256.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7aad4badfab4d9d3430ed6407489e46c6aa056fd"
+          "checksumValue": "7b063659be03511b73c247291d5f8f6bd49119d9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slist-wc.h-225",
-      "fileName": "repos/curl/src/slist_wc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7bf76257a49c9bfe351708f3325b9dc81292c81b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-ldap.h-226",
+      "SPDXID": "SPDXRef-File-curl-ldap.h-228",
       "fileName": "repos/curl/lib/curl_ldap.h",
       "checksums": [
         {
@@ -2350,27 +2357,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apple.c-227",
-      "fileName": "repos/curl/lib/vtls/apple.c",
+      "SPDXID": "SPDXRef-File-version.c-229",
+      "fileName": "repos/curl/lib/version.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7c2ea4989f89f3fb71c3c192480cb7570353c1a8"
+          "checksumValue": "7ccd875dc8e3dc039ecea4d7377b154e2bd04100"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-progress.c-228",
-      "fileName": "repos/curl/lib/progress.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7daa4b4b3efd690d97d055dbb0e268b573dd2e74"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cw-out.h-229",
+      "SPDXID": "SPDXRef-File-cw-out.h-230",
       "fileName": "repos/curl/lib/cw-out.h",
       "checksums": [
         {
@@ -2380,47 +2377,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel.c-230",
-      "fileName": "repos/curl/lib/vtls/schannel.c",
+      "SPDXID": "SPDXRef-File-keylog.h-231",
+      "fileName": "repos/curl/lib/../lib/vtls/keylog.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7eba7843684c2375fefa90bbe583542d2073fc8d"
+          "checksumValue": "7e741b964d596dea3606dd4aec0978752d7f836b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mime.c-231",
-      "fileName": "repos/curl/lib/mime.c",
+      "SPDXID": "SPDXRef-File-tool-operate.h-232",
+      "fileName": "repos/curl/src/tool_operate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7f350ae7e0475d2f196cea6d54f01d08586fa8cc"
+          "checksumValue": "7e886f6ef043017edf50686626c1c0adcde55f6c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socketpair.c-232",
-      "fileName": "repos/curl/lib/socketpair.c",
+      "SPDXID": "SPDXRef-File-parsedate.c-233",
+      "fileName": "repos/curl/lib/parsedate.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7fd7e30bbab8271c2ff28ebd5d217375371c0d0d"
+          "checksumValue": "7efedec7d2452959e80c23647608d48859015d3d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-ares.c-233",
-      "fileName": "repos/curl/lib/asyn-ares.c",
+      "SPDXID": "SPDXRef-File-var.c-234",
+      "fileName": "repos/curl/src/var.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "80126ce056d5aafd41d5e154bf2a133690155578"
+          "checksumValue": "7fb51d656e38279bc603aa06a776af6a64444a23"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-doswin.h-234",
+      "SPDXID": "SPDXRef-File-inet-ntop.c-235",
+      "fileName": "repos/curl/lib/curlx/inet_ntop.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "803b9887ac91c638e0f34a614a97aab8e42b5793"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hash.c-236",
+      "fileName": "repos/curl/lib/hash.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8095ca2e450748cde390aaa07cebb4f2da1f0e5c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-doswin.h-237",
       "fileName": "repos/curl/src/tool_doswin.h",
       "checksums": [
         {
@@ -2430,7 +2447,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options.h-235",
+      "SPDXID": "SPDXRef-File-options.h-238",
       "fileName": "repos/curl/lib/../include/curl/options.h",
       "checksums": [
         {
@@ -2440,27 +2457,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-openldap.c-236",
-      "fileName": "repos/curl/lib/openldap.c",
+      "SPDXID": "SPDXRef-File-setopt.c-239",
+      "fileName": "repos/curl/lib/setopt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "83ae013593d8ab56826d5ad7e1d933dcddcacc3b"
+          "checksumValue": "84f3e02b7b1584191d15844bad6470eaa16fc8ad"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sasl.h-237",
-      "fileName": "repos/curl/lib/curl_sasl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8432d261ecc8386f1af3f18993984ff070a6251f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-dirhie.h-238",
+      "SPDXID": "SPDXRef-File-tool-dirhie.h-240",
       "fileName": "repos/curl/src/tool_dirhie.h",
       "checksums": [
         {
@@ -2470,17 +2477,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cshutdn.c-239",
-      "fileName": "repos/curl/lib/cshutdn.c",
+      "SPDXID": "SPDXRef-File-headers.h-241",
+      "fileName": "repos/curl/lib/headers.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "85863ef93051dd62fd01a46cc251a1f829d4bc49"
+          "checksumValue": "85905e5141dc96e820eb886135e6caee4c39121c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-get-line.c-240",
+      "SPDXID": "SPDXRef-File-curl-get-line.c-242",
       "fileName": "repos/curl/lib/curl_get_line.c",
       "checksums": [
         {
@@ -2490,17 +2497,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-altsvc.h-241",
-      "fileName": "repos/curl/lib/altsvc.h",
+      "SPDXID": "SPDXRef-File-header.h-243",
+      "fileName": "repos/curl/lib/../include/curl/header.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "85da8cceb91ce31062a51388be33bb31cb595ea6"
+          "checksumValue": "85c10c8d7833211bab237dac62a21fdc7f91cff9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-parsecfg.h-242",
+      "SPDXID": "SPDXRef-File-tool-parsecfg.h-244",
       "fileName": "repos/curl/src/tool_parsecfg.h",
       "checksums": [
         {
@@ -2510,7 +2517,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-listhelp.c-243",
+      "SPDXID": "SPDXRef-File-tool-listhelp.c-245",
       "fileName": "repos/curl/src/tool_listhelp.c",
       "checksums": [
         {
@@ -2520,7 +2527,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-endian.c-244",
+      "SPDXID": "SPDXRef-File-curl-endian.c-246",
       "fileName": "repos/curl/lib/curl_endian.c",
       "checksums": [
         {
@@ -2530,62 +2537,42 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-spack.h-245",
-      "fileName": "repos/curl/lib/vtls/vtls_spack.h",
+      "SPDXID": "SPDXRef-File-rand.h-247",
+      "fileName": "repos/curl/lib/rand.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86796ee62ed6ca3f2ecb1ea7cb7ec2b71ce4cda1"
+          "checksumValue": "86765806f90894e0069733a2688e6122bf448064"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conncache.c-246",
-      "fileName": "repos/curl/lib/conncache.c",
+      "SPDXID": "SPDXRef-File-multibyte.h-248",
+      "fileName": "repos/curl/lib/../lib/curlx/multibyte.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "869af4215e457f74df665dbd044884758634ec36"
+          "checksumValue": "8863fb024990faa22fcdaca761cbefa3edbb051e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getparam.c-247",
-      "fileName": "repos/curl/src/tool_getparam.c",
+      "SPDXID": "SPDXRef-File-functypes.h-249",
+      "fileName": "repos/curl/lib/functypes.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86ebed13e8a4e9a1ee673edfe126f998e710b8bd"
+          "checksumValue": "887c2612ef94d83ce89e7fa8a019c3f78d804cbb"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest-sspi.c-248",
-      "fileName": "repos/curl/lib/vauth/digest_sspi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "893838d2cdd5cedd92a6df5de70a342eaf48b6e5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-hugehelp.h-249",
+      "SPDXID": "SPDXRef-File-tool-hugehelp.h-250",
       "fileName": "repos/curl/src/tool_hugehelp.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "89df96ce5fe9a12e0b21bf143c67eaa57ad21614"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-vms.h-250",
-      "fileName": "repos/curl/src/tool_vms.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "89ea31ee1583277ab18498d5fa8ea3f634106c05"
         }
       ]
     },
@@ -2600,12 +2587,12 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnless.h-252",
-      "fileName": "repos/curl/lib/vauth/../curlx/warnless.h",
+      "SPDXID": "SPDXRef-File-curl-sasl.h-252",
+      "fileName": "repos/curl/lib/curl_sasl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8a62ccf6a70b0416582f9b6e893270e7e5a6db7d"
+          "checksumValue": "8a97f52adcff1c1730743e90575565aebd024431"
         }
       ]
     },
@@ -2630,58 +2617,28 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.h-255",
-      "fileName": "repos/curl/lib/vauth/../hash.h",
+      "SPDXID": "SPDXRef-File-bufq.h-255",
+      "fileName": "repos/curl/lib/bufq.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8bf47ccf753dd8043f001ad47f545893cd424ef8"
+          "checksumValue": "8dd186f505535c53e1242b652f6008a9086e3edf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnless.c-256",
-      "fileName": "repos/curl/lib/curlx/warnless.c",
+      "SPDXID": "SPDXRef-File-tool-ipfs.c-256",
+      "fileName": "repos/curl/src/tool_ipfs.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8c1be2d589c8751c353b40254348b0ffd6d3155d"
+          "checksumValue": "8e762b8cf0326b1eaab2dd9506ccc592acde9d78"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls.c-257",
-      "fileName": "repos/curl/lib/vtls/vtls.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8c87dd3d9cd6fe1b4ed3d9a5337783622bd409df"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-fnmatch.c-258",
-      "fileName": "repos/curl/lib/curl_fnmatch.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8e35edeed6306f7484153a169f451c194c7af545"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-mprintf.c-259",
-      "fileName": "repos/curl/lib/mprintf.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8f81f033dcb0c7125beab6183168a1fab87a9f08"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-httpsrr.h-260",
-      "fileName": "repos/curl/lib/vtls/../httpsrr.h",
+      "SPDXID": "SPDXRef-File-httpsrr.h-257",
+      "fileName": "repos/curl/lib/httpsrr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2690,37 +2647,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest.h-261",
-      "fileName": "repos/curl/lib/vauth/digest.h",
+      "SPDXID": "SPDXRef-File-cshutdn.h-258",
+      "fileName": "repos/curl/lib/cshutdn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "902ffab153a8ccfb7c0b73ff6690f5a55db35042"
+          "checksumValue": "9030474032b49953229cb633aae68341978c5570"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-sdecls.h-262",
-      "fileName": "repos/curl/src/tool_sdecls.h",
+      "SPDXID": "SPDXRef-File-idn.h-259",
+      "fileName": "repos/curl/lib/idn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9058233a688e183df4edc2d69812d513ebdd4c5a"
+          "checksumValue": "90d8e811b1a6128e0bafec2b6006ca0cbcfe46be"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hmac.c-263",
-      "fileName": "repos/curl/lib/hmac.c",
+      "SPDXID": "SPDXRef-File-strerr.c-260",
+      "fileName": "repos/curl/lib/curlx/strerr.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9080588341da6efd0262f244873d5b993c9b273f"
+          "checksumValue": "91a329e91502c28ae79cb6d0498a0807a22c6505"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tftp.h-264",
+      "SPDXID": "SPDXRef-File-tftp.h-261",
       "fileName": "repos/curl/lib/tftp.h",
       "checksums": [
         {
@@ -2730,7 +2687,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mprintf.h-265",
+      "SPDXID": "SPDXRef-File-mprintf.h-262",
       "fileName": "repos/curl/lib/../include/curl/mprintf.h",
       "checksums": [
         {
@@ -2740,7 +2697,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-gethostname.h-266",
+      "SPDXID": "SPDXRef-File-curl-gethostname.h-263",
       "fileName": "repos/curl/lib/curl_gethostname.h",
       "checksums": [
         {
@@ -2750,7 +2707,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rtsp.h-267",
+      "SPDXID": "SPDXRef-File-rtsp.h-264",
       "fileName": "repos/curl/lib/rtsp.h",
       "checksums": [
         {
@@ -2760,47 +2717,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operate.h-268",
-      "fileName": "repos/curl/src/tool_operate.h",
+      "SPDXID": "SPDXRef-File-sendf.c-265",
+      "fileName": "repos/curl/lib/sendf.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "93c87e10e65936f2c08b8d4cf8043e50a65d6760"
+          "checksumValue": "92e77b482aeaf049d048dcec2013c44c98d95082"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.c-269",
-      "fileName": "repos/curl/lib/multi.c",
+      "SPDXID": "SPDXRef-File-gsasl.c-266",
+      "fileName": "repos/curl/lib/vauth/gsasl.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9420e3f940b116af32ab383c91043c9c359867c7"
+          "checksumValue": "958f4ffab746546fdb526ca82d6ade0589072d8d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock.c-270",
-      "fileName": "repos/curl/lib/curlx/nonblock.c",
+      "SPDXID": "SPDXRef-File-openldap.c-267",
+      "fileName": "repos/curl/lib/openldap.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "96bf3db64ec8c9f1163e45e0ffba018e99402479"
+          "checksumValue": "95f7681caa8bcd4dbb3e27178e8af9245018dfed"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostcheck.c-271",
-      "fileName": "repos/curl/lib/vtls/hostcheck.c",
+      "SPDXID": "SPDXRef-File-digest.c-268",
+      "fileName": "repos/curl/lib/vauth/digest.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9706336735c210b8d453efe1ff2f837a2285eaa6"
+          "checksumValue": "96093903871fc1215753d6bde0db7ae590b07798"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-range.h-272",
+      "SPDXID": "SPDXRef-File-socks-gssapi.c-269",
+      "fileName": "repos/curl/lib/socks_gssapi.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "962fcd05b2a6db214d86a469cf05460e7850ddab"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-paramhlp.c-270",
+      "fileName": "repos/curl/src/tool_paramhlp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "970d42192adac3e9363d56a4cc980c4485984acb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-range.h-271",
       "fileName": "repos/curl/lib/curl_range.h",
       "checksums": [
         {
@@ -2810,8 +2787,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-psl.h-273",
-      "fileName": "repos/curl/lib/vauth/../psl.h",
+      "SPDXID": "SPDXRef-File-psl.h-272",
+      "fileName": "repos/curl/lib/psl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2820,87 +2797,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strequal.c-274",
-      "fileName": "repos/curl/lib/strequal.c",
+      "SPDXID": "SPDXRef-File-tool-setup.h-273",
+      "fileName": "repos/curl/src/tool_setup.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "98cecdc244d4d3724cee85a0a3c856cf1415de11"
+          "checksumValue": "9860a0b96244562446673af2565ee7ed820b61c1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-netrc.h-275",
-      "fileName": "repos/curl/lib/vauth/../netrc.h",
+      "SPDXID": "SPDXRef-File-select.c-274",
+      "fileName": "repos/curl/lib/select.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "99ddc6253e08da0840eeadec71d9879d43b4acec"
+          "checksumValue": "9a11924976ac384288176a5bf58c06351e318692"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getpass.c-276",
-      "fileName": "repos/curl/src/tool_getpass.c",
+      "SPDXID": "SPDXRef-File-tool-operate.c-275",
+      "fileName": "repos/curl/src/tool_operate.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "99ded8f4c5b57b40fa83aa65eb0c786dc53700fe"
+          "checksumValue": "9a29b8e34c01055915e24e86abde466c7b062750"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedate.c-277",
-      "fileName": "repos/curl/lib/parsedate.c",
+      "SPDXID": "SPDXRef-File-wait.h-276",
+      "fileName": "repos/curl/lib/curlx/wait.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9a3060bd50be97332fd44af19bc34df264bd0fc3"
+          "checksumValue": "9b9c27386e92150fd85c701d3c4f8394316f6c9f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-chunks.c-278",
-      "fileName": "repos/curl/lib/http_chunks.c",
+      "SPDXID": "SPDXRef-File-curl-range.c-277",
+      "fileName": "repos/curl/lib/curl_range.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9b38a3780cae1ea9c372fb94de428570150d2b87"
+          "checksumValue": "9bbafa40cfc38e04c61d69c4814f1c23e6cfc25f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conncache.h-279",
-      "fileName": "repos/curl/lib/vauth/../conncache.h",
+      "SPDXID": "SPDXRef-File-tool-msgs.c-278",
+      "fileName": "repos/curl/src/tool_msgs.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9b392af05ccd2d6f794ca2db680bbd9bfc7475fb"
+          "checksumValue": "9bc8ca18f12f92c64fca976a1bb4112d01b178b3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cfgable.h-280",
-      "fileName": "repos/curl/src/tool_cfgable.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9bd1f59bc9863d1ce68436e7149c8300ae43ca9f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist.c-281",
-      "fileName": "repos/curl/lib/slist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9bfd08ae2ce138477d75f003fca9740537fdd4fc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-prg.h-282",
+      "SPDXID": "SPDXRef-File-tool-cb-prg.h-279",
       "fileName": "repos/curl/src/tool_cb_prg.h",
       "checksums": [
         {
@@ -2910,8 +2867,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-progress.h-283",
-      "fileName": "repos/curl/lib/vtls/../progress.h",
+      "SPDXID": "SPDXRef-File-progress.h-280",
+      "fileName": "repos/curl/lib/progress.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2920,27 +2877,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http1.c-284",
-      "fileName": "repos/curl/lib/http1.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9e584248bedd5532edd81a09267a4770304769c5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-splay.h-285",
-      "fileName": "repos/curl/lib/vauth/../splay.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9ed96f63e4eae5a81731506731b724eb25237c12"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strcase.c-286",
+      "SPDXID": "SPDXRef-File-strcase.c-281",
       "fileName": "repos/curl/lib/strcase.c",
       "checksums": [
         {
@@ -2950,47 +2887,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cfilters.h-287",
-      "fileName": "repos/curl/lib/vtls/../cfilters.h",
+      "SPDXID": "SPDXRef-File-escape.h-282",
+      "fileName": "repos/curl/lib/escape.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9faf01de755d092998b002b5732ef86104f66ba5"
+          "checksumValue": "9f9a89e4022bcdbfb7ebf816492b9f67ea318c28"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.c-288",
-      "fileName": "repos/curl/lib/rand.c",
+      "SPDXID": "SPDXRef-File-vauth.c-283",
+      "fileName": "repos/curl/lib/vauth/vauth.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a02338f206a56bb7be5d4939c2f4ede34a67b020"
+          "checksumValue": "a00078fce1939ececb86458c39e37e3cac80318e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-see.c-289",
-      "fileName": "repos/curl/src/tool_cb_see.c",
+      "SPDXID": "SPDXRef-File-gtls.c-284",
+      "fileName": "repos/curl/lib/vtls/gtls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a1983b94cc5b35179c6b44c36305e26077837d08"
+          "checksumValue": "a0a465c3607ca86322972c16166089cd429cea55"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pingpong.c-290",
-      "fileName": "repos/curl/lib/pingpong.c",
+      "SPDXID": "SPDXRef-File-http2.h-285",
+      "fileName": "repos/curl/lib/http2.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a2ca05ae4767e3649f3f1160688da8e71e2bea82"
+          "checksumValue": "a14c8485cc884baddaaecf3a9d22bef7c2091d1c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.h-291",
+      "SPDXID": "SPDXRef-File-tool-helpers.c-286",
+      "fileName": "repos/curl/src/tool_helpers.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a23c3a80e75b29cc4f9ff2bd08a107d211bb1048"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-file.h-287",
       "fileName": "repos/curl/lib/file.h",
       "checksums": [
         {
@@ -3000,67 +2947,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ev.c-292",
-      "fileName": "repos/curl/lib/multi_ev.c",
+      "SPDXID": "SPDXRef-File-strequal.c-288",
+      "fileName": "repos/curl/lib/strequal.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a399e3f4cbce975b58e07875cbc25ed9254ad327"
+          "checksumValue": "a352fda70b246728660d097bcd4f2e9ae81b13de"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-select.c-293",
-      "fileName": "repos/curl/lib/select.c",
+      "SPDXID": "SPDXRef-File-urlapi.c-289",
+      "fileName": "repos/curl/lib/urlapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a3d77145ce14e8a0f590aea3e0485a8a815951d9"
+          "checksumValue": "a4b82f31bd74f345e0959630fef59469022f66da"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-system.h-294",
-      "fileName": "repos/curl/lib/../include/curl/system.h",
+      "SPDXID": "SPDXRef-File-gtls.h-290",
+      "fileName": "repos/curl/lib/../lib/vtls/gtls.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a5b3e9eba79a055c4c300b1d5d516678e5fbe693"
+          "checksumValue": "a5e55cd4f9f8e7c6489c21af1cfb9e636421f1b9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libssh.c-295",
-      "fileName": "repos/curl/lib/vssh/libssh.c",
+      "SPDXID": "SPDXRef-File-apple.c-291",
+      "fileName": "repos/curl/lib/vtls/apple.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a5d58ec731ba1d7cbaaea991499d9bd54461b8b1"
+          "checksumValue": "a6a5ba01f026f95abab3315a1518e56b4cf80f13"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-win32.h-296",
-      "fileName": "repos/curl/lib/curlx/version_win32.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a5fb8ff3c23fa8a82c1f747f13d005d246dcf949"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-openssl.c-297",
-      "fileName": "repos/curl/lib/vtls/openssl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a632e80943f23feecf144c3580408e24d8622c77"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-negotiate.c-298",
+      "SPDXID": "SPDXRef-File-http-negotiate.c-292",
       "fileName": "repos/curl/lib/http_negotiate.c",
       "checksums": [
         {
@@ -3070,47 +2997,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedate.h-299",
-      "fileName": "repos/curl/lib/vssh/../parsedate.h",
+      "SPDXID": "SPDXRef-File-base64.c-293",
+      "fileName": "repos/curl/lib/curlx/base64.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a6ee43a5d487c425b744c3451cc2dbbf26e55466"
+          "checksumValue": "a7a6703099128d30c29c92c7c837ca546906a87a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-oauth2.c-300",
-      "fileName": "repos/curl/lib/vauth/oauth2.c",
+      "SPDXID": "SPDXRef-File-curl-trc.h-294",
+      "fileName": "repos/curl/lib/curl_trc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a7a061337fa9abd1783da7863346523b2a446e89"
+          "checksumValue": "a82c945e5f9b7e1f0fbfc113c3ea929a7fac1fe7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h1-proxy.c-301",
-      "fileName": "repos/curl/lib/cf-h1-proxy.c",
+      "SPDXID": "SPDXRef-File-conncache.c-295",
+      "fileName": "repos/curl/lib/conncache.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a85cd1d5a6fc0809a1b9f8ad149a72712fff1605"
+          "checksumValue": "a865959709b7c07d30e9a44066b60c68a80d7b5f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sigpipe.h-302",
-      "fileName": "repos/curl/lib/sigpipe.h",
+      "SPDXID": "SPDXRef-File-http-proxy.c-296",
+      "fileName": "repos/curl/lib/http_proxy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a906b27037498037864017c36d8e91e5e4b58900"
+          "checksumValue": "a9521c92dab64ccd604ddd440f0f8a08d4d83bc7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getenv.c-303",
+      "SPDXID": "SPDXRef-File-getenv.c-297",
       "fileName": "repos/curl/lib/getenv.c",
       "checksums": [
         {
@@ -3120,47 +3047,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynbuf.c-304",
-      "fileName": "repos/curl/lib/curlx/dynbuf.c",
+      "SPDXID": "SPDXRef-File-content-encoding.c-298",
+      "fileName": "repos/curl/lib/content_encoding.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a96b2a5974c59a19df2d39058784bdda019ff8bb"
+          "checksumValue": "aa35da840b23251fc37882dbce411b81cdd80f2f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-win32.c-305",
-      "fileName": "repos/curl/lib/curlx/version_win32.c",
+      "SPDXID": "SPDXRef-File-wolfssl.c-299",
+      "fileName": "repos/curl/lib/vtls/wolfssl.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a9a4ee38f9293d5f876b37fff4b74d20ec9e6174"
+          "checksumValue": "aa841a754a944cdaf678460f3618899777692e95"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-out.c-306",
-      "fileName": "repos/curl/lib/cw-out.c",
+      "SPDXID": "SPDXRef-File-tool-doswin.c-300",
+      "fileName": "repos/curl/src/tool_doswin.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ab38109ad900dbec31e3e7a58ec78ad078c662e3"
+          "checksumValue": "ad0386555dbd8c4778c82ef14ea5f8167f831420"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keylog.c-307",
-      "fileName": "repos/curl/lib/vtls/keylog.c",
+      "SPDXID": "SPDXRef-File-hostcheck.c-301",
+      "fileName": "repos/curl/lib/vtls/hostcheck.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ace9cab1ae2b7ffa706695986c9239bbb555f971"
+          "checksumValue": "ad09b8319413891c9065116c7bb8a2d871a8caa5"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-urlglob.h-308",
+      "SPDXID": "SPDXRef-File-tool-urlglob.h-302",
       "fileName": "repos/curl/src/tool_urlglob.h",
       "checksums": [
         {
@@ -3170,97 +3097,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-headers.h-309",
-      "fileName": "repos/curl/lib/headers.h",
+      "SPDXID": "SPDXRef-File-multi.h-303",
+      "fileName": "repos/curl/lib/../include/curl/multi.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "adb03af75b5e1fecf3713fcfb51dcd74fe4f98ff"
+          "checksumValue": "ad6f53f3e2c44a99e7b55f230a0ce9a2b60ab674"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-https-connect.c-310",
-      "fileName": "repos/curl/lib/cf-https-connect.c",
+      "SPDXID": "SPDXRef-File-tool-paramhlp.h-304",
+      "fileName": "repos/curl/src/tool_paramhlp.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ae6721bd41258205ed29170ff8f45d5927e512ad"
+          "checksumValue": "af40f10591b50e3120b6e22e1fd1daf20ccd6091"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strparse.h-311",
-      "fileName": "repos/curl/lib/vauth/../curlx/strparse.h",
+      "SPDXID": "SPDXRef-File-memdebug.c-305",
+      "fileName": "repos/curl/lib/memdebug.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ae8fd19d955e2b53d01b8b81458a849f7e467313"
+          "checksumValue": "af4fc9d6c107cdea99bbac619dc19efe82595f74"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-request.c-312",
-      "fileName": "repos/curl/lib/request.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aed9c7eb3b1608262ff4c4670df52bb919b1672b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-openssl.h-313",
-      "fileName": "repos/curl/lib/vtls/openssl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aeeb8dd805b0fd0e5ad8c0adf27cf127f88fe044"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ftplistparser.h-314",
-      "fileName": "repos/curl/lib/vauth/../ftplistparser.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "afb90dee4cada77f126f9a85461f8ffd814981a2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-escape.c-315",
-      "fileName": "repos/curl/lib/escape.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "afdf18c1b4d91ed7c4c800fc7269615190d6917a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-time.c-316",
-      "fileName": "repos/curl/src/toolx/tool_time.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "affcd7a16730ba0d553468c144f19f2874c6cc74"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-spnego-gssapi.c-317",
+      "SPDXID": "SPDXRef-File-spnego-gssapi.c-306",
       "fileName": "repos/curl/lib/vauth/spnego_gssapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b1ec37cb31686f30197fa9f647b4bd6dc9d54688"
+          "checksumValue": "af8498bad3b942a2ed7b25b63f19c2b2de6a0d14"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sasl.c-318",
+      "SPDXID": "SPDXRef-File-wolfssl.h-307",
+      "fileName": "repos/curl/lib/../lib/vtls/wolfssl.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b097b60b78b72ac6c77b48bce978048c674772d7"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sasl.c-308",
       "fileName": "repos/curl/lib/curl_sasl.c",
       "checksums": [
         {
@@ -3270,47 +3157,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy.c-319",
-      "fileName": "repos/curl/lib/easy.c",
+      "SPDXID": "SPDXRef-File-tool-vms.h-309",
+      "fileName": "repos/curl/src/tool_vms.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b30ce2ace41f926c9cb7cc1ec2fedb53850c770b"
+          "checksumValue": "b459a25ee8a1a8d5917ee2ae1fef3d3bf5070993"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-parsecfg.c-320",
-      "fileName": "repos/curl/src/tool_parsecfg.c",
+      "SPDXID": "SPDXRef-File-sigpipe.h-310",
+      "fileName": "repos/curl/lib/sigpipe.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b36d113232315488f02352660ad0412151f6320f"
+          "checksumValue": "b4897969538a5199c7ab8a5350950bde4b51ed57"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vssh.c-321",
-      "fileName": "repos/curl/lib/vssh/vssh.c",
+      "SPDXID": "SPDXRef-File-ntlm.c-311",
+      "fileName": "repos/curl/lib/vauth/ntlm.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b52b09b696e9beff92e6a27234a4ea59446fd3d5"
+          "checksumValue": "b50cfdd6812903dbe2ddc557138fa57f1fefccad"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-formdata.c-322",
-      "fileName": "repos/curl/lib/formdata.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b5bd1206f1068e46acb8677b8eb55772faa95047"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.h-323",
+      "SPDXID": "SPDXRef-File-dict.h-312",
       "fileName": "repos/curl/lib/dict.h",
       "checksums": [
         {
@@ -3320,17 +3197,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fopen.c-324",
-      "fileName": "repos/curl/lib/curlx/fopen.c",
+      "SPDXID": "SPDXRef-File-arpa-telnet.h-313",
+      "fileName": "repos/curl/lib/arpa_telnet.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b73d4f94a1123767332467e73908a5362a0df06c"
+          "checksumValue": "b5faab419c26d84c0eb713e0e3b666eb7f4d13fd"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fopen.c-325",
+      "SPDXID": "SPDXRef-File-x509asn1.c-314",
+      "fileName": "repos/curl/lib/vtls/x509asn1.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b687a60193d28268d90cc04d4da9b08d2e2fd196"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-rustls.h-315",
+      "fileName": "repos/curl/lib/../lib/vtls/rustls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b6ddbd1b7e012ec04b5c7de6d299c1c51caa3780"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-fopen.c-316",
       "fileName": "repos/curl/lib/curl_fopen.c",
       "checksums": [
         {
@@ -3340,17 +3237,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gsasl.c-326",
-      "fileName": "repos/curl/lib/vauth/gsasl.c",
+      "SPDXID": "SPDXRef-File-socks.c-317",
+      "fileName": "repos/curl/lib/socks.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b95d6e3f0a8e47f7fa5f29bb7b080b242b54ace5"
+          "checksumValue": "b7c3bd61463d76779a8bf53d8eee87762cdb7757"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-table.c-327",
+      "SPDXID": "SPDXRef-File-vtls.h-318",
+      "fileName": "repos/curl/lib/vtls/vtls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b9335bbf18598bb2af2ed387734e11381a2132ff"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-uint-table.c-319",
       "fileName": "repos/curl/lib/uint-table.c",
       "checksums": [
         {
@@ -3360,17 +3267,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-netrc.c-328",
-      "fileName": "repos/curl/lib/netrc.c",
+      "SPDXID": "SPDXRef-File-vtls-scache.h-320",
+      "fileName": "repos/curl/lib/vtls/vtls_scache.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "baabe917a75ab4a1c33f053fdcc90ae604d99f7f"
+          "checksumValue": "b9db0f19b36c4beab5a10080ed6a2526dcbc960f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-main.c-329",
+      "SPDXID": "SPDXRef-File-curl-hmac.h-321",
+      "fileName": "repos/curl/lib/curl_hmac.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b9f218fac930074434dd50816ddbf4a2f2c29e1d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-main.c-322",
       "fileName": "repos/curl/src/tool_main.c",
       "checksums": [
         {
@@ -3380,7 +3297,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-var.h-330",
+      "SPDXID": "SPDXRef-File-var.h-323",
       "fileName": "repos/curl/src/var.h",
       "checksums": [
         {
@@ -3390,17 +3307,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-trc.c-331",
-      "fileName": "repos/curl/lib/curl_trc.c",
+      "SPDXID": "SPDXRef-File-http.h-324",
+      "fileName": "repos/curl/lib/http.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bbec332f99d04b483abf3eac84d10c6c6d71916b"
+          "checksumValue": "bb535955d1f016a272982689f8a24ab4706c4c79"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gopher.h-332",
+      "SPDXID": "SPDXRef-File-tool-setopt.h-325",
+      "fileName": "repos/curl/src/tool_setopt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bb85ae7088bdbb123c2e615312cfe01fa76d6634"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sha256.h-326",
+      "fileName": "repos/curl/lib/curl_sha256.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bc1512e6e8c20dd91e53c29704564ac7fb802091"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-gopher.h-327",
       "fileName": "repos/curl/lib/gopher.h",
       "checksums": [
         {
@@ -3410,17 +3347,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufq.h-333",
-      "fileName": "repos/curl/lib/vauth/../bufq.h",
+      "SPDXID": "SPDXRef-File-tool-setopt.c-328",
+      "fileName": "repos/curl/src/tool_setopt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bcd7df2ab9ddd45a5f321254de43694f9caa642e"
+          "checksumValue": "bd24e4b411e3b522327b8fe0195a6b8f8e467e3a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fopen.h-334",
+      "SPDXID": "SPDXRef-File-curl-fopen.h-329",
       "fileName": "repos/curl/lib/curl_fopen.h",
       "checksums": [
         {
@@ -3430,67 +3367,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vauth.c-335",
-      "fileName": "repos/curl/lib/vauth/vauth.c",
+      "SPDXID": "SPDXRef-File-escape.c-330",
+      "fileName": "repos/curl/lib/escape.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bdf194b99562b3a8abda275fc77d1d9808992c52"
+          "checksumValue": "be44e971569e4da3fc94eecd419f91940c47e1bf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls.h-336",
-      "fileName": "repos/curl/lib/vtls/vtls.h",
+      "SPDXID": "SPDXRef-File-timeval.h-331",
+      "fileName": "repos/curl/lib/curlx/timeval.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bf19572fc62536679010b45a9efb08fdb31ac0f9"
+          "checksumValue": "c01f95d87df0d53dad4ac60cba387449eb5b4d39"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-addrinfo.c-337",
-      "fileName": "repos/curl/lib/fake_addrinfo.c",
+      "SPDXID": "SPDXRef-File-krb5-sspi.c-332",
+      "fileName": "repos/curl/lib/vauth/krb5_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bf5a44892c5d2be4ab1414c34b7922218a7d4aaa"
+          "checksumValue": "c08b6a4c3a5a2d6dac17e825adb23bc7aa2b1c0a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-hugehelp.c-338",
-      "fileName": "repos/curl/src/tool_hugehelp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c0323e2f4dbf1e990d8603fb770362d99079b49a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sha256.c-339",
-      "fileName": "repos/curl/lib/sha256.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c042c1bb0cb70a39877914e86bbd2ce7a5c447e4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-winapi.c-340",
-      "fileName": "repos/curl/lib/curlx/winapi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c0d6b7f861c4308c1fe3acf0edbb5968fb371dbf"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-gssapi.c-341",
+      "SPDXID": "SPDXRef-File-curl-gssapi.c-333",
       "fileName": "repos/curl/lib/curl_gssapi.c",
       "checksums": [
         {
@@ -3500,7 +3407,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-telnet.h-342",
+      "SPDXID": "SPDXRef-File-telnet.h-334",
       "fileName": "repos/curl/lib/telnet.h",
       "checksums": [
         {
@@ -3510,17 +3417,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wait.h-343",
-      "fileName": "repos/curl/lib/curlx/wait.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c140194a8c2dfae9fa8c9393027e1f9ea5dfbe04"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-proxy.h-344",
+      "SPDXID": "SPDXRef-File-http-proxy.h-335",
       "fileName": "repos/curl/lib/http_proxy.h",
       "checksums": [
         {
@@ -3530,17 +3427,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-int.h-345",
-      "fileName": "repos/curl/lib/vtls/vtls_int.h",
+      "SPDXID": "SPDXRef-File-http1.h-336",
+      "fileName": "repos/curl/lib/http1.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c2a44a3a33b1e79bbdd986fd8339b7390ef23394"
+          "checksumValue": "c2894613de7fe48116816174f0dce2aa0decfe47"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-ntlm.c-346",
+      "SPDXID": "SPDXRef-File-md5.c-337",
+      "fileName": "repos/curl/lib/md5.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c2bd176dc96f6a2d3c7681f51323c401767e5fb9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-asyn-thrdd.c-338",
+      "fileName": "repos/curl/lib/asyn-thrdd.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c3ed8eacaaf13be9fc72478a5da4ba9282df0af6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-setopt.h-339",
+      "fileName": "repos/curl/lib/setopt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c421f5c5e5bce7570f4ecefcf7168b9a8f0345d5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-version-win32.h-340",
+      "fileName": "repos/curl/lib/curlx/version_win32.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4a1c0f7586b7aca8c0e82abab2378af96c92706"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-url.h-341",
+      "fileName": "repos/curl/lib/url.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4cd762fb85948a9fb75cd73f6943f59e0915a0e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-ntlm.c-342",
       "fileName": "repos/curl/lib/http_ntlm.c",
       "checksums": [
         {
@@ -3550,17 +3497,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel.h-347",
-      "fileName": "repos/curl/lib/vtls/schannel.h",
+      "SPDXID": "SPDXRef-File-splay.h-343",
+      "fileName": "repos/curl/lib/splay.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c617233e0883e1bae73d9adb5a85e96c85a94c14"
+          "checksumValue": "c6623f2ef0c45d4b324bb8af5cd167f0511f1a00"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ipfs.h-348",
+      "SPDXID": "SPDXRef-File-mprintf.c-344",
+      "fileName": "repos/curl/lib/mprintf.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6a4a494292294c5223b856aad1d95ffb484dc0a"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-slist.c-345",
+      "fileName": "repos/curl/lib/slist.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6dcdc1af0ef4c7041473a7cfb7c36bb1bdf73f0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-snprintf.c-346",
+      "fileName": "repos/curl/lib/curlx/snprintf.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7332520e7a2ddc148cc608f6d0713e2affd4c40"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cfilters.h-347",
+      "fileName": "repos/curl/lib/cfilters.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7546344af42253bf95afcfc9b3f97137b9f58eb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-dbg.c-348",
+      "fileName": "repos/curl/src/tool_cb_dbg.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c9c14e6d131100686fa2ad100a04cc36387ddfb9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-ipfs.h-349",
       "fileName": "repos/curl/src/tool_ipfs.h",
       "checksums": [
         {
@@ -3570,17 +3567,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cookie.h-349",
-      "fileName": "repos/curl/lib/vauth/../cookie.h",
+      "SPDXID": "SPDXRef-File-cf-https-connect.c-350",
+      "fileName": "repos/curl/lib/cf-https-connect.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cbc7b748fc2bdd54a8ca181de38a588092d627b6"
+          "checksumValue": "cabc6ab14b91b06716a3aff500006926c888754d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-helpers.h-350",
+      "SPDXID": "SPDXRef-File-tool-helpers.h-351",
       "fileName": "repos/curl/src/tool_helpers.h",
       "checksums": [
         {
@@ -3590,22 +3587,12 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-xattr.c-351",
-      "fileName": "repos/curl/src/tool_xattr.c",
+      "SPDXID": "SPDXRef-File-tftp.c-352",
+      "fileName": "repos/curl/lib/tftp.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cdf8296307a514ddc2b02fa330fa20e9959f3890"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-formdata.h-352",
-      "fileName": "repos/curl/lib/vauth/../formdata.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ce592a8fd9d02510d89a62834f9a155c37046873"
+          "checksumValue": "cc0769bbb3b540403cabba673445e372d182dd3e"
         }
       ]
     },
@@ -3615,12 +3602,22 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cec410fe6073b96d1f3b6b9dad1290cfeb700055"
+          "checksumValue": "cc0e04388714b1bfdd546682c0c62c2cdf3e305a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy-lock.h-354",
+      "SPDXID": "SPDXRef-File-tool-xattr.c-354",
+      "fileName": "repos/curl/src/tool_xattr.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cdf8296307a514ddc2b02fa330fa20e9959f3890"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easy-lock.h-355",
       "fileName": "repos/curl/lib/easy_lock.h",
       "checksums": [
         {
@@ -3630,57 +3627,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostip.c-355",
-      "fileName": "repos/curl/lib/hostip.c",
+      "SPDXID": "SPDXRef-File-openssl.h-356",
+      "fileName": "repos/curl/lib/../lib/vtls/openssl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cfa7995dbac607c486a1a678abeb0dafd7858bfc"
+          "checksumValue": "cfffe9df1b6846b4dff5ed069d2ac98ca1274fdc"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-wrt.c-356",
-      "fileName": "repos/curl/src/tool_cb_wrt.c",
+      "SPDXID": "SPDXRef-File-easy.c-357",
+      "fileName": "repos/curl/lib/easy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cfeb06d5a47539c94fb2aa9ad85ed0a6da285cae"
+          "checksumValue": "d05674e81959f74c083fb3a88b404c571d262ac8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wolfssl.c-357",
-      "fileName": "repos/curl/lib/vtls/wolfssl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0311facb9ad9d21e18c1ba98fa79465cf328eb6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ntlm.c-358",
-      "fileName": "repos/curl/lib/vauth/ntlm.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0aae81b80e4e18879d6e8f0f1ccedcf5b60a801"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rtsp.c-359",
-      "fileName": "repos/curl/lib/rtsp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0e5cf43e39d5069d19c6221b0e7b21d3df3c2d5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-terminal.c-360",
+      "SPDXID": "SPDXRef-File-terminal.c-358",
       "fileName": "repos/curl/src/terminal.c",
       "checksums": [
         {
@@ -3690,17 +3657,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-telnet.c-361",
-      "fileName": "repos/curl/lib/telnet.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d1b1d8fc5ea795e8ded96c492535f6ae70cd8b8d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-formparse.h-362",
+      "SPDXID": "SPDXRef-File-tool-formparse.h-359",
       "fileName": "repos/curl/src/tool_formparse.h",
       "checksums": [
         {
@@ -3710,17 +3667,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fopen.h-363",
-      "fileName": "repos/curl/lib/vtls/../curlx/fopen.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d23dc82445ddbf6573da449f58917ac77f55ef6e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-filetime.h-364",
+      "SPDXID": "SPDXRef-File-tool-filetime.h-360",
       "fileName": "repos/curl/src/tool_filetime.h",
       "checksums": [
         {
@@ -3730,7 +3677,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amigaos.c-365",
+      "SPDXID": "SPDXRef-File-amigaos.c-361",
       "fileName": "repos/curl/lib/amigaos.c",
       "checksums": [
         {
@@ -3740,7 +3687,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-progress.h-366",
+      "SPDXID": "SPDXRef-File-basename.c-362",
+      "fileName": "repos/curl/lib/curlx/basename.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d2fd160ff224360b5ee05b3190ec97b3aeb9b69f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-progress.h-363",
       "fileName": "repos/curl/src/tool_progress.h",
       "checksums": [
         {
@@ -3750,7 +3707,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-winapi.h-367",
+      "SPDXID": "SPDXRef-File-winapi.h-364",
       "fileName": "repos/curl/lib/curlx/winapi.h",
       "checksums": [
         {
@@ -3760,8 +3717,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-smb.h-368",
-      "fileName": "repos/curl/lib/vauth/../smb.h",
+      "SPDXID": "SPDXRef-File-smb.h-365",
+      "fileName": "repos/curl/lib/smb.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3770,38 +3727,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ws.h-369",
-      "fileName": "repos/curl/lib/ws.h",
+      "SPDXID": "SPDXRef-File-inet-pton.c-366",
+      "fileName": "repos/curl/lib/curlx/inet_pton.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d4d6d46f3a51d788c3b51343508fa7ede68bebef"
+          "checksumValue": "d3c53fb5791610415e125f5495d255a9b86671a6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gtls.c-370",
-      "fileName": "repos/curl/lib/vtls/gtls.c",
+      "SPDXID": "SPDXRef-File-cram.c-367",
+      "fileName": "repos/curl/lib/vauth/cram.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d6093cfe3063138c5105273359da38c73f08f31e"
+          "checksumValue": "d3f2d137b779607e37d9cc3453f7cb0bb2ffa8d3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostcheck.h-371",
-      "fileName": "repos/curl/lib/vtls/hostcheck.h",
+      "SPDXID": "SPDXRef-File-vssh.c-368",
+      "fileName": "repos/curl/lib/vssh/vssh.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d62c721352af1874753e9671e2dc424a9bc99f8f"
+          "checksumValue": "d499a633af4bdff71738d7d1905639c2accdae99"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcopy.h-372",
-      "fileName": "repos/curl/lib/vtls/../curlx/strcopy.h",
+      "SPDXID": "SPDXRef-File-snprintf.h-369",
+      "fileName": "repos/curl/lib/curlx/snprintf.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d6260e4e3931cd4cb8b59bd9407537f1d11d5620"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strcopy.h-370",
+      "fileName": "repos/curl/lib/curlx/strcopy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3810,37 +3777,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi.c-373",
-      "fileName": "repos/curl/lib/urlapi.c",
+      "SPDXID": "SPDXRef-File-krb5-gssapi.c-371",
+      "fileName": "repos/curl/lib/vauth/krb5_gssapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d6a790b06e5b6ede34788e685d54f72cb096200a"
+          "checksumValue": "d6af18f40b5b67d685354937f144eac932a7d66a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcopy.c-374",
-      "fileName": "repos/curl/lib/curlx/strcopy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d6bff15330e9c8f81cb403f0d9ccbeeabb96d279"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-help.c-375",
-      "fileName": "repos/curl/src/tool_help.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d743fe395344a5d8094d9afb1401cf747491ef34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-dbg.h-376",
+      "SPDXID": "SPDXRef-File-tool-cb-dbg.h-372",
       "fileName": "repos/curl/src/tool_cb_dbg.h",
       "checksums": [
         {
@@ -3850,17 +3797,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-md4.c-377",
-      "fileName": "repos/curl/lib/md4.c",
+      "SPDXID": "SPDXRef-File-conncache.h-373",
+      "fileName": "repos/curl/lib/conncache.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d78f84282305ae7c46d2efa0083c2e16d6c13567"
+          "checksumValue": "d8626ae6928c49a828b18e660546491356083190"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyoptions.h-378",
+      "SPDXID": "SPDXRef-File-apple.h-374",
+      "fileName": "repos/curl/lib/../lib/vtls/apple.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d86a56b1f9320ec8e83818d402a0ed2a259c9ff2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easyoptions.h-375",
       "fileName": "repos/curl/lib/easyoptions.h",
       "checksums": [
         {
@@ -3870,8 +3827,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-chunks.h-379",
-      "fileName": "repos/curl/lib/vauth/../http_chunks.h",
+      "SPDXID": "SPDXRef-File-fopen.h-376",
+      "fileName": "repos/curl/lib/curlx/fopen.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d89830edd30eea66d9f5ca00d757c81d2a0f6aa6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-mbedtls.h-377",
+      "fileName": "repos/curl/lib/../lib/vtls/mbedtls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8a0a06eb6aac22289e2b91fcad3a7164b77f9ae"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fake-addrinfo.c-378",
+      "fileName": "repos/curl/lib/fake_addrinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8b139830b83af600dfee6cb4d9b519e898bb221"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostcheck.h-379",
+      "fileName": "repos/curl/lib/../lib/vtls/hostcheck.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8e1a52377129c86dedf7a2252f59b400631adfa"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-chunks.h-380",
+      "fileName": "repos/curl/lib/http_chunks.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3880,47 +3877,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h2-proxy.c-380",
-      "fileName": "repos/curl/lib/cf-h2-proxy.c",
+      "SPDXID": "SPDXRef-File-curl-quiche.c-381",
+      "fileName": "repos/curl/lib/vquic/curl_quiche.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d95716eaff9a5acdd1b25f40ad3d4511bbf7cffe"
+          "checksumValue": "d8e6b30f84bc2997e95705a1b22c66c79dc90ac7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerr.c-381",
-      "fileName": "repos/curl/lib/curlx/strerr.c",
+      "SPDXID": "SPDXRef-File-vtls-spack.c-382",
+      "fileName": "repos/curl/lib/vtls/vtls_spack.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d9c1686e443928c9eef4908414a6f1b554baac5f"
+          "checksumValue": "d96f4e41bd720d08ef2ffc476cb41c5e2324c736"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi.h-382",
-      "fileName": "repos/curl/lib/../include/curl/urlapi.h",
+      "SPDXID": "SPDXRef-File-typecheck-gcc.h-383",
+      "fileName": "repos/curl/lib/../include/curl/typecheck-gcc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "dabe44a47d0d3f73dda0ed97c09c21b0668b825f"
+          "checksumValue": "d9a672ea0b782448bc795a1bc5fdf2524f572442"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cfilters.c-383",
-      "fileName": "repos/curl/lib/cfilters.c",
+      "SPDXID": "SPDXRef-File-strcopy.c-384",
+      "fileName": "repos/curl/lib/curlx/strcopy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "db8efcf2fe867dea43f16d24d30fd3c2c9f1b649"
+          "checksumValue": "da137c3f92cf39033c1d3b053408ec375eb829d3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal.h-384",
+      "SPDXID": "SPDXRef-File-http-chunks.c-385",
+      "fileName": "repos/curl/lib/http_chunks.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "db650b1e1e645b6e0a68dd08e362af7ed5c95b62"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-terminal.h-386",
       "fileName": "repos/curl/src/terminal.h",
       "checksums": [
         {
@@ -3930,28 +3937,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic-int.h-385",
-      "fileName": "repos/curl/lib/vquic/vquic_int.h",
+      "SPDXID": "SPDXRef-File-splay.c-387",
+      "fileName": "repos/curl/lib/splay.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "dbe1fca777a1295aa077a413e8374d389977d550"
+          "checksumValue": "ddab7a4d6e2cfabc69e686311b9784921a814f24"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apple.h-386",
-      "fileName": "repos/curl/lib/vtls/apple.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "dd1b5db357658b0dae9cc6956dd3c1b5af62a760"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-sha512-256.h-387",
-      "fileName": "repos/curl/lib/vauth/../curl_sha512_256.h",
+      "SPDXID": "SPDXRef-File-curl-sha512-256.h-388",
+      "fileName": "repos/curl/lib/curl_sha512_256.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3960,8 +3957,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ev.h-388",
-      "fileName": "repos/curl/lib/vauth/../multi_ev.h",
+      "SPDXID": "SPDXRef-File-multi-ev.h-389",
+      "fileName": "repos/curl/lib/multi_ev.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3970,7 +3967,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-libinfo.h-389",
+      "SPDXID": "SPDXRef-File-tool-libinfo.h-390",
       "fileName": "repos/curl/src/tool_libinfo.h",
       "checksums": [
         {
@@ -3980,7 +3977,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-https-connect.h-390",
+      "SPDXID": "SPDXRef-File-curl-fnmatch.c-391",
+      "fileName": "repos/curl/lib/curl_fnmatch.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dde956c3ac2aa213e1d68c3c72a3b679bb0759bb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-pop3.c-392",
+      "fileName": "repos/curl/lib/pop3.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "de704d11e1a9f1c93b0f2d105a0a3a1e8ad33981"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-getinfo.c-393",
+      "fileName": "repos/curl/lib/getinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dedafd382e5dc44a55e5a148d7df3e27a26fcfd2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-https-connect.h-394",
       "fileName": "repos/curl/lib/cf-https-connect.h",
       "checksums": [
         {
@@ -3990,27 +4017,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-functypes.h-391",
-      "fileName": "repos/curl/lib/vauth/../functypes.h",
+      "SPDXID": "SPDXRef-File-cf-ip-happy.c-395",
+      "fileName": "repos/curl/lib/cf-ip-happy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "df3cfd44c88f3f254dfa1907c1673192b326fd8a"
+          "checksumValue": "dfbf4ae183b528a80f73e5a256768b2fefe05ed9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ntlm-sspi.c-392",
-      "fileName": "repos/curl/lib/vauth/ntlm_sspi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e0a0bebec3e0eff4f496092cded290fdc9a8383a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-operhlp.c-393",
+      "SPDXID": "SPDXRef-File-tool-operhlp.c-396",
       "fileName": "repos/curl/src/tool_operhlp.c",
       "checksums": [
         {
@@ -4020,47 +4037,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-setup.h-394",
-      "fileName": "repos/curl/src/tool_setup.h",
+      "SPDXID": "SPDXRef-File-hsts.h-397",
+      "fileName": "repos/curl/lib/hsts.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e113de8ddae2cc41de16a38adb5c835d4addddb1"
+          "checksumValue": "e0f6363bb355072fdc5a92289c48ce806bf60829"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timediff.h-395",
-      "fileName": "repos/curl/lib/vauth/../curlx/timediff.h",
+      "SPDXID": "SPDXRef-File-vquic-tls.c-398",
+      "fileName": "repos/curl/lib/vquic/vquic-tls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e19b0f4403a1138b7b789e612cb7aa9c29b3cfce"
+          "checksumValue": "e135ac517417add98a34ca092f980e5a84e62556"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-hdr.c-396",
-      "fileName": "repos/curl/src/tool_cb_hdr.c",
+      "SPDXID": "SPDXRef-File-http2.c-399",
+      "fileName": "repos/curl/lib/http2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e22c59694cf579f73ef16092da359d8105663ec7"
+          "checksumValue": "e1c57986e81c2c02ca6b7b1f3527892c7a043e00"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-hash.c-397",
-      "fileName": "repos/curl/lib/uint-hash.c",
+      "SPDXID": "SPDXRef-File-tool-cb-see.c-400",
+      "fileName": "repos/curl/src/tool_cb_see.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e23d249d0571390fc6cc988a2c5502b586140c93"
+          "checksumValue": "e1ebd8d99f65b9e5533971b56b2d69c8b1ca5f31"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-psl.c-398",
+      "SPDXID": "SPDXRef-File-ldap.c-401",
+      "fileName": "repos/curl/lib/ldap.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e223078b03701d19b4e53853082321686570e064"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-psl.c-402",
       "fileName": "repos/curl/lib/psl.c",
       "checksums": [
         {
@@ -4070,17 +4097,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hsts.h-399",
-      "fileName": "repos/curl/lib/hsts.h",
+      "SPDXID": "SPDXRef-File-dynhds.h-403",
+      "fileName": "repos/curl/lib/dynhds.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e2c9922f18ef955b590a6c07f9cca35247936ef2"
+          "checksumValue": "e30eb457257d34fb243073e0b8aeea0121da342f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-see.h-400",
+      "SPDXID": "SPDXRef-File-tool-getparam.h-404",
+      "fileName": "repos/curl/src/tool_getparam.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e3cbe5454a6d429232396e87796b0a1f724be220"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-see.h-405",
       "fileName": "repos/curl/src/tool_cb_see.h",
       "checksums": [
         {
@@ -4090,17 +4127,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h1-proxy.h-401",
-      "fileName": "repos/curl/lib/cf-h1-proxy.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e48d827825d3ebeeac1bd65fd9eb305b2e845106"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-rtmp.h-402",
+      "SPDXID": "SPDXRef-File-curl-rtmp.h-406",
       "fileName": "repos/curl/lib/curl_rtmp.h",
       "checksums": [
         {
@@ -4110,47 +4137,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-md5.c-403",
-      "fileName": "repos/curl/lib/md5.c",
+      "SPDXID": "SPDXRef-File-mqtt.c-407",
+      "fileName": "repos/curl/lib/mqtt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e5a4f534c7cf50d0f52497b377077f228124c2df"
+          "checksumValue": "e591cfcf0100533bdba5a8d6bb42d1f96a85922f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-setopt.c-404",
-      "fileName": "repos/curl/lib/setopt.c",
+      "SPDXID": "SPDXRef-File-tool-getparam.c-408",
+      "fileName": "repos/curl/src/tool_getparam.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e6476dfaf30c2413e630ccd8f20714ec81dcf130"
+          "checksumValue": "e6e641923beef9abf9cd6b0db2cda306f95ea244"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostip.h-405",
-      "fileName": "repos/curl/lib/vauth/../hostip.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e70eac841bf2f1181598e9e3fbeaf6602338a086"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-header.h-406",
-      "fileName": "repos/curl/lib/../include/curl/header.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e7334b5a3a4d35f9d23fc47a4d9826370b0dc0c5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-content-encoding.h-407",
+      "SPDXID": "SPDXRef-File-content-encoding.h-409",
       "fileName": "repos/curl/lib/content_encoding.h",
       "checksums": [
         {
@@ -4160,7 +4167,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operhlp.h-408",
+      "SPDXID": "SPDXRef-File-mime.h-410",
+      "fileName": "repos/curl/lib/mime.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e84f04051b534a0230881cfc810d6b2f53cd1988"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-operhlp.h-411",
       "fileName": "repos/curl/src/tool_operhlp.h",
       "checksums": [
         {
@@ -4170,37 +4187,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-setopt.h-409",
-      "fileName": "repos/curl/src/tool_setopt.h",
+      "SPDXID": "SPDXRef-File-parsedate.h-412",
+      "fileName": "repos/curl/lib/parsedate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e990f08a81a3b4624d7280010f2de7f865ff2216"
+          "checksumValue": "ea136bd30158437fe88efbeb88541aceb44099e6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-proxy.c-410",
-      "fileName": "repos/curl/lib/http_proxy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e9dfb8dbb3bd7a583b8744f4ec1d51589ec58971"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-aws-sigv4.c-411",
-      "fileName": "repos/curl/lib/http_aws_sigv4.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ea1a7ff758b2e51a0ccefdc23e8c38adf5403f56"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-msgs.h-412",
+      "SPDXID": "SPDXRef-File-tool-msgs.h-413",
       "fileName": "repos/curl/src/tool_msgs.h",
       "checksums": [
         {
@@ -4210,37 +4207,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest.c-413",
-      "fileName": "repos/curl/lib/vauth/digest.c",
+      "SPDXID": "SPDXRef-File-tool-cb-rea.c-414",
+      "fileName": "repos/curl/src/tool_cb_rea.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ec82564d2c96834058dc2224aee55e9a1fe22e45"
+          "checksumValue": "eb23f9b907be53e106db188288f0025971daa45c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keylog.h-414",
-      "fileName": "repos/curl/lib/vtls/keylog.h",
+      "SPDXID": "SPDXRef-File-url.c-415",
+      "fileName": "repos/curl/lib/url.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ec82abf547f08b9914e4f4a05c353f454f737dd7"
+          "checksumValue": "ec0457bcdd6f2aacbc5f188aa81955f3654a4ab4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gtls.h-415",
-      "fileName": "repos/curl/lib/vtls/gtls.h",
+      "SPDXID": "SPDXRef-File-cw-pause.c-416",
+      "fileName": "repos/curl/lib/cw-pause.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ecdca0a666a5fd27e2ff82e61f0fec3fdfb72ceb"
+          "checksumValue": "ec611879d1e8a2c378e2302259a667004694b6d6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock.h-416",
+      "SPDXID": "SPDXRef-File-noproxy.c-417",
+      "fileName": "repos/curl/lib/noproxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ee03fd35b9f1ae4f60e2d639d51003da71537077"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-nonblock.h-418",
       "fileName": "repos/curl/lib/curlx/nonblock.h",
       "checksums": [
         {
@@ -4250,17 +4257,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ftp.h-417",
-      "fileName": "repos/curl/lib/vauth/../ftp.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ef1aacb40c89e42c2ff0f57ebfdc4888bfe1187f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-soc.h-418",
+      "SPDXID": "SPDXRef-File-tool-cb-soc.h-419",
       "fileName": "repos/curl/src/tool_cb_soc.h",
       "checksums": [
         {
@@ -4270,27 +4267,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strparse.c-419",
-      "fileName": "repos/curl/lib/curlx/strparse.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f11b58b7eee5e24474be34e836a9c79b0533b18e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl.h-420",
-      "fileName": "repos/curl/lib/../include/curl/curl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f14f887261b4af00e74e4b499539a4d2b13639a9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-gethostname.c-421",
+      "SPDXID": "SPDXRef-File-curl-gethostname.c-420",
       "fileName": "repos/curl/lib/curl_gethostname.c",
       "checksums": [
         {
@@ -4300,7 +4277,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-imap.h-422",
+      "SPDXID": "SPDXRef-File-imap.h-421",
       "fileName": "repos/curl/lib/imap.h",
       "checksums": [
         {
@@ -4310,37 +4287,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-addrinfo.c-423",
-      "fileName": "repos/curl/lib/curl_addrinfo.c",
+      "SPDXID": "SPDXRef-File-digest-sspi.c-422",
+      "fileName": "repos/curl/lib/vauth/digest_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f1eaa6bcb604ac242c6504fbba601ca28a170454"
+          "checksumValue": "f29e569cd1801053bc2c72a67599c7be7dc0426a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connect.h-424",
-      "fileName": "repos/curl/lib/vtls/../connect.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f2b9911073b94df6c1a4770977e45fbd9bd228e8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sendf.c-425",
-      "fileName": "repos/curl/lib/sendf.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f2d30a4269a1eb8b78a0fadf0290f248564a8c34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist-wc.c-426",
+      "SPDXID": "SPDXRef-File-slist-wc.c-423",
       "fileName": "repos/curl/src/slist_wc.c",
       "checksums": [
         {
@@ -4350,37 +4307,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-base.c-427",
-      "fileName": "repos/curl/lib/asyn-base.c",
+      "SPDXID": "SPDXRef-File-tool-easysrc.h-424",
+      "fileName": "repos/curl/src/tool_easysrc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f35e1c988c3f683e0eea38fe13ab25c1d2d7b41f"
+          "checksumValue": "f37ce4ba86f556a6b6fc3074d8a1ad4366f9a222"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-url.c-428",
-      "fileName": "repos/curl/lib/url.c",
+      "SPDXID": "SPDXRef-File-curl-addrinfo.h-425",
+      "fileName": "repos/curl/lib/curl_addrinfo.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f3b24c9de24e17eba9e0317f480d91ef8680dd45"
+          "checksumValue": "f464b5ed7898c5264b5833025c6d409e44c7fb4d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic.h-429",
-      "fileName": "repos/curl/lib/vquic/vquic.h",
+      "SPDXID": "SPDXRef-File-tool-parsecfg.c-426",
+      "fileName": "repos/curl/src/tool_parsecfg.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f5392eb04797f7f2d55d4120d6cc4d3c095f0d1e"
+          "checksumValue": "f5910f404e77a43a7f19f862e298e3cce0031e85"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-digest.c-430",
+      "SPDXID": "SPDXRef-File-http-digest.c-427",
       "fileName": "repos/curl/lib/http_digest.c",
       "checksums": [
         {
@@ -4390,7 +4347,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getinfo.h-431",
+      "SPDXID": "SPDXRef-File-getinfo.h-428",
       "fileName": "repos/curl/lib/getinfo.h",
       "checksums": [
         {
@@ -4400,12 +4357,42 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-threads.c-432",
+      "SPDXID": "SPDXRef-File-curl-threads.c-429",
       "fileName": "repos/curl/lib/curl_threads.c",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "f5fea9804693e1eee1faae8c48e1b2625e014730"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-urlglob.c-430",
+      "fileName": "repos/curl/src/tool_urlglob.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f62d9738ec081a16f19fb34d68501aec22817bb2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-vtls.c-431",
+      "fileName": "repos/curl/lib/vtls/vtls.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f7201d18d6507d9f7d076928385d1304bff16dd1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-urlapi.h-432",
+      "fileName": "repos/curl/lib/../include/curl/urlapi.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f7a42b3b9e0f526a36ae326f3ac3fc82a366de08"
         }
       ]
     },
@@ -4431,7 +4418,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-curl-ntlm-core.h-435",
-      "fileName": "repos/curl/lib/vauth/../curl_ntlm_core.h",
+      "fileName": "repos/curl/lib/curl_ntlm_core.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4440,18 +4427,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-easysrc.h-436",
-      "fileName": "repos/curl/src/tool_easysrc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f9ddacfc3779d941303f0c6e8b4fe277ae4858ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-endian.h-437",
-      "fileName": "repos/curl/lib/vauth/../curl_endian.h",
+      "SPDXID": "SPDXRef-File-curl-endian.h-436",
+      "fileName": "repos/curl/lib/curl_endian.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4460,47 +4437,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sha512-256.c-438",
-      "fileName": "repos/curl/lib/curl_sha512_256.c",
+      "SPDXID": "SPDXRef-File-cookie.h-437",
+      "fileName": "repos/curl/lib/cookie.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fa568b6b041ddb9cc2f7150cfdaef906f38c25ab"
+          "checksumValue": "fabd04d3989bb9fdb078ef57321f884ca7c699b4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi-int.h-439",
-      "fileName": "repos/curl/lib/urlapi-int.h",
+      "SPDXID": "SPDXRef-File-basename.h-438",
+      "fileName": "repos/curl/lib/curlx/basename.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fbce1837ff94fb6c74d47847f687a53332edfeca"
+          "checksumValue": "fb79fed8053dac80b2a526801fce9d6e7cec43c1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-pton.h-440",
-      "fileName": "repos/curl/lib/vtls/../curlx/inet_pton.h",
+      "SPDXID": "SPDXRef-File-tool-cb-hdr.c-439",
+      "fileName": "repos/curl/src/tool_cb_hdr.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fc3ae3d2bb2c20dd9beff7fc3c369addd15f9c94"
+          "checksumValue": "fc03cf143b95a8451c20f326fbdd338693833331"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cleartext.c-441",
-      "fileName": "repos/curl/lib/vauth/cleartext.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fc8a6ebd5102516803695f3bdd91cc94100eed3d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.c-442",
+      "SPDXID": "SPDXRef-File-dict.c-440",
       "fileName": "repos/curl/lib/dict.c",
       "checksums": [
         {
@@ -4510,32 +4477,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getinfo.c-443",
-      "fileName": "repos/curl/lib/getinfo.c",
+      "SPDXID": "SPDXRef-File-schannel.h-441",
+      "fileName": "repos/curl/lib/../lib/vtls/schannel.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fd0d483f0a1137a94b0eb6cd5e3bd5043f2a4333"
+          "checksumValue": "fe49e9a9d0fb50eedb38e6873df19d66e1f89634"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pop3.c-444",
-      "fileName": "repos/curl/lib/pop3.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fdb09f232097032e1e1dfab45c98eaa4501065b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-ntlm.h-445",
+      "SPDXID": "SPDXRef-File-http-ntlm.h-442",
       "fileName": "repos/curl/lib/http_ntlm.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "ff5218d89f6cd740ceb878a6cd7c1e21047f2cf9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-select.h-443",
+      "fileName": "repos/curl/lib/select.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ffcd44cfcfc773158bcc47a6d422ddfb962b39c1"
         }
       ]
     }
@@ -4549,17 +4516,17 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DYNAMIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcurl4-1"
+      "relatedSpdxElement": "SPDXRef-libc6-1"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DYNAMIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libc6-2"
+      "relatedSpdxElement": "SPDXRef-zlib1g-2"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DYNAMIC_LINK",
-      "relatedSpdxElement": "SPDXRef-zlib1g-3"
+      "relatedSpdxElement": "SPDXRef-libcurl-3"
     },
     {
       "spdxElementId": "SPDXRef-gcc-4",
@@ -4569,132 +4536,132 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idn.c-5"
+      "relatedSpdxElement": "SPDXRef-File-smb.c-5"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-scache.c-6"
+      "relatedSpdxElement": "SPDXRef-File-cf-socket.h-6"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.c-7"
+      "relatedSpdxElement": "SPDXRef-File-keylog.c-7"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multiif.h-8"
+      "relatedSpdxElement": "SPDXRef-File-hmac.c-8"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rustls.c-9"
+      "relatedSpdxElement": "SPDXRef-File-inet-pton.h-9"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.h-10"
+      "relatedSpdxElement": "SPDXRef-File-multiif.h-10"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ldap.c-11"
+      "relatedSpdxElement": "SPDXRef-File-hsts.c-11"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transfer.h-12"
+      "relatedSpdxElement": "SPDXRef-File-curl-md5.h-12"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-md4.h-13"
+      "relatedSpdxElement": "SPDXRef-File-imap.c-13"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.h-14"
+      "relatedSpdxElement": "SPDXRef-File-transfer.h-14"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-if2ip.c-15"
+      "relatedSpdxElement": "SPDXRef-File-curl-md4.h-15"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-typecheck-gcc.h-16"
+      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.h-16"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.h-17"
+      "relatedSpdxElement": "SPDXRef-File-if2ip.c-17"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-range.c-18"
+      "relatedSpdxElement": "SPDXRef-File-rustls.c-18"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.h-19"
+      "relatedSpdxElement": "SPDXRef-File-netrc.h-19"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getpass.h-20"
+      "relatedSpdxElement": "SPDXRef-File-system.h-20"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlinfo.c-21"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.h-21"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-macos.h-22"
+      "relatedSpdxElement": "SPDXRef-File-connect.h-22"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha256.h-23"
+      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.h-23"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-ntop.c-24"
+      "relatedSpdxElement": "SPDXRef-File-llist.h-24"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.c-25"
+      "relatedSpdxElement": "SPDXRef-File-tool-getpass.h-25"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.c-26"
+      "relatedSpdxElement": "SPDXRef-File-curlinfo.c-26"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cram.c-27"
+      "relatedSpdxElement": "SPDXRef-File-macos.h-27"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doh.h-28"
+      "relatedSpdxElement": "SPDXRef-File-tool-filetime.c-28"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setopt.h-29"
+      "relatedSpdxElement": "SPDXRef-File-easy.h-29"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smb.c-30"
+      "relatedSpdxElement": "SPDXRef-File-strdup.h-30"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -4709,22 +4676,22 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-thrdd.c-33"
+      "relatedSpdxElement": "SPDXRef-File-llist.c-33"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llist.c-34"
+      "relatedSpdxElement": "SPDXRef-File-netrc.c-34"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base64.c-35"
+      "relatedSpdxElement": "SPDXRef-File-timediff.h-35"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-formparse.c-36"
+      "relatedSpdxElement": "SPDXRef-File-rtsp.c-36"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -4734,747 +4701,747 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http1.h-38"
+      "relatedSpdxElement": "SPDXRef-File-ntlm-sspi.c-38"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-spnego-sspi.c-39"
+      "relatedSpdxElement": "SPDXRef-File-tool-time.c-39"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn.h-40"
+      "relatedSpdxElement": "SPDXRef-File-if2ip.h-40"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-if2ip.h-41"
+      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.c-41"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.c-42"
+      "relatedSpdxElement": "SPDXRef-File-strparse.c-42"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noproxy.c-43"
+      "relatedSpdxElement": "SPDXRef-File-curl-ctype.h-43"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sendf.h-44"
+      "relatedSpdxElement": "SPDXRef-File-tool-time.h-44"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ctype.h-45"
+      "relatedSpdxElement": "SPDXRef-File-httpsrr.c-45"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-time.h-46"
+      "relatedSpdxElement": "SPDXRef-File-http.c-46"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libssh2.c-47"
+      "relatedSpdxElement": "SPDXRef-File-md4.c-47"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsts.c-48"
+      "relatedSpdxElement": "SPDXRef-File-ssh.h-48"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-md5.h-49"
+      "relatedSpdxElement": "SPDXRef-File-system-win32.c-49"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpsrr.c-50"
+      "relatedSpdxElement": "SPDXRef-File-file.c-50"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-pton.c-51"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.c-51"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-msgs.c-52"
+      "relatedSpdxElement": "SPDXRef-File-curl-sspi.c-52"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.h-53"
+      "relatedSpdxElement": "SPDXRef-File-strerror.c-53"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-doswin.c-54"
+      "relatedSpdxElement": "SPDXRef-File-vquic.c-54"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cookie.c-55"
+      "relatedSpdxElement": "SPDXRef-File-spnego-sspi.c-55"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ratelimit.c-56"
+      "relatedSpdxElement": "SPDXRef-File-cipher-suite.c-56"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic.c-57"
+      "relatedSpdxElement": "SPDXRef-File-curl.h-57"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.c-58"
+      "relatedSpdxElement": "SPDXRef-File-ftp.h-58"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sspi.c-59"
+      "relatedSpdxElement": "SPDXRef-File-config2setopts.c-59"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llist.h-60"
+      "relatedSpdxElement": "SPDXRef-File-tool-formparse.c-60"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.h-61"
+      "relatedSpdxElement": "SPDXRef-File-easyif.h-61"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strdup.h-62"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout.c-62"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerror.c-63"
+      "relatedSpdxElement": "SPDXRef-File-tool-ssls.c-63"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.h-64"
+      "relatedSpdxElement": "SPDXRef-File-uint-hash.c-64"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlx.h-65"
+      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.h-65"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-spack.c-66"
+      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.h-66"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-printf.h-67"
+      "relatedSpdxElement": "SPDXRef-File-hash.h-67"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyif.h-68"
+      "relatedSpdxElement": "SPDXRef-File-easygetopt.c-68"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks-gssapi.c-69"
+      "relatedSpdxElement": "SPDXRef-File-tool-findfile.c-69"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ssls.c-70"
+      "relatedSpdxElement": "SPDXRef-File-cfilters.c-70"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.c-71"
+      "relatedSpdxElement": "SPDXRef-File-altsvc.h-71"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smtp.c-72"
+      "relatedSpdxElement": "SPDXRef-File-version-win32.c-72"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.h-73"
+      "relatedSpdxElement": "SPDXRef-File-urlapi-int.h-73"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-pause.c-74"
+      "relatedSpdxElement": "SPDXRef-File-socketpair.h-74"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.h-75"
+      "relatedSpdxElement": "SPDXRef-File-sockaddr.h-75"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snprintf.h-76"
+      "relatedSpdxElement": "SPDXRef-File-mbedtls.c-76"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easygetopt.c-77"
+      "relatedSpdxElement": "SPDXRef-File-timediff.c-77"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-select.h-78"
+      "relatedSpdxElement": "SPDXRef-File-ratelimit.c-78"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multibyte.h-79"
+      "relatedSpdxElement": "SPDXRef-File-idn.c-79"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout.c-80"
+      "relatedSpdxElement": "SPDXRef-File-inet-ntop.h-80"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-findfile.c-81"
+      "relatedSpdxElement": "SPDXRef-File-base64.h-81"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basename.c-82"
+      "relatedSpdxElement": "SPDXRef-File-cf-socket.c-82"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basename.h-83"
+      "relatedSpdxElement": "SPDXRef-File-cshutdn.c-83"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-socket.h-84"
+      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.h-84"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-helpers.c-85"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.c-85"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-scache.h-86"
+      "relatedSpdxElement": "SPDXRef-File-slist-wc.h-86"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wait.c-87"
+      "relatedSpdxElement": "SPDXRef-File-macos.c-87"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socketpair.h-88"
+      "relatedSpdxElement": "SPDXRef-File-curl-share.c-88"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockaddr.h-89"
+      "relatedSpdxElement": "SPDXRef-File-pingpong.h-89"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.c-90"
+      "relatedSpdxElement": "SPDXRef-File-formdata.h-90"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynhds.h-91"
+      "relatedSpdxElement": "SPDXRef-File-fileinfo.c-91"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rustls.h-92"
+      "relatedSpdxElement": "SPDXRef-File-winapi.c-92"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base64.h-93"
+      "relatedSpdxElement": "SPDXRef-File-altsvc.c-93"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.h-94"
+      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.c-94"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ntlm-core.c-95"
+      "relatedSpdxElement": "SPDXRef-File-formdata.c-95"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-system-win32.c-96"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.h-96"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setopt.c-97"
+      "relatedSpdxElement": "SPDXRef-File-mime.c-97"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-var.c-98"
+      "relatedSpdxElement": "SPDXRef-File-uint-table.h-98"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vauth.h-99"
+      "relatedSpdxElement": "SPDXRef-File-smtp.h-99"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.h-100"
+      "relatedSpdxElement": "SPDXRef-File-libssh.c-100"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.c-101"
+      "relatedSpdxElement": "SPDXRef-File-curl-printf.h-101"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-arpa-telnet.h-102"
+      "relatedSpdxElement": "SPDXRef-File-strdup.c-102"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transfer.c-103"
+      "relatedSpdxElement": "SPDXRef-File-config2setopts.h-103"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-macos.c-104"
+      "relatedSpdxElement": "SPDXRef-File-warnless.h-104"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic-tls.c-105"
+      "relatedSpdxElement": "SPDXRef-File-vauth.h-105"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pingpong.h-106"
+      "relatedSpdxElement": "SPDXRef-File-doh.h-106"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fileinfo.c-107"
+      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.c-107"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcase.h-108"
+      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.c-108"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.h-109"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout.h-109"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mbedtls.h-110"
+      "relatedSpdxElement": "SPDXRef-File-websockets.h-110"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-request.h-111"
+      "relatedSpdxElement": "SPDXRef-File-schannel-verify.c-111"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http.c-112"
+      "relatedSpdxElement": "SPDXRef-File-rand.c-112"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smtp.h-113"
+      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.c-113"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config2setopts.h-114"
+      "relatedSpdxElement": "SPDXRef-File-tool-ssls.h-114"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.c-115"
+      "relatedSpdxElement": "SPDXRef-File-timeval.c-115"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-socket.c-116"
+      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.c-116"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mbedtls.c-117"
+      "relatedSpdxElement": "SPDXRef-File-strerr.h-117"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.c-118"
+      "relatedSpdxElement": "SPDXRef-File-vtls-spack.h-118"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.c-119"
+      "relatedSpdxElement": "SPDXRef-File-doh.c-119"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-table.h-120"
+      "relatedSpdxElement": "SPDXRef-File-asyn-base.c-120"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-share.h-121"
+      "relatedSpdxElement": "SPDXRef-File-oauth2.c-121"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-share.c-122"
+      "relatedSpdxElement": "SPDXRef-File-slist.h-122"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout.h-123"
+      "relatedSpdxElement": "SPDXRef-File-tool-stderr.h-123"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-websockets.h-124"
+      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.c-124"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-imap.c-125"
+      "relatedSpdxElement": "SPDXRef-File-vssh.h-125"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idn.h-126"
+      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.c-126"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ssls.h-127"
+      "relatedSpdxElement": "SPDXRef-File-curl-ntlm-core.c-127"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerr.h-128"
+      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.h-128"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mqtt.c-129"
+      "relatedSpdxElement": "SPDXRef-File-uint-spbset.h-129"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-filetime.c-130"
+      "relatedSpdxElement": "SPDXRef-File-curl-trc.c-130"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memdebug.c-131"
+      "relatedSpdxElement": "SPDXRef-File-strerror.h-131"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-ntop.h-132"
+      "relatedSpdxElement": "SPDXRef-File-easyoptions.c-132"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http2.c-133"
+      "relatedSpdxElement": "SPDXRef-File-asyn-ares.c-133"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-hmac.h-134"
+      "relatedSpdxElement": "SPDXRef-File-cookie.c-134"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist.h-135"
+      "relatedSpdxElement": "SPDXRef-File-tool-ca-embed.c-135"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-stderr.h-136"
+      "relatedSpdxElement": "SPDXRef-File-pingpong.c-136"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeval.h-137"
+      "relatedSpdxElement": "SPDXRef-File-curl-setup.h-137"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-spbset.h-138"
+      "relatedSpdxElement": "SPDXRef-File-openssl.c-138"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connect.c-139"
+      "relatedSpdxElement": "SPDXRef-File-tool-help.c-139"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerror.h-140"
+      "relatedSpdxElement": "SPDXRef-File-bufref.c-140"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyoptions.c-141"
+      "relatedSpdxElement": "SPDXRef-File-strparse.h-141"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.c-142"
+      "relatedSpdxElement": "SPDXRef-File-socks.h-142"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getparam.h-143"
+      "relatedSpdxElement": "SPDXRef-File-wait.c-143"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vssh.h-144"
+      "relatedSpdxElement": "SPDXRef-File-vquic.h-144"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ca-embed.c-145"
+      "relatedSpdxElement": "SPDXRef-File-request.h-145"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config2setopts.c-146"
+      "relatedSpdxElement": "SPDXRef-File-tool-sdecls.h-146"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufref.c-147"
+      "relatedSpdxElement": "SPDXRef-File-strcase.h-147"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftp.c-148"
+      "relatedSpdxElement": "SPDXRef-File-hostip.c-148"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel-verify.c-149"
+      "relatedSpdxElement": "SPDXRef-File-cw-pause.h-149"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.h-150"
+      "relatedSpdxElement": "SPDXRef-File-cw-out.c-150"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.c-151"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.h-151"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multibyte.c-152"
+      "relatedSpdxElement": "SPDXRef-File-uint-hash.h-152"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.h-153"
+      "relatedSpdxElement": "SPDXRef-File-amigaos.h-153"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doh.c-154"
+      "relatedSpdxElement": "SPDXRef-File-uint-spbset.c-154"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-pause.h-155"
+      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.c-155"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.h-156"
+      "relatedSpdxElement": "SPDXRef-File-headers.c-156"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-setup.h-157"
+      "relatedSpdxElement": "SPDXRef-File-urldata.h-157"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher-suite.c-158"
+      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.c-158"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-hash.h-159"
+      "relatedSpdxElement": "SPDXRef-File-digest.h-159"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amigaos.h-160"
+      "relatedSpdxElement": "SPDXRef-File-telnet.c-160"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-trc.h-161"
+      "relatedSpdxElement": "SPDXRef-File-curlver.h-161"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-spbset.c-162"
+      "relatedSpdxElement": "SPDXRef-File-bufref.h-162"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.c-163"
+      "relatedSpdxElement": "SPDXRef-File-ftplistparser.h-163"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-headers.c-164"
+      "relatedSpdxElement": "SPDXRef-File-tool-version.h-164"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.c-165"
+      "relatedSpdxElement": "SPDXRef-File-curl-share.h-165"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy.h-166"
+      "relatedSpdxElement": "SPDXRef-File-uint-bset.c-166"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x509asn1.c-167"
+      "relatedSpdxElement": "SPDXRef-File-http-digest.h-167"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlver.h-168"
+      "relatedSpdxElement": "SPDXRef-File-warnless.c-168"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufref.h-169"
+      "relatedSpdxElement": "SPDXRef-File-ws.c-169"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-quiche.c-170"
+      "relatedSpdxElement": "SPDXRef-File-ftp.c-170"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-version.h-171"
+      "relatedSpdxElement": "SPDXRef-File-smtp.c-171"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-splay.c-172"
+      "relatedSpdxElement": "SPDXRef-File-http1.c-172"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http2.h-173"
+      "relatedSpdxElement": "SPDXRef-File-tool-util.c-173"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mime.h-174"
+      "relatedSpdxElement": "SPDXRef-File-multi.c-174"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-bset.c-175"
+      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.h-175"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-digest.h-176"
+      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.c-176"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-util.c-177"
+      "relatedSpdxElement": "SPDXRef-File-tool-findfile.h-177"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operate.c-178"
+      "relatedSpdxElement": "SPDXRef-File-libssh2.c-178"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.h-179"
+      "relatedSpdxElement": "SPDXRef-File-tool-progress.c-179"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.c-180"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.c-180"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-findfile.h-181"
+      "relatedSpdxElement": "SPDXRef-File-schannel.c-181"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.h-182"
+      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.h-182"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-progress.c-183"
+      "relatedSpdxElement": "SPDXRef-File-request.c-183"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-altsvc.c-184"
+      "relatedSpdxElement": "SPDXRef-File-vtls-int.h-184"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.c-185"
+      "relatedSpdxElement": "SPDXRef-File-tool-xattr.h-185"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-xattr.h-186"
+      "relatedSpdxElement": "SPDXRef-File-vtls-scache.c-186"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5484,27 +5451,27 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.c-188"
+      "relatedSpdxElement": "SPDXRef-File-asyn.h-188"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version.c-189"
+      "relatedSpdxElement": "SPDXRef-File-tool-getpass.c-189"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timediff.c-190"
+      "relatedSpdxElement": "SPDXRef-File-multi-ev.c-190"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-help.h-191"
+      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.c-191"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-krb5-gssapi.c-192"
+      "relatedSpdxElement": "SPDXRef-File-tool-help.h-192"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5514,97 +5481,97 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-quiche.h-194"
+      "relatedSpdxElement": "SPDXRef-File-http-negotiate.h-194"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-negotiate.h-195"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.c-195"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.h-196"
+      "relatedSpdxElement": "SPDXRef-File-hostip.h-196"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ws.c-197"
+      "relatedSpdxElement": "SPDXRef-File-progress.c-197"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http.h-198"
+      "relatedSpdxElement": "SPDXRef-File-fopen.c-198"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynbuf.h-199"
+      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.h-199"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-config.h-200"
+      "relatedSpdxElement": "SPDXRef-File-transfer.c-200"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-content-encoding.c-201"
+      "relatedSpdxElement": "SPDXRef-File-dynbuf.h-201"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-vms.c-202"
+      "relatedSpdxElement": "SPDXRef-File-nonblock.c-202"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noproxy.h-203"
+      "relatedSpdxElement": "SPDXRef-File-dynbuf.c-203"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urldata.h-204"
+      "relatedSpdxElement": "SPDXRef-File-multibyte.c-204"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.h-205"
+      "relatedSpdxElement": "SPDXRef-File-noproxy.h-205"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gopher.c-206"
+      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.h-206"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.h-207"
+      "relatedSpdxElement": "SPDXRef-File-gopher.c-207"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeval.c-208"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.h-208"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wolfssl.h-209"
+      "relatedSpdxElement": "SPDXRef-File-fileinfo.h-209"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fileinfo.h-210"
+      "relatedSpdxElement": "SPDXRef-File-dynhds.c-210"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynhds.c-211"
+      "relatedSpdxElement": "SPDXRef-File-uint-bset.h-211"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-bset.h-212"
+      "relatedSpdxElement": "SPDXRef-File-tool-vms.c-212"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5624,177 +5591,177 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.c-216"
+      "relatedSpdxElement": "SPDXRef-File-ws.h-216"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strdup.c-217"
+      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.c-217"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pop3.h-218"
+      "relatedSpdxElement": "SPDXRef-File-sendf.h-218"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.c-219"
+      "relatedSpdxElement": "SPDXRef-File-socketpair.c-219"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tftp.c-220"
+      "relatedSpdxElement": "SPDXRef-File-pop3.h-220"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ssh.h-221"
+      "relatedSpdxElement": "SPDXRef-File-curl-config.h-221"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cshutdn.h-222"
+      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.c-222"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multihandle.h-223"
+      "relatedSpdxElement": "SPDXRef-File-connect.c-223"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-krb5-sspi.c-224"
+      "relatedSpdxElement": "SPDXRef-File-cleartext.c-224"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist-wc.h-225"
+      "relatedSpdxElement": "SPDXRef-File-curlx.h-225"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ldap.h-226"
+      "relatedSpdxElement": "SPDXRef-File-multihandle.h-226"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apple.c-227"
+      "relatedSpdxElement": "SPDXRef-File-sha256.c-227"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-progress.c-228"
+      "relatedSpdxElement": "SPDXRef-File-curl-ldap.h-228"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-out.h-229"
+      "relatedSpdxElement": "SPDXRef-File-version.c-229"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel.c-230"
+      "relatedSpdxElement": "SPDXRef-File-cw-out.h-230"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mime.c-231"
+      "relatedSpdxElement": "SPDXRef-File-keylog.h-231"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socketpair.c-232"
+      "relatedSpdxElement": "SPDXRef-File-tool-operate.h-232"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-ares.c-233"
+      "relatedSpdxElement": "SPDXRef-File-parsedate.c-233"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-doswin.h-234"
+      "relatedSpdxElement": "SPDXRef-File-var.c-234"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options.h-235"
+      "relatedSpdxElement": "SPDXRef-File-inet-ntop.c-235"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openldap.c-236"
+      "relatedSpdxElement": "SPDXRef-File-hash.c-236"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sasl.h-237"
+      "relatedSpdxElement": "SPDXRef-File-tool-doswin.h-237"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.h-238"
+      "relatedSpdxElement": "SPDXRef-File-options.h-238"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cshutdn.c-239"
+      "relatedSpdxElement": "SPDXRef-File-setopt.c-239"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-get-line.c-240"
+      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.h-240"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-altsvc.h-241"
+      "relatedSpdxElement": "SPDXRef-File-headers.h-241"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.h-242"
+      "relatedSpdxElement": "SPDXRef-File-curl-get-line.c-242"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-listhelp.c-243"
+      "relatedSpdxElement": "SPDXRef-File-header.h-243"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-endian.c-244"
+      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.h-244"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-spack.h-245"
+      "relatedSpdxElement": "SPDXRef-File-tool-listhelp.c-245"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conncache.c-246"
+      "relatedSpdxElement": "SPDXRef-File-curl-endian.c-246"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getparam.c-247"
+      "relatedSpdxElement": "SPDXRef-File-rand.h-247"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest-sspi.c-248"
+      "relatedSpdxElement": "SPDXRef-File-multibyte.h-248"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.h-249"
+      "relatedSpdxElement": "SPDXRef-File-functypes.h-249"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-vms.h-250"
+      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.h-250"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5804,7 +5771,7 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnless.h-252"
+      "relatedSpdxElement": "SPDXRef-File-curl-sasl.h-252"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5819,492 +5786,492 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.h-255"
+      "relatedSpdxElement": "SPDXRef-File-bufq.h-255"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnless.c-256"
+      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.c-256"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls.c-257"
+      "relatedSpdxElement": "SPDXRef-File-httpsrr.h-257"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.c-258"
+      "relatedSpdxElement": "SPDXRef-File-cshutdn.h-258"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mprintf.c-259"
+      "relatedSpdxElement": "SPDXRef-File-idn.h-259"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpsrr.h-260"
+      "relatedSpdxElement": "SPDXRef-File-strerr.c-260"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest.h-261"
+      "relatedSpdxElement": "SPDXRef-File-tftp.h-261"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-sdecls.h-262"
+      "relatedSpdxElement": "SPDXRef-File-mprintf.h-262"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hmac.c-263"
+      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.h-263"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tftp.h-264"
+      "relatedSpdxElement": "SPDXRef-File-rtsp.h-264"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mprintf.h-265"
+      "relatedSpdxElement": "SPDXRef-File-sendf.c-265"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.h-266"
+      "relatedSpdxElement": "SPDXRef-File-gsasl.c-266"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rtsp.h-267"
+      "relatedSpdxElement": "SPDXRef-File-openldap.c-267"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operate.h-268"
+      "relatedSpdxElement": "SPDXRef-File-digest.c-268"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.c-269"
+      "relatedSpdxElement": "SPDXRef-File-socks-gssapi.c-269"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock.c-270"
+      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.c-270"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostcheck.c-271"
+      "relatedSpdxElement": "SPDXRef-File-curl-range.h-271"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-range.h-272"
+      "relatedSpdxElement": "SPDXRef-File-psl.h-272"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-psl.h-273"
+      "relatedSpdxElement": "SPDXRef-File-tool-setup.h-273"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strequal.c-274"
+      "relatedSpdxElement": "SPDXRef-File-select.c-274"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-netrc.h-275"
+      "relatedSpdxElement": "SPDXRef-File-tool-operate.c-275"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getpass.c-276"
+      "relatedSpdxElement": "SPDXRef-File-wait.h-276"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedate.c-277"
+      "relatedSpdxElement": "SPDXRef-File-curl-range.c-277"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-chunks.c-278"
+      "relatedSpdxElement": "SPDXRef-File-tool-msgs.c-278"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conncache.h-279"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.h-279"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.h-280"
+      "relatedSpdxElement": "SPDXRef-File-progress.h-280"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist.c-281"
+      "relatedSpdxElement": "SPDXRef-File-strcase.c-281"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.h-282"
+      "relatedSpdxElement": "SPDXRef-File-escape.h-282"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-progress.h-283"
+      "relatedSpdxElement": "SPDXRef-File-vauth.c-283"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http1.c-284"
+      "relatedSpdxElement": "SPDXRef-File-gtls.c-284"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-splay.h-285"
+      "relatedSpdxElement": "SPDXRef-File-http2.h-285"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcase.c-286"
+      "relatedSpdxElement": "SPDXRef-File-tool-helpers.c-286"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cfilters.h-287"
+      "relatedSpdxElement": "SPDXRef-File-file.h-287"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.c-288"
+      "relatedSpdxElement": "SPDXRef-File-strequal.c-288"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.c-289"
+      "relatedSpdxElement": "SPDXRef-File-urlapi.c-289"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pingpong.c-290"
+      "relatedSpdxElement": "SPDXRef-File-gtls.h-290"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.h-291"
+      "relatedSpdxElement": "SPDXRef-File-apple.c-291"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ev.c-292"
+      "relatedSpdxElement": "SPDXRef-File-http-negotiate.c-292"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-select.c-293"
+      "relatedSpdxElement": "SPDXRef-File-base64.c-293"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-system.h-294"
+      "relatedSpdxElement": "SPDXRef-File-curl-trc.h-294"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libssh.c-295"
+      "relatedSpdxElement": "SPDXRef-File-conncache.c-295"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-win32.h-296"
+      "relatedSpdxElement": "SPDXRef-File-http-proxy.c-296"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openssl.c-297"
+      "relatedSpdxElement": "SPDXRef-File-getenv.c-297"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-negotiate.c-298"
+      "relatedSpdxElement": "SPDXRef-File-content-encoding.c-298"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedate.h-299"
+      "relatedSpdxElement": "SPDXRef-File-wolfssl.c-299"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-oauth2.c-300"
+      "relatedSpdxElement": "SPDXRef-File-tool-doswin.c-300"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.c-301"
+      "relatedSpdxElement": "SPDXRef-File-hostcheck.c-301"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sigpipe.h-302"
+      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.h-302"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getenv.c-303"
+      "relatedSpdxElement": "SPDXRef-File-multi.h-303"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynbuf.c-304"
+      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.h-304"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-win32.c-305"
+      "relatedSpdxElement": "SPDXRef-File-memdebug.c-305"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-out.c-306"
+      "relatedSpdxElement": "SPDXRef-File-spnego-gssapi.c-306"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keylog.c-307"
+      "relatedSpdxElement": "SPDXRef-File-wolfssl.h-307"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.h-308"
+      "relatedSpdxElement": "SPDXRef-File-curl-sasl.c-308"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-headers.h-309"
+      "relatedSpdxElement": "SPDXRef-File-tool-vms.h-309"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.c-310"
+      "relatedSpdxElement": "SPDXRef-File-sigpipe.h-310"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strparse.h-311"
+      "relatedSpdxElement": "SPDXRef-File-ntlm.c-311"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-request.c-312"
+      "relatedSpdxElement": "SPDXRef-File-dict.h-312"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openssl.h-313"
+      "relatedSpdxElement": "SPDXRef-File-arpa-telnet.h-313"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftplistparser.h-314"
+      "relatedSpdxElement": "SPDXRef-File-x509asn1.c-314"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.c-315"
+      "relatedSpdxElement": "SPDXRef-File-rustls.h-315"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-time.c-316"
+      "relatedSpdxElement": "SPDXRef-File-curl-fopen.c-316"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-spnego-gssapi.c-317"
+      "relatedSpdxElement": "SPDXRef-File-socks.c-317"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sasl.c-318"
+      "relatedSpdxElement": "SPDXRef-File-vtls.h-318"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy.c-319"
+      "relatedSpdxElement": "SPDXRef-File-uint-table.c-319"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.c-320"
+      "relatedSpdxElement": "SPDXRef-File-vtls-scache.h-320"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vssh.c-321"
+      "relatedSpdxElement": "SPDXRef-File-curl-hmac.h-321"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formdata.c-322"
+      "relatedSpdxElement": "SPDXRef-File-tool-main.c-322"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.h-323"
+      "relatedSpdxElement": "SPDXRef-File-var.h-323"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fopen.c-324"
+      "relatedSpdxElement": "SPDXRef-File-http.h-324"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fopen.c-325"
+      "relatedSpdxElement": "SPDXRef-File-tool-setopt.h-325"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gsasl.c-326"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha256.h-326"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-table.c-327"
+      "relatedSpdxElement": "SPDXRef-File-gopher.h-327"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-netrc.c-328"
+      "relatedSpdxElement": "SPDXRef-File-tool-setopt.c-328"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-main.c-329"
+      "relatedSpdxElement": "SPDXRef-File-curl-fopen.h-329"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-var.h-330"
+      "relatedSpdxElement": "SPDXRef-File-escape.c-330"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-trc.c-331"
+      "relatedSpdxElement": "SPDXRef-File-timeval.h-331"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gopher.h-332"
+      "relatedSpdxElement": "SPDXRef-File-krb5-sspi.c-332"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufq.h-333"
+      "relatedSpdxElement": "SPDXRef-File-curl-gssapi.c-333"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fopen.h-334"
+      "relatedSpdxElement": "SPDXRef-File-telnet.h-334"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vauth.c-335"
+      "relatedSpdxElement": "SPDXRef-File-http-proxy.h-335"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls.h-336"
+      "relatedSpdxElement": "SPDXRef-File-http1.h-336"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.c-337"
+      "relatedSpdxElement": "SPDXRef-File-md5.c-337"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.c-338"
+      "relatedSpdxElement": "SPDXRef-File-asyn-thrdd.c-338"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha256.c-339"
+      "relatedSpdxElement": "SPDXRef-File-setopt.h-339"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-winapi.c-340"
+      "relatedSpdxElement": "SPDXRef-File-version-win32.h-340"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gssapi.c-341"
+      "relatedSpdxElement": "SPDXRef-File-url.h-341"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-telnet.h-342"
+      "relatedSpdxElement": "SPDXRef-File-http-ntlm.c-342"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wait.h-343"
+      "relatedSpdxElement": "SPDXRef-File-splay.h-343"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-proxy.h-344"
+      "relatedSpdxElement": "SPDXRef-File-mprintf.c-344"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-int.h-345"
+      "relatedSpdxElement": "SPDXRef-File-slist.c-345"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-ntlm.c-346"
+      "relatedSpdxElement": "SPDXRef-File-snprintf.c-346"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel.h-347"
+      "relatedSpdxElement": "SPDXRef-File-cfilters.h-347"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.h-348"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.c-348"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cookie.h-349"
+      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.h-349"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-helpers.h-350"
+      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.c-350"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-xattr.c-351"
+      "relatedSpdxElement": "SPDXRef-File-tool-helpers.h-351"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formdata.h-352"
+      "relatedSpdxElement": "SPDXRef-File-tftp.c-352"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -6314,397 +6281,397 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy-lock.h-354"
+      "relatedSpdxElement": "SPDXRef-File-tool-xattr.c-354"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostip.c-355"
+      "relatedSpdxElement": "SPDXRef-File-easy-lock.h-355"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.c-356"
+      "relatedSpdxElement": "SPDXRef-File-openssl.h-356"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wolfssl.c-357"
+      "relatedSpdxElement": "SPDXRef-File-easy.c-357"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ntlm.c-358"
+      "relatedSpdxElement": "SPDXRef-File-terminal.c-358"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rtsp.c-359"
+      "relatedSpdxElement": "SPDXRef-File-tool-formparse.h-359"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.c-360"
+      "relatedSpdxElement": "SPDXRef-File-tool-filetime.h-360"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-telnet.c-361"
+      "relatedSpdxElement": "SPDXRef-File-amigaos.c-361"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-formparse.h-362"
+      "relatedSpdxElement": "SPDXRef-File-basename.c-362"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fopen.h-363"
+      "relatedSpdxElement": "SPDXRef-File-tool-progress.h-363"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-filetime.h-364"
+      "relatedSpdxElement": "SPDXRef-File-winapi.h-364"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amigaos.c-365"
+      "relatedSpdxElement": "SPDXRef-File-smb.h-365"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-progress.h-366"
+      "relatedSpdxElement": "SPDXRef-File-inet-pton.c-366"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-winapi.h-367"
+      "relatedSpdxElement": "SPDXRef-File-cram.c-367"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smb.h-368"
+      "relatedSpdxElement": "SPDXRef-File-vssh.c-368"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ws.h-369"
+      "relatedSpdxElement": "SPDXRef-File-snprintf.h-369"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gtls.c-370"
+      "relatedSpdxElement": "SPDXRef-File-strcopy.h-370"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostcheck.h-371"
+      "relatedSpdxElement": "SPDXRef-File-krb5-gssapi.c-371"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcopy.h-372"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.h-372"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi.c-373"
+      "relatedSpdxElement": "SPDXRef-File-conncache.h-373"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcopy.c-374"
+      "relatedSpdxElement": "SPDXRef-File-apple.h-374"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-help.c-375"
+      "relatedSpdxElement": "SPDXRef-File-easyoptions.h-375"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.h-376"
+      "relatedSpdxElement": "SPDXRef-File-fopen.h-376"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-md4.c-377"
+      "relatedSpdxElement": "SPDXRef-File-mbedtls.h-377"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyoptions.h-378"
+      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.c-378"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-chunks.h-379"
+      "relatedSpdxElement": "SPDXRef-File-hostcheck.h-379"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.c-380"
+      "relatedSpdxElement": "SPDXRef-File-http-chunks.h-380"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerr.c-381"
+      "relatedSpdxElement": "SPDXRef-File-curl-quiche.c-381"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi.h-382"
+      "relatedSpdxElement": "SPDXRef-File-vtls-spack.c-382"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cfilters.c-383"
+      "relatedSpdxElement": "SPDXRef-File-typecheck-gcc.h-383"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.h-384"
+      "relatedSpdxElement": "SPDXRef-File-strcopy.c-384"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic-int.h-385"
+      "relatedSpdxElement": "SPDXRef-File-http-chunks.c-385"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apple.h-386"
+      "relatedSpdxElement": "SPDXRef-File-terminal.h-386"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.h-387"
+      "relatedSpdxElement": "SPDXRef-File-splay.c-387"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ev.h-388"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.h-388"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.h-389"
+      "relatedSpdxElement": "SPDXRef-File-multi-ev.h-389"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.h-390"
+      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.h-390"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-functypes.h-391"
+      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.c-391"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ntlm-sspi.c-392"
+      "relatedSpdxElement": "SPDXRef-File-pop3.c-392"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.c-393"
+      "relatedSpdxElement": "SPDXRef-File-getinfo.c-393"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setup.h-394"
+      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.h-394"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timediff.h-395"
+      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.c-395"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.c-396"
+      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.c-396"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-hash.c-397"
+      "relatedSpdxElement": "SPDXRef-File-hsts.h-397"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-psl.c-398"
+      "relatedSpdxElement": "SPDXRef-File-vquic-tls.c-398"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsts.h-399"
+      "relatedSpdxElement": "SPDXRef-File-http2.c-399"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.h-400"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.c-400"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.h-401"
+      "relatedSpdxElement": "SPDXRef-File-ldap.c-401"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.h-402"
+      "relatedSpdxElement": "SPDXRef-File-psl.c-402"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-md5.c-403"
+      "relatedSpdxElement": "SPDXRef-File-dynhds.h-403"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setopt.c-404"
+      "relatedSpdxElement": "SPDXRef-File-tool-getparam.h-404"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostip.h-405"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.h-405"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-header.h-406"
+      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.h-406"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-content-encoding.h-407"
+      "relatedSpdxElement": "SPDXRef-File-mqtt.c-407"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.h-408"
+      "relatedSpdxElement": "SPDXRef-File-tool-getparam.c-408"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setopt.h-409"
+      "relatedSpdxElement": "SPDXRef-File-content-encoding.h-409"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-proxy.c-410"
+      "relatedSpdxElement": "SPDXRef-File-mime.h-410"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.c-411"
+      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.h-411"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-msgs.h-412"
+      "relatedSpdxElement": "SPDXRef-File-parsedate.h-412"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest.c-413"
+      "relatedSpdxElement": "SPDXRef-File-tool-msgs.h-413"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keylog.h-414"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.c-414"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gtls.h-415"
+      "relatedSpdxElement": "SPDXRef-File-url.c-415"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock.h-416"
+      "relatedSpdxElement": "SPDXRef-File-cw-pause.c-416"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftp.h-417"
+      "relatedSpdxElement": "SPDXRef-File-noproxy.c-417"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-soc.h-418"
+      "relatedSpdxElement": "SPDXRef-File-nonblock.h-418"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strparse.c-419"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-soc.h-419"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl.h-420"
+      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.c-420"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.c-421"
+      "relatedSpdxElement": "SPDXRef-File-imap.h-421"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-imap.h-422"
+      "relatedSpdxElement": "SPDXRef-File-digest-sspi.c-422"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.c-423"
+      "relatedSpdxElement": "SPDXRef-File-slist-wc.c-423"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connect.h-424"
+      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.h-424"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sendf.c-425"
+      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.h-425"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist-wc.c-426"
+      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.c-426"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-base.c-427"
+      "relatedSpdxElement": "SPDXRef-File-http-digest.c-427"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.c-428"
+      "relatedSpdxElement": "SPDXRef-File-getinfo.h-428"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic.h-429"
+      "relatedSpdxElement": "SPDXRef-File-curl-threads.c-429"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-digest.c-430"
+      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.c-430"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getinfo.h-431"
+      "relatedSpdxElement": "SPDXRef-File-vtls.c-431"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-threads.c-432"
+      "relatedSpdxElement": "SPDXRef-File-urlapi.h-432"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -6724,52 +6691,42 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.h-436"
+      "relatedSpdxElement": "SPDXRef-File-curl-endian.h-436"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-endian.h-437"
+      "relatedSpdxElement": "SPDXRef-File-cookie.h-437"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.c-438"
+      "relatedSpdxElement": "SPDXRef-File-basename.h-438"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi-int.h-439"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.c-439"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-pton.h-440"
+      "relatedSpdxElement": "SPDXRef-File-dict.c-440"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cleartext.c-441"
+      "relatedSpdxElement": "SPDXRef-File-schannel.h-441"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.c-442"
+      "relatedSpdxElement": "SPDXRef-File-http-ntlm.h-442"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getinfo.c-443"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pop3.c-444"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-ntlm.h-445"
+      "relatedSpdxElement": "SPDXRef-File-select.h-443"
     }
   ]
 }

--- a/tests/golden/spdx/c-cpp/curl/libcurl.so_analyzed.spdx.json
+++ b/tests/golden/spdx/c-cpp/curl/libcurl.so_analyzed.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "libcurl.so",
-  "documentNamespace": "https://omnibor.io/omnibor-analysis/libcurl.so-5ac0d0e1-8487-4b62-a9e9-fac6f804cc12",
+  "documentNamespace": "https://omnibor.io/omnibor-analysis/libcurl.so-e230e97c-de86-4e18-a098-8252ab8c9ad7",
   "creationInfo": {
-    "created": "2026-03-12T21:58:57Z",
+    "created": "2026-04-02T21:39:27Z",
     "creators": [
       "Tool: bomtrace3-unknown",
       "Tool: bomsh-unknown",
@@ -20,87 +20,107 @@
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": true,
       "primaryPackagePurpose": "LIBRARY",
-      "builtDate": "2026-03-12T21:58:57Z",
+      "builtDate": "2026-04-02T21:39:27Z",
       "externalRefs": [],
       "checksums": [],
       "comment": "Built on Ubuntu 22.04.5 LTS with gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
-      "versionInfo": "8.19.0-DEV"
+      "versionInfo": "8.19.0"
     }
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-File-idn.c-2",
-      "fileName": "repos/curl/lib/idn.c",
+      "SPDXID": "SPDXRef-File-smb.c-2",
+      "fileName": "repos/curl/lib/smb.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "00e2fc6e4cb6dcd2036b24331adc2672a4f9bcd3"
+          "checksumValue": "00297adee7f2116f0ec521167ee5ec3ac411b404"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-scache.c-3",
-      "fileName": "repos/curl/lib/vtls/vtls_scache.c",
+      "SPDXID": "SPDXRef-File-cf-socket.h-3",
+      "fileName": "repos/curl/lib/cf-socket.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0149b51869d7b42c41bfed6c81f6bc5d32921445"
+          "checksumValue": "014f5f7881728246f7f7c0aebda9e5fbe3746325"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-ip-happy.c-4",
-      "fileName": "repos/curl/lib/cf-ip-happy.c",
+      "SPDXID": "SPDXRef-File-keylog.c-4",
+      "fileName": "repos/curl/lib/vtls/keylog.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "01ddd9f3d890ee06d6f1227b06b40546d54f033e"
+          "checksumValue": "0206e32cf8fd21e90cb5d1d8079243472dd6dee8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multiif.h-5",
-      "fileName": "repos/curl/lib/vtls/../multiif.h",
+      "SPDXID": "SPDXRef-File-hmac.c-5",
+      "fileName": "repos/curl/lib/hmac.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0252b2dfd978b5626cc3f8e1e196440ab735c6f6"
+          "checksumValue": "028b476c77a3bdeb67176c058410c5f8220463d5"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rustls.c-6",
-      "fileName": "repos/curl/lib/vtls/rustls.c",
+      "SPDXID": "SPDXRef-File-inet-pton.h-6",
+      "fileName": "repos/curl/lib/curlx/inet_pton.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "02a6b7d5aa8d0237724a487be0dea89c32c98a42"
+          "checksumValue": "02ae7f2269dd1c7131bb833c56a63453fac1c8d1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.h-7",
-      "fileName": "repos/curl/lib/vauth/../rand.h",
+      "SPDXID": "SPDXRef-File-multiif.h-7",
+      "fileName": "repos/curl/lib/multiif.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c69a0df460f64a88df44a55b3cc44d31c28d7c"
+          "checksumValue": "039db269e001d28f6e41b3b2ea010c4d566c19a6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ldap.c-8",
-      "fileName": "repos/curl/lib/ldap.c",
+      "SPDXID": "SPDXRef-File-hsts.c-8",
+      "fileName": "repos/curl/lib/hsts.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "046fcd48e885273cf6cb49d2f6c94ec01024b056"
+          "checksumValue": "03f51f8109d4900c7a287fe297f138fd7aedb13a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transfer.h-9",
-      "fileName": "repos/curl/lib/vtls/../transfer.h",
+      "SPDXID": "SPDXRef-File-curl-md5.h-9",
+      "fileName": "repos/curl/lib/curl_md5.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "042c5f59ae5ecbb33a26f980be5da064629b370d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-imap.c-10",
+      "fileName": "repos/curl/lib/imap.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0546595f8998214cdd0b77784d9d25cd4e52f051"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-transfer.h-11",
+      "fileName": "repos/curl/lib/transfer.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -109,7 +129,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-md4.h-10",
+      "SPDXID": "SPDXRef-File-curl-md4.h-12",
       "fileName": "repos/curl/lib/curl_md4.h",
       "checksums": [
         {
@@ -119,8 +139,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ntfy.h-11",
-      "fileName": "repos/curl/lib/vauth/../multi_ntfy.h",
+      "SPDXID": "SPDXRef-File-multi-ntfy.h-13",
+      "fileName": "repos/curl/lib/multi_ntfy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -129,7 +149,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-if2ip.c-12",
+      "SPDXID": "SPDXRef-File-if2ip.c-14",
       "fileName": "repos/curl/lib/if2ip.c",
       "checksums": [
         {
@@ -139,17 +159,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-typecheck-gcc.h-13",
-      "fileName": "repos/curl/lib/../include/curl/typecheck-gcc.h",
+      "SPDXID": "SPDXRef-File-rustls.c-15",
+      "fileName": "repos/curl/lib/vtls/rustls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0642afd91ed2f07c171ecbf34c69107c6c800748"
+          "checksumValue": "061b444bcefd9b963287da7d1bee1ed3aab1069b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-rea.h-14",
+      "SPDXID": "SPDXRef-File-netrc.h-16",
+      "fileName": "repos/curl/lib/netrc.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "061e1e438b9c956e8e794347492286b9783a60f0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-system.h-17",
+      "fileName": "repos/curl/lib/../include/curl/system.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "064833d6e1e72385ed9e493513c1a2d8219c6443"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-rea.h-18",
       "fileName": "repos/curl/src/tool_cb_rea.h",
       "checksums": [
         {
@@ -159,17 +199,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-range.c-15",
-      "fileName": "repos/curl/lib/curl_range.c",
+      "SPDXID": "SPDXRef-File-connect.h-19",
+      "fileName": "repos/curl/lib/connect.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "070dee428980cd6bacb36dec17a698e98c42a163"
+          "checksumValue": "071b4329c1154c5ce0d97125e23479ca0cec9225"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-addrinfo.h-16",
+      "SPDXID": "SPDXRef-File-fake-addrinfo.h-20",
       "fileName": "repos/curl/lib/fake_addrinfo.h",
       "checksums": [
         {
@@ -179,7 +219,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getpass.h-17",
+      "SPDXID": "SPDXRef-File-llist.h-21",
+      "fileName": "repos/curl/lib/llist.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "09c695d3cfaef70dba17fb05724803c65c3265b9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-getpass.h-22",
       "fileName": "repos/curl/src/tool_getpass.h",
       "checksums": [
         {
@@ -189,7 +239,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlinfo.c-18",
+      "SPDXID": "SPDXRef-File-curlinfo.c-23",
       "fileName": "repos/curl/src/curlinfo.c",
       "checksums": [
         {
@@ -199,7 +249,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-macos.h-19",
+      "SPDXID": "SPDXRef-File-macos.h-24",
       "fileName": "repos/curl/lib/macos.h",
       "checksums": [
         {
@@ -209,82 +259,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sha256.h-20",
-      "fileName": "repos/curl/lib/vauth/../curl_sha256.h",
+      "SPDXID": "SPDXRef-File-tool-filetime.c-25",
+      "fileName": "repos/curl/src/tool_filetime.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0aaa4126f4e3f07fa78d9883b0fada4a3ba07efc"
+          "checksumValue": "0b6cd7b38f397dfb12161399505c507badda253a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-ntop.c-21",
-      "fileName": "repos/curl/lib/curlx/inet_ntop.c",
+      "SPDXID": "SPDXRef-File-easy.h-26",
+      "fileName": "repos/curl/lib/../include/curl/easy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0b10e8a7f63087853c342313f6fe0e57670dd7f8"
+          "checksumValue": "0be6915d92bb21f42dacb2d3cb981af3710437ec"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.c-22",
-      "fileName": "repos/curl/lib/hash.c",
+      "SPDXID": "SPDXRef-File-strdup.h-27",
+      "fileName": "repos/curl/lib/curlx/strdup.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0b6ecc48f7d52d388c7fce4dda3e85ef3055084e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-dbg.c-23",
-      "fileName": "repos/curl/src/tool_cb_dbg.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0c8568ff62ff8a6c0931089b3d96e0762455612a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cram.c-24",
-      "fileName": "repos/curl/lib/vauth/cram.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0d061ebbb029aba5ba5656b285f4e7d161b83655"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-doh.h-25",
-      "fileName": "repos/curl/lib/doh.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0dc6a3f2a490024225e76806399b8d715a094d28"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-setopt.h-26",
-      "fileName": "repos/curl/lib/vtls/../setopt.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0dd60c785f939b50563a053d5286b19f150c9a7c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-smb.c-27",
-      "fileName": "repos/curl/lib/smb.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0ddb167e61514f5376ea17ee5132dff8c84f4219"
+          "checksumValue": "0c4b14161e98dbcd6694358eeb6d424d3ff07358"
         }
       ]
     },
@@ -300,7 +300,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-curl-threads.h-29",
-      "fileName": "repos/curl/lib/vauth/../curl_threads.h",
+      "fileName": "repos/curl/lib/curl_threads.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -309,17 +309,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-thrdd.c-30",
-      "fileName": "repos/curl/lib/asyn-thrdd.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0e06db22ca0cab9e291e14a85eb3a005b863ad5e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-llist.c-31",
+      "SPDXID": "SPDXRef-File-llist.c-30",
       "fileName": "repos/curl/lib/llist.c",
       "checksums": [
         {
@@ -329,22 +319,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base64.c-32",
-      "fileName": "repos/curl/lib/curlx/base64.c",
+      "SPDXID": "SPDXRef-File-netrc.c-31",
+      "fileName": "repos/curl/lib/netrc.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0e44eae7faf3634cb181e6c735aac7f3f876fdba"
+          "checksumValue": "1073cc53656f0bd71017f906c1f4c82fbdb3c222"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-formparse.c-33",
-      "fileName": "repos/curl/src/tool_formparse.c",
+      "SPDXID": "SPDXRef-File-timediff.h-32",
+      "fileName": "repos/curl/lib/../lib/curlx/timediff.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0ec434e2def65be84c10bd3341c07023bd8aedd4"
+          "checksumValue": "1081c75d1c9644a3c47b124e50861ffaf6a1b332"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-rtsp.c-33",
+      "fileName": "repos/curl/lib/rtsp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "11848c82820470ebd6e7617084fca138e4da29e3"
         }
       ]
     },
@@ -359,37 +359,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http1.h-35",
-      "fileName": "repos/curl/lib/http1.h",
+      "SPDXID": "SPDXRef-File-ntlm-sspi.c-35",
+      "fileName": "repos/curl/lib/vauth/ntlm_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "124d32e373cb497fbb2a0e752a18979be32ac614"
+          "checksumValue": "12cf32b8945979d680ff1274f90614952c407ead"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-spnego-sspi.c-36",
-      "fileName": "repos/curl/lib/vauth/spnego_sspi.c",
+      "SPDXID": "SPDXRef-File-tool-time.c-36",
+      "fileName": "repos/curl/src/toolx/tool_time.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "12bdc3afd798ee9c792debd1024ad279de2de4e9"
+          "checksumValue": "12eaea9fe4eed120187b2036408527e57fb692d0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn.h-37",
-      "fileName": "repos/curl/lib/vauth/../asyn.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "12d3e1c33883c850d535b97807806c8901760b68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-if2ip.h-38",
+      "SPDXID": "SPDXRef-File-if2ip.h-37",
       "fileName": "repos/curl/lib/if2ip.h",
       "checksums": [
         {
@@ -399,7 +389,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ntfy.c-39",
+      "SPDXID": "SPDXRef-File-multi-ntfy.c-38",
       "fileName": "repos/curl/lib/multi_ntfy.c",
       "checksums": [
         {
@@ -409,28 +399,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noproxy.c-40",
-      "fileName": "repos/curl/lib/noproxy.c",
+      "SPDXID": "SPDXRef-File-strparse.c-39",
+      "fileName": "repos/curl/lib/curlx/strparse.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1421fb114de2950ba9306090a7145e6f663318d9"
+          "checksumValue": "138b3df1255328b71f6f352d6aa78ae3195c2f6f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sendf.h-41",
-      "fileName": "repos/curl/lib/vssh/../sendf.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1521ccb0f86614d0f2e1a948c988df6026514e8e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-ctype.h-42",
-      "fileName": "repos/curl/lib/vauth/../curl_ctype.h",
+      "SPDXID": "SPDXRef-File-curl-ctype.h-40",
+      "fileName": "repos/curl/lib/curl_ctype.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -439,7 +419,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-time.h-43",
+      "SPDXID": "SPDXRef-File-tool-time.h-41",
       "fileName": "repos/curl/src/toolx/tool_time.h",
       "checksums": [
         {
@@ -449,37 +429,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libssh2.c-44",
-      "fileName": "repos/curl/lib/vssh/libssh2.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "15b7c056dd54a23a08432aaf4d5e4dd836e4a7ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hsts.c-45",
-      "fileName": "repos/curl/lib/hsts.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "15d4207548d319fc021423e1150e50a95ae71f22"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-md5.h-46",
-      "fileName": "repos/curl/lib/vauth/../curl_md5.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "16272c759105bbdd91edef6100c8f9d0a3a4a599"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-httpsrr.c-47",
+      "SPDXID": "SPDXRef-File-httpsrr.c-42",
       "fileName": "repos/curl/lib/httpsrr.c",
       "checksums": [
         {
@@ -489,77 +439,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-pton.c-48",
-      "fileName": "repos/curl/lib/curlx/inet_pton.c",
+      "SPDXID": "SPDXRef-File-http.c-43",
+      "fileName": "repos/curl/lib/http.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1767bf19af715657ff5a393ae84eaad8e95cd995"
+          "checksumValue": "188da5fd832edc887ba50e8aad4d79750dbdbcff"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-msgs.c-49",
-      "fileName": "repos/curl/src/tool_msgs.c",
+      "SPDXID": "SPDXRef-File-md4.c-44",
+      "fileName": "repos/curl/lib/md4.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "18e014950df5f52f71acb18808086f3b6f29fc97"
+          "checksumValue": "1ac6ef1c5b7befa694333d5c363ad77d178ded35"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-paramhlp.h-50",
-      "fileName": "repos/curl/src/tool_paramhlp.h",
+      "SPDXID": "SPDXRef-File-ssh.h-45",
+      "fileName": "repos/curl/lib/vssh/ssh.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "192d242d181d2495bc836f17b572fdd5a24dccd0"
+          "checksumValue": "1afb1e8643d99a8dd4ab35d17df32acb866628e0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-doswin.c-51",
-      "fileName": "repos/curl/src/tool_doswin.c",
+      "SPDXID": "SPDXRef-File-system-win32.c-46",
+      "fileName": "repos/curl/lib/system_win32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "193446cba3869353d81dea0b34b14b7e2aee9c89"
+          "checksumValue": "1b052357b5dd4f7b41117bae8e6e2df05d9603f6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cookie.c-52",
-      "fileName": "repos/curl/lib/cookie.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "19d8fc85474cf205be8439b3574c901253cd7a40"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ratelimit.c-53",
-      "fileName": "repos/curl/lib/ratelimit.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1b1fb6ccedc3e04fa5ad3445bdac113830ef71b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-vquic.c-54",
-      "fileName": "repos/curl/lib/vquic/vquic.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1b7dc1d3aacf071aed30977c1e853cb3ff49ef99"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file.c-55",
+      "SPDXID": "SPDXRef-File-file.c-47",
       "fileName": "repos/curl/lib/file.c",
       "checksums": [
         {
@@ -569,7 +489,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sspi.c-56",
+      "SPDXID": "SPDXRef-File-tool-cb-wrt.c-48",
+      "fileName": "repos/curl/src/tool_cb_wrt.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1d2b81ea7cacb6e3bb09260687f50d464465cb66"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sspi.c-49",
       "fileName": "repos/curl/lib/curl_sspi.c",
       "checksums": [
         {
@@ -579,37 +509,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-llist.h-57",
-      "fileName": "repos/curl/lib/vauth/../llist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1d73db1719da962379938387032ac1b38f0d1052"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-url.h-58",
-      "fileName": "repos/curl/lib/vauth/../url.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e44ebe43bb0d94309e27a15486fc1d040dab958"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strdup.h-59",
-      "fileName": "repos/curl/lib/vauth/../curlx/strdup.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e6bc1981429b9e4055bccd0448e9256a4dd1b41"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strerror.c-60",
+      "SPDXID": "SPDXRef-File-strerror.c-50",
       "fileName": "repos/curl/lib/strerror.c",
       "checksums": [
         {
@@ -619,47 +519,77 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ngtcp2.h-61",
-      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.h",
+      "SPDXID": "SPDXRef-File-vquic.c-51",
+      "fileName": "repos/curl/lib/vquic/vquic.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1e9868e0f7f6d1b2f68b40856824000187affb61"
+          "checksumValue": "1eaabb95f5d47769af808a81fbdfba037ab073c2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlx.h-62",
-      "fileName": "repos/curl/src/../lib/curlx/curlx.h",
+      "SPDXID": "SPDXRef-File-spnego-sspi.c-52",
+      "fileName": "repos/curl/lib/vauth/spnego_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1ee35fa1a029667d290f599fbdcc57264d3b4a0f"
+          "checksumValue": "1f73123a0d79e03637c05d2ef695f7d260fa770c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-spack.c-63",
-      "fileName": "repos/curl/lib/vtls/vtls_spack.c",
+      "SPDXID": "SPDXRef-File-cipher-suite.c-53",
+      "fileName": "repos/curl/lib/vtls/cipher_suite.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2026fe3ed57d0fd96748720ea486b3dddfbf3e63"
+          "checksumValue": "1fc6e9f8c6f909e02c1cacdbd409d0067b63fd5b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-printf.h-64",
-      "fileName": "repos/curl/lib/curlx/../curl_printf.h",
+      "SPDXID": "SPDXRef-File-curl.h-54",
+      "fileName": "repos/curl/lib/../include/curl/curl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "207ba7125d62ab9a358a5644c3adbdc31abd6cef"
+          "checksumValue": "209716b334da52a7260b50fada5785870e431322"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyif.h-65",
+      "SPDXID": "SPDXRef-File-ftp.h-55",
+      "fileName": "repos/curl/lib/ftp.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20b360033e05dfddf23b5eaec31f7b7847cd660b"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-config2setopts.c-56",
+      "fileName": "repos/curl/src/config2setopts.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20d87a070ab54f77784e0cfb4953f20b4af78fa6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-formparse.c-57",
+      "fileName": "repos/curl/src/tool_formparse.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20f7e366a000e2a2cfab633d0a31355cd78f0d34"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easyif.h-58",
       "fileName": "repos/curl/lib/easyif.h",
       "checksums": [
         {
@@ -669,17 +599,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks-gssapi.c-66",
-      "fileName": "repos/curl/lib/socks_gssapi.c",
+      "SPDXID": "SPDXRef-File-tool-writeout.c-59",
+      "fileName": "repos/curl/src/tool_writeout.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "21722f072016b083a86e3cd50c8f85f8f04cf106"
+          "checksumValue": "22c83efd03089b3ef1d43e6a297c86292bb18fcf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ssls.c-67",
+      "SPDXID": "SPDXRef-File-tool-ssls.c-60",
       "fileName": "repos/curl/src/tool_ssls.c",
       "checksums": [
         {
@@ -689,28 +619,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-rea.c-68",
-      "fileName": "repos/curl/src/tool_cb_rea.c",
+      "SPDXID": "SPDXRef-File-uint-hash.c-61",
+      "fileName": "repos/curl/lib/uint-hash.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2343d04a133a5a52cc8eeffbf3b0e4ee5a08c4c5"
+          "checksumValue": "2377840200141e225c72298a18b74addd28192f8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-smtp.c-69",
-      "fileName": "repos/curl/lib/smtp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "23590398f949e6fafb513264d7f0c2823bb2bcd6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-memrchr.h-70",
-      "fileName": "repos/curl/lib/vtls/../curl_memrchr.h",
+      "SPDXID": "SPDXRef-File-curl-memrchr.h-62",
+      "fileName": "repos/curl/lib/curl_memrchr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -719,17 +639,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-pause.c-71",
-      "fileName": "repos/curl/lib/cw-pause.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2489a330a03ba8fc94808f4b142ea54f43723272"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-aws-sigv4.h-72",
+      "SPDXID": "SPDXRef-File-http-aws-sigv4.h-63",
       "fileName": "repos/curl/lib/http_aws_sigv4.h",
       "checksums": [
         {
@@ -739,17 +649,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-snprintf.h-73",
-      "fileName": "repos/curl/lib/curlx/snprintf.h",
+      "SPDXID": "SPDXRef-File-hash.h-64",
+      "fileName": "repos/curl/lib/hash.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "266ea137fae6eb76466219d69ec828facf4edc58"
+          "checksumValue": "267f91d1ae43cc3d9493df25b215d1d4e136ef37"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easygetopt.c-74",
+      "SPDXID": "SPDXRef-File-easygetopt.c-65",
       "fileName": "repos/curl/lib/easygetopt.c",
       "checksums": [
         {
@@ -759,37 +669,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-select.h-75",
-      "fileName": "repos/curl/lib/vtls/../select.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "268ae7cecfd4f9a1e806f506f240448adaeb6017"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-multibyte.h-76",
-      "fileName": "repos/curl/lib/vauth/../curlx/multibyte.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "26da0f0843e09509b3a3f41db92b8fc149caa3a6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-writeout.c-77",
-      "fileName": "repos/curl/src/tool_writeout.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2700abfa44385e8cc290ed158b5ce01fc69935ef"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-findfile.c-78",
+      "SPDXID": "SPDXRef-File-tool-findfile.c-66",
       "fileName": "repos/curl/src/tool_findfile.c",
       "checksums": [
         {
@@ -799,68 +679,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basename.c-79",
-      "fileName": "repos/curl/lib/curlx/basename.c",
+      "SPDXID": "SPDXRef-File-cfilters.c-67",
+      "fileName": "repos/curl/lib/cfilters.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "27c29f3c00aace71a0a9f9194c11dc580c530429"
+          "checksumValue": "27b0306180cf80071b421289dc794578492a3ee3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basename.h-80",
-      "fileName": "repos/curl/lib/curlx/basename.h",
+      "SPDXID": "SPDXRef-File-altsvc.h-68",
+      "fileName": "repos/curl/lib/altsvc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "287a14aa14aef0d2aae54a56a5a4520ba5ad402f"
+          "checksumValue": "2931af452bef3a61b90fc7e502bc646048e19675"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-socket.h-81",
-      "fileName": "repos/curl/lib/vauth/../cf-socket.h",
+      "SPDXID": "SPDXRef-File-version-win32.c-69",
+      "fileName": "repos/curl/lib/curlx/version_win32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "298ced926996b3b35f54a084a73c7352cd3f9c52"
+          "checksumValue": "296a38d9247b176476cd5613ca6c7d1859bd1875"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-helpers.c-82",
-      "fileName": "repos/curl/src/tool_helpers.c",
+      "SPDXID": "SPDXRef-File-urlapi-int.h-70",
+      "fileName": "repos/curl/lib/urlapi-int.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2a84accf2c508f000bf3eab280a7e87cb562cf5d"
+          "checksumValue": "29d4fe5f39a0ee84d7fae0239209ccee9452881b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-scache.h-83",
-      "fileName": "repos/curl/lib/vtls/vtls_scache.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a99e779e5285dee6adcbb396988d374c00489ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-wait.c-84",
-      "fileName": "repos/curl/lib/curlx/wait.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a9f54bb3e4eb8655ce48a1c4ff4cdc7ce9e08ce"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socketpair.h-85",
-      "fileName": "repos/curl/lib/vauth/../socketpair.h",
+      "SPDXID": "SPDXRef-File-socketpair.h-71",
+      "fileName": "repos/curl/lib/socketpair.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -869,8 +729,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockaddr.h-86",
-      "fileName": "repos/curl/lib/vauth/../sockaddr.h",
+      "SPDXID": "SPDXRef-File-sockaddr.h-72",
+      "fileName": "repos/curl/lib/sockaddr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -879,38 +739,58 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-prg.c-87",
-      "fileName": "repos/curl/src/tool_cb_prg.c",
+      "SPDXID": "SPDXRef-File-mbedtls.c-73",
+      "fileName": "repos/curl/lib/vtls/mbedtls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2b9e6d63112b864e7ada0c956dd664e98c16116f"
+          "checksumValue": "2bac406c359b21ed33a7e1d16a548409f522745a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynhds.h-88",
-      "fileName": "repos/curl/lib/vauth/../dynhds.h",
+      "SPDXID": "SPDXRef-File-timediff.c-74",
+      "fileName": "repos/curl/lib/curlx/timediff.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2cfa290571201bfbed02112326973f7e5ffe3b73"
+          "checksumValue": "2bf786941d080ba5d552ac28be9089c0abe1ae4d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rustls.h-89",
-      "fileName": "repos/curl/lib/vtls/rustls.h",
+      "SPDXID": "SPDXRef-File-ratelimit.c-75",
+      "fileName": "repos/curl/lib/ratelimit.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2d3b0bb11f1daff419f2b8a37ce0673717b0ec1a"
+          "checksumValue": "2d88cdd7c94428a1cddbb7cd8554d7123e33fabe"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base64.h-90",
-      "fileName": "repos/curl/lib/vauth/../curlx/base64.h",
+      "SPDXID": "SPDXRef-File-idn.c-76",
+      "fileName": "repos/curl/lib/idn.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2db4f6d79e2edfec2afdb5019c0d925017f077ab"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-inet-ntop.h-77",
+      "fileName": "repos/curl/lib/curlx/inet_ntop.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2e3419f02be577ee15228e20f63052c5d81a5b46"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-base64.h-78",
+      "fileName": "repos/curl/lib/curlx/base64.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -919,67 +799,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-escape.h-91",
-      "fileName": "repos/curl/lib/vtls/../escape.h",
+      "SPDXID": "SPDXRef-File-cf-socket.c-79",
+      "fileName": "repos/curl/lib/cf-socket.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2ea06c444fd32f164769906430cef2da8829a137"
+          "checksumValue": "2ebbe4df4da503e272cac2a73db28652867793b4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ntlm-core.c-92",
-      "fileName": "repos/curl/lib/curl_ntlm_core.c",
+      "SPDXID": "SPDXRef-File-cshutdn.c-80",
+      "fileName": "repos/curl/lib/cshutdn.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2edc7b07ce5a1e3f48b304a6cea451867abe8d2f"
+          "checksumValue": "308f2aaa82dfb5f3f389ada7aa8a6320056e7a7a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-system-win32.c-93",
-      "fileName": "repos/curl/lib/system_win32.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2f24fe5c0ccec9c72477a785086e073a8cfd9e51"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-setopt.c-94",
-      "fileName": "repos/curl/src/tool_setopt.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2ffcd1076b978b354dfd80d972f70973d9746daa"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-var.c-95",
-      "fileName": "repos/curl/src/var.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "306ed1b02bcbec022ec8f11da63ca3898a908932"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-vauth.h-96",
-      "fileName": "repos/curl/lib/vauth/vauth.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "312bd8da5ad474c66012fc26fe9d36bcea8ec894"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cf-h2-proxy.h-97",
+      "SPDXID": "SPDXRef-File-cf-h2-proxy.h-81",
       "fileName": "repos/curl/lib/cf-h2-proxy.h",
       "checksums": [
         {
@@ -989,7 +829,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-writeout-json.c-98",
+      "SPDXID": "SPDXRef-File-tool-writeout-json.c-82",
       "fileName": "repos/curl/src/tool_writeout_json.c",
       "checksums": [
         {
@@ -999,27 +839,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-arpa-telnet.h-99",
-      "fileName": "repos/curl/lib/arpa_telnet.h",
+      "SPDXID": "SPDXRef-File-slist-wc.h-83",
+      "fileName": "repos/curl/src/slist_wc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "329f4bcd1c5414f5c28b7767725e1cbd3e98aaae"
+          "checksumValue": "328d6b00f5ba7e1be00a0c48fe62d50087098e40"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transfer.c-100",
-      "fileName": "repos/curl/lib/transfer.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "32c31c6e9378298bd25affb9b90244128710ceed"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-macos.c-101",
+      "SPDXID": "SPDXRef-File-macos.c-84",
       "fileName": "repos/curl/lib/macos.c",
       "checksums": [
         {
@@ -1029,18 +859,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic-tls.c-102",
-      "fileName": "repos/curl/lib/vquic/vquic-tls.c",
+      "SPDXID": "SPDXRef-File-curl-share.c-85",
+      "fileName": "repos/curl/lib/curl_share.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3391d98074088f646498adafd8d3ee74b6fcb76c"
+          "checksumValue": "338727a4fab265303d41853ee4b169cb4e567666"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pingpong.h-103",
-      "fileName": "repos/curl/lib/vauth/../pingpong.h",
+      "SPDXID": "SPDXRef-File-pingpong.h-86",
+      "fileName": "repos/curl/lib/pingpong.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1049,7 +879,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fileinfo.c-104",
+      "SPDXID": "SPDXRef-File-formdata.h-87",
+      "fileName": "repos/curl/lib/formdata.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "33d7d0ae33d540bfb7f734f6c367fd3c4cf1245d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fileinfo.c-88",
       "fileName": "repos/curl/lib/fileinfo.c",
       "checksums": [
         {
@@ -1059,17 +899,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcase.h-105",
-      "fileName": "repos/curl/lib/vtls/../strcase.h",
+      "SPDXID": "SPDXRef-File-winapi.c-89",
+      "fileName": "repos/curl/lib/curlx/winapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "35f726c3eecef87a51ef1a576514266feed7253f"
+          "checksumValue": "3417df269e056282d37ab70a4432bca5fdc1c951"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-hdr.h-106",
+      "SPDXID": "SPDXRef-File-altsvc.c-90",
+      "fileName": "repos/curl/lib/altsvc.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "34da3e1ac86d083a31afb81d71ea3da74e8b5297"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-hugehelp.c-91",
+      "fileName": "repos/curl/src/tool_hugehelp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "374cf39809682272c1c8034d1d803c7783186357"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-formdata.c-92",
+      "fileName": "repos/curl/lib/formdata.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3770d28b18ec9f8bfc0cfea4b7be2a79239437a2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-hdr.h-93",
       "fileName": "repos/curl/src/tool_cb_hdr.h",
       "checksums": [
         {
@@ -1079,37 +949,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mbedtls.h-107",
-      "fileName": "repos/curl/lib/vtls/mbedtls.h",
+      "SPDXID": "SPDXRef-File-mime.c-94",
+      "fileName": "repos/curl/lib/mime.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3876fe36fc5d82a56c1022c67aac4446f6cc036c"
+          "checksumValue": "37ea514e4f8715557562aea4bd1cc3e4342e195e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-request.h-108",
-      "fileName": "repos/curl/lib/vauth/../request.h",
+      "SPDXID": "SPDXRef-File-uint-table.h-95",
+      "fileName": "repos/curl/lib/uint-table.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "389ae4d8b1f8d7d6db078637f29304f6e5cf36a7"
+          "checksumValue": "398a26a64843389caffdbe0359d2e35e91e7065c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http.c-109",
-      "fileName": "repos/curl/lib/http.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "39f0a0d194056356c3f6339497e141bdba3ebca4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-smtp.h-110",
+      "SPDXID": "SPDXRef-File-smtp.h-96",
       "fileName": "repos/curl/lib/smtp.h",
       "checksums": [
         {
@@ -1119,7 +979,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config2setopts.h-111",
+      "SPDXID": "SPDXRef-File-libssh.c-97",
+      "fileName": "repos/curl/lib/vssh/libssh.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3a2a52e1f84fb57a17a2081375efbff799ea8b13"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-printf.h-98",
+      "fileName": "repos/curl/lib/curl_printf.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3b1a5af3b4593f544383faee11c07d8618a9d8ea"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strdup.c-99",
+      "fileName": "repos/curl/lib/curlx/strdup.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3c967dbe0a5d144dc4c77ad8e9ffac848d3c6d22"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-config2setopts.h-100",
       "fileName": "repos/curl/src/config2setopts.h",
       "checksums": [
         {
@@ -1129,37 +1019,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ipfs.c-112",
-      "fileName": "repos/curl/src/tool_ipfs.c",
+      "SPDXID": "SPDXRef-File-warnless.h-101",
+      "fileName": "repos/curl/lib/curlx/warnless.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3d2d5dea8424432dfe85fb138e171135c563643c"
+          "checksumValue": "3d0341e418a51614a644704a617f934681d0518e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-socket.c-113",
-      "fileName": "repos/curl/lib/cf-socket.c",
+      "SPDXID": "SPDXRef-File-vauth.h-102",
+      "fileName": "repos/curl/lib/vauth/vauth.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3e47a98722fc435f72915441868f473955a8c64c"
+          "checksumValue": "3e66c89cb5199edc6d792df91c9df50ccf6434a9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mbedtls.c-114",
-      "fileName": "repos/curl/lib/vtls/mbedtls.c",
+      "SPDXID": "SPDXRef-File-doh.h-103",
+      "fileName": "repos/curl/lib/doh.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3f5654ea0be7078ddafb2ec50407b663b7eb539d"
+          "checksumValue": "3eba4df26e29f5fe3b6065b2a4a8392f0c618cc0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-dirhie.c-115",
+      "SPDXID": "SPDXRef-File-tool-dirhie.c-104",
       "fileName": "repos/curl/src/tool_dirhie.c",
       "checksums": [
         {
@@ -1169,7 +1059,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cfgable.c-116",
+      "SPDXID": "SPDXRef-File-tool-cfgable.c-105",
       "fileName": "repos/curl/src/tool_cfgable.c",
       "checksums": [
         {
@@ -1179,37 +1069,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-table.h-117",
-      "fileName": "repos/curl/lib/vauth/../uint-table.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3fc7e34ef436e9c53ce465f736b8cdd550cace9f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-share.h-118",
-      "fileName": "repos/curl/lib/vtls/../curl_share.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3fcaaecd4ad64586c5db922a04a1c4ceb7f92783"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-share.c-119",
-      "fileName": "repos/curl/lib/curl_share.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3ff27556845f3f8ae0b1e31de45b7007310437f0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-writeout.h-120",
+      "SPDXID": "SPDXRef-File-tool-writeout.h-106",
       "fileName": "repos/curl/src/tool_writeout.h",
       "checksums": [
         {
@@ -1219,7 +1079,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-websockets.h-121",
+      "SPDXID": "SPDXRef-File-websockets.h-107",
       "fileName": "repos/curl/lib/../include/curl/websockets.h",
       "checksums": [
         {
@@ -1229,27 +1089,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-imap.c-122",
-      "fileName": "repos/curl/lib/imap.c",
+      "SPDXID": "SPDXRef-File-schannel-verify.c-108",
+      "fileName": "repos/curl/lib/vtls/schannel_verify.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "414ee32466d374da767cfc38ac55da587d6770be"
+          "checksumValue": "414b2e915aaaf7086002f5217db5f2cfda0b2881"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-idn.h-123",
-      "fileName": "repos/curl/lib/idn.h",
+      "SPDXID": "SPDXRef-File-rand.c-109",
+      "fileName": "repos/curl/lib/rand.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "42613af5096c058f000c2a8809e88d0f6c6844a2"
+          "checksumValue": "4232e819e17bbf101bfd7cd7593b9c72f28465ee"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ssls.h-124",
+      "SPDXID": "SPDXRef-File-cf-h2-proxy.c-110",
+      "fileName": "repos/curl/lib/cf-h2-proxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4275e1ef5aef37f4d1a5d7ef716d38c41e413272"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-ssls.h-111",
       "fileName": "repos/curl/src/tool_ssls.h",
       "checksums": [
         {
@@ -1259,8 +1129,28 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerr.h-125",
-      "fileName": "repos/curl/lib/vtls/../curlx/strerr.h",
+      "SPDXID": "SPDXRef-File-timeval.c-112",
+      "fileName": "repos/curl/lib/curlx/timeval.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "435804c2996b90f81c25c073a55e00ec67b1a8a1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-addrinfo.c-113",
+      "fileName": "repos/curl/lib/curl_addrinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "43d398d119216ea4ea4e53e25873807dafe949f3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strerr.h-114",
+      "fileName": "repos/curl/lib/curlx/strerr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1269,68 +1159,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mqtt.c-126",
-      "fileName": "repos/curl/lib/mqtt.c",
+      "SPDXID": "SPDXRef-File-vtls-spack.h-115",
+      "fileName": "repos/curl/lib/../lib/vtls/vtls_spack.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "446918cc44886a99b297d41aa1437c8d8e9ac702"
+          "checksumValue": "4479384de978cac1836eb55288466211663e1d0e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-filetime.c-127",
-      "fileName": "repos/curl/src/tool_filetime.c",
+      "SPDXID": "SPDXRef-File-doh.c-116",
+      "fileName": "repos/curl/lib/doh.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "45598413cd487828115d35fa1dae7912994a9b52"
+          "checksumValue": "4488d422b12cd93b8824cc689ef7ab75be8f80f9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-memdebug.c-128",
-      "fileName": "repos/curl/lib/memdebug.c",
+      "SPDXID": "SPDXRef-File-asyn-base.c-117",
+      "fileName": "repos/curl/lib/asyn-base.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "457034ebdae2227ed453e777681031b6de84b77f"
+          "checksumValue": "44bf98c8e4f912a7f2903f8f320d7db8f1d8a668"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-ntop.h-129",
-      "fileName": "repos/curl/lib/curlx/inet_ntop.h",
+      "SPDXID": "SPDXRef-File-oauth2.c-118",
+      "fileName": "repos/curl/lib/vauth/oauth2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "45b63d97a5958b327e288e0baed020b5bf5a8387"
+          "checksumValue": "4541d1d551bb94f687eab71dff4658cade41d6ae"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http2.c-130",
-      "fileName": "repos/curl/lib/http2.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "45f82192b024a77bc48bcc6b0a0f4b78c2334f64"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-hmac.h-131",
-      "fileName": "repos/curl/lib/vauth/../curl_hmac.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4759ff6ec6626e91f728ade60137ba5e573ff9e4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist.h-132",
-      "fileName": "repos/curl/lib/vtls/../slist.h",
+      "SPDXID": "SPDXRef-File-slist.h-119",
+      "fileName": "repos/curl/lib/slist.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1339,7 +1209,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-stderr.h-133",
+      "SPDXID": "SPDXRef-File-tool-stderr.h-120",
       "fileName": "repos/curl/src/tool_stderr.h",
       "checksums": [
         {
@@ -1349,18 +1219,58 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timeval.h-134",
-      "fileName": "repos/curl/lib/vauth/../curlx/timeval.h",
+      "SPDXID": "SPDXRef-File-curl-ngtcp2.c-121",
+      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4aab17519d8bfe74a78f1dfd761fc4ed760b627a"
+          "checksumValue": "48905d3e201780d2dde1742d7db4a6b4140b3b76"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-spbset.h-135",
-      "fileName": "repos/curl/lib/vauth/../uint-spbset.h",
+      "SPDXID": "SPDXRef-File-vssh.h-122",
+      "fileName": "repos/curl/lib/vssh/vssh.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "492108fbd7663d1629f6fcefe9ac7b13f0eee1c0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-aws-sigv4.c-123",
+      "fileName": "repos/curl/lib/http_aws_sigv4.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "492be1ab58634f8f6ef5773a21c6d54753fa7a5e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-ntlm-core.c-124",
+      "fileName": "repos/curl/lib/curl_ntlm_core.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4a9433b2936771dadc46831804ba91815606ffea"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cfgable.h-125",
+      "fileName": "repos/curl/src/tool_cfgable.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4af31b802e7b0012a9fd82e341ad19a049708c4d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-uint-spbset.h-126",
+      "fileName": "repos/curl/lib/uint-spbset.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1369,17 +1279,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connect.c-136",
-      "fileName": "repos/curl/lib/connect.c",
+      "SPDXID": "SPDXRef-File-curl-trc.c-127",
+      "fileName": "repos/curl/lib/curl_trc.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4b363ebe31b04b79f6c4b780a8471c211a60918a"
+          "checksumValue": "4b8734a7e9d50ef4f44ff0b3ecb8ffa039735e54"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerror.h-137",
+      "SPDXID": "SPDXRef-File-strerror.h-128",
       "fileName": "repos/curl/lib/strerror.h",
       "checksums": [
         {
@@ -1389,7 +1299,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyoptions.c-138",
+      "SPDXID": "SPDXRef-File-easyoptions.c-129",
       "fileName": "repos/curl/lib/easyoptions.c",
       "checksums": [
         {
@@ -1399,37 +1309,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-urlglob.c-139",
-      "fileName": "repos/curl/src/tool_urlglob.c",
+      "SPDXID": "SPDXRef-File-asyn-ares.c-130",
+      "fileName": "repos/curl/lib/asyn-ares.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4c5973875b2ef5a5a828220bd2d9f1c19549449f"
+          "checksumValue": "4d063d9f26574d5a93a402e497053703c93fa828"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getparam.h-140",
-      "fileName": "repos/curl/src/tool_getparam.h",
+      "SPDXID": "SPDXRef-File-cookie.c-131",
+      "fileName": "repos/curl/lib/cookie.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4d345413931debbcd76798ac0eac7b15793ddf04"
+          "checksumValue": "4d53cc460cb82b2df44a86a829f454423b3c62b2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vssh.h-141",
-      "fileName": "repos/curl/lib/vssh/vssh.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4d5b7ad24e98046a6ef2ca2e88073cf5b678b188"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-ca-embed.c-142",
+      "SPDXID": "SPDXRef-File-tool-ca-embed.c-132",
       "fileName": "repos/curl/src/tool_ca_embed.c",
       "checksums": [
         {
@@ -1439,17 +1339,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config2setopts.c-143",
-      "fileName": "repos/curl/src/config2setopts.c",
+      "SPDXID": "SPDXRef-File-pingpong.c-133",
+      "fileName": "repos/curl/lib/pingpong.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4ea65f453c24faee45d9bba96233bfd95f13cec1"
+          "checksumValue": "4ede0a5985db595d164eaf8993b4efd5b23702c2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufref.c-144",
+      "SPDXID": "SPDXRef-File-curl-setup.h-134",
+      "fileName": "repos/curl/lib/curl_setup.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4f8d65af8b5d8c3c13720f28a4edf36bfe021bcd"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-openssl.c-135",
+      "fileName": "repos/curl/lib/vtls/openssl.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50bf1e04766e90ef5d7744a35fff0ed2f79093e5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-help.c-136",
+      "fileName": "repos/curl/src/tool_help.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50cca527057333b3dfcfd0e3f8bdea076f7a59df"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-bufref.c-137",
       "fileName": "repos/curl/lib/bufref.c",
       "checksums": [
         {
@@ -1459,27 +1389,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ftp.c-145",
-      "fileName": "repos/curl/lib/ftp.c",
+      "SPDXID": "SPDXRef-File-strparse.h-138",
+      "fileName": "repos/curl/lib/curlx/strparse.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5110ee1397e14ba4e61b127a584822719e11bf40"
+          "checksumValue": "514203dc92fad6a5f39c9428d243e06a37ff249b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel-verify.c-146",
-      "fileName": "repos/curl/lib/vtls/schannel_verify.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5129b8b04d33871489166eee0bf87b6186fb097f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socks.h-147",
+      "SPDXID": "SPDXRef-File-socks.h-139",
       "fileName": "repos/curl/lib/socks.h",
       "checksums": [
         {
@@ -1489,47 +1409,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-paramhlp.c-148",
-      "fileName": "repos/curl/src/tool_paramhlp.c",
+      "SPDXID": "SPDXRef-File-wait.c-140",
+      "fileName": "repos/curl/lib/curlx/wait.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "523b52629c93e5083ab4f940cf7b37961aba5b57"
+          "checksumValue": "52784269ef51fabb405b91e12a02682fc56a0e9f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multibyte.c-149",
-      "fileName": "repos/curl/lib/curlx/multibyte.c",
+      "SPDXID": "SPDXRef-File-vquic.h-141",
+      "fileName": "repos/curl/lib/vquic/vquic.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "529091ad92d6ae8ceb5fbc8a9b79c6becddb6ede"
+          "checksumValue": "528e18476d48d0b565c8fdc8bf95505a46396fc4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.h-150",
-      "fileName": "repos/curl/lib/../include/curl/multi.h",
+      "SPDXID": "SPDXRef-File-request.h-142",
+      "fileName": "repos/curl/lib/request.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "531c1a954a955b9f4c42f64a87be1ca9918f601c"
+          "checksumValue": "5332d48538d9e519ddfda5cc86edb4dc0e92c97d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doh.c-151",
-      "fileName": "repos/curl/lib/doh.c",
+      "SPDXID": "SPDXRef-File-tool-sdecls.h-143",
+      "fileName": "repos/curl/src/tool_sdecls.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5401256bf895aff995b26184bac2d436dcae2694"
+          "checksumValue": "5350b71a3714bc38f04f045180bfb82dd535d11c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-pause.h-152",
+      "SPDXID": "SPDXRef-File-strcase.h-144",
+      "fileName": "repos/curl/lib/strcase.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "54299812beaed5ac5d98f210c997982572824fa0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostip.c-145",
+      "fileName": "repos/curl/lib/hostip.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "542b655b113d14d1fbdd29985ab32ca1e92a03fd"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cw-pause.h-146",
       "fileName": "repos/curl/lib/cw-pause.h",
       "checksums": [
         {
@@ -1539,7 +1479,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-wrt.h-153",
+      "SPDXID": "SPDXRef-File-cw-out.c-147",
+      "fileName": "repos/curl/lib/cw-out.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "554c32e84ecdd31de8d70669ce9c5e389745c5db"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-wrt.h-148",
       "fileName": "repos/curl/src/tool_cb_wrt.h",
       "checksums": [
         {
@@ -1549,27 +1499,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-setup.h-154",
-      "fileName": "repos/curl/lib/vauth/../curl_setup.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "559f586b7859f561f1067a1d976ed2667c0a4665"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cipher-suite.c-155",
-      "fileName": "repos/curl/lib/vtls/cipher_suite.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "562a3477355d7764c16550460966d9563df18b8f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-hash.h-156",
+      "SPDXID": "SPDXRef-File-uint-hash.h-149",
       "fileName": "repos/curl/lib/uint-hash.h",
       "checksums": [
         {
@@ -1579,7 +1509,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amigaos.h-157",
+      "SPDXID": "SPDXRef-File-amigaos.h-150",
       "fileName": "repos/curl/lib/amigaos.h",
       "checksums": [
         {
@@ -1589,17 +1519,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-trc.h-158",
-      "fileName": "repos/curl/lib/vauth/../curl_trc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "58903844acf1c8f5063ed79980bfe7acfcd3013d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-spbset.c-159",
+      "SPDXID": "SPDXRef-File-uint-spbset.c-151",
       "fileName": "repos/curl/lib/uint-spbset.c",
       "checksums": [
         {
@@ -1609,7 +1529,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-memrchr.c-160",
+      "SPDXID": "SPDXRef-File-curl-memrchr.c-152",
       "fileName": "repos/curl/lib/curl_memrchr.c",
       "checksums": [
         {
@@ -1619,7 +1539,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-headers.c-161",
+      "SPDXID": "SPDXRef-File-headers.c-153",
       "fileName": "repos/curl/lib/headers.c",
       "checksums": [
         {
@@ -1629,7 +1549,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-easysrc.c-162",
+      "SPDXID": "SPDXRef-File-urldata.h-154",
+      "fileName": "repos/curl/lib/urldata.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5ae148054baf7c04c0b38a585af0baaa0be11cef"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-easysrc.c-155",
       "fileName": "repos/curl/src/tool_easysrc.c",
       "checksums": [
         {
@@ -1639,27 +1569,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy.h-163",
-      "fileName": "repos/curl/lib/../include/curl/easy.h",
+      "SPDXID": "SPDXRef-File-digest.h-156",
+      "fileName": "repos/curl/lib/../lib/vauth/digest.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5b3cdbd64e805870cf8a30193cb945ef99e446d8"
+          "checksumValue": "5b8f3ae7675f4d45d7b6b83ec953c5e97530297e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x509asn1.c-164",
-      "fileName": "repos/curl/lib/vtls/x509asn1.c",
+      "SPDXID": "SPDXRef-File-telnet.c-157",
+      "fileName": "repos/curl/lib/telnet.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5c3a727e63c47edcf846dc58b6649937887935e3"
+          "checksumValue": "5bae99e1fcca877fd0919424f6f9ea5359d99441"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlver.h-165",
+      "SPDXID": "SPDXRef-File-curlver.h-158",
       "fileName": "repos/curl/lib/../include/curl/curlver.h",
       "checksums": [
         {
@@ -1669,8 +1599,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufref.h-166",
-      "fileName": "repos/curl/lib/vauth/../bufref.h",
+      "SPDXID": "SPDXRef-File-bufref.h-159",
+      "fileName": "repos/curl/lib/bufref.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1679,17 +1609,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-quiche.c-167",
-      "fileName": "repos/curl/lib/vquic/curl_quiche.c",
+      "SPDXID": "SPDXRef-File-ftplistparser.h-160",
+      "fileName": "repos/curl/lib/ftplistparser.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5d981cb2e6bf35f7a7257e698f90fca6de26c30c"
+          "checksumValue": "5d7aa492ba4eda791a2bc74a342ba088f0a28d59"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-version.h-168",
+      "SPDXID": "SPDXRef-File-tool-version.h-161",
       "fileName": "repos/curl/src/tool_version.h",
       "checksums": [
         {
@@ -1699,37 +1629,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-splay.c-169",
-      "fileName": "repos/curl/lib/splay.c",
+      "SPDXID": "SPDXRef-File-curl-share.h-162",
+      "fileName": "repos/curl/lib/curl_share.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5e4cd54d27babe055c6bfed9b11af06f016d128e"
+          "checksumValue": "5e3f82aa56b2b2835daf1de4e65de75be47b6821"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http2.h-170",
-      "fileName": "repos/curl/lib/http2.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5e545b234900946021d14c443a6259326af621f6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-mime.h-171",
-      "fileName": "repos/curl/lib/vauth/../mime.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5ef05506a4be35e593b92d8070bdbd40fca85f47"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-bset.c-172",
+      "SPDXID": "SPDXRef-File-uint-bset.c-163",
       "fileName": "repos/curl/lib/uint-bset.c",
       "checksums": [
         {
@@ -1739,7 +1649,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-digest.h-173",
+      "SPDXID": "SPDXRef-File-http-digest.h-164",
       "fileName": "repos/curl/lib/http_digest.h",
       "checksums": [
         {
@@ -1749,7 +1659,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-util.c-174",
+      "SPDXID": "SPDXRef-File-warnless.c-165",
+      "fileName": "repos/curl/lib/curlx/warnless.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5fc36ac9a8762103e3688a6dd5e31236ff7b176c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-ws.c-166",
+      "fileName": "repos/curl/lib/ws.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60465611bb74ce21cb20f715e418d4de253f5f11"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-ftp.c-167",
+      "fileName": "repos/curl/lib/ftp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6047759e7850a78de48e9e983ea4a3a38fb68222"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-smtp.c-168",
+      "fileName": "repos/curl/lib/smtp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60889858d3e2756869d1e903581ad352ecd4382c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http1.c-169",
+      "fileName": "repos/curl/lib/http1.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60ad32ce89b95832a753d01baa75303aac013b7b"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-util.c-170",
       "fileName": "repos/curl/src/tool_util.c",
       "checksums": [
         {
@@ -1759,17 +1719,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operate.c-175",
-      "fileName": "repos/curl/src/tool_operate.c",
+      "SPDXID": "SPDXRef-File-multi.c-171",
+      "fileName": "repos/curl/lib/multi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "618508aca49f4e6f662ed558a1657821613096ac"
+          "checksumValue": "6133736525778b122b1b3e615388b5c622296d9e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fnmatch.h-176",
+      "SPDXID": "SPDXRef-File-curl-fnmatch.h-172",
       "fileName": "repos/curl/lib/curl_fnmatch.h",
       "checksums": [
         {
@@ -1779,7 +1739,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-libinfo.c-177",
+      "SPDXID": "SPDXRef-File-tool-libinfo.c-173",
       "fileName": "repos/curl/src/tool_libinfo.c",
       "checksums": [
         {
@@ -1789,7 +1749,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-findfile.h-178",
+      "SPDXID": "SPDXRef-File-tool-findfile.h-174",
       "fileName": "repos/curl/src/tool_findfile.h",
       "checksums": [
         {
@@ -1799,17 +1759,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-addrinfo.h-179",
-      "fileName": "repos/curl/lib/vauth/../curl_addrinfo.h",
+      "SPDXID": "SPDXRef-File-libssh2.c-175",
+      "fileName": "repos/curl/lib/vssh/libssh2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "63d3f7a2442c75c48ab232cabb28f92ecf475bd6"
+          "checksumValue": "63f5735b835b38017b0544993e1ca2253d3fdefc"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-progress.c-180",
+      "SPDXID": "SPDXRef-File-tool-progress.c-176",
       "fileName": "repos/curl/src/tool_progress.c",
       "checksums": [
         {
@@ -1819,27 +1779,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-altsvc.c-181",
-      "fileName": "repos/curl/lib/altsvc.c",
+      "SPDXID": "SPDXRef-File-curl-sha512-256.c-177",
+      "fileName": "repos/curl/lib/curl_sha512_256.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "64bfec420bd518583f9c696df156affc2ffb5c93"
+          "checksumValue": "648e3e38e960be028a92a3b48a576f41bbc6a0ac"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ngtcp2.c-182",
-      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.c",
+      "SPDXID": "SPDXRef-File-schannel.c-178",
+      "fileName": "repos/curl/lib/vtls/schannel.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "65c78e68485b63468465175893f00cc8eff04c1b"
+          "checksumValue": "650a0e38ca8bf04eee4aba3b40d089a1b7e1d530"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-xattr.h-183",
+      "SPDXID": "SPDXRef-File-cf-h1-proxy.h-179",
+      "fileName": "repos/curl/lib/cf-h1-proxy.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6544ec58d026839cdbe1117bea42e77ed0a10c3f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-request.c-180",
+      "fileName": "repos/curl/lib/request.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "66077530d72637f0bc4af84dcd96163ae6b9c269"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-vtls-int.h-181",
+      "fileName": "repos/curl/lib/../lib/vtls/vtls_int.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6700ee74cbe163fbf45d378e898cabe0b1e6a6b4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-xattr.h-182",
       "fileName": "repos/curl/src/tool_xattr.h",
       "checksums": [
         {
@@ -1849,8 +1839,18 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-File-vtls-scache.c-183",
+      "fileName": "repos/curl/lib/vtls/vtls_scache.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "673abcfe0dbf7c1699fdc7e7b050e508e460165f"
+        }
+      ]
+    },
+    {
       "SPDXID": "SPDXRef-File-mqtt.h-184",
-      "fileName": "repos/curl/lib/vauth/../mqtt.h",
+      "fileName": "repos/curl/lib/mqtt.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1859,52 +1859,52 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks.c-185",
-      "fileName": "repos/curl/lib/socks.c",
+      "SPDXID": "SPDXRef-File-asyn.h-185",
+      "fileName": "repos/curl/lib/asyn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "67e9c9b3c7cf132efbeb936148d8da2f3a1094ad"
+          "checksumValue": "68628f90c007f0a27b26c1f8d2ee4588d91c761b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version.c-186",
-      "fileName": "repos/curl/lib/version.c",
+      "SPDXID": "SPDXRef-File-tool-getpass.c-186",
+      "fileName": "repos/curl/src/tool_getpass.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6949278f47d31d540ba01f5471e4dbff0b8eab3b"
+          "checksumValue": "68a16cab3e611bab75a18399525db1e622bb2c85"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timediff.c-187",
-      "fileName": "repos/curl/lib/curlx/timediff.c",
+      "SPDXID": "SPDXRef-File-multi-ev.c-187",
+      "fileName": "repos/curl/lib/multi_ev.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "694c8d83520673b844cdeb2d67f3b125b74ecb9a"
+          "checksumValue": "696a012ebff74fbf31ece59b5f45d99175f7ab18"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-help.h-188",
+      "SPDXID": "SPDXRef-File-cf-h1-proxy.c-188",
+      "fileName": "repos/curl/lib/cf-h1-proxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "69e050b9d63ee3f61e70a07f6652daa5f373bd70"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-help.h-189",
       "fileName": "repos/curl/src/tool_help.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "6a2ecdb0622e90fa34dcd01a74aa3354e0bcc670"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-krb5-gssapi.c-189",
-      "fileName": "repos/curl/lib/vauth/krb5_gssapi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6a9f182864c034b0b8c9fd8e40fb87942c45b898"
         }
       ]
     },
@@ -1919,17 +1919,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-quiche.h-191",
-      "fileName": "repos/curl/lib/vquic/curl_quiche.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6c0fb9ee1ee695f4780d34a45c050575ff8501ce"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-negotiate.h-192",
+      "SPDXID": "SPDXRef-File-http-negotiate.h-191",
       "fileName": "repos/curl/lib/http_negotiate.h",
       "checksums": [
         {
@@ -1939,7 +1929,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-haproxy.h-193",
+      "SPDXID": "SPDXRef-File-tool-cb-prg.c-192",
+      "fileName": "repos/curl/src/tool_cb_prg.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c3a366fa632b9c967f8d47fc57bfcc8c1cec4bc"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostip.h-193",
+      "fileName": "repos/curl/lib/hostip.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c7f1291b261c01dde04ab5ae190ab83df38e404"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-progress.c-194",
+      "fileName": "repos/curl/lib/progress.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6cde5678be84f4e430035912d4341da6ec6633a3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fopen.c-195",
+      "fileName": "repos/curl/lib/curlx/fopen.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6d0ef7e683564b162fd4ab8c1c2e342a32b6c2a9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-haproxy.h-196",
       "fileName": "repos/curl/lib/cf-haproxy.h",
       "checksums": [
         {
@@ -1949,28 +1979,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ws.c-194",
-      "fileName": "repos/curl/lib/ws.c",
+      "SPDXID": "SPDXRef-File-transfer.c-197",
+      "fileName": "repos/curl/lib/transfer.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6ed417185e1d927ffaf85a51c0a5af3b413667fd"
+          "checksumValue": "6dd2f52fe572801b4f48d7f0b25c19057cdc6c12"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http.h-195",
-      "fileName": "repos/curl/lib/vauth/../http.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6ef391af60200b7b3b86df2e1655cacdfae88d93"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dynbuf.h-196",
-      "fileName": "repos/curl/lib/vauth/../curlx/dynbuf.h",
+      "SPDXID": "SPDXRef-File-dynbuf.h-198",
+      "fileName": "repos/curl/lib/curlx/dynbuf.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1979,37 +1999,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-config.h-197",
-      "fileName": "repos/curl/lib/vauth/../curl_config.h",
+      "SPDXID": "SPDXRef-File-nonblock.c-199",
+      "fileName": "repos/curl/lib/curlx/nonblock.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6f16a673ffc1baa4164b57425e4515fd3253185c"
+          "checksumValue": "6f6458f2b3427985ec0c3cb4ba4e8b93bb4f178d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-content-encoding.c-198",
-      "fileName": "repos/curl/lib/content_encoding.c",
+      "SPDXID": "SPDXRef-File-dynbuf.c-200",
+      "fileName": "repos/curl/lib/curlx/dynbuf.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6f58054bb29557117890f53a973c3ecae58c404b"
+          "checksumValue": "7045a1f2940b9047cb299bf41d547925a783c7f4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-vms.c-199",
-      "fileName": "repos/curl/src/tool_vms.c",
+      "SPDXID": "SPDXRef-File-multibyte.c-201",
+      "fileName": "repos/curl/lib/curlx/multibyte.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "71606f3d66c5e20a20d88523e2ad4129596f2686"
+          "checksumValue": "715d2b8dc20d7600e3769773a2b7ec90781919e4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noproxy.h-200",
+      "SPDXID": "SPDXRef-File-noproxy.h-202",
       "fileName": "repos/curl/lib/noproxy.h",
       "checksums": [
         {
@@ -2019,17 +2039,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urldata.h-201",
-      "fileName": "repos/curl/lib/vauth/../urldata.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "71e5d6f4a11a9e69119c56d48f108bc17fff5f01"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cf-ip-happy.h-202",
+      "SPDXID": "SPDXRef-File-cf-ip-happy.h-203",
       "fileName": "repos/curl/lib/cf-ip-happy.h",
       "checksums": [
         {
@@ -2039,7 +2049,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gopher.c-203",
+      "SPDXID": "SPDXRef-File-gopher.c-204",
       "fileName": "repos/curl/lib/gopher.c",
       "checksums": [
         {
@@ -2049,7 +2059,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-writeout-json.h-204",
+      "SPDXID": "SPDXRef-File-tool-writeout-json.h-205",
       "fileName": "repos/curl/src/tool_writeout_json.h",
       "checksums": [
         {
@@ -2059,27 +2069,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timeval.c-205",
-      "fileName": "repos/curl/lib/curlx/timeval.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "734b784c04f04b4b2258106dad2ba52a7551f951"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-wolfssl.h-206",
-      "fileName": "repos/curl/lib/vtls/wolfssl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "736da9a1a6a205ca918de6e47d61a9fdc5772d68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fileinfo.h-207",
+      "SPDXID": "SPDXRef-File-fileinfo.h-206",
       "fileName": "repos/curl/lib/fileinfo.h",
       "checksums": [
         {
@@ -2089,7 +2079,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynhds.c-208",
+      "SPDXID": "SPDXRef-File-dynhds.c-207",
       "fileName": "repos/curl/lib/dynhds.c",
       "checksums": [
         {
@@ -2099,12 +2089,22 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-bset.h-209",
-      "fileName": "repos/curl/lib/vauth/../uint-bset.h",
+      "SPDXID": "SPDXRef-File-uint-bset.h-208",
+      "fileName": "repos/curl/lib/uint-bset.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "7455c427df94f3a624cb820c92ff61a9044e06d5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-vms.c-209",
+      "fileName": "repos/curl/src/tool_vms.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "74eb210ab54658fed417d735f49933ff09e485f6"
         }
       ]
     },
@@ -2120,7 +2120,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-ratelimit.h-211",
-      "fileName": "repos/curl/lib/vauth/../ratelimit.h",
+      "fileName": "repos/curl/lib/ratelimit.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2139,7 +2139,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-rtmp.c-213",
+      "SPDXID": "SPDXRef-File-ws.h-213",
+      "fileName": "repos/curl/lib/ws.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "757eae0f0f69f898821ad80a622be2fdd4aa4b90"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-rtmp.c-214",
       "fileName": "repos/curl/lib/curl_rtmp.c",
       "checksums": [
         {
@@ -2149,17 +2159,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strdup.c-214",
-      "fileName": "repos/curl/lib/curlx/strdup.c",
+      "SPDXID": "SPDXRef-File-sendf.h-215",
+      "fileName": "repos/curl/lib/sendf.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "75e088fe4ce605e7ce7f0706265533caecae2ebc"
+          "checksumValue": "75c6e248ea473f8a94f819186cad0aaeb6efb020"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pop3.h-215",
+      "SPDXID": "SPDXRef-File-socketpair.c-216",
+      "fileName": "repos/curl/lib/socketpair.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "76b959dd4afc698252290be068b482940a041b5e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-pop3.h-217",
       "fileName": "repos/curl/lib/pop3.h",
       "checksums": [
         {
@@ -2169,7 +2189,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-haproxy.c-216",
+      "SPDXID": "SPDXRef-File-curl-config.h-218",
+      "fileName": "repos/curl/lib/curl_config.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "780ceae0a2f299041c7085c2d564f097e4eab5a3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-haproxy.c-219",
       "fileName": "repos/curl/lib/cf-haproxy.c",
       "checksums": [
         {
@@ -2179,38 +2209,38 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tftp.c-217",
-      "fileName": "repos/curl/lib/tftp.c",
+      "SPDXID": "SPDXRef-File-connect.c-220",
+      "fileName": "repos/curl/lib/connect.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "782cb1959a8e186e219b076b9a1455ad9176d066"
+          "checksumValue": "78c9370804824d6626e4540ad593ee4863b24a88"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ssh.h-218",
-      "fileName": "repos/curl/lib/vssh/ssh.h",
+      "SPDXID": "SPDXRef-File-cleartext.c-221",
+      "fileName": "repos/curl/lib/vauth/cleartext.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "78889bf60e6b96c85d6683afb4ed07aa75f2df07"
+          "checksumValue": "7976adec9c8fec28baaa8a9c42684677e7d20f28"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cshutdn.h-219",
-      "fileName": "repos/curl/lib/vauth/../cshutdn.h",
+      "SPDXID": "SPDXRef-File-curlx.h-222",
+      "fileName": "repos/curl/src/../lib/curlx/curlx.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "79c95cca5917d8d3a8d56707707aa34c955cd696"
+          "checksumValue": "79cffc8f6dbcd2df6ff7499164ae2b601103f41a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multihandle.h-220",
-      "fileName": "repos/curl/lib/vauth/../multihandle.h",
+      "SPDXID": "SPDXRef-File-multihandle.h-223",
+      "fileName": "repos/curl/lib/multihandle.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2219,27 +2249,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-krb5-sspi.c-221",
-      "fileName": "repos/curl/lib/vauth/krb5_sspi.c",
+      "SPDXID": "SPDXRef-File-sha256.c-224",
+      "fileName": "repos/curl/lib/sha256.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7aad4badfab4d9d3430ed6407489e46c6aa056fd"
+          "checksumValue": "7b063659be03511b73c247291d5f8f6bd49119d9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slist-wc.h-222",
-      "fileName": "repos/curl/src/slist_wc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7bf76257a49c9bfe351708f3325b9dc81292c81b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-ldap.h-223",
+      "SPDXID": "SPDXRef-File-curl-ldap.h-225",
       "fileName": "repos/curl/lib/curl_ldap.h",
       "checksums": [
         {
@@ -2249,27 +2269,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apple.c-224",
-      "fileName": "repos/curl/lib/vtls/apple.c",
+      "SPDXID": "SPDXRef-File-version.c-226",
+      "fileName": "repos/curl/lib/version.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7c2ea4989f89f3fb71c3c192480cb7570353c1a8"
+          "checksumValue": "7ccd875dc8e3dc039ecea4d7377b154e2bd04100"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-progress.c-225",
-      "fileName": "repos/curl/lib/progress.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7daa4b4b3efd690d97d055dbb0e268b573dd2e74"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cw-out.h-226",
+      "SPDXID": "SPDXRef-File-cw-out.h-227",
       "fileName": "repos/curl/lib/cw-out.h",
       "checksums": [
         {
@@ -2279,47 +2289,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel.c-227",
-      "fileName": "repos/curl/lib/vtls/schannel.c",
+      "SPDXID": "SPDXRef-File-keylog.h-228",
+      "fileName": "repos/curl/lib/../lib/vtls/keylog.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7eba7843684c2375fefa90bbe583542d2073fc8d"
+          "checksumValue": "7e741b964d596dea3606dd4aec0978752d7f836b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mime.c-228",
-      "fileName": "repos/curl/lib/mime.c",
+      "SPDXID": "SPDXRef-File-tool-operate.h-229",
+      "fileName": "repos/curl/src/tool_operate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7f350ae7e0475d2f196cea6d54f01d08586fa8cc"
+          "checksumValue": "7e886f6ef043017edf50686626c1c0adcde55f6c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socketpair.c-229",
-      "fileName": "repos/curl/lib/socketpair.c",
+      "SPDXID": "SPDXRef-File-parsedate.c-230",
+      "fileName": "repos/curl/lib/parsedate.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7fd7e30bbab8271c2ff28ebd5d217375371c0d0d"
+          "checksumValue": "7efedec7d2452959e80c23647608d48859015d3d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-ares.c-230",
-      "fileName": "repos/curl/lib/asyn-ares.c",
+      "SPDXID": "SPDXRef-File-var.c-231",
+      "fileName": "repos/curl/src/var.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "80126ce056d5aafd41d5e154bf2a133690155578"
+          "checksumValue": "7fb51d656e38279bc603aa06a776af6a64444a23"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-doswin.h-231",
+      "SPDXID": "SPDXRef-File-inet-ntop.c-232",
+      "fileName": "repos/curl/lib/curlx/inet_ntop.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "803b9887ac91c638e0f34a614a97aab8e42b5793"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hash.c-233",
+      "fileName": "repos/curl/lib/hash.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8095ca2e450748cde390aaa07cebb4f2da1f0e5c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-doswin.h-234",
       "fileName": "repos/curl/src/tool_doswin.h",
       "checksums": [
         {
@@ -2329,7 +2359,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options.h-232",
+      "SPDXID": "SPDXRef-File-options.h-235",
       "fileName": "repos/curl/lib/../include/curl/options.h",
       "checksums": [
         {
@@ -2339,27 +2369,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-openldap.c-233",
-      "fileName": "repos/curl/lib/openldap.c",
+      "SPDXID": "SPDXRef-File-setopt.c-236",
+      "fileName": "repos/curl/lib/setopt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "83ae013593d8ab56826d5ad7e1d933dcddcacc3b"
+          "checksumValue": "84f3e02b7b1584191d15844bad6470eaa16fc8ad"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sasl.h-234",
-      "fileName": "repos/curl/lib/curl_sasl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8432d261ecc8386f1af3f18993984ff070a6251f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-dirhie.h-235",
+      "SPDXID": "SPDXRef-File-tool-dirhie.h-237",
       "fileName": "repos/curl/src/tool_dirhie.h",
       "checksums": [
         {
@@ -2369,17 +2389,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cshutdn.c-236",
-      "fileName": "repos/curl/lib/cshutdn.c",
+      "SPDXID": "SPDXRef-File-headers.h-238",
+      "fileName": "repos/curl/lib/headers.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "85863ef93051dd62fd01a46cc251a1f829d4bc49"
+          "checksumValue": "85905e5141dc96e820eb886135e6caee4c39121c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-get-line.c-237",
+      "SPDXID": "SPDXRef-File-curl-get-line.c-239",
       "fileName": "repos/curl/lib/curl_get_line.c",
       "checksums": [
         {
@@ -2389,17 +2409,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-altsvc.h-238",
-      "fileName": "repos/curl/lib/altsvc.h",
+      "SPDXID": "SPDXRef-File-header.h-240",
+      "fileName": "repos/curl/lib/../include/curl/header.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "85da8cceb91ce31062a51388be33bb31cb595ea6"
+          "checksumValue": "85c10c8d7833211bab237dac62a21fdc7f91cff9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-parsecfg.h-239",
+      "SPDXID": "SPDXRef-File-tool-parsecfg.h-241",
       "fileName": "repos/curl/src/tool_parsecfg.h",
       "checksums": [
         {
@@ -2409,7 +2429,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-listhelp.c-240",
+      "SPDXID": "SPDXRef-File-tool-listhelp.c-242",
       "fileName": "repos/curl/src/tool_listhelp.c",
       "checksums": [
         {
@@ -2419,7 +2439,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-endian.c-241",
+      "SPDXID": "SPDXRef-File-curl-endian.c-243",
       "fileName": "repos/curl/lib/curl_endian.c",
       "checksums": [
         {
@@ -2429,62 +2449,42 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-spack.h-242",
-      "fileName": "repos/curl/lib/vtls/vtls_spack.h",
+      "SPDXID": "SPDXRef-File-rand.h-244",
+      "fileName": "repos/curl/lib/rand.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86796ee62ed6ca3f2ecb1ea7cb7ec2b71ce4cda1"
+          "checksumValue": "86765806f90894e0069733a2688e6122bf448064"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conncache.c-243",
-      "fileName": "repos/curl/lib/conncache.c",
+      "SPDXID": "SPDXRef-File-multibyte.h-245",
+      "fileName": "repos/curl/lib/../lib/curlx/multibyte.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "869af4215e457f74df665dbd044884758634ec36"
+          "checksumValue": "8863fb024990faa22fcdaca761cbefa3edbb051e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getparam.c-244",
-      "fileName": "repos/curl/src/tool_getparam.c",
+      "SPDXID": "SPDXRef-File-functypes.h-246",
+      "fileName": "repos/curl/lib/functypes.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86ebed13e8a4e9a1ee673edfe126f998e710b8bd"
+          "checksumValue": "887c2612ef94d83ce89e7fa8a019c3f78d804cbb"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest-sspi.c-245",
-      "fileName": "repos/curl/lib/vauth/digest_sspi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "893838d2cdd5cedd92a6df5de70a342eaf48b6e5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-hugehelp.h-246",
+      "SPDXID": "SPDXRef-File-tool-hugehelp.h-247",
       "fileName": "repos/curl/src/tool_hugehelp.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "89df96ce5fe9a12e0b21bf143c67eaa57ad21614"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-vms.h-247",
-      "fileName": "repos/curl/src/tool_vms.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "89ea31ee1583277ab18498d5fa8ea3f634106c05"
         }
       ]
     },
@@ -2499,12 +2499,12 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnless.h-249",
-      "fileName": "repos/curl/lib/vauth/../curlx/warnless.h",
+      "SPDXID": "SPDXRef-File-curl-sasl.h-249",
+      "fileName": "repos/curl/lib/curl_sasl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8a62ccf6a70b0416582f9b6e893270e7e5a6db7d"
+          "checksumValue": "8a97f52adcff1c1730743e90575565aebd024431"
         }
       ]
     },
@@ -2529,58 +2529,28 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.h-252",
-      "fileName": "repos/curl/lib/vauth/../hash.h",
+      "SPDXID": "SPDXRef-File-bufq.h-252",
+      "fileName": "repos/curl/lib/bufq.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8bf47ccf753dd8043f001ad47f545893cd424ef8"
+          "checksumValue": "8dd186f505535c53e1242b652f6008a9086e3edf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnless.c-253",
-      "fileName": "repos/curl/lib/curlx/warnless.c",
+      "SPDXID": "SPDXRef-File-tool-ipfs.c-253",
+      "fileName": "repos/curl/src/tool_ipfs.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8c1be2d589c8751c353b40254348b0ffd6d3155d"
+          "checksumValue": "8e762b8cf0326b1eaab2dd9506ccc592acde9d78"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls.c-254",
-      "fileName": "repos/curl/lib/vtls/vtls.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8c87dd3d9cd6fe1b4ed3d9a5337783622bd409df"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-fnmatch.c-255",
-      "fileName": "repos/curl/lib/curl_fnmatch.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8e35edeed6306f7484153a169f451c194c7af545"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-mprintf.c-256",
-      "fileName": "repos/curl/lib/mprintf.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8f81f033dcb0c7125beab6183168a1fab87a9f08"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-httpsrr.h-257",
-      "fileName": "repos/curl/lib/vtls/../httpsrr.h",
+      "SPDXID": "SPDXRef-File-httpsrr.h-254",
+      "fileName": "repos/curl/lib/httpsrr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2589,37 +2559,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest.h-258",
-      "fileName": "repos/curl/lib/vauth/digest.h",
+      "SPDXID": "SPDXRef-File-cshutdn.h-255",
+      "fileName": "repos/curl/lib/cshutdn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "902ffab153a8ccfb7c0b73ff6690f5a55db35042"
+          "checksumValue": "9030474032b49953229cb633aae68341978c5570"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-sdecls.h-259",
-      "fileName": "repos/curl/src/tool_sdecls.h",
+      "SPDXID": "SPDXRef-File-idn.h-256",
+      "fileName": "repos/curl/lib/idn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9058233a688e183df4edc2d69812d513ebdd4c5a"
+          "checksumValue": "90d8e811b1a6128e0bafec2b6006ca0cbcfe46be"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hmac.c-260",
-      "fileName": "repos/curl/lib/hmac.c",
+      "SPDXID": "SPDXRef-File-strerr.c-257",
+      "fileName": "repos/curl/lib/curlx/strerr.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9080588341da6efd0262f244873d5b993c9b273f"
+          "checksumValue": "91a329e91502c28ae79cb6d0498a0807a22c6505"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tftp.h-261",
+      "SPDXID": "SPDXRef-File-tftp.h-258",
       "fileName": "repos/curl/lib/tftp.h",
       "checksums": [
         {
@@ -2629,7 +2599,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mprintf.h-262",
+      "SPDXID": "SPDXRef-File-mprintf.h-259",
       "fileName": "repos/curl/lib/../include/curl/mprintf.h",
       "checksums": [
         {
@@ -2639,7 +2609,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-gethostname.h-263",
+      "SPDXID": "SPDXRef-File-curl-gethostname.h-260",
       "fileName": "repos/curl/lib/curl_gethostname.h",
       "checksums": [
         {
@@ -2649,7 +2619,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rtsp.h-264",
+      "SPDXID": "SPDXRef-File-rtsp.h-261",
       "fileName": "repos/curl/lib/rtsp.h",
       "checksums": [
         {
@@ -2659,47 +2629,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operate.h-265",
-      "fileName": "repos/curl/src/tool_operate.h",
+      "SPDXID": "SPDXRef-File-sendf.c-262",
+      "fileName": "repos/curl/lib/sendf.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "93c87e10e65936f2c08b8d4cf8043e50a65d6760"
+          "checksumValue": "92e77b482aeaf049d048dcec2013c44c98d95082"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.c-266",
-      "fileName": "repos/curl/lib/multi.c",
+      "SPDXID": "SPDXRef-File-gsasl.c-263",
+      "fileName": "repos/curl/lib/vauth/gsasl.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9420e3f940b116af32ab383c91043c9c359867c7"
+          "checksumValue": "958f4ffab746546fdb526ca82d6ade0589072d8d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock.c-267",
-      "fileName": "repos/curl/lib/curlx/nonblock.c",
+      "SPDXID": "SPDXRef-File-openldap.c-264",
+      "fileName": "repos/curl/lib/openldap.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "96bf3db64ec8c9f1163e45e0ffba018e99402479"
+          "checksumValue": "95f7681caa8bcd4dbb3e27178e8af9245018dfed"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostcheck.c-268",
-      "fileName": "repos/curl/lib/vtls/hostcheck.c",
+      "SPDXID": "SPDXRef-File-digest.c-265",
+      "fileName": "repos/curl/lib/vauth/digest.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9706336735c210b8d453efe1ff2f837a2285eaa6"
+          "checksumValue": "96093903871fc1215753d6bde0db7ae590b07798"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-range.h-269",
+      "SPDXID": "SPDXRef-File-socks-gssapi.c-266",
+      "fileName": "repos/curl/lib/socks_gssapi.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "962fcd05b2a6db214d86a469cf05460e7850ddab"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-paramhlp.c-267",
+      "fileName": "repos/curl/src/tool_paramhlp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "970d42192adac3e9363d56a4cc980c4485984acb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-range.h-268",
       "fileName": "repos/curl/lib/curl_range.h",
       "checksums": [
         {
@@ -2709,8 +2699,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-psl.h-270",
-      "fileName": "repos/curl/lib/vauth/../psl.h",
+      "SPDXID": "SPDXRef-File-psl.h-269",
+      "fileName": "repos/curl/lib/psl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2719,87 +2709,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strequal.c-271",
-      "fileName": "repos/curl/lib/strequal.c",
+      "SPDXID": "SPDXRef-File-tool-setup.h-270",
+      "fileName": "repos/curl/src/tool_setup.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "98cecdc244d4d3724cee85a0a3c856cf1415de11"
+          "checksumValue": "9860a0b96244562446673af2565ee7ed820b61c1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-netrc.h-272",
-      "fileName": "repos/curl/lib/vauth/../netrc.h",
+      "SPDXID": "SPDXRef-File-select.c-271",
+      "fileName": "repos/curl/lib/select.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "99ddc6253e08da0840eeadec71d9879d43b4acec"
+          "checksumValue": "9a11924976ac384288176a5bf58c06351e318692"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getpass.c-273",
-      "fileName": "repos/curl/src/tool_getpass.c",
+      "SPDXID": "SPDXRef-File-tool-operate.c-272",
+      "fileName": "repos/curl/src/tool_operate.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "99ded8f4c5b57b40fa83aa65eb0c786dc53700fe"
+          "checksumValue": "9a29b8e34c01055915e24e86abde466c7b062750"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedate.c-274",
-      "fileName": "repos/curl/lib/parsedate.c",
+      "SPDXID": "SPDXRef-File-wait.h-273",
+      "fileName": "repos/curl/lib/curlx/wait.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9a3060bd50be97332fd44af19bc34df264bd0fc3"
+          "checksumValue": "9b9c27386e92150fd85c701d3c4f8394316f6c9f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-chunks.c-275",
-      "fileName": "repos/curl/lib/http_chunks.c",
+      "SPDXID": "SPDXRef-File-curl-range.c-274",
+      "fileName": "repos/curl/lib/curl_range.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9b38a3780cae1ea9c372fb94de428570150d2b87"
+          "checksumValue": "9bbafa40cfc38e04c61d69c4814f1c23e6cfc25f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conncache.h-276",
-      "fileName": "repos/curl/lib/vauth/../conncache.h",
+      "SPDXID": "SPDXRef-File-tool-msgs.c-275",
+      "fileName": "repos/curl/src/tool_msgs.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9b392af05ccd2d6f794ca2db680bbd9bfc7475fb"
+          "checksumValue": "9bc8ca18f12f92c64fca976a1bb4112d01b178b3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cfgable.h-277",
-      "fileName": "repos/curl/src/tool_cfgable.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9bd1f59bc9863d1ce68436e7149c8300ae43ca9f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist.c-278",
-      "fileName": "repos/curl/lib/slist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9bfd08ae2ce138477d75f003fca9740537fdd4fc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-prg.h-279",
+      "SPDXID": "SPDXRef-File-tool-cb-prg.h-276",
       "fileName": "repos/curl/src/tool_cb_prg.h",
       "checksums": [
         {
@@ -2809,8 +2779,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-progress.h-280",
-      "fileName": "repos/curl/lib/vtls/../progress.h",
+      "SPDXID": "SPDXRef-File-progress.h-277",
+      "fileName": "repos/curl/lib/progress.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2819,27 +2789,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http1.c-281",
-      "fileName": "repos/curl/lib/http1.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9e584248bedd5532edd81a09267a4770304769c5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-splay.h-282",
-      "fileName": "repos/curl/lib/vauth/../splay.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9ed96f63e4eae5a81731506731b724eb25237c12"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strcase.c-283",
+      "SPDXID": "SPDXRef-File-strcase.c-278",
       "fileName": "repos/curl/lib/strcase.c",
       "checksums": [
         {
@@ -2849,47 +2799,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cfilters.h-284",
-      "fileName": "repos/curl/lib/vtls/../cfilters.h",
+      "SPDXID": "SPDXRef-File-escape.h-279",
+      "fileName": "repos/curl/lib/escape.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9faf01de755d092998b002b5732ef86104f66ba5"
+          "checksumValue": "9f9a89e4022bcdbfb7ebf816492b9f67ea318c28"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.c-285",
-      "fileName": "repos/curl/lib/rand.c",
+      "SPDXID": "SPDXRef-File-vauth.c-280",
+      "fileName": "repos/curl/lib/vauth/vauth.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a02338f206a56bb7be5d4939c2f4ede34a67b020"
+          "checksumValue": "a00078fce1939ececb86458c39e37e3cac80318e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-see.c-286",
-      "fileName": "repos/curl/src/tool_cb_see.c",
+      "SPDXID": "SPDXRef-File-gtls.c-281",
+      "fileName": "repos/curl/lib/vtls/gtls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a1983b94cc5b35179c6b44c36305e26077837d08"
+          "checksumValue": "a0a465c3607ca86322972c16166089cd429cea55"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pingpong.c-287",
-      "fileName": "repos/curl/lib/pingpong.c",
+      "SPDXID": "SPDXRef-File-http2.h-282",
+      "fileName": "repos/curl/lib/http2.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a2ca05ae4767e3649f3f1160688da8e71e2bea82"
+          "checksumValue": "a14c8485cc884baddaaecf3a9d22bef7c2091d1c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.h-288",
+      "SPDXID": "SPDXRef-File-tool-helpers.c-283",
+      "fileName": "repos/curl/src/tool_helpers.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a23c3a80e75b29cc4f9ff2bd08a107d211bb1048"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-file.h-284",
       "fileName": "repos/curl/lib/file.h",
       "checksums": [
         {
@@ -2899,67 +2859,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ev.c-289",
-      "fileName": "repos/curl/lib/multi_ev.c",
+      "SPDXID": "SPDXRef-File-strequal.c-285",
+      "fileName": "repos/curl/lib/strequal.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a399e3f4cbce975b58e07875cbc25ed9254ad327"
+          "checksumValue": "a352fda70b246728660d097bcd4f2e9ae81b13de"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-select.c-290",
-      "fileName": "repos/curl/lib/select.c",
+      "SPDXID": "SPDXRef-File-urlapi.c-286",
+      "fileName": "repos/curl/lib/urlapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a3d77145ce14e8a0f590aea3e0485a8a815951d9"
+          "checksumValue": "a4b82f31bd74f345e0959630fef59469022f66da"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-system.h-291",
-      "fileName": "repos/curl/lib/../include/curl/system.h",
+      "SPDXID": "SPDXRef-File-gtls.h-287",
+      "fileName": "repos/curl/lib/../lib/vtls/gtls.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a5b3e9eba79a055c4c300b1d5d516678e5fbe693"
+          "checksumValue": "a5e55cd4f9f8e7c6489c21af1cfb9e636421f1b9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libssh.c-292",
-      "fileName": "repos/curl/lib/vssh/libssh.c",
+      "SPDXID": "SPDXRef-File-apple.c-288",
+      "fileName": "repos/curl/lib/vtls/apple.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a5d58ec731ba1d7cbaaea991499d9bd54461b8b1"
+          "checksumValue": "a6a5ba01f026f95abab3315a1518e56b4cf80f13"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-win32.h-293",
-      "fileName": "repos/curl/lib/curlx/version_win32.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a5fb8ff3c23fa8a82c1f747f13d005d246dcf949"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-openssl.c-294",
-      "fileName": "repos/curl/lib/vtls/openssl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a632e80943f23feecf144c3580408e24d8622c77"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-negotiate.c-295",
+      "SPDXID": "SPDXRef-File-http-negotiate.c-289",
       "fileName": "repos/curl/lib/http_negotiate.c",
       "checksums": [
         {
@@ -2969,47 +2909,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedate.h-296",
-      "fileName": "repos/curl/lib/vssh/../parsedate.h",
+      "SPDXID": "SPDXRef-File-base64.c-290",
+      "fileName": "repos/curl/lib/curlx/base64.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a6ee43a5d487c425b744c3451cc2dbbf26e55466"
+          "checksumValue": "a7a6703099128d30c29c92c7c837ca546906a87a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-oauth2.c-297",
-      "fileName": "repos/curl/lib/vauth/oauth2.c",
+      "SPDXID": "SPDXRef-File-curl-trc.h-291",
+      "fileName": "repos/curl/lib/curl_trc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a7a061337fa9abd1783da7863346523b2a446e89"
+          "checksumValue": "a82c945e5f9b7e1f0fbfc113c3ea929a7fac1fe7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h1-proxy.c-298",
-      "fileName": "repos/curl/lib/cf-h1-proxy.c",
+      "SPDXID": "SPDXRef-File-conncache.c-292",
+      "fileName": "repos/curl/lib/conncache.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a85cd1d5a6fc0809a1b9f8ad149a72712fff1605"
+          "checksumValue": "a865959709b7c07d30e9a44066b60c68a80d7b5f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sigpipe.h-299",
-      "fileName": "repos/curl/lib/sigpipe.h",
+      "SPDXID": "SPDXRef-File-http-proxy.c-293",
+      "fileName": "repos/curl/lib/http_proxy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a906b27037498037864017c36d8e91e5e4b58900"
+          "checksumValue": "a9521c92dab64ccd604ddd440f0f8a08d4d83bc7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getenv.c-300",
+      "SPDXID": "SPDXRef-File-getenv.c-294",
       "fileName": "repos/curl/lib/getenv.c",
       "checksums": [
         {
@@ -3019,47 +2959,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynbuf.c-301",
-      "fileName": "repos/curl/lib/curlx/dynbuf.c",
+      "SPDXID": "SPDXRef-File-content-encoding.c-295",
+      "fileName": "repos/curl/lib/content_encoding.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a96b2a5974c59a19df2d39058784bdda019ff8bb"
+          "checksumValue": "aa35da840b23251fc37882dbce411b81cdd80f2f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-win32.c-302",
-      "fileName": "repos/curl/lib/curlx/version_win32.c",
+      "SPDXID": "SPDXRef-File-wolfssl.c-296",
+      "fileName": "repos/curl/lib/vtls/wolfssl.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a9a4ee38f9293d5f876b37fff4b74d20ec9e6174"
+          "checksumValue": "aa841a754a944cdaf678460f3618899777692e95"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-out.c-303",
-      "fileName": "repos/curl/lib/cw-out.c",
+      "SPDXID": "SPDXRef-File-tool-doswin.c-297",
+      "fileName": "repos/curl/src/tool_doswin.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ab38109ad900dbec31e3e7a58ec78ad078c662e3"
+          "checksumValue": "ad0386555dbd8c4778c82ef14ea5f8167f831420"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keylog.c-304",
-      "fileName": "repos/curl/lib/vtls/keylog.c",
+      "SPDXID": "SPDXRef-File-hostcheck.c-298",
+      "fileName": "repos/curl/lib/vtls/hostcheck.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ace9cab1ae2b7ffa706695986c9239bbb555f971"
+          "checksumValue": "ad09b8319413891c9065116c7bb8a2d871a8caa5"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-urlglob.h-305",
+      "SPDXID": "SPDXRef-File-tool-urlglob.h-299",
       "fileName": "repos/curl/src/tool_urlglob.h",
       "checksums": [
         {
@@ -3069,97 +3009,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-headers.h-306",
-      "fileName": "repos/curl/lib/headers.h",
+      "SPDXID": "SPDXRef-File-multi.h-300",
+      "fileName": "repos/curl/lib/../include/curl/multi.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "adb03af75b5e1fecf3713fcfb51dcd74fe4f98ff"
+          "checksumValue": "ad6f53f3e2c44a99e7b55f230a0ce9a2b60ab674"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-https-connect.c-307",
-      "fileName": "repos/curl/lib/cf-https-connect.c",
+      "SPDXID": "SPDXRef-File-tool-paramhlp.h-301",
+      "fileName": "repos/curl/src/tool_paramhlp.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ae6721bd41258205ed29170ff8f45d5927e512ad"
+          "checksumValue": "af40f10591b50e3120b6e22e1fd1daf20ccd6091"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strparse.h-308",
-      "fileName": "repos/curl/lib/vauth/../curlx/strparse.h",
+      "SPDXID": "SPDXRef-File-memdebug.c-302",
+      "fileName": "repos/curl/lib/memdebug.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ae8fd19d955e2b53d01b8b81458a849f7e467313"
+          "checksumValue": "af4fc9d6c107cdea99bbac619dc19efe82595f74"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-request.c-309",
-      "fileName": "repos/curl/lib/request.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aed9c7eb3b1608262ff4c4670df52bb919b1672b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-openssl.h-310",
-      "fileName": "repos/curl/lib/vtls/openssl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aeeb8dd805b0fd0e5ad8c0adf27cf127f88fe044"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ftplistparser.h-311",
-      "fileName": "repos/curl/lib/vauth/../ftplistparser.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "afb90dee4cada77f126f9a85461f8ffd814981a2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-escape.c-312",
-      "fileName": "repos/curl/lib/escape.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "afdf18c1b4d91ed7c4c800fc7269615190d6917a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-time.c-313",
-      "fileName": "repos/curl/src/toolx/tool_time.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "affcd7a16730ba0d553468c144f19f2874c6cc74"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-spnego-gssapi.c-314",
+      "SPDXID": "SPDXRef-File-spnego-gssapi.c-303",
       "fileName": "repos/curl/lib/vauth/spnego_gssapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b1ec37cb31686f30197fa9f647b4bd6dc9d54688"
+          "checksumValue": "af8498bad3b942a2ed7b25b63f19c2b2de6a0d14"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sasl.c-315",
+      "SPDXID": "SPDXRef-File-wolfssl.h-304",
+      "fileName": "repos/curl/lib/../lib/vtls/wolfssl.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b097b60b78b72ac6c77b48bce978048c674772d7"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sasl.c-305",
       "fileName": "repos/curl/lib/curl_sasl.c",
       "checksums": [
         {
@@ -3169,47 +3069,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy.c-316",
-      "fileName": "repos/curl/lib/easy.c",
+      "SPDXID": "SPDXRef-File-tool-vms.h-306",
+      "fileName": "repos/curl/src/tool_vms.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b30ce2ace41f926c9cb7cc1ec2fedb53850c770b"
+          "checksumValue": "b459a25ee8a1a8d5917ee2ae1fef3d3bf5070993"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-parsecfg.c-317",
-      "fileName": "repos/curl/src/tool_parsecfg.c",
+      "SPDXID": "SPDXRef-File-sigpipe.h-307",
+      "fileName": "repos/curl/lib/sigpipe.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b36d113232315488f02352660ad0412151f6320f"
+          "checksumValue": "b4897969538a5199c7ab8a5350950bde4b51ed57"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vssh.c-318",
-      "fileName": "repos/curl/lib/vssh/vssh.c",
+      "SPDXID": "SPDXRef-File-ntlm.c-308",
+      "fileName": "repos/curl/lib/vauth/ntlm.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b52b09b696e9beff92e6a27234a4ea59446fd3d5"
+          "checksumValue": "b50cfdd6812903dbe2ddc557138fa57f1fefccad"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-formdata.c-319",
-      "fileName": "repos/curl/lib/formdata.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b5bd1206f1068e46acb8677b8eb55772faa95047"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.h-320",
+      "SPDXID": "SPDXRef-File-dict.h-309",
       "fileName": "repos/curl/lib/dict.h",
       "checksums": [
         {
@@ -3219,17 +3109,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fopen.c-321",
-      "fileName": "repos/curl/lib/curlx/fopen.c",
+      "SPDXID": "SPDXRef-File-arpa-telnet.h-310",
+      "fileName": "repos/curl/lib/arpa_telnet.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b73d4f94a1123767332467e73908a5362a0df06c"
+          "checksumValue": "b5faab419c26d84c0eb713e0e3b666eb7f4d13fd"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fopen.c-322",
+      "SPDXID": "SPDXRef-File-x509asn1.c-311",
+      "fileName": "repos/curl/lib/vtls/x509asn1.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b687a60193d28268d90cc04d4da9b08d2e2fd196"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-rustls.h-312",
+      "fileName": "repos/curl/lib/../lib/vtls/rustls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b6ddbd1b7e012ec04b5c7de6d299c1c51caa3780"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-fopen.c-313",
       "fileName": "repos/curl/lib/curl_fopen.c",
       "checksums": [
         {
@@ -3239,17 +3149,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gsasl.c-323",
-      "fileName": "repos/curl/lib/vauth/gsasl.c",
+      "SPDXID": "SPDXRef-File-socks.c-314",
+      "fileName": "repos/curl/lib/socks.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b95d6e3f0a8e47f7fa5f29bb7b080b242b54ace5"
+          "checksumValue": "b7c3bd61463d76779a8bf53d8eee87762cdb7757"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-table.c-324",
+      "SPDXID": "SPDXRef-File-vtls.h-315",
+      "fileName": "repos/curl/lib/vtls/vtls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b9335bbf18598bb2af2ed387734e11381a2132ff"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-uint-table.c-316",
       "fileName": "repos/curl/lib/uint-table.c",
       "checksums": [
         {
@@ -3259,17 +3179,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-netrc.c-325",
-      "fileName": "repos/curl/lib/netrc.c",
+      "SPDXID": "SPDXRef-File-vtls-scache.h-317",
+      "fileName": "repos/curl/lib/vtls/vtls_scache.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "baabe917a75ab4a1c33f053fdcc90ae604d99f7f"
+          "checksumValue": "b9db0f19b36c4beab5a10080ed6a2526dcbc960f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-main.c-326",
+      "SPDXID": "SPDXRef-File-curl-hmac.h-318",
+      "fileName": "repos/curl/lib/curl_hmac.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b9f218fac930074434dd50816ddbf4a2f2c29e1d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-main.c-319",
       "fileName": "repos/curl/src/tool_main.c",
       "checksums": [
         {
@@ -3279,7 +3209,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-var.h-327",
+      "SPDXID": "SPDXRef-File-var.h-320",
       "fileName": "repos/curl/src/var.h",
       "checksums": [
         {
@@ -3289,17 +3219,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-trc.c-328",
-      "fileName": "repos/curl/lib/curl_trc.c",
+      "SPDXID": "SPDXRef-File-http.h-321",
+      "fileName": "repos/curl/lib/http.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bbec332f99d04b483abf3eac84d10c6c6d71916b"
+          "checksumValue": "bb535955d1f016a272982689f8a24ab4706c4c79"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gopher.h-329",
+      "SPDXID": "SPDXRef-File-tool-setopt.h-322",
+      "fileName": "repos/curl/src/tool_setopt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bb85ae7088bdbb123c2e615312cfe01fa76d6634"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sha256.h-323",
+      "fileName": "repos/curl/lib/curl_sha256.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bc1512e6e8c20dd91e53c29704564ac7fb802091"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-gopher.h-324",
       "fileName": "repos/curl/lib/gopher.h",
       "checksums": [
         {
@@ -3309,17 +3259,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufq.h-330",
-      "fileName": "repos/curl/lib/vauth/../bufq.h",
+      "SPDXID": "SPDXRef-File-tool-setopt.c-325",
+      "fileName": "repos/curl/src/tool_setopt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bcd7df2ab9ddd45a5f321254de43694f9caa642e"
+          "checksumValue": "bd24e4b411e3b522327b8fe0195a6b8f8e467e3a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fopen.h-331",
+      "SPDXID": "SPDXRef-File-curl-fopen.h-326",
       "fileName": "repos/curl/lib/curl_fopen.h",
       "checksums": [
         {
@@ -3329,67 +3279,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vauth.c-332",
-      "fileName": "repos/curl/lib/vauth/vauth.c",
+      "SPDXID": "SPDXRef-File-escape.c-327",
+      "fileName": "repos/curl/lib/escape.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bdf194b99562b3a8abda275fc77d1d9808992c52"
+          "checksumValue": "be44e971569e4da3fc94eecd419f91940c47e1bf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls.h-333",
-      "fileName": "repos/curl/lib/vtls/vtls.h",
+      "SPDXID": "SPDXRef-File-timeval.h-328",
+      "fileName": "repos/curl/lib/curlx/timeval.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bf19572fc62536679010b45a9efb08fdb31ac0f9"
+          "checksumValue": "c01f95d87df0d53dad4ac60cba387449eb5b4d39"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-addrinfo.c-334",
-      "fileName": "repos/curl/lib/fake_addrinfo.c",
+      "SPDXID": "SPDXRef-File-krb5-sspi.c-329",
+      "fileName": "repos/curl/lib/vauth/krb5_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bf5a44892c5d2be4ab1414c34b7922218a7d4aaa"
+          "checksumValue": "c08b6a4c3a5a2d6dac17e825adb23bc7aa2b1c0a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-hugehelp.c-335",
-      "fileName": "repos/curl/src/tool_hugehelp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c0323e2f4dbf1e990d8603fb770362d99079b49a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sha256.c-336",
-      "fileName": "repos/curl/lib/sha256.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c042c1bb0cb70a39877914e86bbd2ce7a5c447e4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-winapi.c-337",
-      "fileName": "repos/curl/lib/curlx/winapi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c0d6b7f861c4308c1fe3acf0edbb5968fb371dbf"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-gssapi.c-338",
+      "SPDXID": "SPDXRef-File-curl-gssapi.c-330",
       "fileName": "repos/curl/lib/curl_gssapi.c",
       "checksums": [
         {
@@ -3399,7 +3319,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-telnet.h-339",
+      "SPDXID": "SPDXRef-File-telnet.h-331",
       "fileName": "repos/curl/lib/telnet.h",
       "checksums": [
         {
@@ -3409,17 +3329,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wait.h-340",
-      "fileName": "repos/curl/lib/curlx/wait.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c140194a8c2dfae9fa8c9393027e1f9ea5dfbe04"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-proxy.h-341",
+      "SPDXID": "SPDXRef-File-http-proxy.h-332",
       "fileName": "repos/curl/lib/http_proxy.h",
       "checksums": [
         {
@@ -3429,17 +3339,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-int.h-342",
-      "fileName": "repos/curl/lib/vtls/vtls_int.h",
+      "SPDXID": "SPDXRef-File-http1.h-333",
+      "fileName": "repos/curl/lib/http1.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c2a44a3a33b1e79bbdd986fd8339b7390ef23394"
+          "checksumValue": "c2894613de7fe48116816174f0dce2aa0decfe47"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-ntlm.c-343",
+      "SPDXID": "SPDXRef-File-md5.c-334",
+      "fileName": "repos/curl/lib/md5.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c2bd176dc96f6a2d3c7681f51323c401767e5fb9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-asyn-thrdd.c-335",
+      "fileName": "repos/curl/lib/asyn-thrdd.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c3ed8eacaaf13be9fc72478a5da4ba9282df0af6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-setopt.h-336",
+      "fileName": "repos/curl/lib/setopt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c421f5c5e5bce7570f4ecefcf7168b9a8f0345d5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-version-win32.h-337",
+      "fileName": "repos/curl/lib/curlx/version_win32.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4a1c0f7586b7aca8c0e82abab2378af96c92706"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-url.h-338",
+      "fileName": "repos/curl/lib/url.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4cd762fb85948a9fb75cd73f6943f59e0915a0e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-ntlm.c-339",
       "fileName": "repos/curl/lib/http_ntlm.c",
       "checksums": [
         {
@@ -3449,17 +3409,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel.h-344",
-      "fileName": "repos/curl/lib/vtls/schannel.h",
+      "SPDXID": "SPDXRef-File-splay.h-340",
+      "fileName": "repos/curl/lib/splay.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c617233e0883e1bae73d9adb5a85e96c85a94c14"
+          "checksumValue": "c6623f2ef0c45d4b324bb8af5cd167f0511f1a00"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ipfs.h-345",
+      "SPDXID": "SPDXRef-File-mprintf.c-341",
+      "fileName": "repos/curl/lib/mprintf.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6a4a494292294c5223b856aad1d95ffb484dc0a"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-slist.c-342",
+      "fileName": "repos/curl/lib/slist.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6dcdc1af0ef4c7041473a7cfb7c36bb1bdf73f0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-snprintf.c-343",
+      "fileName": "repos/curl/lib/curlx/snprintf.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7332520e7a2ddc148cc608f6d0713e2affd4c40"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cfilters.h-344",
+      "fileName": "repos/curl/lib/cfilters.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7546344af42253bf95afcfc9b3f97137b9f58eb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-dbg.c-345",
+      "fileName": "repos/curl/src/tool_cb_dbg.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c9c14e6d131100686fa2ad100a04cc36387ddfb9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-ipfs.h-346",
       "fileName": "repos/curl/src/tool_ipfs.h",
       "checksums": [
         {
@@ -3469,17 +3479,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cookie.h-346",
-      "fileName": "repos/curl/lib/vauth/../cookie.h",
+      "SPDXID": "SPDXRef-File-cf-https-connect.c-347",
+      "fileName": "repos/curl/lib/cf-https-connect.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cbc7b748fc2bdd54a8ca181de38a588092d627b6"
+          "checksumValue": "cabc6ab14b91b06716a3aff500006926c888754d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-helpers.h-347",
+      "SPDXID": "SPDXRef-File-tool-helpers.h-348",
       "fileName": "repos/curl/src/tool_helpers.h",
       "checksums": [
         {
@@ -3489,22 +3499,12 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-xattr.c-348",
-      "fileName": "repos/curl/src/tool_xattr.c",
+      "SPDXID": "SPDXRef-File-tftp.c-349",
+      "fileName": "repos/curl/lib/tftp.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cdf8296307a514ddc2b02fa330fa20e9959f3890"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-formdata.h-349",
-      "fileName": "repos/curl/lib/vauth/../formdata.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ce592a8fd9d02510d89a62834f9a155c37046873"
+          "checksumValue": "cc0769bbb3b540403cabba673445e372d182dd3e"
         }
       ]
     },
@@ -3514,12 +3514,22 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cec410fe6073b96d1f3b6b9dad1290cfeb700055"
+          "checksumValue": "cc0e04388714b1bfdd546682c0c62c2cdf3e305a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy-lock.h-351",
+      "SPDXID": "SPDXRef-File-tool-xattr.c-351",
+      "fileName": "repos/curl/src/tool_xattr.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cdf8296307a514ddc2b02fa330fa20e9959f3890"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easy-lock.h-352",
       "fileName": "repos/curl/lib/easy_lock.h",
       "checksums": [
         {
@@ -3529,57 +3539,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostip.c-352",
-      "fileName": "repos/curl/lib/hostip.c",
+      "SPDXID": "SPDXRef-File-openssl.h-353",
+      "fileName": "repos/curl/lib/../lib/vtls/openssl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cfa7995dbac607c486a1a678abeb0dafd7858bfc"
+          "checksumValue": "cfffe9df1b6846b4dff5ed069d2ac98ca1274fdc"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-wrt.c-353",
-      "fileName": "repos/curl/src/tool_cb_wrt.c",
+      "SPDXID": "SPDXRef-File-easy.c-354",
+      "fileName": "repos/curl/lib/easy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cfeb06d5a47539c94fb2aa9ad85ed0a6da285cae"
+          "checksumValue": "d05674e81959f74c083fb3a88b404c571d262ac8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wolfssl.c-354",
-      "fileName": "repos/curl/lib/vtls/wolfssl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0311facb9ad9d21e18c1ba98fa79465cf328eb6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ntlm.c-355",
-      "fileName": "repos/curl/lib/vauth/ntlm.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0aae81b80e4e18879d6e8f0f1ccedcf5b60a801"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rtsp.c-356",
-      "fileName": "repos/curl/lib/rtsp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0e5cf43e39d5069d19c6221b0e7b21d3df3c2d5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-terminal.c-357",
+      "SPDXID": "SPDXRef-File-terminal.c-355",
       "fileName": "repos/curl/src/terminal.c",
       "checksums": [
         {
@@ -3589,17 +3569,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-telnet.c-358",
-      "fileName": "repos/curl/lib/telnet.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d1b1d8fc5ea795e8ded96c492535f6ae70cd8b8d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-formparse.h-359",
+      "SPDXID": "SPDXRef-File-tool-formparse.h-356",
       "fileName": "repos/curl/src/tool_formparse.h",
       "checksums": [
         {
@@ -3609,17 +3579,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fopen.h-360",
-      "fileName": "repos/curl/lib/vtls/../curlx/fopen.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d23dc82445ddbf6573da449f58917ac77f55ef6e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-filetime.h-361",
+      "SPDXID": "SPDXRef-File-tool-filetime.h-357",
       "fileName": "repos/curl/src/tool_filetime.h",
       "checksums": [
         {
@@ -3629,7 +3589,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amigaos.c-362",
+      "SPDXID": "SPDXRef-File-amigaos.c-358",
       "fileName": "repos/curl/lib/amigaos.c",
       "checksums": [
         {
@@ -3639,7 +3599,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-progress.h-363",
+      "SPDXID": "SPDXRef-File-basename.c-359",
+      "fileName": "repos/curl/lib/curlx/basename.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d2fd160ff224360b5ee05b3190ec97b3aeb9b69f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-progress.h-360",
       "fileName": "repos/curl/src/tool_progress.h",
       "checksums": [
         {
@@ -3649,7 +3619,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-winapi.h-364",
+      "SPDXID": "SPDXRef-File-winapi.h-361",
       "fileName": "repos/curl/lib/curlx/winapi.h",
       "checksums": [
         {
@@ -3659,8 +3629,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-smb.h-365",
-      "fileName": "repos/curl/lib/vauth/../smb.h",
+      "SPDXID": "SPDXRef-File-smb.h-362",
+      "fileName": "repos/curl/lib/smb.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3669,38 +3639,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ws.h-366",
-      "fileName": "repos/curl/lib/ws.h",
+      "SPDXID": "SPDXRef-File-inet-pton.c-363",
+      "fileName": "repos/curl/lib/curlx/inet_pton.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d4d6d46f3a51d788c3b51343508fa7ede68bebef"
+          "checksumValue": "d3c53fb5791610415e125f5495d255a9b86671a6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gtls.c-367",
-      "fileName": "repos/curl/lib/vtls/gtls.c",
+      "SPDXID": "SPDXRef-File-cram.c-364",
+      "fileName": "repos/curl/lib/vauth/cram.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d6093cfe3063138c5105273359da38c73f08f31e"
+          "checksumValue": "d3f2d137b779607e37d9cc3453f7cb0bb2ffa8d3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostcheck.h-368",
-      "fileName": "repos/curl/lib/vtls/hostcheck.h",
+      "SPDXID": "SPDXRef-File-vssh.c-365",
+      "fileName": "repos/curl/lib/vssh/vssh.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d62c721352af1874753e9671e2dc424a9bc99f8f"
+          "checksumValue": "d499a633af4bdff71738d7d1905639c2accdae99"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcopy.h-369",
-      "fileName": "repos/curl/lib/vtls/../curlx/strcopy.h",
+      "SPDXID": "SPDXRef-File-snprintf.h-366",
+      "fileName": "repos/curl/lib/curlx/snprintf.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d6260e4e3931cd4cb8b59bd9407537f1d11d5620"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strcopy.h-367",
+      "fileName": "repos/curl/lib/curlx/strcopy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3709,37 +3689,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi.c-370",
-      "fileName": "repos/curl/lib/urlapi.c",
+      "SPDXID": "SPDXRef-File-krb5-gssapi.c-368",
+      "fileName": "repos/curl/lib/vauth/krb5_gssapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d6a790b06e5b6ede34788e685d54f72cb096200a"
+          "checksumValue": "d6af18f40b5b67d685354937f144eac932a7d66a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcopy.c-371",
-      "fileName": "repos/curl/lib/curlx/strcopy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d6bff15330e9c8f81cb403f0d9ccbeeabb96d279"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-help.c-372",
-      "fileName": "repos/curl/src/tool_help.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d743fe395344a5d8094d9afb1401cf747491ef34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-dbg.h-373",
+      "SPDXID": "SPDXRef-File-tool-cb-dbg.h-369",
       "fileName": "repos/curl/src/tool_cb_dbg.h",
       "checksums": [
         {
@@ -3749,17 +3709,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-md4.c-374",
-      "fileName": "repos/curl/lib/md4.c",
+      "SPDXID": "SPDXRef-File-conncache.h-370",
+      "fileName": "repos/curl/lib/conncache.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d78f84282305ae7c46d2efa0083c2e16d6c13567"
+          "checksumValue": "d8626ae6928c49a828b18e660546491356083190"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyoptions.h-375",
+      "SPDXID": "SPDXRef-File-apple.h-371",
+      "fileName": "repos/curl/lib/../lib/vtls/apple.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d86a56b1f9320ec8e83818d402a0ed2a259c9ff2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easyoptions.h-372",
       "fileName": "repos/curl/lib/easyoptions.h",
       "checksums": [
         {
@@ -3769,8 +3739,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-chunks.h-376",
-      "fileName": "repos/curl/lib/vauth/../http_chunks.h",
+      "SPDXID": "SPDXRef-File-fopen.h-373",
+      "fileName": "repos/curl/lib/curlx/fopen.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d89830edd30eea66d9f5ca00d757c81d2a0f6aa6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-mbedtls.h-374",
+      "fileName": "repos/curl/lib/../lib/vtls/mbedtls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8a0a06eb6aac22289e2b91fcad3a7164b77f9ae"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fake-addrinfo.c-375",
+      "fileName": "repos/curl/lib/fake_addrinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8b139830b83af600dfee6cb4d9b519e898bb221"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostcheck.h-376",
+      "fileName": "repos/curl/lib/../lib/vtls/hostcheck.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8e1a52377129c86dedf7a2252f59b400631adfa"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-chunks.h-377",
+      "fileName": "repos/curl/lib/http_chunks.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3779,47 +3789,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h2-proxy.c-377",
-      "fileName": "repos/curl/lib/cf-h2-proxy.c",
+      "SPDXID": "SPDXRef-File-curl-quiche.c-378",
+      "fileName": "repos/curl/lib/vquic/curl_quiche.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d95716eaff9a5acdd1b25f40ad3d4511bbf7cffe"
+          "checksumValue": "d8e6b30f84bc2997e95705a1b22c66c79dc90ac7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerr.c-378",
-      "fileName": "repos/curl/lib/curlx/strerr.c",
+      "SPDXID": "SPDXRef-File-vtls-spack.c-379",
+      "fileName": "repos/curl/lib/vtls/vtls_spack.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d9c1686e443928c9eef4908414a6f1b554baac5f"
+          "checksumValue": "d96f4e41bd720d08ef2ffc476cb41c5e2324c736"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi.h-379",
-      "fileName": "repos/curl/lib/../include/curl/urlapi.h",
+      "SPDXID": "SPDXRef-File-typecheck-gcc.h-380",
+      "fileName": "repos/curl/lib/../include/curl/typecheck-gcc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "dabe44a47d0d3f73dda0ed97c09c21b0668b825f"
+          "checksumValue": "d9a672ea0b782448bc795a1bc5fdf2524f572442"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cfilters.c-380",
-      "fileName": "repos/curl/lib/cfilters.c",
+      "SPDXID": "SPDXRef-File-strcopy.c-381",
+      "fileName": "repos/curl/lib/curlx/strcopy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "db8efcf2fe867dea43f16d24d30fd3c2c9f1b649"
+          "checksumValue": "da137c3f92cf39033c1d3b053408ec375eb829d3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal.h-381",
+      "SPDXID": "SPDXRef-File-http-chunks.c-382",
+      "fileName": "repos/curl/lib/http_chunks.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "db650b1e1e645b6e0a68dd08e362af7ed5c95b62"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-terminal.h-383",
       "fileName": "repos/curl/src/terminal.h",
       "checksums": [
         {
@@ -3829,28 +3849,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic-int.h-382",
-      "fileName": "repos/curl/lib/vquic/vquic_int.h",
+      "SPDXID": "SPDXRef-File-splay.c-384",
+      "fileName": "repos/curl/lib/splay.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "dbe1fca777a1295aa077a413e8374d389977d550"
+          "checksumValue": "ddab7a4d6e2cfabc69e686311b9784921a814f24"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apple.h-383",
-      "fileName": "repos/curl/lib/vtls/apple.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "dd1b5db357658b0dae9cc6956dd3c1b5af62a760"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-sha512-256.h-384",
-      "fileName": "repos/curl/lib/vauth/../curl_sha512_256.h",
+      "SPDXID": "SPDXRef-File-curl-sha512-256.h-385",
+      "fileName": "repos/curl/lib/curl_sha512_256.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3859,8 +3869,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ev.h-385",
-      "fileName": "repos/curl/lib/vauth/../multi_ev.h",
+      "SPDXID": "SPDXRef-File-multi-ev.h-386",
+      "fileName": "repos/curl/lib/multi_ev.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3869,7 +3879,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-libinfo.h-386",
+      "SPDXID": "SPDXRef-File-tool-libinfo.h-387",
       "fileName": "repos/curl/src/tool_libinfo.h",
       "checksums": [
         {
@@ -3879,7 +3889,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-https-connect.h-387",
+      "SPDXID": "SPDXRef-File-curl-fnmatch.c-388",
+      "fileName": "repos/curl/lib/curl_fnmatch.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dde956c3ac2aa213e1d68c3c72a3b679bb0759bb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-pop3.c-389",
+      "fileName": "repos/curl/lib/pop3.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "de704d11e1a9f1c93b0f2d105a0a3a1e8ad33981"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-getinfo.c-390",
+      "fileName": "repos/curl/lib/getinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dedafd382e5dc44a55e5a148d7df3e27a26fcfd2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-https-connect.h-391",
       "fileName": "repos/curl/lib/cf-https-connect.h",
       "checksums": [
         {
@@ -3889,27 +3929,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-functypes.h-388",
-      "fileName": "repos/curl/lib/vauth/../functypes.h",
+      "SPDXID": "SPDXRef-File-cf-ip-happy.c-392",
+      "fileName": "repos/curl/lib/cf-ip-happy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "df3cfd44c88f3f254dfa1907c1673192b326fd8a"
+          "checksumValue": "dfbf4ae183b528a80f73e5a256768b2fefe05ed9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ntlm-sspi.c-389",
-      "fileName": "repos/curl/lib/vauth/ntlm_sspi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e0a0bebec3e0eff4f496092cded290fdc9a8383a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-operhlp.c-390",
+      "SPDXID": "SPDXRef-File-tool-operhlp.c-393",
       "fileName": "repos/curl/src/tool_operhlp.c",
       "checksums": [
         {
@@ -3919,47 +3949,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-setup.h-391",
-      "fileName": "repos/curl/src/tool_setup.h",
+      "SPDXID": "SPDXRef-File-hsts.h-394",
+      "fileName": "repos/curl/lib/hsts.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e113de8ddae2cc41de16a38adb5c835d4addddb1"
+          "checksumValue": "e0f6363bb355072fdc5a92289c48ce806bf60829"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timediff.h-392",
-      "fileName": "repos/curl/lib/vauth/../curlx/timediff.h",
+      "SPDXID": "SPDXRef-File-vquic-tls.c-395",
+      "fileName": "repos/curl/lib/vquic/vquic-tls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e19b0f4403a1138b7b789e612cb7aa9c29b3cfce"
+          "checksumValue": "e135ac517417add98a34ca092f980e5a84e62556"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-hdr.c-393",
-      "fileName": "repos/curl/src/tool_cb_hdr.c",
+      "SPDXID": "SPDXRef-File-http2.c-396",
+      "fileName": "repos/curl/lib/http2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e22c59694cf579f73ef16092da359d8105663ec7"
+          "checksumValue": "e1c57986e81c2c02ca6b7b1f3527892c7a043e00"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-hash.c-394",
-      "fileName": "repos/curl/lib/uint-hash.c",
+      "SPDXID": "SPDXRef-File-tool-cb-see.c-397",
+      "fileName": "repos/curl/src/tool_cb_see.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e23d249d0571390fc6cc988a2c5502b586140c93"
+          "checksumValue": "e1ebd8d99f65b9e5533971b56b2d69c8b1ca5f31"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-psl.c-395",
+      "SPDXID": "SPDXRef-File-ldap.c-398",
+      "fileName": "repos/curl/lib/ldap.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e223078b03701d19b4e53853082321686570e064"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-psl.c-399",
       "fileName": "repos/curl/lib/psl.c",
       "checksums": [
         {
@@ -3969,17 +4009,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hsts.h-396",
-      "fileName": "repos/curl/lib/hsts.h",
+      "SPDXID": "SPDXRef-File-dynhds.h-400",
+      "fileName": "repos/curl/lib/dynhds.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e2c9922f18ef955b590a6c07f9cca35247936ef2"
+          "checksumValue": "e30eb457257d34fb243073e0b8aeea0121da342f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-see.h-397",
+      "SPDXID": "SPDXRef-File-tool-getparam.h-401",
+      "fileName": "repos/curl/src/tool_getparam.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e3cbe5454a6d429232396e87796b0a1f724be220"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-see.h-402",
       "fileName": "repos/curl/src/tool_cb_see.h",
       "checksums": [
         {
@@ -3989,17 +4039,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h1-proxy.h-398",
-      "fileName": "repos/curl/lib/cf-h1-proxy.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e48d827825d3ebeeac1bd65fd9eb305b2e845106"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-rtmp.h-399",
+      "SPDXID": "SPDXRef-File-curl-rtmp.h-403",
       "fileName": "repos/curl/lib/curl_rtmp.h",
       "checksums": [
         {
@@ -4009,47 +4049,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-md5.c-400",
-      "fileName": "repos/curl/lib/md5.c",
+      "SPDXID": "SPDXRef-File-mqtt.c-404",
+      "fileName": "repos/curl/lib/mqtt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e5a4f534c7cf50d0f52497b377077f228124c2df"
+          "checksumValue": "e591cfcf0100533bdba5a8d6bb42d1f96a85922f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-setopt.c-401",
-      "fileName": "repos/curl/lib/setopt.c",
+      "SPDXID": "SPDXRef-File-tool-getparam.c-405",
+      "fileName": "repos/curl/src/tool_getparam.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e6476dfaf30c2413e630ccd8f20714ec81dcf130"
+          "checksumValue": "e6e641923beef9abf9cd6b0db2cda306f95ea244"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostip.h-402",
-      "fileName": "repos/curl/lib/vauth/../hostip.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e70eac841bf2f1181598e9e3fbeaf6602338a086"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-header.h-403",
-      "fileName": "repos/curl/lib/../include/curl/header.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e7334b5a3a4d35f9d23fc47a4d9826370b0dc0c5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-content-encoding.h-404",
+      "SPDXID": "SPDXRef-File-content-encoding.h-406",
       "fileName": "repos/curl/lib/content_encoding.h",
       "checksums": [
         {
@@ -4059,7 +4079,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operhlp.h-405",
+      "SPDXID": "SPDXRef-File-mime.h-407",
+      "fileName": "repos/curl/lib/mime.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e84f04051b534a0230881cfc810d6b2f53cd1988"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-operhlp.h-408",
       "fileName": "repos/curl/src/tool_operhlp.h",
       "checksums": [
         {
@@ -4069,37 +4099,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-setopt.h-406",
-      "fileName": "repos/curl/src/tool_setopt.h",
+      "SPDXID": "SPDXRef-File-parsedate.h-409",
+      "fileName": "repos/curl/lib/parsedate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e990f08a81a3b4624d7280010f2de7f865ff2216"
+          "checksumValue": "ea136bd30158437fe88efbeb88541aceb44099e6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-proxy.c-407",
-      "fileName": "repos/curl/lib/http_proxy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e9dfb8dbb3bd7a583b8744f4ec1d51589ec58971"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-aws-sigv4.c-408",
-      "fileName": "repos/curl/lib/http_aws_sigv4.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ea1a7ff758b2e51a0ccefdc23e8c38adf5403f56"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-msgs.h-409",
+      "SPDXID": "SPDXRef-File-tool-msgs.h-410",
       "fileName": "repos/curl/src/tool_msgs.h",
       "checksums": [
         {
@@ -4109,37 +4119,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest.c-410",
-      "fileName": "repos/curl/lib/vauth/digest.c",
+      "SPDXID": "SPDXRef-File-tool-cb-rea.c-411",
+      "fileName": "repos/curl/src/tool_cb_rea.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ec82564d2c96834058dc2224aee55e9a1fe22e45"
+          "checksumValue": "eb23f9b907be53e106db188288f0025971daa45c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keylog.h-411",
-      "fileName": "repos/curl/lib/vtls/keylog.h",
+      "SPDXID": "SPDXRef-File-url.c-412",
+      "fileName": "repos/curl/lib/url.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ec82abf547f08b9914e4f4a05c353f454f737dd7"
+          "checksumValue": "ec0457bcdd6f2aacbc5f188aa81955f3654a4ab4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gtls.h-412",
-      "fileName": "repos/curl/lib/vtls/gtls.h",
+      "SPDXID": "SPDXRef-File-cw-pause.c-413",
+      "fileName": "repos/curl/lib/cw-pause.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ecdca0a666a5fd27e2ff82e61f0fec3fdfb72ceb"
+          "checksumValue": "ec611879d1e8a2c378e2302259a667004694b6d6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock.h-413",
+      "SPDXID": "SPDXRef-File-noproxy.c-414",
+      "fileName": "repos/curl/lib/noproxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ee03fd35b9f1ae4f60e2d639d51003da71537077"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-nonblock.h-415",
       "fileName": "repos/curl/lib/curlx/nonblock.h",
       "checksums": [
         {
@@ -4149,17 +4169,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ftp.h-414",
-      "fileName": "repos/curl/lib/vauth/../ftp.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ef1aacb40c89e42c2ff0f57ebfdc4888bfe1187f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-soc.h-415",
+      "SPDXID": "SPDXRef-File-tool-cb-soc.h-416",
       "fileName": "repos/curl/src/tool_cb_soc.h",
       "checksums": [
         {
@@ -4169,27 +4179,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strparse.c-416",
-      "fileName": "repos/curl/lib/curlx/strparse.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f11b58b7eee5e24474be34e836a9c79b0533b18e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl.h-417",
-      "fileName": "repos/curl/lib/../include/curl/curl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f14f887261b4af00e74e4b499539a4d2b13639a9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-gethostname.c-418",
+      "SPDXID": "SPDXRef-File-curl-gethostname.c-417",
       "fileName": "repos/curl/lib/curl_gethostname.c",
       "checksums": [
         {
@@ -4199,7 +4189,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-imap.h-419",
+      "SPDXID": "SPDXRef-File-imap.h-418",
       "fileName": "repos/curl/lib/imap.h",
       "checksums": [
         {
@@ -4209,37 +4199,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-addrinfo.c-420",
-      "fileName": "repos/curl/lib/curl_addrinfo.c",
+      "SPDXID": "SPDXRef-File-digest-sspi.c-419",
+      "fileName": "repos/curl/lib/vauth/digest_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f1eaa6bcb604ac242c6504fbba601ca28a170454"
+          "checksumValue": "f29e569cd1801053bc2c72a67599c7be7dc0426a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connect.h-421",
-      "fileName": "repos/curl/lib/vtls/../connect.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f2b9911073b94df6c1a4770977e45fbd9bd228e8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sendf.c-422",
-      "fileName": "repos/curl/lib/sendf.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f2d30a4269a1eb8b78a0fadf0290f248564a8c34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist-wc.c-423",
+      "SPDXID": "SPDXRef-File-slist-wc.c-420",
       "fileName": "repos/curl/src/slist_wc.c",
       "checksums": [
         {
@@ -4249,37 +4219,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-base.c-424",
-      "fileName": "repos/curl/lib/asyn-base.c",
+      "SPDXID": "SPDXRef-File-tool-easysrc.h-421",
+      "fileName": "repos/curl/src/tool_easysrc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f35e1c988c3f683e0eea38fe13ab25c1d2d7b41f"
+          "checksumValue": "f37ce4ba86f556a6b6fc3074d8a1ad4366f9a222"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-url.c-425",
-      "fileName": "repos/curl/lib/url.c",
+      "SPDXID": "SPDXRef-File-curl-addrinfo.h-422",
+      "fileName": "repos/curl/lib/curl_addrinfo.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f3b24c9de24e17eba9e0317f480d91ef8680dd45"
+          "checksumValue": "f464b5ed7898c5264b5833025c6d409e44c7fb4d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic.h-426",
-      "fileName": "repos/curl/lib/vquic/vquic.h",
+      "SPDXID": "SPDXRef-File-tool-parsecfg.c-423",
+      "fileName": "repos/curl/src/tool_parsecfg.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f5392eb04797f7f2d55d4120d6cc4d3c095f0d1e"
+          "checksumValue": "f5910f404e77a43a7f19f862e298e3cce0031e85"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-digest.c-427",
+      "SPDXID": "SPDXRef-File-http-digest.c-424",
       "fileName": "repos/curl/lib/http_digest.c",
       "checksums": [
         {
@@ -4289,7 +4259,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getinfo.h-428",
+      "SPDXID": "SPDXRef-File-getinfo.h-425",
       "fileName": "repos/curl/lib/getinfo.h",
       "checksums": [
         {
@@ -4299,12 +4269,42 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-threads.c-429",
+      "SPDXID": "SPDXRef-File-curl-threads.c-426",
       "fileName": "repos/curl/lib/curl_threads.c",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "f5fea9804693e1eee1faae8c48e1b2625e014730"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-urlglob.c-427",
+      "fileName": "repos/curl/src/tool_urlglob.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f62d9738ec081a16f19fb34d68501aec22817bb2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-vtls.c-428",
+      "fileName": "repos/curl/lib/vtls/vtls.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f7201d18d6507d9f7d076928385d1304bff16dd1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-urlapi.h-429",
+      "fileName": "repos/curl/lib/../include/curl/urlapi.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f7a42b3b9e0f526a36ae326f3ac3fc82a366de08"
         }
       ]
     },
@@ -4330,7 +4330,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-curl-ntlm-core.h-432",
-      "fileName": "repos/curl/lib/vauth/../curl_ntlm_core.h",
+      "fileName": "repos/curl/lib/curl_ntlm_core.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4339,18 +4339,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-easysrc.h-433",
-      "fileName": "repos/curl/src/tool_easysrc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f9ddacfc3779d941303f0c6e8b4fe277ae4858ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-endian.h-434",
-      "fileName": "repos/curl/lib/vauth/../curl_endian.h",
+      "SPDXID": "SPDXRef-File-curl-endian.h-433",
+      "fileName": "repos/curl/lib/curl_endian.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4359,47 +4349,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sha512-256.c-435",
-      "fileName": "repos/curl/lib/curl_sha512_256.c",
+      "SPDXID": "SPDXRef-File-cookie.h-434",
+      "fileName": "repos/curl/lib/cookie.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fa568b6b041ddb9cc2f7150cfdaef906f38c25ab"
+          "checksumValue": "fabd04d3989bb9fdb078ef57321f884ca7c699b4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi-int.h-436",
-      "fileName": "repos/curl/lib/urlapi-int.h",
+      "SPDXID": "SPDXRef-File-basename.h-435",
+      "fileName": "repos/curl/lib/curlx/basename.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fbce1837ff94fb6c74d47847f687a53332edfeca"
+          "checksumValue": "fb79fed8053dac80b2a526801fce9d6e7cec43c1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-pton.h-437",
-      "fileName": "repos/curl/lib/vtls/../curlx/inet_pton.h",
+      "SPDXID": "SPDXRef-File-tool-cb-hdr.c-436",
+      "fileName": "repos/curl/src/tool_cb_hdr.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fc3ae3d2bb2c20dd9beff7fc3c369addd15f9c94"
+          "checksumValue": "fc03cf143b95a8451c20f326fbdd338693833331"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cleartext.c-438",
-      "fileName": "repos/curl/lib/vauth/cleartext.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fc8a6ebd5102516803695f3bdd91cc94100eed3d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.c-439",
+      "SPDXID": "SPDXRef-File-dict.c-437",
       "fileName": "repos/curl/lib/dict.c",
       "checksums": [
         {
@@ -4409,32 +4389,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getinfo.c-440",
-      "fileName": "repos/curl/lib/getinfo.c",
+      "SPDXID": "SPDXRef-File-schannel.h-438",
+      "fileName": "repos/curl/lib/../lib/vtls/schannel.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fd0d483f0a1137a94b0eb6cd5e3bd5043f2a4333"
+          "checksumValue": "fe49e9a9d0fb50eedb38e6873df19d66e1f89634"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pop3.c-441",
-      "fileName": "repos/curl/lib/pop3.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fdb09f232097032e1e1dfab45c98eaa4501065b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-ntlm.h-442",
+      "SPDXID": "SPDXRef-File-http-ntlm.h-439",
       "fileName": "repos/curl/lib/http_ntlm.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "ff5218d89f6cd740ceb878a6cd7c1e21047f2cf9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-select.h-440",
+      "fileName": "repos/curl/lib/select.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ffcd44cfcfc773158bcc47a6d422ddfb962b39c1"
         }
       ]
     }
@@ -4448,132 +4428,132 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idn.c-2"
+      "relatedSpdxElement": "SPDXRef-File-smb.c-2"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-scache.c-3"
+      "relatedSpdxElement": "SPDXRef-File-cf-socket.h-3"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.c-4"
+      "relatedSpdxElement": "SPDXRef-File-keylog.c-4"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multiif.h-5"
+      "relatedSpdxElement": "SPDXRef-File-hmac.c-5"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rustls.c-6"
+      "relatedSpdxElement": "SPDXRef-File-inet-pton.h-6"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.h-7"
+      "relatedSpdxElement": "SPDXRef-File-multiif.h-7"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ldap.c-8"
+      "relatedSpdxElement": "SPDXRef-File-hsts.c-8"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transfer.h-9"
+      "relatedSpdxElement": "SPDXRef-File-curl-md5.h-9"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-md4.h-10"
+      "relatedSpdxElement": "SPDXRef-File-imap.c-10"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.h-11"
+      "relatedSpdxElement": "SPDXRef-File-transfer.h-11"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-if2ip.c-12"
+      "relatedSpdxElement": "SPDXRef-File-curl-md4.h-12"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-typecheck-gcc.h-13"
+      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.h-13"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.h-14"
+      "relatedSpdxElement": "SPDXRef-File-if2ip.c-14"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-range.c-15"
+      "relatedSpdxElement": "SPDXRef-File-rustls.c-15"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.h-16"
+      "relatedSpdxElement": "SPDXRef-File-netrc.h-16"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getpass.h-17"
+      "relatedSpdxElement": "SPDXRef-File-system.h-17"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlinfo.c-18"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.h-18"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-macos.h-19"
+      "relatedSpdxElement": "SPDXRef-File-connect.h-19"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha256.h-20"
+      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.h-20"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-ntop.c-21"
+      "relatedSpdxElement": "SPDXRef-File-llist.h-21"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.c-22"
+      "relatedSpdxElement": "SPDXRef-File-tool-getpass.h-22"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.c-23"
+      "relatedSpdxElement": "SPDXRef-File-curlinfo.c-23"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cram.c-24"
+      "relatedSpdxElement": "SPDXRef-File-macos.h-24"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doh.h-25"
+      "relatedSpdxElement": "SPDXRef-File-tool-filetime.c-25"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setopt.h-26"
+      "relatedSpdxElement": "SPDXRef-File-easy.h-26"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smb.c-27"
+      "relatedSpdxElement": "SPDXRef-File-strdup.h-27"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -4588,22 +4568,22 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-thrdd.c-30"
+      "relatedSpdxElement": "SPDXRef-File-llist.c-30"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llist.c-31"
+      "relatedSpdxElement": "SPDXRef-File-netrc.c-31"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base64.c-32"
+      "relatedSpdxElement": "SPDXRef-File-timediff.h-32"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-formparse.c-33"
+      "relatedSpdxElement": "SPDXRef-File-rtsp.c-33"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -4613,747 +4593,747 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http1.h-35"
+      "relatedSpdxElement": "SPDXRef-File-ntlm-sspi.c-35"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-spnego-sspi.c-36"
+      "relatedSpdxElement": "SPDXRef-File-tool-time.c-36"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn.h-37"
+      "relatedSpdxElement": "SPDXRef-File-if2ip.h-37"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-if2ip.h-38"
+      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.c-38"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.c-39"
+      "relatedSpdxElement": "SPDXRef-File-strparse.c-39"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noproxy.c-40"
+      "relatedSpdxElement": "SPDXRef-File-curl-ctype.h-40"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sendf.h-41"
+      "relatedSpdxElement": "SPDXRef-File-tool-time.h-41"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ctype.h-42"
+      "relatedSpdxElement": "SPDXRef-File-httpsrr.c-42"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-time.h-43"
+      "relatedSpdxElement": "SPDXRef-File-http.c-43"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libssh2.c-44"
+      "relatedSpdxElement": "SPDXRef-File-md4.c-44"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsts.c-45"
+      "relatedSpdxElement": "SPDXRef-File-ssh.h-45"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-md5.h-46"
+      "relatedSpdxElement": "SPDXRef-File-system-win32.c-46"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpsrr.c-47"
+      "relatedSpdxElement": "SPDXRef-File-file.c-47"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-pton.c-48"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.c-48"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-msgs.c-49"
+      "relatedSpdxElement": "SPDXRef-File-curl-sspi.c-49"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.h-50"
+      "relatedSpdxElement": "SPDXRef-File-strerror.c-50"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-doswin.c-51"
+      "relatedSpdxElement": "SPDXRef-File-vquic.c-51"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cookie.c-52"
+      "relatedSpdxElement": "SPDXRef-File-spnego-sspi.c-52"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ratelimit.c-53"
+      "relatedSpdxElement": "SPDXRef-File-cipher-suite.c-53"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic.c-54"
+      "relatedSpdxElement": "SPDXRef-File-curl.h-54"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.c-55"
+      "relatedSpdxElement": "SPDXRef-File-ftp.h-55"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sspi.c-56"
+      "relatedSpdxElement": "SPDXRef-File-config2setopts.c-56"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llist.h-57"
+      "relatedSpdxElement": "SPDXRef-File-tool-formparse.c-57"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.h-58"
+      "relatedSpdxElement": "SPDXRef-File-easyif.h-58"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strdup.h-59"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout.c-59"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerror.c-60"
+      "relatedSpdxElement": "SPDXRef-File-tool-ssls.c-60"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.h-61"
+      "relatedSpdxElement": "SPDXRef-File-uint-hash.c-61"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlx.h-62"
+      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.h-62"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-spack.c-63"
+      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.h-63"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-printf.h-64"
+      "relatedSpdxElement": "SPDXRef-File-hash.h-64"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyif.h-65"
+      "relatedSpdxElement": "SPDXRef-File-easygetopt.c-65"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks-gssapi.c-66"
+      "relatedSpdxElement": "SPDXRef-File-tool-findfile.c-66"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ssls.c-67"
+      "relatedSpdxElement": "SPDXRef-File-cfilters.c-67"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.c-68"
+      "relatedSpdxElement": "SPDXRef-File-altsvc.h-68"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smtp.c-69"
+      "relatedSpdxElement": "SPDXRef-File-version-win32.c-69"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.h-70"
+      "relatedSpdxElement": "SPDXRef-File-urlapi-int.h-70"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-pause.c-71"
+      "relatedSpdxElement": "SPDXRef-File-socketpair.h-71"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.h-72"
+      "relatedSpdxElement": "SPDXRef-File-sockaddr.h-72"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snprintf.h-73"
+      "relatedSpdxElement": "SPDXRef-File-mbedtls.c-73"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easygetopt.c-74"
+      "relatedSpdxElement": "SPDXRef-File-timediff.c-74"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-select.h-75"
+      "relatedSpdxElement": "SPDXRef-File-ratelimit.c-75"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multibyte.h-76"
+      "relatedSpdxElement": "SPDXRef-File-idn.c-76"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout.c-77"
+      "relatedSpdxElement": "SPDXRef-File-inet-ntop.h-77"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-findfile.c-78"
+      "relatedSpdxElement": "SPDXRef-File-base64.h-78"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basename.c-79"
+      "relatedSpdxElement": "SPDXRef-File-cf-socket.c-79"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basename.h-80"
+      "relatedSpdxElement": "SPDXRef-File-cshutdn.c-80"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-socket.h-81"
+      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.h-81"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-helpers.c-82"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.c-82"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-scache.h-83"
+      "relatedSpdxElement": "SPDXRef-File-slist-wc.h-83"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wait.c-84"
+      "relatedSpdxElement": "SPDXRef-File-macos.c-84"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socketpair.h-85"
+      "relatedSpdxElement": "SPDXRef-File-curl-share.c-85"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockaddr.h-86"
+      "relatedSpdxElement": "SPDXRef-File-pingpong.h-86"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.c-87"
+      "relatedSpdxElement": "SPDXRef-File-formdata.h-87"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynhds.h-88"
+      "relatedSpdxElement": "SPDXRef-File-fileinfo.c-88"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rustls.h-89"
+      "relatedSpdxElement": "SPDXRef-File-winapi.c-89"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base64.h-90"
+      "relatedSpdxElement": "SPDXRef-File-altsvc.c-90"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.h-91"
+      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.c-91"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ntlm-core.c-92"
+      "relatedSpdxElement": "SPDXRef-File-formdata.c-92"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-system-win32.c-93"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.h-93"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setopt.c-94"
+      "relatedSpdxElement": "SPDXRef-File-mime.c-94"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-var.c-95"
+      "relatedSpdxElement": "SPDXRef-File-uint-table.h-95"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vauth.h-96"
+      "relatedSpdxElement": "SPDXRef-File-smtp.h-96"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.h-97"
+      "relatedSpdxElement": "SPDXRef-File-libssh.c-97"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.c-98"
+      "relatedSpdxElement": "SPDXRef-File-curl-printf.h-98"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-arpa-telnet.h-99"
+      "relatedSpdxElement": "SPDXRef-File-strdup.c-99"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transfer.c-100"
+      "relatedSpdxElement": "SPDXRef-File-config2setopts.h-100"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-macos.c-101"
+      "relatedSpdxElement": "SPDXRef-File-warnless.h-101"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic-tls.c-102"
+      "relatedSpdxElement": "SPDXRef-File-vauth.h-102"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pingpong.h-103"
+      "relatedSpdxElement": "SPDXRef-File-doh.h-103"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fileinfo.c-104"
+      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.c-104"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcase.h-105"
+      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.c-105"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.h-106"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout.h-106"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mbedtls.h-107"
+      "relatedSpdxElement": "SPDXRef-File-websockets.h-107"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-request.h-108"
+      "relatedSpdxElement": "SPDXRef-File-schannel-verify.c-108"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http.c-109"
+      "relatedSpdxElement": "SPDXRef-File-rand.c-109"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smtp.h-110"
+      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.c-110"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config2setopts.h-111"
+      "relatedSpdxElement": "SPDXRef-File-tool-ssls.h-111"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.c-112"
+      "relatedSpdxElement": "SPDXRef-File-timeval.c-112"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-socket.c-113"
+      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.c-113"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mbedtls.c-114"
+      "relatedSpdxElement": "SPDXRef-File-strerr.h-114"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.c-115"
+      "relatedSpdxElement": "SPDXRef-File-vtls-spack.h-115"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.c-116"
+      "relatedSpdxElement": "SPDXRef-File-doh.c-116"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-table.h-117"
+      "relatedSpdxElement": "SPDXRef-File-asyn-base.c-117"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-share.h-118"
+      "relatedSpdxElement": "SPDXRef-File-oauth2.c-118"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-share.c-119"
+      "relatedSpdxElement": "SPDXRef-File-slist.h-119"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout.h-120"
+      "relatedSpdxElement": "SPDXRef-File-tool-stderr.h-120"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-websockets.h-121"
+      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.c-121"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-imap.c-122"
+      "relatedSpdxElement": "SPDXRef-File-vssh.h-122"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idn.h-123"
+      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.c-123"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ssls.h-124"
+      "relatedSpdxElement": "SPDXRef-File-curl-ntlm-core.c-124"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerr.h-125"
+      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.h-125"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mqtt.c-126"
+      "relatedSpdxElement": "SPDXRef-File-uint-spbset.h-126"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-filetime.c-127"
+      "relatedSpdxElement": "SPDXRef-File-curl-trc.c-127"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memdebug.c-128"
+      "relatedSpdxElement": "SPDXRef-File-strerror.h-128"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-ntop.h-129"
+      "relatedSpdxElement": "SPDXRef-File-easyoptions.c-129"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http2.c-130"
+      "relatedSpdxElement": "SPDXRef-File-asyn-ares.c-130"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-hmac.h-131"
+      "relatedSpdxElement": "SPDXRef-File-cookie.c-131"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist.h-132"
+      "relatedSpdxElement": "SPDXRef-File-tool-ca-embed.c-132"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-stderr.h-133"
+      "relatedSpdxElement": "SPDXRef-File-pingpong.c-133"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeval.h-134"
+      "relatedSpdxElement": "SPDXRef-File-curl-setup.h-134"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-spbset.h-135"
+      "relatedSpdxElement": "SPDXRef-File-openssl.c-135"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connect.c-136"
+      "relatedSpdxElement": "SPDXRef-File-tool-help.c-136"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerror.h-137"
+      "relatedSpdxElement": "SPDXRef-File-bufref.c-137"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyoptions.c-138"
+      "relatedSpdxElement": "SPDXRef-File-strparse.h-138"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.c-139"
+      "relatedSpdxElement": "SPDXRef-File-socks.h-139"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getparam.h-140"
+      "relatedSpdxElement": "SPDXRef-File-wait.c-140"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vssh.h-141"
+      "relatedSpdxElement": "SPDXRef-File-vquic.h-141"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ca-embed.c-142"
+      "relatedSpdxElement": "SPDXRef-File-request.h-142"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config2setopts.c-143"
+      "relatedSpdxElement": "SPDXRef-File-tool-sdecls.h-143"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufref.c-144"
+      "relatedSpdxElement": "SPDXRef-File-strcase.h-144"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftp.c-145"
+      "relatedSpdxElement": "SPDXRef-File-hostip.c-145"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel-verify.c-146"
+      "relatedSpdxElement": "SPDXRef-File-cw-pause.h-146"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.h-147"
+      "relatedSpdxElement": "SPDXRef-File-cw-out.c-147"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.c-148"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.h-148"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multibyte.c-149"
+      "relatedSpdxElement": "SPDXRef-File-uint-hash.h-149"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.h-150"
+      "relatedSpdxElement": "SPDXRef-File-amigaos.h-150"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doh.c-151"
+      "relatedSpdxElement": "SPDXRef-File-uint-spbset.c-151"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-pause.h-152"
+      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.c-152"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.h-153"
+      "relatedSpdxElement": "SPDXRef-File-headers.c-153"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-setup.h-154"
+      "relatedSpdxElement": "SPDXRef-File-urldata.h-154"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher-suite.c-155"
+      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.c-155"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-hash.h-156"
+      "relatedSpdxElement": "SPDXRef-File-digest.h-156"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amigaos.h-157"
+      "relatedSpdxElement": "SPDXRef-File-telnet.c-157"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-trc.h-158"
+      "relatedSpdxElement": "SPDXRef-File-curlver.h-158"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-spbset.c-159"
+      "relatedSpdxElement": "SPDXRef-File-bufref.h-159"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.c-160"
+      "relatedSpdxElement": "SPDXRef-File-ftplistparser.h-160"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-headers.c-161"
+      "relatedSpdxElement": "SPDXRef-File-tool-version.h-161"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.c-162"
+      "relatedSpdxElement": "SPDXRef-File-curl-share.h-162"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy.h-163"
+      "relatedSpdxElement": "SPDXRef-File-uint-bset.c-163"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x509asn1.c-164"
+      "relatedSpdxElement": "SPDXRef-File-http-digest.h-164"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlver.h-165"
+      "relatedSpdxElement": "SPDXRef-File-warnless.c-165"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufref.h-166"
+      "relatedSpdxElement": "SPDXRef-File-ws.c-166"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-quiche.c-167"
+      "relatedSpdxElement": "SPDXRef-File-ftp.c-167"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-version.h-168"
+      "relatedSpdxElement": "SPDXRef-File-smtp.c-168"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-splay.c-169"
+      "relatedSpdxElement": "SPDXRef-File-http1.c-169"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http2.h-170"
+      "relatedSpdxElement": "SPDXRef-File-tool-util.c-170"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mime.h-171"
+      "relatedSpdxElement": "SPDXRef-File-multi.c-171"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-bset.c-172"
+      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.h-172"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-digest.h-173"
+      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.c-173"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-util.c-174"
+      "relatedSpdxElement": "SPDXRef-File-tool-findfile.h-174"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operate.c-175"
+      "relatedSpdxElement": "SPDXRef-File-libssh2.c-175"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.h-176"
+      "relatedSpdxElement": "SPDXRef-File-tool-progress.c-176"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.c-177"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.c-177"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-findfile.h-178"
+      "relatedSpdxElement": "SPDXRef-File-schannel.c-178"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.h-179"
+      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.h-179"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-progress.c-180"
+      "relatedSpdxElement": "SPDXRef-File-request.c-180"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-altsvc.c-181"
+      "relatedSpdxElement": "SPDXRef-File-vtls-int.h-181"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.c-182"
+      "relatedSpdxElement": "SPDXRef-File-tool-xattr.h-182"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-xattr.h-183"
+      "relatedSpdxElement": "SPDXRef-File-vtls-scache.c-183"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5363,27 +5343,27 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.c-185"
+      "relatedSpdxElement": "SPDXRef-File-asyn.h-185"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version.c-186"
+      "relatedSpdxElement": "SPDXRef-File-tool-getpass.c-186"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timediff.c-187"
+      "relatedSpdxElement": "SPDXRef-File-multi-ev.c-187"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-help.h-188"
+      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.c-188"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-krb5-gssapi.c-189"
+      "relatedSpdxElement": "SPDXRef-File-tool-help.h-189"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5393,97 +5373,97 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-quiche.h-191"
+      "relatedSpdxElement": "SPDXRef-File-http-negotiate.h-191"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-negotiate.h-192"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.c-192"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.h-193"
+      "relatedSpdxElement": "SPDXRef-File-hostip.h-193"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ws.c-194"
+      "relatedSpdxElement": "SPDXRef-File-progress.c-194"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http.h-195"
+      "relatedSpdxElement": "SPDXRef-File-fopen.c-195"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynbuf.h-196"
+      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.h-196"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-config.h-197"
+      "relatedSpdxElement": "SPDXRef-File-transfer.c-197"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-content-encoding.c-198"
+      "relatedSpdxElement": "SPDXRef-File-dynbuf.h-198"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-vms.c-199"
+      "relatedSpdxElement": "SPDXRef-File-nonblock.c-199"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noproxy.h-200"
+      "relatedSpdxElement": "SPDXRef-File-dynbuf.c-200"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urldata.h-201"
+      "relatedSpdxElement": "SPDXRef-File-multibyte.c-201"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.h-202"
+      "relatedSpdxElement": "SPDXRef-File-noproxy.h-202"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gopher.c-203"
+      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.h-203"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.h-204"
+      "relatedSpdxElement": "SPDXRef-File-gopher.c-204"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeval.c-205"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.h-205"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wolfssl.h-206"
+      "relatedSpdxElement": "SPDXRef-File-fileinfo.h-206"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fileinfo.h-207"
+      "relatedSpdxElement": "SPDXRef-File-dynhds.c-207"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynhds.c-208"
+      "relatedSpdxElement": "SPDXRef-File-uint-bset.h-208"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-bset.h-209"
+      "relatedSpdxElement": "SPDXRef-File-tool-vms.c-209"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5503,177 +5483,177 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.c-213"
+      "relatedSpdxElement": "SPDXRef-File-ws.h-213"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strdup.c-214"
+      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.c-214"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pop3.h-215"
+      "relatedSpdxElement": "SPDXRef-File-sendf.h-215"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.c-216"
+      "relatedSpdxElement": "SPDXRef-File-socketpair.c-216"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tftp.c-217"
+      "relatedSpdxElement": "SPDXRef-File-pop3.h-217"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ssh.h-218"
+      "relatedSpdxElement": "SPDXRef-File-curl-config.h-218"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cshutdn.h-219"
+      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.c-219"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multihandle.h-220"
+      "relatedSpdxElement": "SPDXRef-File-connect.c-220"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-krb5-sspi.c-221"
+      "relatedSpdxElement": "SPDXRef-File-cleartext.c-221"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist-wc.h-222"
+      "relatedSpdxElement": "SPDXRef-File-curlx.h-222"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ldap.h-223"
+      "relatedSpdxElement": "SPDXRef-File-multihandle.h-223"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apple.c-224"
+      "relatedSpdxElement": "SPDXRef-File-sha256.c-224"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-progress.c-225"
+      "relatedSpdxElement": "SPDXRef-File-curl-ldap.h-225"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-out.h-226"
+      "relatedSpdxElement": "SPDXRef-File-version.c-226"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel.c-227"
+      "relatedSpdxElement": "SPDXRef-File-cw-out.h-227"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mime.c-228"
+      "relatedSpdxElement": "SPDXRef-File-keylog.h-228"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socketpair.c-229"
+      "relatedSpdxElement": "SPDXRef-File-tool-operate.h-229"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-ares.c-230"
+      "relatedSpdxElement": "SPDXRef-File-parsedate.c-230"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-doswin.h-231"
+      "relatedSpdxElement": "SPDXRef-File-var.c-231"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options.h-232"
+      "relatedSpdxElement": "SPDXRef-File-inet-ntop.c-232"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openldap.c-233"
+      "relatedSpdxElement": "SPDXRef-File-hash.c-233"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sasl.h-234"
+      "relatedSpdxElement": "SPDXRef-File-tool-doswin.h-234"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.h-235"
+      "relatedSpdxElement": "SPDXRef-File-options.h-235"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cshutdn.c-236"
+      "relatedSpdxElement": "SPDXRef-File-setopt.c-236"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-get-line.c-237"
+      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.h-237"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-altsvc.h-238"
+      "relatedSpdxElement": "SPDXRef-File-headers.h-238"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.h-239"
+      "relatedSpdxElement": "SPDXRef-File-curl-get-line.c-239"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-listhelp.c-240"
+      "relatedSpdxElement": "SPDXRef-File-header.h-240"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-endian.c-241"
+      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.h-241"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-spack.h-242"
+      "relatedSpdxElement": "SPDXRef-File-tool-listhelp.c-242"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conncache.c-243"
+      "relatedSpdxElement": "SPDXRef-File-curl-endian.c-243"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getparam.c-244"
+      "relatedSpdxElement": "SPDXRef-File-rand.h-244"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest-sspi.c-245"
+      "relatedSpdxElement": "SPDXRef-File-multibyte.h-245"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.h-246"
+      "relatedSpdxElement": "SPDXRef-File-functypes.h-246"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-vms.h-247"
+      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.h-247"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5683,7 +5663,7 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnless.h-249"
+      "relatedSpdxElement": "SPDXRef-File-curl-sasl.h-249"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5698,492 +5678,492 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.h-252"
+      "relatedSpdxElement": "SPDXRef-File-bufq.h-252"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnless.c-253"
+      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.c-253"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls.c-254"
+      "relatedSpdxElement": "SPDXRef-File-httpsrr.h-254"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.c-255"
+      "relatedSpdxElement": "SPDXRef-File-cshutdn.h-255"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mprintf.c-256"
+      "relatedSpdxElement": "SPDXRef-File-idn.h-256"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpsrr.h-257"
+      "relatedSpdxElement": "SPDXRef-File-strerr.c-257"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest.h-258"
+      "relatedSpdxElement": "SPDXRef-File-tftp.h-258"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-sdecls.h-259"
+      "relatedSpdxElement": "SPDXRef-File-mprintf.h-259"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hmac.c-260"
+      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.h-260"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tftp.h-261"
+      "relatedSpdxElement": "SPDXRef-File-rtsp.h-261"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mprintf.h-262"
+      "relatedSpdxElement": "SPDXRef-File-sendf.c-262"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.h-263"
+      "relatedSpdxElement": "SPDXRef-File-gsasl.c-263"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rtsp.h-264"
+      "relatedSpdxElement": "SPDXRef-File-openldap.c-264"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operate.h-265"
+      "relatedSpdxElement": "SPDXRef-File-digest.c-265"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.c-266"
+      "relatedSpdxElement": "SPDXRef-File-socks-gssapi.c-266"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock.c-267"
+      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.c-267"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostcheck.c-268"
+      "relatedSpdxElement": "SPDXRef-File-curl-range.h-268"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-range.h-269"
+      "relatedSpdxElement": "SPDXRef-File-psl.h-269"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-psl.h-270"
+      "relatedSpdxElement": "SPDXRef-File-tool-setup.h-270"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strequal.c-271"
+      "relatedSpdxElement": "SPDXRef-File-select.c-271"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-netrc.h-272"
+      "relatedSpdxElement": "SPDXRef-File-tool-operate.c-272"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getpass.c-273"
+      "relatedSpdxElement": "SPDXRef-File-wait.h-273"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedate.c-274"
+      "relatedSpdxElement": "SPDXRef-File-curl-range.c-274"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-chunks.c-275"
+      "relatedSpdxElement": "SPDXRef-File-tool-msgs.c-275"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conncache.h-276"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.h-276"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.h-277"
+      "relatedSpdxElement": "SPDXRef-File-progress.h-277"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist.c-278"
+      "relatedSpdxElement": "SPDXRef-File-strcase.c-278"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.h-279"
+      "relatedSpdxElement": "SPDXRef-File-escape.h-279"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-progress.h-280"
+      "relatedSpdxElement": "SPDXRef-File-vauth.c-280"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http1.c-281"
+      "relatedSpdxElement": "SPDXRef-File-gtls.c-281"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-splay.h-282"
+      "relatedSpdxElement": "SPDXRef-File-http2.h-282"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcase.c-283"
+      "relatedSpdxElement": "SPDXRef-File-tool-helpers.c-283"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cfilters.h-284"
+      "relatedSpdxElement": "SPDXRef-File-file.h-284"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.c-285"
+      "relatedSpdxElement": "SPDXRef-File-strequal.c-285"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.c-286"
+      "relatedSpdxElement": "SPDXRef-File-urlapi.c-286"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pingpong.c-287"
+      "relatedSpdxElement": "SPDXRef-File-gtls.h-287"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.h-288"
+      "relatedSpdxElement": "SPDXRef-File-apple.c-288"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ev.c-289"
+      "relatedSpdxElement": "SPDXRef-File-http-negotiate.c-289"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-select.c-290"
+      "relatedSpdxElement": "SPDXRef-File-base64.c-290"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-system.h-291"
+      "relatedSpdxElement": "SPDXRef-File-curl-trc.h-291"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libssh.c-292"
+      "relatedSpdxElement": "SPDXRef-File-conncache.c-292"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-win32.h-293"
+      "relatedSpdxElement": "SPDXRef-File-http-proxy.c-293"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openssl.c-294"
+      "relatedSpdxElement": "SPDXRef-File-getenv.c-294"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-negotiate.c-295"
+      "relatedSpdxElement": "SPDXRef-File-content-encoding.c-295"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedate.h-296"
+      "relatedSpdxElement": "SPDXRef-File-wolfssl.c-296"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-oauth2.c-297"
+      "relatedSpdxElement": "SPDXRef-File-tool-doswin.c-297"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.c-298"
+      "relatedSpdxElement": "SPDXRef-File-hostcheck.c-298"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sigpipe.h-299"
+      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.h-299"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getenv.c-300"
+      "relatedSpdxElement": "SPDXRef-File-multi.h-300"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynbuf.c-301"
+      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.h-301"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-win32.c-302"
+      "relatedSpdxElement": "SPDXRef-File-memdebug.c-302"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-out.c-303"
+      "relatedSpdxElement": "SPDXRef-File-spnego-gssapi.c-303"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keylog.c-304"
+      "relatedSpdxElement": "SPDXRef-File-wolfssl.h-304"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.h-305"
+      "relatedSpdxElement": "SPDXRef-File-curl-sasl.c-305"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-headers.h-306"
+      "relatedSpdxElement": "SPDXRef-File-tool-vms.h-306"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.c-307"
+      "relatedSpdxElement": "SPDXRef-File-sigpipe.h-307"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strparse.h-308"
+      "relatedSpdxElement": "SPDXRef-File-ntlm.c-308"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-request.c-309"
+      "relatedSpdxElement": "SPDXRef-File-dict.h-309"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openssl.h-310"
+      "relatedSpdxElement": "SPDXRef-File-arpa-telnet.h-310"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftplistparser.h-311"
+      "relatedSpdxElement": "SPDXRef-File-x509asn1.c-311"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.c-312"
+      "relatedSpdxElement": "SPDXRef-File-rustls.h-312"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-time.c-313"
+      "relatedSpdxElement": "SPDXRef-File-curl-fopen.c-313"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-spnego-gssapi.c-314"
+      "relatedSpdxElement": "SPDXRef-File-socks.c-314"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sasl.c-315"
+      "relatedSpdxElement": "SPDXRef-File-vtls.h-315"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy.c-316"
+      "relatedSpdxElement": "SPDXRef-File-uint-table.c-316"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.c-317"
+      "relatedSpdxElement": "SPDXRef-File-vtls-scache.h-317"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vssh.c-318"
+      "relatedSpdxElement": "SPDXRef-File-curl-hmac.h-318"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formdata.c-319"
+      "relatedSpdxElement": "SPDXRef-File-tool-main.c-319"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.h-320"
+      "relatedSpdxElement": "SPDXRef-File-var.h-320"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fopen.c-321"
+      "relatedSpdxElement": "SPDXRef-File-http.h-321"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fopen.c-322"
+      "relatedSpdxElement": "SPDXRef-File-tool-setopt.h-322"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gsasl.c-323"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha256.h-323"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-table.c-324"
+      "relatedSpdxElement": "SPDXRef-File-gopher.h-324"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-netrc.c-325"
+      "relatedSpdxElement": "SPDXRef-File-tool-setopt.c-325"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-main.c-326"
+      "relatedSpdxElement": "SPDXRef-File-curl-fopen.h-326"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-var.h-327"
+      "relatedSpdxElement": "SPDXRef-File-escape.c-327"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-trc.c-328"
+      "relatedSpdxElement": "SPDXRef-File-timeval.h-328"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gopher.h-329"
+      "relatedSpdxElement": "SPDXRef-File-krb5-sspi.c-329"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufq.h-330"
+      "relatedSpdxElement": "SPDXRef-File-curl-gssapi.c-330"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fopen.h-331"
+      "relatedSpdxElement": "SPDXRef-File-telnet.h-331"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vauth.c-332"
+      "relatedSpdxElement": "SPDXRef-File-http-proxy.h-332"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls.h-333"
+      "relatedSpdxElement": "SPDXRef-File-http1.h-333"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.c-334"
+      "relatedSpdxElement": "SPDXRef-File-md5.c-334"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.c-335"
+      "relatedSpdxElement": "SPDXRef-File-asyn-thrdd.c-335"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha256.c-336"
+      "relatedSpdxElement": "SPDXRef-File-setopt.h-336"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-winapi.c-337"
+      "relatedSpdxElement": "SPDXRef-File-version-win32.h-337"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gssapi.c-338"
+      "relatedSpdxElement": "SPDXRef-File-url.h-338"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-telnet.h-339"
+      "relatedSpdxElement": "SPDXRef-File-http-ntlm.c-339"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wait.h-340"
+      "relatedSpdxElement": "SPDXRef-File-splay.h-340"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-proxy.h-341"
+      "relatedSpdxElement": "SPDXRef-File-mprintf.c-341"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-int.h-342"
+      "relatedSpdxElement": "SPDXRef-File-slist.c-342"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-ntlm.c-343"
+      "relatedSpdxElement": "SPDXRef-File-snprintf.c-343"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel.h-344"
+      "relatedSpdxElement": "SPDXRef-File-cfilters.h-344"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.h-345"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.c-345"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cookie.h-346"
+      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.h-346"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-helpers.h-347"
+      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.c-347"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-xattr.c-348"
+      "relatedSpdxElement": "SPDXRef-File-tool-helpers.h-348"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formdata.h-349"
+      "relatedSpdxElement": "SPDXRef-File-tftp.c-349"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -6193,397 +6173,397 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy-lock.h-351"
+      "relatedSpdxElement": "SPDXRef-File-tool-xattr.c-351"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostip.c-352"
+      "relatedSpdxElement": "SPDXRef-File-easy-lock.h-352"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.c-353"
+      "relatedSpdxElement": "SPDXRef-File-openssl.h-353"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wolfssl.c-354"
+      "relatedSpdxElement": "SPDXRef-File-easy.c-354"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ntlm.c-355"
+      "relatedSpdxElement": "SPDXRef-File-terminal.c-355"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rtsp.c-356"
+      "relatedSpdxElement": "SPDXRef-File-tool-formparse.h-356"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.c-357"
+      "relatedSpdxElement": "SPDXRef-File-tool-filetime.h-357"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-telnet.c-358"
+      "relatedSpdxElement": "SPDXRef-File-amigaos.c-358"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-formparse.h-359"
+      "relatedSpdxElement": "SPDXRef-File-basename.c-359"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fopen.h-360"
+      "relatedSpdxElement": "SPDXRef-File-tool-progress.h-360"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-filetime.h-361"
+      "relatedSpdxElement": "SPDXRef-File-winapi.h-361"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amigaos.c-362"
+      "relatedSpdxElement": "SPDXRef-File-smb.h-362"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-progress.h-363"
+      "relatedSpdxElement": "SPDXRef-File-inet-pton.c-363"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-winapi.h-364"
+      "relatedSpdxElement": "SPDXRef-File-cram.c-364"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smb.h-365"
+      "relatedSpdxElement": "SPDXRef-File-vssh.c-365"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ws.h-366"
+      "relatedSpdxElement": "SPDXRef-File-snprintf.h-366"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gtls.c-367"
+      "relatedSpdxElement": "SPDXRef-File-strcopy.h-367"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostcheck.h-368"
+      "relatedSpdxElement": "SPDXRef-File-krb5-gssapi.c-368"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcopy.h-369"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.h-369"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi.c-370"
+      "relatedSpdxElement": "SPDXRef-File-conncache.h-370"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcopy.c-371"
+      "relatedSpdxElement": "SPDXRef-File-apple.h-371"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-help.c-372"
+      "relatedSpdxElement": "SPDXRef-File-easyoptions.h-372"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.h-373"
+      "relatedSpdxElement": "SPDXRef-File-fopen.h-373"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-md4.c-374"
+      "relatedSpdxElement": "SPDXRef-File-mbedtls.h-374"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyoptions.h-375"
+      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.c-375"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-chunks.h-376"
+      "relatedSpdxElement": "SPDXRef-File-hostcheck.h-376"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.c-377"
+      "relatedSpdxElement": "SPDXRef-File-http-chunks.h-377"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerr.c-378"
+      "relatedSpdxElement": "SPDXRef-File-curl-quiche.c-378"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi.h-379"
+      "relatedSpdxElement": "SPDXRef-File-vtls-spack.c-379"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cfilters.c-380"
+      "relatedSpdxElement": "SPDXRef-File-typecheck-gcc.h-380"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.h-381"
+      "relatedSpdxElement": "SPDXRef-File-strcopy.c-381"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic-int.h-382"
+      "relatedSpdxElement": "SPDXRef-File-http-chunks.c-382"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apple.h-383"
+      "relatedSpdxElement": "SPDXRef-File-terminal.h-383"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.h-384"
+      "relatedSpdxElement": "SPDXRef-File-splay.c-384"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ev.h-385"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.h-385"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.h-386"
+      "relatedSpdxElement": "SPDXRef-File-multi-ev.h-386"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.h-387"
+      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.h-387"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-functypes.h-388"
+      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.c-388"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ntlm-sspi.c-389"
+      "relatedSpdxElement": "SPDXRef-File-pop3.c-389"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.c-390"
+      "relatedSpdxElement": "SPDXRef-File-getinfo.c-390"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setup.h-391"
+      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.h-391"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timediff.h-392"
+      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.c-392"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.c-393"
+      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.c-393"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-hash.c-394"
+      "relatedSpdxElement": "SPDXRef-File-hsts.h-394"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-psl.c-395"
+      "relatedSpdxElement": "SPDXRef-File-vquic-tls.c-395"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsts.h-396"
+      "relatedSpdxElement": "SPDXRef-File-http2.c-396"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.h-397"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.c-397"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.h-398"
+      "relatedSpdxElement": "SPDXRef-File-ldap.c-398"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.h-399"
+      "relatedSpdxElement": "SPDXRef-File-psl.c-399"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-md5.c-400"
+      "relatedSpdxElement": "SPDXRef-File-dynhds.h-400"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setopt.c-401"
+      "relatedSpdxElement": "SPDXRef-File-tool-getparam.h-401"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostip.h-402"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.h-402"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-header.h-403"
+      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.h-403"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-content-encoding.h-404"
+      "relatedSpdxElement": "SPDXRef-File-mqtt.c-404"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.h-405"
+      "relatedSpdxElement": "SPDXRef-File-tool-getparam.c-405"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setopt.h-406"
+      "relatedSpdxElement": "SPDXRef-File-content-encoding.h-406"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-proxy.c-407"
+      "relatedSpdxElement": "SPDXRef-File-mime.h-407"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.c-408"
+      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.h-408"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-msgs.h-409"
+      "relatedSpdxElement": "SPDXRef-File-parsedate.h-409"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest.c-410"
+      "relatedSpdxElement": "SPDXRef-File-tool-msgs.h-410"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keylog.h-411"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.c-411"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gtls.h-412"
+      "relatedSpdxElement": "SPDXRef-File-url.c-412"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock.h-413"
+      "relatedSpdxElement": "SPDXRef-File-cw-pause.c-413"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftp.h-414"
+      "relatedSpdxElement": "SPDXRef-File-noproxy.c-414"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-soc.h-415"
+      "relatedSpdxElement": "SPDXRef-File-nonblock.h-415"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strparse.c-416"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-soc.h-416"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl.h-417"
+      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.c-417"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.c-418"
+      "relatedSpdxElement": "SPDXRef-File-imap.h-418"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-imap.h-419"
+      "relatedSpdxElement": "SPDXRef-File-digest-sspi.c-419"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.c-420"
+      "relatedSpdxElement": "SPDXRef-File-slist-wc.c-420"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connect.h-421"
+      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.h-421"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sendf.c-422"
+      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.h-422"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist-wc.c-423"
+      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.c-423"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-base.c-424"
+      "relatedSpdxElement": "SPDXRef-File-http-digest.c-424"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.c-425"
+      "relatedSpdxElement": "SPDXRef-File-getinfo.h-425"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic.h-426"
+      "relatedSpdxElement": "SPDXRef-File-curl-threads.c-426"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-digest.c-427"
+      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.c-427"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getinfo.h-428"
+      "relatedSpdxElement": "SPDXRef-File-vtls.c-428"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-threads.c-429"
+      "relatedSpdxElement": "SPDXRef-File-urlapi.h-429"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -6603,52 +6583,42 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.h-433"
+      "relatedSpdxElement": "SPDXRef-File-curl-endian.h-433"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-endian.h-434"
+      "relatedSpdxElement": "SPDXRef-File-cookie.h-434"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.c-435"
+      "relatedSpdxElement": "SPDXRef-File-basename.h-435"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi-int.h-436"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.c-436"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-pton.h-437"
+      "relatedSpdxElement": "SPDXRef-File-dict.c-437"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cleartext.c-438"
+      "relatedSpdxElement": "SPDXRef-File-schannel.h-438"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.c-439"
+      "relatedSpdxElement": "SPDXRef-File-http-ntlm.h-439"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getinfo.c-440"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pop3.c-441"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-ntlm.h-442"
+      "relatedSpdxElement": "SPDXRef-File-select.h-440"
     }
   ]
 }

--- a/tests/golden/spdx/c-cpp/curl/libcurl.so_build.spdx.json
+++ b/tests/golden/spdx/c-cpp/curl/libcurl.so_build.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "libcurl.so",
-  "documentNamespace": "https://omnibor.io/omnibor-analysis/libcurl.so-3d83a2b4-e411-43e4-8daf-919bef5d1b16",
+  "documentNamespace": "https://omnibor.io/omnibor-analysis/libcurl.so-5b8db59c-96e6-4824-84f1-cbca6c662f62",
   "creationInfo": {
-    "created": "2026-03-12T21:58:57Z",
+    "created": "2026-04-02T21:39:27Z",
     "creators": [
       "Tool: bomtrace3-unknown",
       "Tool: bomsh-unknown",
@@ -20,11 +20,11 @@
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": true,
       "primaryPackagePurpose": "LIBRARY",
-      "builtDate": "2026-03-12T21:58:57Z",
+      "builtDate": "2026-04-02T21:39:27Z",
       "externalRefs": [],
       "checksums": [],
       "comment": "Built on Ubuntu 22.04.5 LTS with gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
-      "versionInfo": "8.19.0-DEV"
+      "versionInfo": "8.19.0"
     },
     {
       "SPDXID": "SPDXRef-libbrotli1-1",
@@ -287,78 +287,98 @@
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-File-idn.c-12",
-      "fileName": "repos/curl/lib/idn.c",
+      "SPDXID": "SPDXRef-File-smb.c-12",
+      "fileName": "repos/curl/lib/smb.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "00e2fc6e4cb6dcd2036b24331adc2672a4f9bcd3"
+          "checksumValue": "00297adee7f2116f0ec521167ee5ec3ac411b404"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-scache.c-13",
-      "fileName": "repos/curl/lib/vtls/vtls_scache.c",
+      "SPDXID": "SPDXRef-File-cf-socket.h-13",
+      "fileName": "repos/curl/lib/cf-socket.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0149b51869d7b42c41bfed6c81f6bc5d32921445"
+          "checksumValue": "014f5f7881728246f7f7c0aebda9e5fbe3746325"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-ip-happy.c-14",
-      "fileName": "repos/curl/lib/cf-ip-happy.c",
+      "SPDXID": "SPDXRef-File-keylog.c-14",
+      "fileName": "repos/curl/lib/vtls/keylog.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "01ddd9f3d890ee06d6f1227b06b40546d54f033e"
+          "checksumValue": "0206e32cf8fd21e90cb5d1d8079243472dd6dee8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multiif.h-15",
-      "fileName": "repos/curl/lib/vtls/../multiif.h",
+      "SPDXID": "SPDXRef-File-hmac.c-15",
+      "fileName": "repos/curl/lib/hmac.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0252b2dfd978b5626cc3f8e1e196440ab735c6f6"
+          "checksumValue": "028b476c77a3bdeb67176c058410c5f8220463d5"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rustls.c-16",
-      "fileName": "repos/curl/lib/vtls/rustls.c",
+      "SPDXID": "SPDXRef-File-inet-pton.h-16",
+      "fileName": "repos/curl/lib/curlx/inet_pton.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "02a6b7d5aa8d0237724a487be0dea89c32c98a42"
+          "checksumValue": "02ae7f2269dd1c7131bb833c56a63453fac1c8d1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.h-17",
-      "fileName": "repos/curl/lib/vauth/../rand.h",
+      "SPDXID": "SPDXRef-File-multiif.h-17",
+      "fileName": "repos/curl/lib/multiif.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c69a0df460f64a88df44a55b3cc44d31c28d7c"
+          "checksumValue": "039db269e001d28f6e41b3b2ea010c4d566c19a6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ldap.c-18",
-      "fileName": "repos/curl/lib/ldap.c",
+      "SPDXID": "SPDXRef-File-hsts.c-18",
+      "fileName": "repos/curl/lib/hsts.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "046fcd48e885273cf6cb49d2f6c94ec01024b056"
+          "checksumValue": "03f51f8109d4900c7a287fe297f138fd7aedb13a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transfer.h-19",
-      "fileName": "repos/curl/lib/vtls/../transfer.h",
+      "SPDXID": "SPDXRef-File-curl-md5.h-19",
+      "fileName": "repos/curl/lib/curl_md5.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "042c5f59ae5ecbb33a26f980be5da064629b370d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-imap.c-20",
+      "fileName": "repos/curl/lib/imap.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0546595f8998214cdd0b77784d9d25cd4e52f051"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-transfer.h-21",
+      "fileName": "repos/curl/lib/transfer.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -367,7 +387,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-md4.h-20",
+      "SPDXID": "SPDXRef-File-curl-md4.h-22",
       "fileName": "repos/curl/lib/curl_md4.h",
       "checksums": [
         {
@@ -377,8 +397,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ntfy.h-21",
-      "fileName": "repos/curl/lib/vauth/../multi_ntfy.h",
+      "SPDXID": "SPDXRef-File-multi-ntfy.h-23",
+      "fileName": "repos/curl/lib/multi_ntfy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -387,7 +407,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-if2ip.c-22",
+      "SPDXID": "SPDXRef-File-if2ip.c-24",
       "fileName": "repos/curl/lib/if2ip.c",
       "checksums": [
         {
@@ -397,17 +417,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-typecheck-gcc.h-23",
-      "fileName": "repos/curl/lib/../include/curl/typecheck-gcc.h",
+      "SPDXID": "SPDXRef-File-rustls.c-25",
+      "fileName": "repos/curl/lib/vtls/rustls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0642afd91ed2f07c171ecbf34c69107c6c800748"
+          "checksumValue": "061b444bcefd9b963287da7d1bee1ed3aab1069b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-rea.h-24",
+      "SPDXID": "SPDXRef-File-netrc.h-26",
+      "fileName": "repos/curl/lib/netrc.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "061e1e438b9c956e8e794347492286b9783a60f0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-system.h-27",
+      "fileName": "repos/curl/lib/../include/curl/system.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "064833d6e1e72385ed9e493513c1a2d8219c6443"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-rea.h-28",
       "fileName": "repos/curl/src/tool_cb_rea.h",
       "checksums": [
         {
@@ -417,17 +457,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-range.c-25",
-      "fileName": "repos/curl/lib/curl_range.c",
+      "SPDXID": "SPDXRef-File-connect.h-29",
+      "fileName": "repos/curl/lib/connect.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "070dee428980cd6bacb36dec17a698e98c42a163"
+          "checksumValue": "071b4329c1154c5ce0d97125e23479ca0cec9225"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-addrinfo.h-26",
+      "SPDXID": "SPDXRef-File-fake-addrinfo.h-30",
       "fileName": "repos/curl/lib/fake_addrinfo.h",
       "checksums": [
         {
@@ -437,7 +477,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getpass.h-27",
+      "SPDXID": "SPDXRef-File-llist.h-31",
+      "fileName": "repos/curl/lib/llist.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "09c695d3cfaef70dba17fb05724803c65c3265b9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-getpass.h-32",
       "fileName": "repos/curl/src/tool_getpass.h",
       "checksums": [
         {
@@ -447,7 +497,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlinfo.c-28",
+      "SPDXID": "SPDXRef-File-curlinfo.c-33",
       "fileName": "repos/curl/src/curlinfo.c",
       "checksums": [
         {
@@ -457,7 +507,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-macos.h-29",
+      "SPDXID": "SPDXRef-File-macos.h-34",
       "fileName": "repos/curl/lib/macos.h",
       "checksums": [
         {
@@ -467,82 +517,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sha256.h-30",
-      "fileName": "repos/curl/lib/vauth/../curl_sha256.h",
+      "SPDXID": "SPDXRef-File-tool-filetime.c-35",
+      "fileName": "repos/curl/src/tool_filetime.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0aaa4126f4e3f07fa78d9883b0fada4a3ba07efc"
+          "checksumValue": "0b6cd7b38f397dfb12161399505c507badda253a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-ntop.c-31",
-      "fileName": "repos/curl/lib/curlx/inet_ntop.c",
+      "SPDXID": "SPDXRef-File-easy.h-36",
+      "fileName": "repos/curl/lib/../include/curl/easy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0b10e8a7f63087853c342313f6fe0e57670dd7f8"
+          "checksumValue": "0be6915d92bb21f42dacb2d3cb981af3710437ec"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.c-32",
-      "fileName": "repos/curl/lib/hash.c",
+      "SPDXID": "SPDXRef-File-strdup.h-37",
+      "fileName": "repos/curl/lib/curlx/strdup.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0b6ecc48f7d52d388c7fce4dda3e85ef3055084e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-dbg.c-33",
-      "fileName": "repos/curl/src/tool_cb_dbg.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0c8568ff62ff8a6c0931089b3d96e0762455612a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cram.c-34",
-      "fileName": "repos/curl/lib/vauth/cram.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0d061ebbb029aba5ba5656b285f4e7d161b83655"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-doh.h-35",
-      "fileName": "repos/curl/lib/doh.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0dc6a3f2a490024225e76806399b8d715a094d28"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-setopt.h-36",
-      "fileName": "repos/curl/lib/vtls/../setopt.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0dd60c785f939b50563a053d5286b19f150c9a7c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-smb.c-37",
-      "fileName": "repos/curl/lib/smb.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0ddb167e61514f5376ea17ee5132dff8c84f4219"
+          "checksumValue": "0c4b14161e98dbcd6694358eeb6d424d3ff07358"
         }
       ]
     },
@@ -558,7 +558,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-curl-threads.h-39",
-      "fileName": "repos/curl/lib/vauth/../curl_threads.h",
+      "fileName": "repos/curl/lib/curl_threads.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -567,17 +567,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-thrdd.c-40",
-      "fileName": "repos/curl/lib/asyn-thrdd.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0e06db22ca0cab9e291e14a85eb3a005b863ad5e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-llist.c-41",
+      "SPDXID": "SPDXRef-File-llist.c-40",
       "fileName": "repos/curl/lib/llist.c",
       "checksums": [
         {
@@ -587,22 +577,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base64.c-42",
-      "fileName": "repos/curl/lib/curlx/base64.c",
+      "SPDXID": "SPDXRef-File-netrc.c-41",
+      "fileName": "repos/curl/lib/netrc.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0e44eae7faf3634cb181e6c735aac7f3f876fdba"
+          "checksumValue": "1073cc53656f0bd71017f906c1f4c82fbdb3c222"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-formparse.c-43",
-      "fileName": "repos/curl/src/tool_formparse.c",
+      "SPDXID": "SPDXRef-File-timediff.h-42",
+      "fileName": "repos/curl/lib/../lib/curlx/timediff.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "0ec434e2def65be84c10bd3341c07023bd8aedd4"
+          "checksumValue": "1081c75d1c9644a3c47b124e50861ffaf6a1b332"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-rtsp.c-43",
+      "fileName": "repos/curl/lib/rtsp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "11848c82820470ebd6e7617084fca138e4da29e3"
         }
       ]
     },
@@ -617,37 +617,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http1.h-45",
-      "fileName": "repos/curl/lib/http1.h",
+      "SPDXID": "SPDXRef-File-ntlm-sspi.c-45",
+      "fileName": "repos/curl/lib/vauth/ntlm_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "124d32e373cb497fbb2a0e752a18979be32ac614"
+          "checksumValue": "12cf32b8945979d680ff1274f90614952c407ead"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-spnego-sspi.c-46",
-      "fileName": "repos/curl/lib/vauth/spnego_sspi.c",
+      "SPDXID": "SPDXRef-File-tool-time.c-46",
+      "fileName": "repos/curl/src/toolx/tool_time.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "12bdc3afd798ee9c792debd1024ad279de2de4e9"
+          "checksumValue": "12eaea9fe4eed120187b2036408527e57fb692d0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn.h-47",
-      "fileName": "repos/curl/lib/vauth/../asyn.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "12d3e1c33883c850d535b97807806c8901760b68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-if2ip.h-48",
+      "SPDXID": "SPDXRef-File-if2ip.h-47",
       "fileName": "repos/curl/lib/if2ip.h",
       "checksums": [
         {
@@ -657,7 +647,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ntfy.c-49",
+      "SPDXID": "SPDXRef-File-multi-ntfy.c-48",
       "fileName": "repos/curl/lib/multi_ntfy.c",
       "checksums": [
         {
@@ -667,28 +657,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noproxy.c-50",
-      "fileName": "repos/curl/lib/noproxy.c",
+      "SPDXID": "SPDXRef-File-strparse.c-49",
+      "fileName": "repos/curl/lib/curlx/strparse.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1421fb114de2950ba9306090a7145e6f663318d9"
+          "checksumValue": "138b3df1255328b71f6f352d6aa78ae3195c2f6f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sendf.h-51",
-      "fileName": "repos/curl/lib/vssh/../sendf.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1521ccb0f86614d0f2e1a948c988df6026514e8e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-ctype.h-52",
-      "fileName": "repos/curl/lib/vauth/../curl_ctype.h",
+      "SPDXID": "SPDXRef-File-curl-ctype.h-50",
+      "fileName": "repos/curl/lib/curl_ctype.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -697,7 +677,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-time.h-53",
+      "SPDXID": "SPDXRef-File-tool-time.h-51",
       "fileName": "repos/curl/src/toolx/tool_time.h",
       "checksums": [
         {
@@ -707,37 +687,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libssh2.c-54",
-      "fileName": "repos/curl/lib/vssh/libssh2.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "15b7c056dd54a23a08432aaf4d5e4dd836e4a7ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hsts.c-55",
-      "fileName": "repos/curl/lib/hsts.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "15d4207548d319fc021423e1150e50a95ae71f22"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-md5.h-56",
-      "fileName": "repos/curl/lib/vauth/../curl_md5.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "16272c759105bbdd91edef6100c8f9d0a3a4a599"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-httpsrr.c-57",
+      "SPDXID": "SPDXRef-File-httpsrr.c-52",
       "fileName": "repos/curl/lib/httpsrr.c",
       "checksums": [
         {
@@ -747,77 +697,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-pton.c-58",
-      "fileName": "repos/curl/lib/curlx/inet_pton.c",
+      "SPDXID": "SPDXRef-File-http.c-53",
+      "fileName": "repos/curl/lib/http.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1767bf19af715657ff5a393ae84eaad8e95cd995"
+          "checksumValue": "188da5fd832edc887ba50e8aad4d79750dbdbcff"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-msgs.c-59",
-      "fileName": "repos/curl/src/tool_msgs.c",
+      "SPDXID": "SPDXRef-File-md4.c-54",
+      "fileName": "repos/curl/lib/md4.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "18e014950df5f52f71acb18808086f3b6f29fc97"
+          "checksumValue": "1ac6ef1c5b7befa694333d5c363ad77d178ded35"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-paramhlp.h-60",
-      "fileName": "repos/curl/src/tool_paramhlp.h",
+      "SPDXID": "SPDXRef-File-ssh.h-55",
+      "fileName": "repos/curl/lib/vssh/ssh.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "192d242d181d2495bc836f17b572fdd5a24dccd0"
+          "checksumValue": "1afb1e8643d99a8dd4ab35d17df32acb866628e0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-doswin.c-61",
-      "fileName": "repos/curl/src/tool_doswin.c",
+      "SPDXID": "SPDXRef-File-system-win32.c-56",
+      "fileName": "repos/curl/lib/system_win32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "193446cba3869353d81dea0b34b14b7e2aee9c89"
+          "checksumValue": "1b052357b5dd4f7b41117bae8e6e2df05d9603f6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cookie.c-62",
-      "fileName": "repos/curl/lib/cookie.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "19d8fc85474cf205be8439b3574c901253cd7a40"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ratelimit.c-63",
-      "fileName": "repos/curl/lib/ratelimit.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1b1fb6ccedc3e04fa5ad3445bdac113830ef71b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-vquic.c-64",
-      "fileName": "repos/curl/lib/vquic/vquic.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1b7dc1d3aacf071aed30977c1e853cb3ff49ef99"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file.c-65",
+      "SPDXID": "SPDXRef-File-file.c-57",
       "fileName": "repos/curl/lib/file.c",
       "checksums": [
         {
@@ -827,7 +747,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sspi.c-66",
+      "SPDXID": "SPDXRef-File-tool-cb-wrt.c-58",
+      "fileName": "repos/curl/src/tool_cb_wrt.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1d2b81ea7cacb6e3bb09260687f50d464465cb66"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sspi.c-59",
       "fileName": "repos/curl/lib/curl_sspi.c",
       "checksums": [
         {
@@ -837,37 +767,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-llist.h-67",
-      "fileName": "repos/curl/lib/vauth/../llist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1d73db1719da962379938387032ac1b38f0d1052"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-url.h-68",
-      "fileName": "repos/curl/lib/vauth/../url.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e44ebe43bb0d94309e27a15486fc1d040dab958"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strdup.h-69",
-      "fileName": "repos/curl/lib/vauth/../curlx/strdup.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e6bc1981429b9e4055bccd0448e9256a4dd1b41"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strerror.c-70",
+      "SPDXID": "SPDXRef-File-strerror.c-60",
       "fileName": "repos/curl/lib/strerror.c",
       "checksums": [
         {
@@ -877,47 +777,77 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ngtcp2.h-71",
-      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.h",
+      "SPDXID": "SPDXRef-File-vquic.c-61",
+      "fileName": "repos/curl/lib/vquic/vquic.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1e9868e0f7f6d1b2f68b40856824000187affb61"
+          "checksumValue": "1eaabb95f5d47769af808a81fbdfba037ab073c2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlx.h-72",
-      "fileName": "repos/curl/src/../lib/curlx/curlx.h",
+      "SPDXID": "SPDXRef-File-spnego-sspi.c-62",
+      "fileName": "repos/curl/lib/vauth/spnego_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "1ee35fa1a029667d290f599fbdcc57264d3b4a0f"
+          "checksumValue": "1f73123a0d79e03637c05d2ef695f7d260fa770c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-spack.c-73",
-      "fileName": "repos/curl/lib/vtls/vtls_spack.c",
+      "SPDXID": "SPDXRef-File-cipher-suite.c-63",
+      "fileName": "repos/curl/lib/vtls/cipher_suite.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2026fe3ed57d0fd96748720ea486b3dddfbf3e63"
+          "checksumValue": "1fc6e9f8c6f909e02c1cacdbd409d0067b63fd5b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-printf.h-74",
-      "fileName": "repos/curl/lib/curlx/../curl_printf.h",
+      "SPDXID": "SPDXRef-File-curl.h-64",
+      "fileName": "repos/curl/lib/../include/curl/curl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "207ba7125d62ab9a358a5644c3adbdc31abd6cef"
+          "checksumValue": "209716b334da52a7260b50fada5785870e431322"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyif.h-75",
+      "SPDXID": "SPDXRef-File-ftp.h-65",
+      "fileName": "repos/curl/lib/ftp.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20b360033e05dfddf23b5eaec31f7b7847cd660b"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-config2setopts.c-66",
+      "fileName": "repos/curl/src/config2setopts.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20d87a070ab54f77784e0cfb4953f20b4af78fa6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-formparse.c-67",
+      "fileName": "repos/curl/src/tool_formparse.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "20f7e366a000e2a2cfab633d0a31355cd78f0d34"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easyif.h-68",
       "fileName": "repos/curl/lib/easyif.h",
       "checksums": [
         {
@@ -927,17 +857,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks-gssapi.c-76",
-      "fileName": "repos/curl/lib/socks_gssapi.c",
+      "SPDXID": "SPDXRef-File-tool-writeout.c-69",
+      "fileName": "repos/curl/src/tool_writeout.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "21722f072016b083a86e3cd50c8f85f8f04cf106"
+          "checksumValue": "22c83efd03089b3ef1d43e6a297c86292bb18fcf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ssls.c-77",
+      "SPDXID": "SPDXRef-File-tool-ssls.c-70",
       "fileName": "repos/curl/src/tool_ssls.c",
       "checksums": [
         {
@@ -947,28 +877,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-rea.c-78",
-      "fileName": "repos/curl/src/tool_cb_rea.c",
+      "SPDXID": "SPDXRef-File-uint-hash.c-71",
+      "fileName": "repos/curl/lib/uint-hash.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2343d04a133a5a52cc8eeffbf3b0e4ee5a08c4c5"
+          "checksumValue": "2377840200141e225c72298a18b74addd28192f8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-smtp.c-79",
-      "fileName": "repos/curl/lib/smtp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "23590398f949e6fafb513264d7f0c2823bb2bcd6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-memrchr.h-80",
-      "fileName": "repos/curl/lib/vtls/../curl_memrchr.h",
+      "SPDXID": "SPDXRef-File-curl-memrchr.h-72",
+      "fileName": "repos/curl/lib/curl_memrchr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -977,17 +897,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-pause.c-81",
-      "fileName": "repos/curl/lib/cw-pause.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2489a330a03ba8fc94808f4b142ea54f43723272"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-aws-sigv4.h-82",
+      "SPDXID": "SPDXRef-File-http-aws-sigv4.h-73",
       "fileName": "repos/curl/lib/http_aws_sigv4.h",
       "checksums": [
         {
@@ -997,17 +907,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-snprintf.h-83",
-      "fileName": "repos/curl/lib/curlx/snprintf.h",
+      "SPDXID": "SPDXRef-File-hash.h-74",
+      "fileName": "repos/curl/lib/hash.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "266ea137fae6eb76466219d69ec828facf4edc58"
+          "checksumValue": "267f91d1ae43cc3d9493df25b215d1d4e136ef37"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easygetopt.c-84",
+      "SPDXID": "SPDXRef-File-easygetopt.c-75",
       "fileName": "repos/curl/lib/easygetopt.c",
       "checksums": [
         {
@@ -1017,37 +927,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-select.h-85",
-      "fileName": "repos/curl/lib/vtls/../select.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "268ae7cecfd4f9a1e806f506f240448adaeb6017"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-multibyte.h-86",
-      "fileName": "repos/curl/lib/vauth/../curlx/multibyte.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "26da0f0843e09509b3a3f41db92b8fc149caa3a6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-writeout.c-87",
-      "fileName": "repos/curl/src/tool_writeout.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2700abfa44385e8cc290ed158b5ce01fc69935ef"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-findfile.c-88",
+      "SPDXID": "SPDXRef-File-tool-findfile.c-76",
       "fileName": "repos/curl/src/tool_findfile.c",
       "checksums": [
         {
@@ -1057,68 +937,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basename.c-89",
-      "fileName": "repos/curl/lib/curlx/basename.c",
+      "SPDXID": "SPDXRef-File-cfilters.c-77",
+      "fileName": "repos/curl/lib/cfilters.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "27c29f3c00aace71a0a9f9194c11dc580c530429"
+          "checksumValue": "27b0306180cf80071b421289dc794578492a3ee3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basename.h-90",
-      "fileName": "repos/curl/lib/curlx/basename.h",
+      "SPDXID": "SPDXRef-File-altsvc.h-78",
+      "fileName": "repos/curl/lib/altsvc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "287a14aa14aef0d2aae54a56a5a4520ba5ad402f"
+          "checksumValue": "2931af452bef3a61b90fc7e502bc646048e19675"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-socket.h-91",
-      "fileName": "repos/curl/lib/vauth/../cf-socket.h",
+      "SPDXID": "SPDXRef-File-version-win32.c-79",
+      "fileName": "repos/curl/lib/curlx/version_win32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "298ced926996b3b35f54a084a73c7352cd3f9c52"
+          "checksumValue": "296a38d9247b176476cd5613ca6c7d1859bd1875"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-helpers.c-92",
-      "fileName": "repos/curl/src/tool_helpers.c",
+      "SPDXID": "SPDXRef-File-urlapi-int.h-80",
+      "fileName": "repos/curl/lib/urlapi-int.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2a84accf2c508f000bf3eab280a7e87cb562cf5d"
+          "checksumValue": "29d4fe5f39a0ee84d7fae0239209ccee9452881b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-scache.h-93",
-      "fileName": "repos/curl/lib/vtls/vtls_scache.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a99e779e5285dee6adcbb396988d374c00489ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-wait.c-94",
-      "fileName": "repos/curl/lib/curlx/wait.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a9f54bb3e4eb8655ce48a1c4ff4cdc7ce9e08ce"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socketpair.h-95",
-      "fileName": "repos/curl/lib/vauth/../socketpair.h",
+      "SPDXID": "SPDXRef-File-socketpair.h-81",
+      "fileName": "repos/curl/lib/socketpair.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1127,8 +987,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockaddr.h-96",
-      "fileName": "repos/curl/lib/vauth/../sockaddr.h",
+      "SPDXID": "SPDXRef-File-sockaddr.h-82",
+      "fileName": "repos/curl/lib/sockaddr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1137,38 +997,58 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-prg.c-97",
-      "fileName": "repos/curl/src/tool_cb_prg.c",
+      "SPDXID": "SPDXRef-File-mbedtls.c-83",
+      "fileName": "repos/curl/lib/vtls/mbedtls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2b9e6d63112b864e7ada0c956dd664e98c16116f"
+          "checksumValue": "2bac406c359b21ed33a7e1d16a548409f522745a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynhds.h-98",
-      "fileName": "repos/curl/lib/vauth/../dynhds.h",
+      "SPDXID": "SPDXRef-File-timediff.c-84",
+      "fileName": "repos/curl/lib/curlx/timediff.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2cfa290571201bfbed02112326973f7e5ffe3b73"
+          "checksumValue": "2bf786941d080ba5d552ac28be9089c0abe1ae4d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rustls.h-99",
-      "fileName": "repos/curl/lib/vtls/rustls.h",
+      "SPDXID": "SPDXRef-File-ratelimit.c-85",
+      "fileName": "repos/curl/lib/ratelimit.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2d3b0bb11f1daff419f2b8a37ce0673717b0ec1a"
+          "checksumValue": "2d88cdd7c94428a1cddbb7cd8554d7123e33fabe"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base64.h-100",
-      "fileName": "repos/curl/lib/vauth/../curlx/base64.h",
+      "SPDXID": "SPDXRef-File-idn.c-86",
+      "fileName": "repos/curl/lib/idn.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2db4f6d79e2edfec2afdb5019c0d925017f077ab"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-inet-ntop.h-87",
+      "fileName": "repos/curl/lib/curlx/inet_ntop.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2e3419f02be577ee15228e20f63052c5d81a5b46"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-base64.h-88",
+      "fileName": "repos/curl/lib/curlx/base64.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1177,67 +1057,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-escape.h-101",
-      "fileName": "repos/curl/lib/vtls/../escape.h",
+      "SPDXID": "SPDXRef-File-cf-socket.c-89",
+      "fileName": "repos/curl/lib/cf-socket.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2ea06c444fd32f164769906430cef2da8829a137"
+          "checksumValue": "2ebbe4df4da503e272cac2a73db28652867793b4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ntlm-core.c-102",
-      "fileName": "repos/curl/lib/curl_ntlm_core.c",
+      "SPDXID": "SPDXRef-File-cshutdn.c-90",
+      "fileName": "repos/curl/lib/cshutdn.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2edc7b07ce5a1e3f48b304a6cea451867abe8d2f"
+          "checksumValue": "308f2aaa82dfb5f3f389ada7aa8a6320056e7a7a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-system-win32.c-103",
-      "fileName": "repos/curl/lib/system_win32.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2f24fe5c0ccec9c72477a785086e073a8cfd9e51"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-setopt.c-104",
-      "fileName": "repos/curl/src/tool_setopt.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2ffcd1076b978b354dfd80d972f70973d9746daa"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-var.c-105",
-      "fileName": "repos/curl/src/var.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "306ed1b02bcbec022ec8f11da63ca3898a908932"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-vauth.h-106",
-      "fileName": "repos/curl/lib/vauth/vauth.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "312bd8da5ad474c66012fc26fe9d36bcea8ec894"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cf-h2-proxy.h-107",
+      "SPDXID": "SPDXRef-File-cf-h2-proxy.h-91",
       "fileName": "repos/curl/lib/cf-h2-proxy.h",
       "checksums": [
         {
@@ -1247,7 +1087,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-writeout-json.c-108",
+      "SPDXID": "SPDXRef-File-tool-writeout-json.c-92",
       "fileName": "repos/curl/src/tool_writeout_json.c",
       "checksums": [
         {
@@ -1257,27 +1097,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-arpa-telnet.h-109",
-      "fileName": "repos/curl/lib/arpa_telnet.h",
+      "SPDXID": "SPDXRef-File-slist-wc.h-93",
+      "fileName": "repos/curl/src/slist_wc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "329f4bcd1c5414f5c28b7767725e1cbd3e98aaae"
+          "checksumValue": "328d6b00f5ba7e1be00a0c48fe62d50087098e40"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transfer.c-110",
-      "fileName": "repos/curl/lib/transfer.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "32c31c6e9378298bd25affb9b90244128710ceed"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-macos.c-111",
+      "SPDXID": "SPDXRef-File-macos.c-94",
       "fileName": "repos/curl/lib/macos.c",
       "checksums": [
         {
@@ -1287,18 +1117,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic-tls.c-112",
-      "fileName": "repos/curl/lib/vquic/vquic-tls.c",
+      "SPDXID": "SPDXRef-File-curl-share.c-95",
+      "fileName": "repos/curl/lib/curl_share.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3391d98074088f646498adafd8d3ee74b6fcb76c"
+          "checksumValue": "338727a4fab265303d41853ee4b169cb4e567666"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pingpong.h-113",
-      "fileName": "repos/curl/lib/vauth/../pingpong.h",
+      "SPDXID": "SPDXRef-File-pingpong.h-96",
+      "fileName": "repos/curl/lib/pingpong.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1307,7 +1137,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fileinfo.c-114",
+      "SPDXID": "SPDXRef-File-formdata.h-97",
+      "fileName": "repos/curl/lib/formdata.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "33d7d0ae33d540bfb7f734f6c367fd3c4cf1245d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fileinfo.c-98",
       "fileName": "repos/curl/lib/fileinfo.c",
       "checksums": [
         {
@@ -1317,17 +1157,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcase.h-115",
-      "fileName": "repos/curl/lib/vtls/../strcase.h",
+      "SPDXID": "SPDXRef-File-winapi.c-99",
+      "fileName": "repos/curl/lib/curlx/winapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "35f726c3eecef87a51ef1a576514266feed7253f"
+          "checksumValue": "3417df269e056282d37ab70a4432bca5fdc1c951"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-hdr.h-116",
+      "SPDXID": "SPDXRef-File-altsvc.c-100",
+      "fileName": "repos/curl/lib/altsvc.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "34da3e1ac86d083a31afb81d71ea3da74e8b5297"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-hugehelp.c-101",
+      "fileName": "repos/curl/src/tool_hugehelp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "374cf39809682272c1c8034d1d803c7783186357"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-formdata.c-102",
+      "fileName": "repos/curl/lib/formdata.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3770d28b18ec9f8bfc0cfea4b7be2a79239437a2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-hdr.h-103",
       "fileName": "repos/curl/src/tool_cb_hdr.h",
       "checksums": [
         {
@@ -1337,37 +1207,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mbedtls.h-117",
-      "fileName": "repos/curl/lib/vtls/mbedtls.h",
+      "SPDXID": "SPDXRef-File-mime.c-104",
+      "fileName": "repos/curl/lib/mime.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3876fe36fc5d82a56c1022c67aac4446f6cc036c"
+          "checksumValue": "37ea514e4f8715557562aea4bd1cc3e4342e195e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-request.h-118",
-      "fileName": "repos/curl/lib/vauth/../request.h",
+      "SPDXID": "SPDXRef-File-uint-table.h-105",
+      "fileName": "repos/curl/lib/uint-table.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "389ae4d8b1f8d7d6db078637f29304f6e5cf36a7"
+          "checksumValue": "398a26a64843389caffdbe0359d2e35e91e7065c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http.c-119",
-      "fileName": "repos/curl/lib/http.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "39f0a0d194056356c3f6339497e141bdba3ebca4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-smtp.h-120",
+      "SPDXID": "SPDXRef-File-smtp.h-106",
       "fileName": "repos/curl/lib/smtp.h",
       "checksums": [
         {
@@ -1377,7 +1237,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config2setopts.h-121",
+      "SPDXID": "SPDXRef-File-libssh.c-107",
+      "fileName": "repos/curl/lib/vssh/libssh.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3a2a52e1f84fb57a17a2081375efbff799ea8b13"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-printf.h-108",
+      "fileName": "repos/curl/lib/curl_printf.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3b1a5af3b4593f544383faee11c07d8618a9d8ea"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strdup.c-109",
+      "fileName": "repos/curl/lib/curlx/strdup.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3c967dbe0a5d144dc4c77ad8e9ffac848d3c6d22"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-config2setopts.h-110",
       "fileName": "repos/curl/src/config2setopts.h",
       "checksums": [
         {
@@ -1387,37 +1277,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ipfs.c-122",
-      "fileName": "repos/curl/src/tool_ipfs.c",
+      "SPDXID": "SPDXRef-File-warnless.h-111",
+      "fileName": "repos/curl/lib/curlx/warnless.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3d2d5dea8424432dfe85fb138e171135c563643c"
+          "checksumValue": "3d0341e418a51614a644704a617f934681d0518e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-socket.c-123",
-      "fileName": "repos/curl/lib/cf-socket.c",
+      "SPDXID": "SPDXRef-File-vauth.h-112",
+      "fileName": "repos/curl/lib/vauth/vauth.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3e47a98722fc435f72915441868f473955a8c64c"
+          "checksumValue": "3e66c89cb5199edc6d792df91c9df50ccf6434a9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mbedtls.c-124",
-      "fileName": "repos/curl/lib/vtls/mbedtls.c",
+      "SPDXID": "SPDXRef-File-doh.h-113",
+      "fileName": "repos/curl/lib/doh.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "3f5654ea0be7078ddafb2ec50407b663b7eb539d"
+          "checksumValue": "3eba4df26e29f5fe3b6065b2a4a8392f0c618cc0"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-dirhie.c-125",
+      "SPDXID": "SPDXRef-File-tool-dirhie.c-114",
       "fileName": "repos/curl/src/tool_dirhie.c",
       "checksums": [
         {
@@ -1427,7 +1317,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cfgable.c-126",
+      "SPDXID": "SPDXRef-File-tool-cfgable.c-115",
       "fileName": "repos/curl/src/tool_cfgable.c",
       "checksums": [
         {
@@ -1437,37 +1327,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-table.h-127",
-      "fileName": "repos/curl/lib/vauth/../uint-table.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3fc7e34ef436e9c53ce465f736b8cdd550cace9f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-share.h-128",
-      "fileName": "repos/curl/lib/vtls/../curl_share.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3fcaaecd4ad64586c5db922a04a1c4ceb7f92783"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-share.c-129",
-      "fileName": "repos/curl/lib/curl_share.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3ff27556845f3f8ae0b1e31de45b7007310437f0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-writeout.h-130",
+      "SPDXID": "SPDXRef-File-tool-writeout.h-116",
       "fileName": "repos/curl/src/tool_writeout.h",
       "checksums": [
         {
@@ -1477,7 +1337,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-websockets.h-131",
+      "SPDXID": "SPDXRef-File-websockets.h-117",
       "fileName": "repos/curl/lib/../include/curl/websockets.h",
       "checksums": [
         {
@@ -1487,27 +1347,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-imap.c-132",
-      "fileName": "repos/curl/lib/imap.c",
+      "SPDXID": "SPDXRef-File-schannel-verify.c-118",
+      "fileName": "repos/curl/lib/vtls/schannel_verify.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "414ee32466d374da767cfc38ac55da587d6770be"
+          "checksumValue": "414b2e915aaaf7086002f5217db5f2cfda0b2881"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-idn.h-133",
-      "fileName": "repos/curl/lib/idn.h",
+      "SPDXID": "SPDXRef-File-rand.c-119",
+      "fileName": "repos/curl/lib/rand.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "42613af5096c058f000c2a8809e88d0f6c6844a2"
+          "checksumValue": "4232e819e17bbf101bfd7cd7593b9c72f28465ee"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ssls.h-134",
+      "SPDXID": "SPDXRef-File-cf-h2-proxy.c-120",
+      "fileName": "repos/curl/lib/cf-h2-proxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4275e1ef5aef37f4d1a5d7ef716d38c41e413272"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-ssls.h-121",
       "fileName": "repos/curl/src/tool_ssls.h",
       "checksums": [
         {
@@ -1517,8 +1387,28 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerr.h-135",
-      "fileName": "repos/curl/lib/vtls/../curlx/strerr.h",
+      "SPDXID": "SPDXRef-File-timeval.c-122",
+      "fileName": "repos/curl/lib/curlx/timeval.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "435804c2996b90f81c25c073a55e00ec67b1a8a1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-addrinfo.c-123",
+      "fileName": "repos/curl/lib/curl_addrinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "43d398d119216ea4ea4e53e25873807dafe949f3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strerr.h-124",
+      "fileName": "repos/curl/lib/curlx/strerr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1527,68 +1417,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mqtt.c-136",
-      "fileName": "repos/curl/lib/mqtt.c",
+      "SPDXID": "SPDXRef-File-vtls-spack.h-125",
+      "fileName": "repos/curl/lib/../lib/vtls/vtls_spack.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "446918cc44886a99b297d41aa1437c8d8e9ac702"
+          "checksumValue": "4479384de978cac1836eb55288466211663e1d0e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-filetime.c-137",
-      "fileName": "repos/curl/src/tool_filetime.c",
+      "SPDXID": "SPDXRef-File-doh.c-126",
+      "fileName": "repos/curl/lib/doh.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "45598413cd487828115d35fa1dae7912994a9b52"
+          "checksumValue": "4488d422b12cd93b8824cc689ef7ab75be8f80f9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-memdebug.c-138",
-      "fileName": "repos/curl/lib/memdebug.c",
+      "SPDXID": "SPDXRef-File-asyn-base.c-127",
+      "fileName": "repos/curl/lib/asyn-base.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "457034ebdae2227ed453e777681031b6de84b77f"
+          "checksumValue": "44bf98c8e4f912a7f2903f8f320d7db8f1d8a668"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-ntop.h-139",
-      "fileName": "repos/curl/lib/curlx/inet_ntop.h",
+      "SPDXID": "SPDXRef-File-oauth2.c-128",
+      "fileName": "repos/curl/lib/vauth/oauth2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "45b63d97a5958b327e288e0baed020b5bf5a8387"
+          "checksumValue": "4541d1d551bb94f687eab71dff4658cade41d6ae"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http2.c-140",
-      "fileName": "repos/curl/lib/http2.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "45f82192b024a77bc48bcc6b0a0f4b78c2334f64"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-hmac.h-141",
-      "fileName": "repos/curl/lib/vauth/../curl_hmac.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4759ff6ec6626e91f728ade60137ba5e573ff9e4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist.h-142",
-      "fileName": "repos/curl/lib/vtls/../slist.h",
+      "SPDXID": "SPDXRef-File-slist.h-129",
+      "fileName": "repos/curl/lib/slist.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1597,7 +1467,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-stderr.h-143",
+      "SPDXID": "SPDXRef-File-tool-stderr.h-130",
       "fileName": "repos/curl/src/tool_stderr.h",
       "checksums": [
         {
@@ -1607,18 +1477,58 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timeval.h-144",
-      "fileName": "repos/curl/lib/vauth/../curlx/timeval.h",
+      "SPDXID": "SPDXRef-File-curl-ngtcp2.c-131",
+      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4aab17519d8bfe74a78f1dfd761fc4ed760b627a"
+          "checksumValue": "48905d3e201780d2dde1742d7db4a6b4140b3b76"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-spbset.h-145",
-      "fileName": "repos/curl/lib/vauth/../uint-spbset.h",
+      "SPDXID": "SPDXRef-File-vssh.h-132",
+      "fileName": "repos/curl/lib/vssh/vssh.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "492108fbd7663d1629f6fcefe9ac7b13f0eee1c0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-aws-sigv4.c-133",
+      "fileName": "repos/curl/lib/http_aws_sigv4.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "492be1ab58634f8f6ef5773a21c6d54753fa7a5e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-ntlm-core.c-134",
+      "fileName": "repos/curl/lib/curl_ntlm_core.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4a9433b2936771dadc46831804ba91815606ffea"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cfgable.h-135",
+      "fileName": "repos/curl/src/tool_cfgable.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4af31b802e7b0012a9fd82e341ad19a049708c4d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-uint-spbset.h-136",
+      "fileName": "repos/curl/lib/uint-spbset.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1627,17 +1537,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connect.c-146",
-      "fileName": "repos/curl/lib/connect.c",
+      "SPDXID": "SPDXRef-File-curl-trc.c-137",
+      "fileName": "repos/curl/lib/curl_trc.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4b363ebe31b04b79f6c4b780a8471c211a60918a"
+          "checksumValue": "4b8734a7e9d50ef4f44ff0b3ecb8ffa039735e54"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerror.h-147",
+      "SPDXID": "SPDXRef-File-strerror.h-138",
       "fileName": "repos/curl/lib/strerror.h",
       "checksums": [
         {
@@ -1647,7 +1557,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyoptions.c-148",
+      "SPDXID": "SPDXRef-File-easyoptions.c-139",
       "fileName": "repos/curl/lib/easyoptions.c",
       "checksums": [
         {
@@ -1657,37 +1567,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-urlglob.c-149",
-      "fileName": "repos/curl/src/tool_urlglob.c",
+      "SPDXID": "SPDXRef-File-asyn-ares.c-140",
+      "fileName": "repos/curl/lib/asyn-ares.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4c5973875b2ef5a5a828220bd2d9f1c19549449f"
+          "checksumValue": "4d063d9f26574d5a93a402e497053703c93fa828"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getparam.h-150",
-      "fileName": "repos/curl/src/tool_getparam.h",
+      "SPDXID": "SPDXRef-File-cookie.c-141",
+      "fileName": "repos/curl/lib/cookie.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4d345413931debbcd76798ac0eac7b15793ddf04"
+          "checksumValue": "4d53cc460cb82b2df44a86a829f454423b3c62b2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vssh.h-151",
-      "fileName": "repos/curl/lib/vssh/vssh.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4d5b7ad24e98046a6ef2ca2e88073cf5b678b188"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-ca-embed.c-152",
+      "SPDXID": "SPDXRef-File-tool-ca-embed.c-142",
       "fileName": "repos/curl/src/tool_ca_embed.c",
       "checksums": [
         {
@@ -1697,17 +1597,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config2setopts.c-153",
-      "fileName": "repos/curl/src/config2setopts.c",
+      "SPDXID": "SPDXRef-File-pingpong.c-143",
+      "fileName": "repos/curl/lib/pingpong.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4ea65f453c24faee45d9bba96233bfd95f13cec1"
+          "checksumValue": "4ede0a5985db595d164eaf8993b4efd5b23702c2"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufref.c-154",
+      "SPDXID": "SPDXRef-File-curl-setup.h-144",
+      "fileName": "repos/curl/lib/curl_setup.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4f8d65af8b5d8c3c13720f28a4edf36bfe021bcd"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-openssl.c-145",
+      "fileName": "repos/curl/lib/vtls/openssl.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50bf1e04766e90ef5d7744a35fff0ed2f79093e5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-help.c-146",
+      "fileName": "repos/curl/src/tool_help.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50cca527057333b3dfcfd0e3f8bdea076f7a59df"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-bufref.c-147",
       "fileName": "repos/curl/lib/bufref.c",
       "checksums": [
         {
@@ -1717,27 +1647,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ftp.c-155",
-      "fileName": "repos/curl/lib/ftp.c",
+      "SPDXID": "SPDXRef-File-strparse.h-148",
+      "fileName": "repos/curl/lib/curlx/strparse.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5110ee1397e14ba4e61b127a584822719e11bf40"
+          "checksumValue": "514203dc92fad6a5f39c9428d243e06a37ff249b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel-verify.c-156",
-      "fileName": "repos/curl/lib/vtls/schannel_verify.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5129b8b04d33871489166eee0bf87b6186fb097f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socks.h-157",
+      "SPDXID": "SPDXRef-File-socks.h-149",
       "fileName": "repos/curl/lib/socks.h",
       "checksums": [
         {
@@ -1747,47 +1667,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-paramhlp.c-158",
-      "fileName": "repos/curl/src/tool_paramhlp.c",
+      "SPDXID": "SPDXRef-File-wait.c-150",
+      "fileName": "repos/curl/lib/curlx/wait.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "523b52629c93e5083ab4f940cf7b37961aba5b57"
+          "checksumValue": "52784269ef51fabb405b91e12a02682fc56a0e9f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multibyte.c-159",
-      "fileName": "repos/curl/lib/curlx/multibyte.c",
+      "SPDXID": "SPDXRef-File-vquic.h-151",
+      "fileName": "repos/curl/lib/vquic/vquic.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "529091ad92d6ae8ceb5fbc8a9b79c6becddb6ede"
+          "checksumValue": "528e18476d48d0b565c8fdc8bf95505a46396fc4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.h-160",
-      "fileName": "repos/curl/lib/../include/curl/multi.h",
+      "SPDXID": "SPDXRef-File-request.h-152",
+      "fileName": "repos/curl/lib/request.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "531c1a954a955b9f4c42f64a87be1ca9918f601c"
+          "checksumValue": "5332d48538d9e519ddfda5cc86edb4dc0e92c97d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doh.c-161",
-      "fileName": "repos/curl/lib/doh.c",
+      "SPDXID": "SPDXRef-File-tool-sdecls.h-153",
+      "fileName": "repos/curl/src/tool_sdecls.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5401256bf895aff995b26184bac2d436dcae2694"
+          "checksumValue": "5350b71a3714bc38f04f045180bfb82dd535d11c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-pause.h-162",
+      "SPDXID": "SPDXRef-File-strcase.h-154",
+      "fileName": "repos/curl/lib/strcase.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "54299812beaed5ac5d98f210c997982572824fa0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostip.c-155",
+      "fileName": "repos/curl/lib/hostip.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "542b655b113d14d1fbdd29985ab32ca1e92a03fd"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cw-pause.h-156",
       "fileName": "repos/curl/lib/cw-pause.h",
       "checksums": [
         {
@@ -1797,7 +1737,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-wrt.h-163",
+      "SPDXID": "SPDXRef-File-cw-out.c-157",
+      "fileName": "repos/curl/lib/cw-out.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "554c32e84ecdd31de8d70669ce9c5e389745c5db"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-wrt.h-158",
       "fileName": "repos/curl/src/tool_cb_wrt.h",
       "checksums": [
         {
@@ -1807,27 +1757,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-setup.h-164",
-      "fileName": "repos/curl/lib/vauth/../curl_setup.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "559f586b7859f561f1067a1d976ed2667c0a4665"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cipher-suite.c-165",
-      "fileName": "repos/curl/lib/vtls/cipher_suite.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "562a3477355d7764c16550460966d9563df18b8f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-hash.h-166",
+      "SPDXID": "SPDXRef-File-uint-hash.h-159",
       "fileName": "repos/curl/lib/uint-hash.h",
       "checksums": [
         {
@@ -1837,7 +1767,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amigaos.h-167",
+      "SPDXID": "SPDXRef-File-amigaos.h-160",
       "fileName": "repos/curl/lib/amigaos.h",
       "checksums": [
         {
@@ -1847,17 +1777,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-trc.h-168",
-      "fileName": "repos/curl/lib/vauth/../curl_trc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "58903844acf1c8f5063ed79980bfe7acfcd3013d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-spbset.c-169",
+      "SPDXID": "SPDXRef-File-uint-spbset.c-161",
       "fileName": "repos/curl/lib/uint-spbset.c",
       "checksums": [
         {
@@ -1867,7 +1787,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-memrchr.c-170",
+      "SPDXID": "SPDXRef-File-curl-memrchr.c-162",
       "fileName": "repos/curl/lib/curl_memrchr.c",
       "checksums": [
         {
@@ -1877,7 +1797,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-headers.c-171",
+      "SPDXID": "SPDXRef-File-headers.c-163",
       "fileName": "repos/curl/lib/headers.c",
       "checksums": [
         {
@@ -1887,7 +1807,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-easysrc.c-172",
+      "SPDXID": "SPDXRef-File-urldata.h-164",
+      "fileName": "repos/curl/lib/urldata.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5ae148054baf7c04c0b38a585af0baaa0be11cef"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-easysrc.c-165",
       "fileName": "repos/curl/src/tool_easysrc.c",
       "checksums": [
         {
@@ -1897,27 +1827,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy.h-173",
-      "fileName": "repos/curl/lib/../include/curl/easy.h",
+      "SPDXID": "SPDXRef-File-digest.h-166",
+      "fileName": "repos/curl/lib/../lib/vauth/digest.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5b3cdbd64e805870cf8a30193cb945ef99e446d8"
+          "checksumValue": "5b8f3ae7675f4d45d7b6b83ec953c5e97530297e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x509asn1.c-174",
-      "fileName": "repos/curl/lib/vtls/x509asn1.c",
+      "SPDXID": "SPDXRef-File-telnet.c-167",
+      "fileName": "repos/curl/lib/telnet.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5c3a727e63c47edcf846dc58b6649937887935e3"
+          "checksumValue": "5bae99e1fcca877fd0919424f6f9ea5359d99441"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curlver.h-175",
+      "SPDXID": "SPDXRef-File-curlver.h-168",
       "fileName": "repos/curl/lib/../include/curl/curlver.h",
       "checksums": [
         {
@@ -1927,8 +1857,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufref.h-176",
-      "fileName": "repos/curl/lib/vauth/../bufref.h",
+      "SPDXID": "SPDXRef-File-bufref.h-169",
+      "fileName": "repos/curl/lib/bufref.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1937,17 +1867,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-quiche.c-177",
-      "fileName": "repos/curl/lib/vquic/curl_quiche.c",
+      "SPDXID": "SPDXRef-File-ftplistparser.h-170",
+      "fileName": "repos/curl/lib/ftplistparser.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5d981cb2e6bf35f7a7257e698f90fca6de26c30c"
+          "checksumValue": "5d7aa492ba4eda791a2bc74a342ba088f0a28d59"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-version.h-178",
+      "SPDXID": "SPDXRef-File-tool-version.h-171",
       "fileName": "repos/curl/src/tool_version.h",
       "checksums": [
         {
@@ -1957,37 +1887,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-splay.c-179",
-      "fileName": "repos/curl/lib/splay.c",
+      "SPDXID": "SPDXRef-File-curl-share.h-172",
+      "fileName": "repos/curl/lib/curl_share.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "5e4cd54d27babe055c6bfed9b11af06f016d128e"
+          "checksumValue": "5e3f82aa56b2b2835daf1de4e65de75be47b6821"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http2.h-180",
-      "fileName": "repos/curl/lib/http2.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5e545b234900946021d14c443a6259326af621f6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-mime.h-181",
-      "fileName": "repos/curl/lib/vauth/../mime.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5ef05506a4be35e593b92d8070bdbd40fca85f47"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-uint-bset.c-182",
+      "SPDXID": "SPDXRef-File-uint-bset.c-173",
       "fileName": "repos/curl/lib/uint-bset.c",
       "checksums": [
         {
@@ -1997,7 +1907,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-digest.h-183",
+      "SPDXID": "SPDXRef-File-http-digest.h-174",
       "fileName": "repos/curl/lib/http_digest.h",
       "checksums": [
         {
@@ -2007,7 +1917,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-util.c-184",
+      "SPDXID": "SPDXRef-File-warnless.c-175",
+      "fileName": "repos/curl/lib/curlx/warnless.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5fc36ac9a8762103e3688a6dd5e31236ff7b176c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-ws.c-176",
+      "fileName": "repos/curl/lib/ws.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60465611bb74ce21cb20f715e418d4de253f5f11"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-ftp.c-177",
+      "fileName": "repos/curl/lib/ftp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6047759e7850a78de48e9e983ea4a3a38fb68222"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-smtp.c-178",
+      "fileName": "repos/curl/lib/smtp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60889858d3e2756869d1e903581ad352ecd4382c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http1.c-179",
+      "fileName": "repos/curl/lib/http1.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60ad32ce89b95832a753d01baa75303aac013b7b"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-util.c-180",
       "fileName": "repos/curl/src/tool_util.c",
       "checksums": [
         {
@@ -2017,17 +1977,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operate.c-185",
-      "fileName": "repos/curl/src/tool_operate.c",
+      "SPDXID": "SPDXRef-File-multi.c-181",
+      "fileName": "repos/curl/lib/multi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "618508aca49f4e6f662ed558a1657821613096ac"
+          "checksumValue": "6133736525778b122b1b3e615388b5c622296d9e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fnmatch.h-186",
+      "SPDXID": "SPDXRef-File-curl-fnmatch.h-182",
       "fileName": "repos/curl/lib/curl_fnmatch.h",
       "checksums": [
         {
@@ -2037,7 +1997,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-libinfo.c-187",
+      "SPDXID": "SPDXRef-File-tool-libinfo.c-183",
       "fileName": "repos/curl/src/tool_libinfo.c",
       "checksums": [
         {
@@ -2047,7 +2007,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-findfile.h-188",
+      "SPDXID": "SPDXRef-File-tool-findfile.h-184",
       "fileName": "repos/curl/src/tool_findfile.h",
       "checksums": [
         {
@@ -2057,17 +2017,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-addrinfo.h-189",
-      "fileName": "repos/curl/lib/vauth/../curl_addrinfo.h",
+      "SPDXID": "SPDXRef-File-libssh2.c-185",
+      "fileName": "repos/curl/lib/vssh/libssh2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "63d3f7a2442c75c48ab232cabb28f92ecf475bd6"
+          "checksumValue": "63f5735b835b38017b0544993e1ca2253d3fdefc"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-progress.c-190",
+      "SPDXID": "SPDXRef-File-tool-progress.c-186",
       "fileName": "repos/curl/src/tool_progress.c",
       "checksums": [
         {
@@ -2077,27 +2037,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-altsvc.c-191",
-      "fileName": "repos/curl/lib/altsvc.c",
+      "SPDXID": "SPDXRef-File-curl-sha512-256.c-187",
+      "fileName": "repos/curl/lib/curl_sha512_256.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "64bfec420bd518583f9c696df156affc2ffb5c93"
+          "checksumValue": "648e3e38e960be028a92a3b48a576f41bbc6a0ac"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-ngtcp2.c-192",
-      "fileName": "repos/curl/lib/vquic/curl_ngtcp2.c",
+      "SPDXID": "SPDXRef-File-schannel.c-188",
+      "fileName": "repos/curl/lib/vtls/schannel.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "65c78e68485b63468465175893f00cc8eff04c1b"
+          "checksumValue": "650a0e38ca8bf04eee4aba3b40d089a1b7e1d530"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-xattr.h-193",
+      "SPDXID": "SPDXRef-File-cf-h1-proxy.h-189",
+      "fileName": "repos/curl/lib/cf-h1-proxy.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6544ec58d026839cdbe1117bea42e77ed0a10c3f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-request.c-190",
+      "fileName": "repos/curl/lib/request.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "66077530d72637f0bc4af84dcd96163ae6b9c269"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-vtls-int.h-191",
+      "fileName": "repos/curl/lib/../lib/vtls/vtls_int.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6700ee74cbe163fbf45d378e898cabe0b1e6a6b4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-xattr.h-192",
       "fileName": "repos/curl/src/tool_xattr.h",
       "checksums": [
         {
@@ -2107,8 +2097,18 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-File-vtls-scache.c-193",
+      "fileName": "repos/curl/lib/vtls/vtls_scache.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "673abcfe0dbf7c1699fdc7e7b050e508e460165f"
+        }
+      ]
+    },
+    {
       "SPDXID": "SPDXRef-File-mqtt.h-194",
-      "fileName": "repos/curl/lib/vauth/../mqtt.h",
+      "fileName": "repos/curl/lib/mqtt.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2117,52 +2117,52 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks.c-195",
-      "fileName": "repos/curl/lib/socks.c",
+      "SPDXID": "SPDXRef-File-asyn.h-195",
+      "fileName": "repos/curl/lib/asyn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "67e9c9b3c7cf132efbeb936148d8da2f3a1094ad"
+          "checksumValue": "68628f90c007f0a27b26c1f8d2ee4588d91c761b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version.c-196",
-      "fileName": "repos/curl/lib/version.c",
+      "SPDXID": "SPDXRef-File-tool-getpass.c-196",
+      "fileName": "repos/curl/src/tool_getpass.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6949278f47d31d540ba01f5471e4dbff0b8eab3b"
+          "checksumValue": "68a16cab3e611bab75a18399525db1e622bb2c85"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timediff.c-197",
-      "fileName": "repos/curl/lib/curlx/timediff.c",
+      "SPDXID": "SPDXRef-File-multi-ev.c-197",
+      "fileName": "repos/curl/lib/multi_ev.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "694c8d83520673b844cdeb2d67f3b125b74ecb9a"
+          "checksumValue": "696a012ebff74fbf31ece59b5f45d99175f7ab18"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-help.h-198",
+      "SPDXID": "SPDXRef-File-cf-h1-proxy.c-198",
+      "fileName": "repos/curl/lib/cf-h1-proxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "69e050b9d63ee3f61e70a07f6652daa5f373bd70"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-help.h-199",
       "fileName": "repos/curl/src/tool_help.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "6a2ecdb0622e90fa34dcd01a74aa3354e0bcc670"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-krb5-gssapi.c-199",
-      "fileName": "repos/curl/lib/vauth/krb5_gssapi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6a9f182864c034b0b8c9fd8e40fb87942c45b898"
         }
       ]
     },
@@ -2177,17 +2177,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-quiche.h-201",
-      "fileName": "repos/curl/lib/vquic/curl_quiche.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6c0fb9ee1ee695f4780d34a45c050575ff8501ce"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-negotiate.h-202",
+      "SPDXID": "SPDXRef-File-http-negotiate.h-201",
       "fileName": "repos/curl/lib/http_negotiate.h",
       "checksums": [
         {
@@ -2197,7 +2187,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-haproxy.h-203",
+      "SPDXID": "SPDXRef-File-tool-cb-prg.c-202",
+      "fileName": "repos/curl/src/tool_cb_prg.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c3a366fa632b9c967f8d47fc57bfcc8c1cec4bc"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostip.h-203",
+      "fileName": "repos/curl/lib/hostip.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c7f1291b261c01dde04ab5ae190ab83df38e404"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-progress.c-204",
+      "fileName": "repos/curl/lib/progress.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6cde5678be84f4e430035912d4341da6ec6633a3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fopen.c-205",
+      "fileName": "repos/curl/lib/curlx/fopen.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6d0ef7e683564b162fd4ab8c1c2e342a32b6c2a9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-haproxy.h-206",
       "fileName": "repos/curl/lib/cf-haproxy.h",
       "checksums": [
         {
@@ -2207,28 +2237,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ws.c-204",
-      "fileName": "repos/curl/lib/ws.c",
+      "SPDXID": "SPDXRef-File-transfer.c-207",
+      "fileName": "repos/curl/lib/transfer.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6ed417185e1d927ffaf85a51c0a5af3b413667fd"
+          "checksumValue": "6dd2f52fe572801b4f48d7f0b25c19057cdc6c12"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http.h-205",
-      "fileName": "repos/curl/lib/vauth/../http.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6ef391af60200b7b3b86df2e1655cacdfae88d93"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dynbuf.h-206",
-      "fileName": "repos/curl/lib/vauth/../curlx/dynbuf.h",
+      "SPDXID": "SPDXRef-File-dynbuf.h-208",
+      "fileName": "repos/curl/lib/curlx/dynbuf.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2237,37 +2257,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-config.h-207",
-      "fileName": "repos/curl/lib/vauth/../curl_config.h",
+      "SPDXID": "SPDXRef-File-nonblock.c-209",
+      "fileName": "repos/curl/lib/curlx/nonblock.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6f16a673ffc1baa4164b57425e4515fd3253185c"
+          "checksumValue": "6f6458f2b3427985ec0c3cb4ba4e8b93bb4f178d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-content-encoding.c-208",
-      "fileName": "repos/curl/lib/content_encoding.c",
+      "SPDXID": "SPDXRef-File-dynbuf.c-210",
+      "fileName": "repos/curl/lib/curlx/dynbuf.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6f58054bb29557117890f53a973c3ecae58c404b"
+          "checksumValue": "7045a1f2940b9047cb299bf41d547925a783c7f4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-vms.c-209",
-      "fileName": "repos/curl/src/tool_vms.c",
+      "SPDXID": "SPDXRef-File-multibyte.c-211",
+      "fileName": "repos/curl/lib/curlx/multibyte.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "71606f3d66c5e20a20d88523e2ad4129596f2686"
+          "checksumValue": "715d2b8dc20d7600e3769773a2b7ec90781919e4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noproxy.h-210",
+      "SPDXID": "SPDXRef-File-noproxy.h-212",
       "fileName": "repos/curl/lib/noproxy.h",
       "checksums": [
         {
@@ -2277,17 +2297,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urldata.h-211",
-      "fileName": "repos/curl/lib/vauth/../urldata.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "71e5d6f4a11a9e69119c56d48f108bc17fff5f01"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cf-ip-happy.h-212",
+      "SPDXID": "SPDXRef-File-cf-ip-happy.h-213",
       "fileName": "repos/curl/lib/cf-ip-happy.h",
       "checksums": [
         {
@@ -2297,7 +2307,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gopher.c-213",
+      "SPDXID": "SPDXRef-File-gopher.c-214",
       "fileName": "repos/curl/lib/gopher.c",
       "checksums": [
         {
@@ -2307,7 +2317,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-writeout-json.h-214",
+      "SPDXID": "SPDXRef-File-tool-writeout-json.h-215",
       "fileName": "repos/curl/src/tool_writeout_json.h",
       "checksums": [
         {
@@ -2317,27 +2327,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timeval.c-215",
-      "fileName": "repos/curl/lib/curlx/timeval.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "734b784c04f04b4b2258106dad2ba52a7551f951"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-wolfssl.h-216",
-      "fileName": "repos/curl/lib/vtls/wolfssl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "736da9a1a6a205ca918de6e47d61a9fdc5772d68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fileinfo.h-217",
+      "SPDXID": "SPDXRef-File-fileinfo.h-216",
       "fileName": "repos/curl/lib/fileinfo.h",
       "checksums": [
         {
@@ -2347,7 +2337,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynhds.c-218",
+      "SPDXID": "SPDXRef-File-dynhds.c-217",
       "fileName": "repos/curl/lib/dynhds.c",
       "checksums": [
         {
@@ -2357,12 +2347,22 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-bset.h-219",
-      "fileName": "repos/curl/lib/vauth/../uint-bset.h",
+      "SPDXID": "SPDXRef-File-uint-bset.h-218",
+      "fileName": "repos/curl/lib/uint-bset.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "7455c427df94f3a624cb820c92ff61a9044e06d5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-vms.c-219",
+      "fileName": "repos/curl/src/tool_vms.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "74eb210ab54658fed417d735f49933ff09e485f6"
         }
       ]
     },
@@ -2378,7 +2378,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-ratelimit.h-221",
-      "fileName": "repos/curl/lib/vauth/../ratelimit.h",
+      "fileName": "repos/curl/lib/ratelimit.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2397,7 +2397,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-rtmp.c-223",
+      "SPDXID": "SPDXRef-File-ws.h-223",
+      "fileName": "repos/curl/lib/ws.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "757eae0f0f69f898821ad80a622be2fdd4aa4b90"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-rtmp.c-224",
       "fileName": "repos/curl/lib/curl_rtmp.c",
       "checksums": [
         {
@@ -2407,17 +2417,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strdup.c-224",
-      "fileName": "repos/curl/lib/curlx/strdup.c",
+      "SPDXID": "SPDXRef-File-sendf.h-225",
+      "fileName": "repos/curl/lib/sendf.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "75e088fe4ce605e7ce7f0706265533caecae2ebc"
+          "checksumValue": "75c6e248ea473f8a94f819186cad0aaeb6efb020"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pop3.h-225",
+      "SPDXID": "SPDXRef-File-socketpair.c-226",
+      "fileName": "repos/curl/lib/socketpair.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "76b959dd4afc698252290be068b482940a041b5e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-pop3.h-227",
       "fileName": "repos/curl/lib/pop3.h",
       "checksums": [
         {
@@ -2427,7 +2447,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-haproxy.c-226",
+      "SPDXID": "SPDXRef-File-curl-config.h-228",
+      "fileName": "repos/curl/lib/curl_config.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "780ceae0a2f299041c7085c2d564f097e4eab5a3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-haproxy.c-229",
       "fileName": "repos/curl/lib/cf-haproxy.c",
       "checksums": [
         {
@@ -2437,38 +2467,38 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tftp.c-227",
-      "fileName": "repos/curl/lib/tftp.c",
+      "SPDXID": "SPDXRef-File-connect.c-230",
+      "fileName": "repos/curl/lib/connect.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "782cb1959a8e186e219b076b9a1455ad9176d066"
+          "checksumValue": "78c9370804824d6626e4540ad593ee4863b24a88"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ssh.h-228",
-      "fileName": "repos/curl/lib/vssh/ssh.h",
+      "SPDXID": "SPDXRef-File-cleartext.c-231",
+      "fileName": "repos/curl/lib/vauth/cleartext.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "78889bf60e6b96c85d6683afb4ed07aa75f2df07"
+          "checksumValue": "7976adec9c8fec28baaa8a9c42684677e7d20f28"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cshutdn.h-229",
-      "fileName": "repos/curl/lib/vauth/../cshutdn.h",
+      "SPDXID": "SPDXRef-File-curlx.h-232",
+      "fileName": "repos/curl/src/../lib/curlx/curlx.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "79c95cca5917d8d3a8d56707707aa34c955cd696"
+          "checksumValue": "79cffc8f6dbcd2df6ff7499164ae2b601103f41a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multihandle.h-230",
-      "fileName": "repos/curl/lib/vauth/../multihandle.h",
+      "SPDXID": "SPDXRef-File-multihandle.h-233",
+      "fileName": "repos/curl/lib/multihandle.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2477,27 +2507,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-krb5-sspi.c-231",
-      "fileName": "repos/curl/lib/vauth/krb5_sspi.c",
+      "SPDXID": "SPDXRef-File-sha256.c-234",
+      "fileName": "repos/curl/lib/sha256.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7aad4badfab4d9d3430ed6407489e46c6aa056fd"
+          "checksumValue": "7b063659be03511b73c247291d5f8f6bd49119d9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slist-wc.h-232",
-      "fileName": "repos/curl/src/slist_wc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7bf76257a49c9bfe351708f3325b9dc81292c81b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-ldap.h-233",
+      "SPDXID": "SPDXRef-File-curl-ldap.h-235",
       "fileName": "repos/curl/lib/curl_ldap.h",
       "checksums": [
         {
@@ -2507,27 +2527,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apple.c-234",
-      "fileName": "repos/curl/lib/vtls/apple.c",
+      "SPDXID": "SPDXRef-File-version.c-236",
+      "fileName": "repos/curl/lib/version.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7c2ea4989f89f3fb71c3c192480cb7570353c1a8"
+          "checksumValue": "7ccd875dc8e3dc039ecea4d7377b154e2bd04100"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-progress.c-235",
-      "fileName": "repos/curl/lib/progress.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7daa4b4b3efd690d97d055dbb0e268b573dd2e74"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cw-out.h-236",
+      "SPDXID": "SPDXRef-File-cw-out.h-237",
       "fileName": "repos/curl/lib/cw-out.h",
       "checksums": [
         {
@@ -2537,47 +2547,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel.c-237",
-      "fileName": "repos/curl/lib/vtls/schannel.c",
+      "SPDXID": "SPDXRef-File-keylog.h-238",
+      "fileName": "repos/curl/lib/../lib/vtls/keylog.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7eba7843684c2375fefa90bbe583542d2073fc8d"
+          "checksumValue": "7e741b964d596dea3606dd4aec0978752d7f836b"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mime.c-238",
-      "fileName": "repos/curl/lib/mime.c",
+      "SPDXID": "SPDXRef-File-tool-operate.h-239",
+      "fileName": "repos/curl/src/tool_operate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7f350ae7e0475d2f196cea6d54f01d08586fa8cc"
+          "checksumValue": "7e886f6ef043017edf50686626c1c0adcde55f6c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socketpair.c-239",
-      "fileName": "repos/curl/lib/socketpair.c",
+      "SPDXID": "SPDXRef-File-parsedate.c-240",
+      "fileName": "repos/curl/lib/parsedate.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "7fd7e30bbab8271c2ff28ebd5d217375371c0d0d"
+          "checksumValue": "7efedec7d2452959e80c23647608d48859015d3d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-ares.c-240",
-      "fileName": "repos/curl/lib/asyn-ares.c",
+      "SPDXID": "SPDXRef-File-var.c-241",
+      "fileName": "repos/curl/src/var.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "80126ce056d5aafd41d5e154bf2a133690155578"
+          "checksumValue": "7fb51d656e38279bc603aa06a776af6a64444a23"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-doswin.h-241",
+      "SPDXID": "SPDXRef-File-inet-ntop.c-242",
+      "fileName": "repos/curl/lib/curlx/inet_ntop.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "803b9887ac91c638e0f34a614a97aab8e42b5793"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hash.c-243",
+      "fileName": "repos/curl/lib/hash.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8095ca2e450748cde390aaa07cebb4f2da1f0e5c"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-doswin.h-244",
       "fileName": "repos/curl/src/tool_doswin.h",
       "checksums": [
         {
@@ -2587,7 +2617,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options.h-242",
+      "SPDXID": "SPDXRef-File-options.h-245",
       "fileName": "repos/curl/lib/../include/curl/options.h",
       "checksums": [
         {
@@ -2597,27 +2627,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-openldap.c-243",
-      "fileName": "repos/curl/lib/openldap.c",
+      "SPDXID": "SPDXRef-File-setopt.c-246",
+      "fileName": "repos/curl/lib/setopt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "83ae013593d8ab56826d5ad7e1d933dcddcacc3b"
+          "checksumValue": "84f3e02b7b1584191d15844bad6470eaa16fc8ad"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sasl.h-244",
-      "fileName": "repos/curl/lib/curl_sasl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8432d261ecc8386f1af3f18993984ff070a6251f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-dirhie.h-245",
+      "SPDXID": "SPDXRef-File-tool-dirhie.h-247",
       "fileName": "repos/curl/src/tool_dirhie.h",
       "checksums": [
         {
@@ -2627,17 +2647,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cshutdn.c-246",
-      "fileName": "repos/curl/lib/cshutdn.c",
+      "SPDXID": "SPDXRef-File-headers.h-248",
+      "fileName": "repos/curl/lib/headers.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "85863ef93051dd62fd01a46cc251a1f829d4bc49"
+          "checksumValue": "85905e5141dc96e820eb886135e6caee4c39121c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-get-line.c-247",
+      "SPDXID": "SPDXRef-File-curl-get-line.c-249",
       "fileName": "repos/curl/lib/curl_get_line.c",
       "checksums": [
         {
@@ -2647,17 +2667,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-altsvc.h-248",
-      "fileName": "repos/curl/lib/altsvc.h",
+      "SPDXID": "SPDXRef-File-header.h-250",
+      "fileName": "repos/curl/lib/../include/curl/header.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "85da8cceb91ce31062a51388be33bb31cb595ea6"
+          "checksumValue": "85c10c8d7833211bab237dac62a21fdc7f91cff9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-parsecfg.h-249",
+      "SPDXID": "SPDXRef-File-tool-parsecfg.h-251",
       "fileName": "repos/curl/src/tool_parsecfg.h",
       "checksums": [
         {
@@ -2667,7 +2687,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-listhelp.c-250",
+      "SPDXID": "SPDXRef-File-tool-listhelp.c-252",
       "fileName": "repos/curl/src/tool_listhelp.c",
       "checksums": [
         {
@@ -2677,7 +2697,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-endian.c-251",
+      "SPDXID": "SPDXRef-File-curl-endian.c-253",
       "fileName": "repos/curl/lib/curl_endian.c",
       "checksums": [
         {
@@ -2687,62 +2707,42 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-spack.h-252",
-      "fileName": "repos/curl/lib/vtls/vtls_spack.h",
+      "SPDXID": "SPDXRef-File-rand.h-254",
+      "fileName": "repos/curl/lib/rand.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86796ee62ed6ca3f2ecb1ea7cb7ec2b71ce4cda1"
+          "checksumValue": "86765806f90894e0069733a2688e6122bf448064"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conncache.c-253",
-      "fileName": "repos/curl/lib/conncache.c",
+      "SPDXID": "SPDXRef-File-multibyte.h-255",
+      "fileName": "repos/curl/lib/../lib/curlx/multibyte.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "869af4215e457f74df665dbd044884758634ec36"
+          "checksumValue": "8863fb024990faa22fcdaca761cbefa3edbb051e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getparam.c-254",
-      "fileName": "repos/curl/src/tool_getparam.c",
+      "SPDXID": "SPDXRef-File-functypes.h-256",
+      "fileName": "repos/curl/lib/functypes.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86ebed13e8a4e9a1ee673edfe126f998e710b8bd"
+          "checksumValue": "887c2612ef94d83ce89e7fa8a019c3f78d804cbb"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest-sspi.c-255",
-      "fileName": "repos/curl/lib/vauth/digest_sspi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "893838d2cdd5cedd92a6df5de70a342eaf48b6e5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-hugehelp.h-256",
+      "SPDXID": "SPDXRef-File-tool-hugehelp.h-257",
       "fileName": "repos/curl/src/tool_hugehelp.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "89df96ce5fe9a12e0b21bf143c67eaa57ad21614"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-vms.h-257",
-      "fileName": "repos/curl/src/tool_vms.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "89ea31ee1583277ab18498d5fa8ea3f634106c05"
         }
       ]
     },
@@ -2757,12 +2757,12 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnless.h-259",
-      "fileName": "repos/curl/lib/vauth/../curlx/warnless.h",
+      "SPDXID": "SPDXRef-File-curl-sasl.h-259",
+      "fileName": "repos/curl/lib/curl_sasl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8a62ccf6a70b0416582f9b6e893270e7e5a6db7d"
+          "checksumValue": "8a97f52adcff1c1730743e90575565aebd024431"
         }
       ]
     },
@@ -2787,58 +2787,28 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.h-262",
-      "fileName": "repos/curl/lib/vauth/../hash.h",
+      "SPDXID": "SPDXRef-File-bufq.h-262",
+      "fileName": "repos/curl/lib/bufq.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8bf47ccf753dd8043f001ad47f545893cd424ef8"
+          "checksumValue": "8dd186f505535c53e1242b652f6008a9086e3edf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnless.c-263",
-      "fileName": "repos/curl/lib/curlx/warnless.c",
+      "SPDXID": "SPDXRef-File-tool-ipfs.c-263",
+      "fileName": "repos/curl/src/tool_ipfs.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "8c1be2d589c8751c353b40254348b0ffd6d3155d"
+          "checksumValue": "8e762b8cf0326b1eaab2dd9506ccc592acde9d78"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls.c-264",
-      "fileName": "repos/curl/lib/vtls/vtls.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8c87dd3d9cd6fe1b4ed3d9a5337783622bd409df"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-fnmatch.c-265",
-      "fileName": "repos/curl/lib/curl_fnmatch.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8e35edeed6306f7484153a169f451c194c7af545"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-mprintf.c-266",
-      "fileName": "repos/curl/lib/mprintf.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8f81f033dcb0c7125beab6183168a1fab87a9f08"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-httpsrr.h-267",
-      "fileName": "repos/curl/lib/vtls/../httpsrr.h",
+      "SPDXID": "SPDXRef-File-httpsrr.h-264",
+      "fileName": "repos/curl/lib/httpsrr.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2847,37 +2817,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest.h-268",
-      "fileName": "repos/curl/lib/vauth/digest.h",
+      "SPDXID": "SPDXRef-File-cshutdn.h-265",
+      "fileName": "repos/curl/lib/cshutdn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "902ffab153a8ccfb7c0b73ff6690f5a55db35042"
+          "checksumValue": "9030474032b49953229cb633aae68341978c5570"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-sdecls.h-269",
-      "fileName": "repos/curl/src/tool_sdecls.h",
+      "SPDXID": "SPDXRef-File-idn.h-266",
+      "fileName": "repos/curl/lib/idn.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9058233a688e183df4edc2d69812d513ebdd4c5a"
+          "checksumValue": "90d8e811b1a6128e0bafec2b6006ca0cbcfe46be"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hmac.c-270",
-      "fileName": "repos/curl/lib/hmac.c",
+      "SPDXID": "SPDXRef-File-strerr.c-267",
+      "fileName": "repos/curl/lib/curlx/strerr.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9080588341da6efd0262f244873d5b993c9b273f"
+          "checksumValue": "91a329e91502c28ae79cb6d0498a0807a22c6505"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tftp.h-271",
+      "SPDXID": "SPDXRef-File-tftp.h-268",
       "fileName": "repos/curl/lib/tftp.h",
       "checksums": [
         {
@@ -2887,7 +2857,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mprintf.h-272",
+      "SPDXID": "SPDXRef-File-mprintf.h-269",
       "fileName": "repos/curl/lib/../include/curl/mprintf.h",
       "checksums": [
         {
@@ -2897,7 +2867,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-gethostname.h-273",
+      "SPDXID": "SPDXRef-File-curl-gethostname.h-270",
       "fileName": "repos/curl/lib/curl_gethostname.h",
       "checksums": [
         {
@@ -2907,7 +2877,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rtsp.h-274",
+      "SPDXID": "SPDXRef-File-rtsp.h-271",
       "fileName": "repos/curl/lib/rtsp.h",
       "checksums": [
         {
@@ -2917,47 +2887,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operate.h-275",
-      "fileName": "repos/curl/src/tool_operate.h",
+      "SPDXID": "SPDXRef-File-sendf.c-272",
+      "fileName": "repos/curl/lib/sendf.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "93c87e10e65936f2c08b8d4cf8043e50a65d6760"
+          "checksumValue": "92e77b482aeaf049d048dcec2013c44c98d95082"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.c-276",
-      "fileName": "repos/curl/lib/multi.c",
+      "SPDXID": "SPDXRef-File-gsasl.c-273",
+      "fileName": "repos/curl/lib/vauth/gsasl.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9420e3f940b116af32ab383c91043c9c359867c7"
+          "checksumValue": "958f4ffab746546fdb526ca82d6ade0589072d8d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock.c-277",
-      "fileName": "repos/curl/lib/curlx/nonblock.c",
+      "SPDXID": "SPDXRef-File-openldap.c-274",
+      "fileName": "repos/curl/lib/openldap.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "96bf3db64ec8c9f1163e45e0ffba018e99402479"
+          "checksumValue": "95f7681caa8bcd4dbb3e27178e8af9245018dfed"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostcheck.c-278",
-      "fileName": "repos/curl/lib/vtls/hostcheck.c",
+      "SPDXID": "SPDXRef-File-digest.c-275",
+      "fileName": "repos/curl/lib/vauth/digest.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9706336735c210b8d453efe1ff2f837a2285eaa6"
+          "checksumValue": "96093903871fc1215753d6bde0db7ae590b07798"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-range.h-279",
+      "SPDXID": "SPDXRef-File-socks-gssapi.c-276",
+      "fileName": "repos/curl/lib/socks_gssapi.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "962fcd05b2a6db214d86a469cf05460e7850ddab"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-paramhlp.c-277",
+      "fileName": "repos/curl/src/tool_paramhlp.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "970d42192adac3e9363d56a4cc980c4485984acb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-range.h-278",
       "fileName": "repos/curl/lib/curl_range.h",
       "checksums": [
         {
@@ -2967,8 +2957,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-psl.h-280",
-      "fileName": "repos/curl/lib/vauth/../psl.h",
+      "SPDXID": "SPDXRef-File-psl.h-279",
+      "fileName": "repos/curl/lib/psl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2977,87 +2967,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strequal.c-281",
-      "fileName": "repos/curl/lib/strequal.c",
+      "SPDXID": "SPDXRef-File-tool-setup.h-280",
+      "fileName": "repos/curl/src/tool_setup.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "98cecdc244d4d3724cee85a0a3c856cf1415de11"
+          "checksumValue": "9860a0b96244562446673af2565ee7ed820b61c1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-netrc.h-282",
-      "fileName": "repos/curl/lib/vauth/../netrc.h",
+      "SPDXID": "SPDXRef-File-select.c-281",
+      "fileName": "repos/curl/lib/select.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "99ddc6253e08da0840eeadec71d9879d43b4acec"
+          "checksumValue": "9a11924976ac384288176a5bf58c06351e318692"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-getpass.c-283",
-      "fileName": "repos/curl/src/tool_getpass.c",
+      "SPDXID": "SPDXRef-File-tool-operate.c-282",
+      "fileName": "repos/curl/src/tool_operate.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "99ded8f4c5b57b40fa83aa65eb0c786dc53700fe"
+          "checksumValue": "9a29b8e34c01055915e24e86abde466c7b062750"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedate.c-284",
-      "fileName": "repos/curl/lib/parsedate.c",
+      "SPDXID": "SPDXRef-File-wait.h-283",
+      "fileName": "repos/curl/lib/curlx/wait.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9a3060bd50be97332fd44af19bc34df264bd0fc3"
+          "checksumValue": "9b9c27386e92150fd85c701d3c4f8394316f6c9f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-chunks.c-285",
-      "fileName": "repos/curl/lib/http_chunks.c",
+      "SPDXID": "SPDXRef-File-curl-range.c-284",
+      "fileName": "repos/curl/lib/curl_range.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9b38a3780cae1ea9c372fb94de428570150d2b87"
+          "checksumValue": "9bbafa40cfc38e04c61d69c4814f1c23e6cfc25f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conncache.h-286",
-      "fileName": "repos/curl/lib/vauth/../conncache.h",
+      "SPDXID": "SPDXRef-File-tool-msgs.c-285",
+      "fileName": "repos/curl/src/tool_msgs.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9b392af05ccd2d6f794ca2db680bbd9bfc7475fb"
+          "checksumValue": "9bc8ca18f12f92c64fca976a1bb4112d01b178b3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cfgable.h-287",
-      "fileName": "repos/curl/src/tool_cfgable.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9bd1f59bc9863d1ce68436e7149c8300ae43ca9f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist.c-288",
-      "fileName": "repos/curl/lib/slist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9bfd08ae2ce138477d75f003fca9740537fdd4fc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-prg.h-289",
+      "SPDXID": "SPDXRef-File-tool-cb-prg.h-286",
       "fileName": "repos/curl/src/tool_cb_prg.h",
       "checksums": [
         {
@@ -3067,8 +3037,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-progress.h-290",
-      "fileName": "repos/curl/lib/vtls/../progress.h",
+      "SPDXID": "SPDXRef-File-progress.h-287",
+      "fileName": "repos/curl/lib/progress.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3077,27 +3047,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http1.c-291",
-      "fileName": "repos/curl/lib/http1.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9e584248bedd5532edd81a09267a4770304769c5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-splay.h-292",
-      "fileName": "repos/curl/lib/vauth/../splay.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9ed96f63e4eae5a81731506731b724eb25237c12"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-strcase.c-293",
+      "SPDXID": "SPDXRef-File-strcase.c-288",
       "fileName": "repos/curl/lib/strcase.c",
       "checksums": [
         {
@@ -3107,47 +3057,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cfilters.h-294",
-      "fileName": "repos/curl/lib/vtls/../cfilters.h",
+      "SPDXID": "SPDXRef-File-escape.h-289",
+      "fileName": "repos/curl/lib/escape.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "9faf01de755d092998b002b5732ef86104f66ba5"
+          "checksumValue": "9f9a89e4022bcdbfb7ebf816492b9f67ea318c28"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.c-295",
-      "fileName": "repos/curl/lib/rand.c",
+      "SPDXID": "SPDXRef-File-vauth.c-290",
+      "fileName": "repos/curl/lib/vauth/vauth.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a02338f206a56bb7be5d4939c2f4ede34a67b020"
+          "checksumValue": "a00078fce1939ececb86458c39e37e3cac80318e"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-see.c-296",
-      "fileName": "repos/curl/src/tool_cb_see.c",
+      "SPDXID": "SPDXRef-File-gtls.c-291",
+      "fileName": "repos/curl/lib/vtls/gtls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a1983b94cc5b35179c6b44c36305e26077837d08"
+          "checksumValue": "a0a465c3607ca86322972c16166089cd429cea55"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pingpong.c-297",
-      "fileName": "repos/curl/lib/pingpong.c",
+      "SPDXID": "SPDXRef-File-http2.h-292",
+      "fileName": "repos/curl/lib/http2.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a2ca05ae4767e3649f3f1160688da8e71e2bea82"
+          "checksumValue": "a14c8485cc884baddaaecf3a9d22bef7c2091d1c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.h-298",
+      "SPDXID": "SPDXRef-File-tool-helpers.c-293",
+      "fileName": "repos/curl/src/tool_helpers.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a23c3a80e75b29cc4f9ff2bd08a107d211bb1048"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-file.h-294",
       "fileName": "repos/curl/lib/file.h",
       "checksums": [
         {
@@ -3157,67 +3117,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ev.c-299",
-      "fileName": "repos/curl/lib/multi_ev.c",
+      "SPDXID": "SPDXRef-File-strequal.c-295",
+      "fileName": "repos/curl/lib/strequal.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a399e3f4cbce975b58e07875cbc25ed9254ad327"
+          "checksumValue": "a352fda70b246728660d097bcd4f2e9ae81b13de"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-select.c-300",
-      "fileName": "repos/curl/lib/select.c",
+      "SPDXID": "SPDXRef-File-urlapi.c-296",
+      "fileName": "repos/curl/lib/urlapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a3d77145ce14e8a0f590aea3e0485a8a815951d9"
+          "checksumValue": "a4b82f31bd74f345e0959630fef59469022f66da"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-system.h-301",
-      "fileName": "repos/curl/lib/../include/curl/system.h",
+      "SPDXID": "SPDXRef-File-gtls.h-297",
+      "fileName": "repos/curl/lib/../lib/vtls/gtls.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a5b3e9eba79a055c4c300b1d5d516678e5fbe693"
+          "checksumValue": "a5e55cd4f9f8e7c6489c21af1cfb9e636421f1b9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libssh.c-302",
-      "fileName": "repos/curl/lib/vssh/libssh.c",
+      "SPDXID": "SPDXRef-File-apple.c-298",
+      "fileName": "repos/curl/lib/vtls/apple.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a5d58ec731ba1d7cbaaea991499d9bd54461b8b1"
+          "checksumValue": "a6a5ba01f026f95abab3315a1518e56b4cf80f13"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-win32.h-303",
-      "fileName": "repos/curl/lib/curlx/version_win32.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a5fb8ff3c23fa8a82c1f747f13d005d246dcf949"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-openssl.c-304",
-      "fileName": "repos/curl/lib/vtls/openssl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a632e80943f23feecf144c3580408e24d8622c77"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-negotiate.c-305",
+      "SPDXID": "SPDXRef-File-http-negotiate.c-299",
       "fileName": "repos/curl/lib/http_negotiate.c",
       "checksums": [
         {
@@ -3227,47 +3167,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedate.h-306",
-      "fileName": "repos/curl/lib/vssh/../parsedate.h",
+      "SPDXID": "SPDXRef-File-base64.c-300",
+      "fileName": "repos/curl/lib/curlx/base64.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a6ee43a5d487c425b744c3451cc2dbbf26e55466"
+          "checksumValue": "a7a6703099128d30c29c92c7c837ca546906a87a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-oauth2.c-307",
-      "fileName": "repos/curl/lib/vauth/oauth2.c",
+      "SPDXID": "SPDXRef-File-curl-trc.h-301",
+      "fileName": "repos/curl/lib/curl_trc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a7a061337fa9abd1783da7863346523b2a446e89"
+          "checksumValue": "a82c945e5f9b7e1f0fbfc113c3ea929a7fac1fe7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h1-proxy.c-308",
-      "fileName": "repos/curl/lib/cf-h1-proxy.c",
+      "SPDXID": "SPDXRef-File-conncache.c-302",
+      "fileName": "repos/curl/lib/conncache.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a85cd1d5a6fc0809a1b9f8ad149a72712fff1605"
+          "checksumValue": "a865959709b7c07d30e9a44066b60c68a80d7b5f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sigpipe.h-309",
-      "fileName": "repos/curl/lib/sigpipe.h",
+      "SPDXID": "SPDXRef-File-http-proxy.c-303",
+      "fileName": "repos/curl/lib/http_proxy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a906b27037498037864017c36d8e91e5e4b58900"
+          "checksumValue": "a9521c92dab64ccd604ddd440f0f8a08d4d83bc7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getenv.c-310",
+      "SPDXID": "SPDXRef-File-getenv.c-304",
       "fileName": "repos/curl/lib/getenv.c",
       "checksums": [
         {
@@ -3277,47 +3217,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynbuf.c-311",
-      "fileName": "repos/curl/lib/curlx/dynbuf.c",
+      "SPDXID": "SPDXRef-File-content-encoding.c-305",
+      "fileName": "repos/curl/lib/content_encoding.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a96b2a5974c59a19df2d39058784bdda019ff8bb"
+          "checksumValue": "aa35da840b23251fc37882dbce411b81cdd80f2f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-win32.c-312",
-      "fileName": "repos/curl/lib/curlx/version_win32.c",
+      "SPDXID": "SPDXRef-File-wolfssl.c-306",
+      "fileName": "repos/curl/lib/vtls/wolfssl.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "a9a4ee38f9293d5f876b37fff4b74d20ec9e6174"
+          "checksumValue": "aa841a754a944cdaf678460f3618899777692e95"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cw-out.c-313",
-      "fileName": "repos/curl/lib/cw-out.c",
+      "SPDXID": "SPDXRef-File-tool-doswin.c-307",
+      "fileName": "repos/curl/src/tool_doswin.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ab38109ad900dbec31e3e7a58ec78ad078c662e3"
+          "checksumValue": "ad0386555dbd8c4778c82ef14ea5f8167f831420"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keylog.c-314",
-      "fileName": "repos/curl/lib/vtls/keylog.c",
+      "SPDXID": "SPDXRef-File-hostcheck.c-308",
+      "fileName": "repos/curl/lib/vtls/hostcheck.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ace9cab1ae2b7ffa706695986c9239bbb555f971"
+          "checksumValue": "ad09b8319413891c9065116c7bb8a2d871a8caa5"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-urlglob.h-315",
+      "SPDXID": "SPDXRef-File-tool-urlglob.h-309",
       "fileName": "repos/curl/src/tool_urlglob.h",
       "checksums": [
         {
@@ -3327,97 +3267,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-headers.h-316",
-      "fileName": "repos/curl/lib/headers.h",
+      "SPDXID": "SPDXRef-File-multi.h-310",
+      "fileName": "repos/curl/lib/../include/curl/multi.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "adb03af75b5e1fecf3713fcfb51dcd74fe4f98ff"
+          "checksumValue": "ad6f53f3e2c44a99e7b55f230a0ce9a2b60ab674"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-https-connect.c-317",
-      "fileName": "repos/curl/lib/cf-https-connect.c",
+      "SPDXID": "SPDXRef-File-tool-paramhlp.h-311",
+      "fileName": "repos/curl/src/tool_paramhlp.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ae6721bd41258205ed29170ff8f45d5927e512ad"
+          "checksumValue": "af40f10591b50e3120b6e22e1fd1daf20ccd6091"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strparse.h-318",
-      "fileName": "repos/curl/lib/vauth/../curlx/strparse.h",
+      "SPDXID": "SPDXRef-File-memdebug.c-312",
+      "fileName": "repos/curl/lib/memdebug.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ae8fd19d955e2b53d01b8b81458a849f7e467313"
+          "checksumValue": "af4fc9d6c107cdea99bbac619dc19efe82595f74"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-request.c-319",
-      "fileName": "repos/curl/lib/request.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aed9c7eb3b1608262ff4c4670df52bb919b1672b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-openssl.h-320",
-      "fileName": "repos/curl/lib/vtls/openssl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aeeb8dd805b0fd0e5ad8c0adf27cf127f88fe044"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ftplistparser.h-321",
-      "fileName": "repos/curl/lib/vauth/../ftplistparser.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "afb90dee4cada77f126f9a85461f8ffd814981a2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-escape.c-322",
-      "fileName": "repos/curl/lib/escape.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "afdf18c1b4d91ed7c4c800fc7269615190d6917a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-time.c-323",
-      "fileName": "repos/curl/src/toolx/tool_time.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "affcd7a16730ba0d553468c144f19f2874c6cc74"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-spnego-gssapi.c-324",
+      "SPDXID": "SPDXRef-File-spnego-gssapi.c-313",
       "fileName": "repos/curl/lib/vauth/spnego_gssapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b1ec37cb31686f30197fa9f647b4bd6dc9d54688"
+          "checksumValue": "af8498bad3b942a2ed7b25b63f19c2b2de6a0d14"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sasl.c-325",
+      "SPDXID": "SPDXRef-File-wolfssl.h-314",
+      "fileName": "repos/curl/lib/../lib/vtls/wolfssl.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b097b60b78b72ac6c77b48bce978048c674772d7"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sasl.c-315",
       "fileName": "repos/curl/lib/curl_sasl.c",
       "checksums": [
         {
@@ -3427,47 +3327,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy.c-326",
-      "fileName": "repos/curl/lib/easy.c",
+      "SPDXID": "SPDXRef-File-tool-vms.h-316",
+      "fileName": "repos/curl/src/tool_vms.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b30ce2ace41f926c9cb7cc1ec2fedb53850c770b"
+          "checksumValue": "b459a25ee8a1a8d5917ee2ae1fef3d3bf5070993"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-parsecfg.c-327",
-      "fileName": "repos/curl/src/tool_parsecfg.c",
+      "SPDXID": "SPDXRef-File-sigpipe.h-317",
+      "fileName": "repos/curl/lib/sigpipe.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b36d113232315488f02352660ad0412151f6320f"
+          "checksumValue": "b4897969538a5199c7ab8a5350950bde4b51ed57"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vssh.c-328",
-      "fileName": "repos/curl/lib/vssh/vssh.c",
+      "SPDXID": "SPDXRef-File-ntlm.c-318",
+      "fileName": "repos/curl/lib/vauth/ntlm.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b52b09b696e9beff92e6a27234a4ea59446fd3d5"
+          "checksumValue": "b50cfdd6812903dbe2ddc557138fa57f1fefccad"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-formdata.c-329",
-      "fileName": "repos/curl/lib/formdata.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b5bd1206f1068e46acb8677b8eb55772faa95047"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.h-330",
+      "SPDXID": "SPDXRef-File-dict.h-319",
       "fileName": "repos/curl/lib/dict.h",
       "checksums": [
         {
@@ -3477,17 +3367,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fopen.c-331",
-      "fileName": "repos/curl/lib/curlx/fopen.c",
+      "SPDXID": "SPDXRef-File-arpa-telnet.h-320",
+      "fileName": "repos/curl/lib/arpa_telnet.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b73d4f94a1123767332467e73908a5362a0df06c"
+          "checksumValue": "b5faab419c26d84c0eb713e0e3b666eb7f4d13fd"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fopen.c-332",
+      "SPDXID": "SPDXRef-File-x509asn1.c-321",
+      "fileName": "repos/curl/lib/vtls/x509asn1.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b687a60193d28268d90cc04d4da9b08d2e2fd196"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-rustls.h-322",
+      "fileName": "repos/curl/lib/../lib/vtls/rustls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b6ddbd1b7e012ec04b5c7de6d299c1c51caa3780"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-fopen.c-323",
       "fileName": "repos/curl/lib/curl_fopen.c",
       "checksums": [
         {
@@ -3497,17 +3407,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gsasl.c-333",
-      "fileName": "repos/curl/lib/vauth/gsasl.c",
+      "SPDXID": "SPDXRef-File-socks.c-324",
+      "fileName": "repos/curl/lib/socks.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "b95d6e3f0a8e47f7fa5f29bb7b080b242b54ace5"
+          "checksumValue": "b7c3bd61463d76779a8bf53d8eee87762cdb7757"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-table.c-334",
+      "SPDXID": "SPDXRef-File-vtls.h-325",
+      "fileName": "repos/curl/lib/vtls/vtls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b9335bbf18598bb2af2ed387734e11381a2132ff"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-uint-table.c-326",
       "fileName": "repos/curl/lib/uint-table.c",
       "checksums": [
         {
@@ -3517,17 +3437,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-netrc.c-335",
-      "fileName": "repos/curl/lib/netrc.c",
+      "SPDXID": "SPDXRef-File-vtls-scache.h-327",
+      "fileName": "repos/curl/lib/vtls/vtls_scache.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "baabe917a75ab4a1c33f053fdcc90ae604d99f7f"
+          "checksumValue": "b9db0f19b36c4beab5a10080ed6a2526dcbc960f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-main.c-336",
+      "SPDXID": "SPDXRef-File-curl-hmac.h-328",
+      "fileName": "repos/curl/lib/curl_hmac.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b9f218fac930074434dd50816ddbf4a2f2c29e1d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-main.c-329",
       "fileName": "repos/curl/src/tool_main.c",
       "checksums": [
         {
@@ -3537,7 +3467,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-var.h-337",
+      "SPDXID": "SPDXRef-File-var.h-330",
       "fileName": "repos/curl/src/var.h",
       "checksums": [
         {
@@ -3547,17 +3477,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-trc.c-338",
-      "fileName": "repos/curl/lib/curl_trc.c",
+      "SPDXID": "SPDXRef-File-http.h-331",
+      "fileName": "repos/curl/lib/http.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bbec332f99d04b483abf3eac84d10c6c6d71916b"
+          "checksumValue": "bb535955d1f016a272982689f8a24ab4706c4c79"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gopher.h-339",
+      "SPDXID": "SPDXRef-File-tool-setopt.h-332",
+      "fileName": "repos/curl/src/tool_setopt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bb85ae7088bdbb123c2e615312cfe01fa76d6634"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-curl-sha256.h-333",
+      "fileName": "repos/curl/lib/curl_sha256.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bc1512e6e8c20dd91e53c29704564ac7fb802091"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-gopher.h-334",
       "fileName": "repos/curl/lib/gopher.h",
       "checksums": [
         {
@@ -3567,17 +3517,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufq.h-340",
-      "fileName": "repos/curl/lib/vauth/../bufq.h",
+      "SPDXID": "SPDXRef-File-tool-setopt.c-335",
+      "fileName": "repos/curl/src/tool_setopt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bcd7df2ab9ddd45a5f321254de43694f9caa642e"
+          "checksumValue": "bd24e4b411e3b522327b8fe0195a6b8f8e467e3a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-fopen.h-341",
+      "SPDXID": "SPDXRef-File-curl-fopen.h-336",
       "fileName": "repos/curl/lib/curl_fopen.h",
       "checksums": [
         {
@@ -3587,67 +3537,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vauth.c-342",
-      "fileName": "repos/curl/lib/vauth/vauth.c",
+      "SPDXID": "SPDXRef-File-escape.c-337",
+      "fileName": "repos/curl/lib/escape.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bdf194b99562b3a8abda275fc77d1d9808992c52"
+          "checksumValue": "be44e971569e4da3fc94eecd419f91940c47e1bf"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls.h-343",
-      "fileName": "repos/curl/lib/vtls/vtls.h",
+      "SPDXID": "SPDXRef-File-timeval.h-338",
+      "fileName": "repos/curl/lib/curlx/timeval.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bf19572fc62536679010b45a9efb08fdb31ac0f9"
+          "checksumValue": "c01f95d87df0d53dad4ac60cba387449eb5b4d39"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-addrinfo.c-344",
-      "fileName": "repos/curl/lib/fake_addrinfo.c",
+      "SPDXID": "SPDXRef-File-krb5-sspi.c-339",
+      "fileName": "repos/curl/lib/vauth/krb5_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "bf5a44892c5d2be4ab1414c34b7922218a7d4aaa"
+          "checksumValue": "c08b6a4c3a5a2d6dac17e825adb23bc7aa2b1c0a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-hugehelp.c-345",
-      "fileName": "repos/curl/src/tool_hugehelp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c0323e2f4dbf1e990d8603fb770362d99079b49a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sha256.c-346",
-      "fileName": "repos/curl/lib/sha256.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c042c1bb0cb70a39877914e86bbd2ce7a5c447e4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-winapi.c-347",
-      "fileName": "repos/curl/lib/curlx/winapi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c0d6b7f861c4308c1fe3acf0edbb5968fb371dbf"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-gssapi.c-348",
+      "SPDXID": "SPDXRef-File-curl-gssapi.c-340",
       "fileName": "repos/curl/lib/curl_gssapi.c",
       "checksums": [
         {
@@ -3657,7 +3577,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-telnet.h-349",
+      "SPDXID": "SPDXRef-File-telnet.h-341",
       "fileName": "repos/curl/lib/telnet.h",
       "checksums": [
         {
@@ -3667,17 +3587,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wait.h-350",
-      "fileName": "repos/curl/lib/curlx/wait.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c140194a8c2dfae9fa8c9393027e1f9ea5dfbe04"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-proxy.h-351",
+      "SPDXID": "SPDXRef-File-http-proxy.h-342",
       "fileName": "repos/curl/lib/http_proxy.h",
       "checksums": [
         {
@@ -3687,17 +3597,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vtls-int.h-352",
-      "fileName": "repos/curl/lib/vtls/vtls_int.h",
+      "SPDXID": "SPDXRef-File-http1.h-343",
+      "fileName": "repos/curl/lib/http1.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c2a44a3a33b1e79bbdd986fd8339b7390ef23394"
+          "checksumValue": "c2894613de7fe48116816174f0dce2aa0decfe47"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-ntlm.c-353",
+      "SPDXID": "SPDXRef-File-md5.c-344",
+      "fileName": "repos/curl/lib/md5.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c2bd176dc96f6a2d3c7681f51323c401767e5fb9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-asyn-thrdd.c-345",
+      "fileName": "repos/curl/lib/asyn-thrdd.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c3ed8eacaaf13be9fc72478a5da4ba9282df0af6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-setopt.h-346",
+      "fileName": "repos/curl/lib/setopt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c421f5c5e5bce7570f4ecefcf7168b9a8f0345d5"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-version-win32.h-347",
+      "fileName": "repos/curl/lib/curlx/version_win32.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4a1c0f7586b7aca8c0e82abab2378af96c92706"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-url.h-348",
+      "fileName": "repos/curl/lib/url.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4cd762fb85948a9fb75cd73f6943f59e0915a0e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-ntlm.c-349",
       "fileName": "repos/curl/lib/http_ntlm.c",
       "checksums": [
         {
@@ -3707,17 +3667,67 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-schannel.h-354",
-      "fileName": "repos/curl/lib/vtls/schannel.h",
+      "SPDXID": "SPDXRef-File-splay.h-350",
+      "fileName": "repos/curl/lib/splay.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c617233e0883e1bae73d9adb5a85e96c85a94c14"
+          "checksumValue": "c6623f2ef0c45d4b324bb8af5cd167f0511f1a00"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-ipfs.h-355",
+      "SPDXID": "SPDXRef-File-mprintf.c-351",
+      "fileName": "repos/curl/lib/mprintf.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6a4a494292294c5223b856aad1d95ffb484dc0a"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-slist.c-352",
+      "fileName": "repos/curl/lib/slist.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c6dcdc1af0ef4c7041473a7cfb7c36bb1bdf73f0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-snprintf.c-353",
+      "fileName": "repos/curl/lib/curlx/snprintf.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7332520e7a2ddc148cc608f6d0713e2affd4c40"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cfilters.h-354",
+      "fileName": "repos/curl/lib/cfilters.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7546344af42253bf95afcfc9b3f97137b9f58eb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-dbg.c-355",
+      "fileName": "repos/curl/src/tool_cb_dbg.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c9c14e6d131100686fa2ad100a04cc36387ddfb9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-ipfs.h-356",
       "fileName": "repos/curl/src/tool_ipfs.h",
       "checksums": [
         {
@@ -3727,17 +3737,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cookie.h-356",
-      "fileName": "repos/curl/lib/vauth/../cookie.h",
+      "SPDXID": "SPDXRef-File-cf-https-connect.c-357",
+      "fileName": "repos/curl/lib/cf-https-connect.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cbc7b748fc2bdd54a8ca181de38a588092d627b6"
+          "checksumValue": "cabc6ab14b91b06716a3aff500006926c888754d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-helpers.h-357",
+      "SPDXID": "SPDXRef-File-tool-helpers.h-358",
       "fileName": "repos/curl/src/tool_helpers.h",
       "checksums": [
         {
@@ -3747,22 +3757,12 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-xattr.c-358",
-      "fileName": "repos/curl/src/tool_xattr.c",
+      "SPDXID": "SPDXRef-File-tftp.c-359",
+      "fileName": "repos/curl/lib/tftp.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cdf8296307a514ddc2b02fa330fa20e9959f3890"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-formdata.h-359",
-      "fileName": "repos/curl/lib/vauth/../formdata.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ce592a8fd9d02510d89a62834f9a155c37046873"
+          "checksumValue": "cc0769bbb3b540403cabba673445e372d182dd3e"
         }
       ]
     },
@@ -3772,12 +3772,22 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cec410fe6073b96d1f3b6b9dad1290cfeb700055"
+          "checksumValue": "cc0e04388714b1bfdd546682c0c62c2cdf3e305a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easy-lock.h-361",
+      "SPDXID": "SPDXRef-File-tool-xattr.c-361",
+      "fileName": "repos/curl/src/tool_xattr.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cdf8296307a514ddc2b02fa330fa20e9959f3890"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easy-lock.h-362",
       "fileName": "repos/curl/lib/easy_lock.h",
       "checksums": [
         {
@@ -3787,57 +3797,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostip.c-362",
-      "fileName": "repos/curl/lib/hostip.c",
+      "SPDXID": "SPDXRef-File-openssl.h-363",
+      "fileName": "repos/curl/lib/../lib/vtls/openssl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cfa7995dbac607c486a1a678abeb0dafd7858bfc"
+          "checksumValue": "cfffe9df1b6846b4dff5ed069d2ac98ca1274fdc"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-wrt.c-363",
-      "fileName": "repos/curl/src/tool_cb_wrt.c",
+      "SPDXID": "SPDXRef-File-easy.c-364",
+      "fileName": "repos/curl/lib/easy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "cfeb06d5a47539c94fb2aa9ad85ed0a6da285cae"
+          "checksumValue": "d05674e81959f74c083fb3a88b404c571d262ac8"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wolfssl.c-364",
-      "fileName": "repos/curl/lib/vtls/wolfssl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0311facb9ad9d21e18c1ba98fa79465cf328eb6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ntlm.c-365",
-      "fileName": "repos/curl/lib/vauth/ntlm.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0aae81b80e4e18879d6e8f0f1ccedcf5b60a801"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rtsp.c-366",
-      "fileName": "repos/curl/lib/rtsp.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0e5cf43e39d5069d19c6221b0e7b21d3df3c2d5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-terminal.c-367",
+      "SPDXID": "SPDXRef-File-terminal.c-365",
       "fileName": "repos/curl/src/terminal.c",
       "checksums": [
         {
@@ -3847,17 +3827,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-telnet.c-368",
-      "fileName": "repos/curl/lib/telnet.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d1b1d8fc5ea795e8ded96c492535f6ae70cd8b8d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-formparse.h-369",
+      "SPDXID": "SPDXRef-File-tool-formparse.h-366",
       "fileName": "repos/curl/src/tool_formparse.h",
       "checksums": [
         {
@@ -3867,17 +3837,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fopen.h-370",
-      "fileName": "repos/curl/lib/vtls/../curlx/fopen.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d23dc82445ddbf6573da449f58917ac77f55ef6e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-filetime.h-371",
+      "SPDXID": "SPDXRef-File-tool-filetime.h-367",
       "fileName": "repos/curl/src/tool_filetime.h",
       "checksums": [
         {
@@ -3887,7 +3847,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amigaos.c-372",
+      "SPDXID": "SPDXRef-File-amigaos.c-368",
       "fileName": "repos/curl/lib/amigaos.c",
       "checksums": [
         {
@@ -3897,7 +3857,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-progress.h-373",
+      "SPDXID": "SPDXRef-File-basename.c-369",
+      "fileName": "repos/curl/lib/curlx/basename.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d2fd160ff224360b5ee05b3190ec97b3aeb9b69f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-progress.h-370",
       "fileName": "repos/curl/src/tool_progress.h",
       "checksums": [
         {
@@ -3907,7 +3877,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-winapi.h-374",
+      "SPDXID": "SPDXRef-File-winapi.h-371",
       "fileName": "repos/curl/lib/curlx/winapi.h",
       "checksums": [
         {
@@ -3917,8 +3887,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-smb.h-375",
-      "fileName": "repos/curl/lib/vauth/../smb.h",
+      "SPDXID": "SPDXRef-File-smb.h-372",
+      "fileName": "repos/curl/lib/smb.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3927,38 +3897,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ws.h-376",
-      "fileName": "repos/curl/lib/ws.h",
+      "SPDXID": "SPDXRef-File-inet-pton.c-373",
+      "fileName": "repos/curl/lib/curlx/inet_pton.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d4d6d46f3a51d788c3b51343508fa7ede68bebef"
+          "checksumValue": "d3c53fb5791610415e125f5495d255a9b86671a6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gtls.c-377",
-      "fileName": "repos/curl/lib/vtls/gtls.c",
+      "SPDXID": "SPDXRef-File-cram.c-374",
+      "fileName": "repos/curl/lib/vauth/cram.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d6093cfe3063138c5105273359da38c73f08f31e"
+          "checksumValue": "d3f2d137b779607e37d9cc3453f7cb0bb2ffa8d3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostcheck.h-378",
-      "fileName": "repos/curl/lib/vtls/hostcheck.h",
+      "SPDXID": "SPDXRef-File-vssh.c-375",
+      "fileName": "repos/curl/lib/vssh/vssh.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d62c721352af1874753e9671e2dc424a9bc99f8f"
+          "checksumValue": "d499a633af4bdff71738d7d1905639c2accdae99"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcopy.h-379",
-      "fileName": "repos/curl/lib/vtls/../curlx/strcopy.h",
+      "SPDXID": "SPDXRef-File-snprintf.h-376",
+      "fileName": "repos/curl/lib/curlx/snprintf.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d6260e4e3931cd4cb8b59bd9407537f1d11d5620"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-strcopy.h-377",
+      "fileName": "repos/curl/lib/curlx/strcopy.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -3967,37 +3947,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi.c-380",
-      "fileName": "repos/curl/lib/urlapi.c",
+      "SPDXID": "SPDXRef-File-krb5-gssapi.c-378",
+      "fileName": "repos/curl/lib/vauth/krb5_gssapi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d6a790b06e5b6ede34788e685d54f72cb096200a"
+          "checksumValue": "d6af18f40b5b67d685354937f144eac932a7d66a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strcopy.c-381",
-      "fileName": "repos/curl/lib/curlx/strcopy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d6bff15330e9c8f81cb403f0d9ccbeeabb96d279"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-help.c-382",
-      "fileName": "repos/curl/src/tool_help.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d743fe395344a5d8094d9afb1401cf747491ef34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-dbg.h-383",
+      "SPDXID": "SPDXRef-File-tool-cb-dbg.h-379",
       "fileName": "repos/curl/src/tool_cb_dbg.h",
       "checksums": [
         {
@@ -4007,17 +3967,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-md4.c-384",
-      "fileName": "repos/curl/lib/md4.c",
+      "SPDXID": "SPDXRef-File-conncache.h-380",
+      "fileName": "repos/curl/lib/conncache.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d78f84282305ae7c46d2efa0083c2e16d6c13567"
+          "checksumValue": "d8626ae6928c49a828b18e660546491356083190"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-easyoptions.h-385",
+      "SPDXID": "SPDXRef-File-apple.h-381",
+      "fileName": "repos/curl/lib/../lib/vtls/apple.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d86a56b1f9320ec8e83818d402a0ed2a259c9ff2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-easyoptions.h-382",
       "fileName": "repos/curl/lib/easyoptions.h",
       "checksums": [
         {
@@ -4027,8 +3997,48 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-chunks.h-386",
-      "fileName": "repos/curl/lib/vauth/../http_chunks.h",
+      "SPDXID": "SPDXRef-File-fopen.h-383",
+      "fileName": "repos/curl/lib/curlx/fopen.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d89830edd30eea66d9f5ca00d757c81d2a0f6aa6"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-mbedtls.h-384",
+      "fileName": "repos/curl/lib/../lib/vtls/mbedtls.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8a0a06eb6aac22289e2b91fcad3a7164b77f9ae"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-fake-addrinfo.c-385",
+      "fileName": "repos/curl/lib/fake_addrinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8b139830b83af600dfee6cb4d9b519e898bb221"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-hostcheck.h-386",
+      "fileName": "repos/curl/lib/../lib/vtls/hostcheck.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8e1a52377129c86dedf7a2252f59b400631adfa"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-http-chunks.h-387",
+      "fileName": "repos/curl/lib/http_chunks.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4037,47 +4047,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h2-proxy.c-387",
-      "fileName": "repos/curl/lib/cf-h2-proxy.c",
+      "SPDXID": "SPDXRef-File-curl-quiche.c-388",
+      "fileName": "repos/curl/lib/vquic/curl_quiche.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d95716eaff9a5acdd1b25f40ad3d4511bbf7cffe"
+          "checksumValue": "d8e6b30f84bc2997e95705a1b22c66c79dc90ac7"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strerr.c-388",
-      "fileName": "repos/curl/lib/curlx/strerr.c",
+      "SPDXID": "SPDXRef-File-vtls-spack.c-389",
+      "fileName": "repos/curl/lib/vtls/vtls_spack.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d9c1686e443928c9eef4908414a6f1b554baac5f"
+          "checksumValue": "d96f4e41bd720d08ef2ffc476cb41c5e2324c736"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi.h-389",
-      "fileName": "repos/curl/lib/../include/curl/urlapi.h",
+      "SPDXID": "SPDXRef-File-typecheck-gcc.h-390",
+      "fileName": "repos/curl/lib/../include/curl/typecheck-gcc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "dabe44a47d0d3f73dda0ed97c09c21b0668b825f"
+          "checksumValue": "d9a672ea0b782448bc795a1bc5fdf2524f572442"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cfilters.c-390",
-      "fileName": "repos/curl/lib/cfilters.c",
+      "SPDXID": "SPDXRef-File-strcopy.c-391",
+      "fileName": "repos/curl/lib/curlx/strcopy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "db8efcf2fe867dea43f16d24d30fd3c2c9f1b649"
+          "checksumValue": "da137c3f92cf39033c1d3b053408ec375eb829d3"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal.h-391",
+      "SPDXID": "SPDXRef-File-http-chunks.c-392",
+      "fileName": "repos/curl/lib/http_chunks.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "db650b1e1e645b6e0a68dd08e362af7ed5c95b62"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-terminal.h-393",
       "fileName": "repos/curl/src/terminal.h",
       "checksums": [
         {
@@ -4087,28 +4107,18 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic-int.h-392",
-      "fileName": "repos/curl/lib/vquic/vquic_int.h",
+      "SPDXID": "SPDXRef-File-splay.c-394",
+      "fileName": "repos/curl/lib/splay.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "dbe1fca777a1295aa077a413e8374d389977d550"
+          "checksumValue": "ddab7a4d6e2cfabc69e686311b9784921a814f24"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apple.h-393",
-      "fileName": "repos/curl/lib/vtls/apple.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "dd1b5db357658b0dae9cc6956dd3c1b5af62a760"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-sha512-256.h-394",
-      "fileName": "repos/curl/lib/vauth/../curl_sha512_256.h",
+      "SPDXID": "SPDXRef-File-curl-sha512-256.h-395",
+      "fileName": "repos/curl/lib/curl_sha512_256.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4117,8 +4127,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi-ev.h-395",
-      "fileName": "repos/curl/lib/vauth/../multi_ev.h",
+      "SPDXID": "SPDXRef-File-multi-ev.h-396",
+      "fileName": "repos/curl/lib/multi_ev.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4127,7 +4137,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-libinfo.h-396",
+      "SPDXID": "SPDXRef-File-tool-libinfo.h-397",
       "fileName": "repos/curl/src/tool_libinfo.h",
       "checksums": [
         {
@@ -4137,7 +4147,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-https-connect.h-397",
+      "SPDXID": "SPDXRef-File-curl-fnmatch.c-398",
+      "fileName": "repos/curl/lib/curl_fnmatch.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dde956c3ac2aa213e1d68c3c72a3b679bb0759bb"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-pop3.c-399",
+      "fileName": "repos/curl/lib/pop3.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "de704d11e1a9f1c93b0f2d105a0a3a1e8ad33981"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-getinfo.c-400",
+      "fileName": "repos/curl/lib/getinfo.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dedafd382e5dc44a55e5a148d7df3e27a26fcfd2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-cf-https-connect.h-401",
       "fileName": "repos/curl/lib/cf-https-connect.h",
       "checksums": [
         {
@@ -4147,27 +4187,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-functypes.h-398",
-      "fileName": "repos/curl/lib/vauth/../functypes.h",
+      "SPDXID": "SPDXRef-File-cf-ip-happy.c-402",
+      "fileName": "repos/curl/lib/cf-ip-happy.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "df3cfd44c88f3f254dfa1907c1673192b326fd8a"
+          "checksumValue": "dfbf4ae183b528a80f73e5a256768b2fefe05ed9"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ntlm-sspi.c-399",
-      "fileName": "repos/curl/lib/vauth/ntlm_sspi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e0a0bebec3e0eff4f496092cded290fdc9a8383a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-operhlp.c-400",
+      "SPDXID": "SPDXRef-File-tool-operhlp.c-403",
       "fileName": "repos/curl/src/tool_operhlp.c",
       "checksums": [
         {
@@ -4177,47 +4207,57 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-setup.h-401",
-      "fileName": "repos/curl/src/tool_setup.h",
+      "SPDXID": "SPDXRef-File-hsts.h-404",
+      "fileName": "repos/curl/lib/hsts.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e113de8ddae2cc41de16a38adb5c835d4addddb1"
+          "checksumValue": "e0f6363bb355072fdc5a92289c48ce806bf60829"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timediff.h-402",
-      "fileName": "repos/curl/lib/vauth/../curlx/timediff.h",
+      "SPDXID": "SPDXRef-File-vquic-tls.c-405",
+      "fileName": "repos/curl/lib/vquic/vquic-tls.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e19b0f4403a1138b7b789e612cb7aa9c29b3cfce"
+          "checksumValue": "e135ac517417add98a34ca092f980e5a84e62556"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-hdr.c-403",
-      "fileName": "repos/curl/src/tool_cb_hdr.c",
+      "SPDXID": "SPDXRef-File-http2.c-406",
+      "fileName": "repos/curl/lib/http2.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e22c59694cf579f73ef16092da359d8105663ec7"
+          "checksumValue": "e1c57986e81c2c02ca6b7b1f3527892c7a043e00"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uint-hash.c-404",
-      "fileName": "repos/curl/lib/uint-hash.c",
+      "SPDXID": "SPDXRef-File-tool-cb-see.c-407",
+      "fileName": "repos/curl/src/tool_cb_see.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e23d249d0571390fc6cc988a2c5502b586140c93"
+          "checksumValue": "e1ebd8d99f65b9e5533971b56b2d69c8b1ca5f31"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-psl.c-405",
+      "SPDXID": "SPDXRef-File-ldap.c-408",
+      "fileName": "repos/curl/lib/ldap.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e223078b03701d19b4e53853082321686570e064"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-psl.c-409",
       "fileName": "repos/curl/lib/psl.c",
       "checksums": [
         {
@@ -4227,17 +4267,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hsts.h-406",
-      "fileName": "repos/curl/lib/hsts.h",
+      "SPDXID": "SPDXRef-File-dynhds.h-410",
+      "fileName": "repos/curl/lib/dynhds.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e2c9922f18ef955b590a6c07f9cca35247936ef2"
+          "checksumValue": "e30eb457257d34fb243073e0b8aeea0121da342f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-cb-see.h-407",
+      "SPDXID": "SPDXRef-File-tool-getparam.h-411",
+      "fileName": "repos/curl/src/tool_getparam.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e3cbe5454a6d429232396e87796b0a1f724be220"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-cb-see.h-412",
       "fileName": "repos/curl/src/tool_cb_see.h",
       "checksums": [
         {
@@ -4247,17 +4297,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cf-h1-proxy.h-408",
-      "fileName": "repos/curl/lib/cf-h1-proxy.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e48d827825d3ebeeac1bd65fd9eb305b2e845106"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-rtmp.h-409",
+      "SPDXID": "SPDXRef-File-curl-rtmp.h-413",
       "fileName": "repos/curl/lib/curl_rtmp.h",
       "checksums": [
         {
@@ -4267,47 +4307,27 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-md5.c-410",
-      "fileName": "repos/curl/lib/md5.c",
+      "SPDXID": "SPDXRef-File-mqtt.c-414",
+      "fileName": "repos/curl/lib/mqtt.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e5a4f534c7cf50d0f52497b377077f228124c2df"
+          "checksumValue": "e591cfcf0100533bdba5a8d6bb42d1f96a85922f"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-setopt.c-411",
-      "fileName": "repos/curl/lib/setopt.c",
+      "SPDXID": "SPDXRef-File-tool-getparam.c-415",
+      "fileName": "repos/curl/src/tool_getparam.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e6476dfaf30c2413e630ccd8f20714ec81dcf130"
+          "checksumValue": "e6e641923beef9abf9cd6b0db2cda306f95ea244"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hostip.h-412",
-      "fileName": "repos/curl/lib/vauth/../hostip.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e70eac841bf2f1181598e9e3fbeaf6602338a086"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-header.h-413",
-      "fileName": "repos/curl/lib/../include/curl/header.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e7334b5a3a4d35f9d23fc47a4d9826370b0dc0c5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-content-encoding.h-414",
+      "SPDXID": "SPDXRef-File-content-encoding.h-416",
       "fileName": "repos/curl/lib/content_encoding.h",
       "checksums": [
         {
@@ -4317,7 +4337,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-operhlp.h-415",
+      "SPDXID": "SPDXRef-File-mime.h-417",
+      "fileName": "repos/curl/lib/mime.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e84f04051b534a0230881cfc810d6b2f53cd1988"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-operhlp.h-418",
       "fileName": "repos/curl/src/tool_operhlp.h",
       "checksums": [
         {
@@ -4327,37 +4357,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-setopt.h-416",
-      "fileName": "repos/curl/src/tool_setopt.h",
+      "SPDXID": "SPDXRef-File-parsedate.h-419",
+      "fileName": "repos/curl/lib/parsedate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "e990f08a81a3b4624d7280010f2de7f865ff2216"
+          "checksumValue": "ea136bd30158437fe88efbeb88541aceb44099e6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-proxy.c-417",
-      "fileName": "repos/curl/lib/http_proxy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e9dfb8dbb3bd7a583b8744f4ec1d51589ec58971"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-aws-sigv4.c-418",
-      "fileName": "repos/curl/lib/http_aws_sigv4.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ea1a7ff758b2e51a0ccefdc23e8c38adf5403f56"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-msgs.h-419",
+      "SPDXID": "SPDXRef-File-tool-msgs.h-420",
       "fileName": "repos/curl/src/tool_msgs.h",
       "checksums": [
         {
@@ -4367,37 +4377,47 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-digest.c-420",
-      "fileName": "repos/curl/lib/vauth/digest.c",
+      "SPDXID": "SPDXRef-File-tool-cb-rea.c-421",
+      "fileName": "repos/curl/src/tool_cb_rea.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ec82564d2c96834058dc2224aee55e9a1fe22e45"
+          "checksumValue": "eb23f9b907be53e106db188288f0025971daa45c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keylog.h-421",
-      "fileName": "repos/curl/lib/vtls/keylog.h",
+      "SPDXID": "SPDXRef-File-url.c-422",
+      "fileName": "repos/curl/lib/url.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ec82abf547f08b9914e4f4a05c353f454f737dd7"
+          "checksumValue": "ec0457bcdd6f2aacbc5f188aa81955f3654a4ab4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gtls.h-422",
-      "fileName": "repos/curl/lib/vtls/gtls.h",
+      "SPDXID": "SPDXRef-File-cw-pause.c-423",
+      "fileName": "repos/curl/lib/cw-pause.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "ecdca0a666a5fd27e2ff82e61f0fec3fdfb72ceb"
+          "checksumValue": "ec611879d1e8a2c378e2302259a667004694b6d6"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock.h-423",
+      "SPDXID": "SPDXRef-File-noproxy.c-424",
+      "fileName": "repos/curl/lib/noproxy.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ee03fd35b9f1ae4f60e2d639d51003da71537077"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-nonblock.h-425",
       "fileName": "repos/curl/lib/curlx/nonblock.h",
       "checksums": [
         {
@@ -4407,17 +4427,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ftp.h-424",
-      "fileName": "repos/curl/lib/vauth/../ftp.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ef1aacb40c89e42c2ff0f57ebfdc4888bfe1187f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tool-cb-soc.h-425",
+      "SPDXID": "SPDXRef-File-tool-cb-soc.h-426",
       "fileName": "repos/curl/src/tool_cb_soc.h",
       "checksums": [
         {
@@ -4427,27 +4437,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strparse.c-426",
-      "fileName": "repos/curl/lib/curlx/strparse.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f11b58b7eee5e24474be34e836a9c79b0533b18e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl.h-427",
-      "fileName": "repos/curl/lib/../include/curl/curl.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f14f887261b4af00e74e4b499539a4d2b13639a9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-gethostname.c-428",
+      "SPDXID": "SPDXRef-File-curl-gethostname.c-427",
       "fileName": "repos/curl/lib/curl_gethostname.c",
       "checksums": [
         {
@@ -4457,7 +4447,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-imap.h-429",
+      "SPDXID": "SPDXRef-File-imap.h-428",
       "fileName": "repos/curl/lib/imap.h",
       "checksums": [
         {
@@ -4467,37 +4457,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-addrinfo.c-430",
-      "fileName": "repos/curl/lib/curl_addrinfo.c",
+      "SPDXID": "SPDXRef-File-digest-sspi.c-429",
+      "fileName": "repos/curl/lib/vauth/digest_sspi.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f1eaa6bcb604ac242c6504fbba601ca28a170454"
+          "checksumValue": "f29e569cd1801053bc2c72a67599c7be7dc0426a"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connect.h-431",
-      "fileName": "repos/curl/lib/vtls/../connect.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f2b9911073b94df6c1a4770977e45fbd9bd228e8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sendf.c-432",
-      "fileName": "repos/curl/lib/sendf.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f2d30a4269a1eb8b78a0fadf0290f248564a8c34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slist-wc.c-433",
+      "SPDXID": "SPDXRef-File-slist-wc.c-430",
       "fileName": "repos/curl/src/slist_wc.c",
       "checksums": [
         {
@@ -4507,37 +4477,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asyn-base.c-434",
-      "fileName": "repos/curl/lib/asyn-base.c",
+      "SPDXID": "SPDXRef-File-tool-easysrc.h-431",
+      "fileName": "repos/curl/src/tool_easysrc.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f35e1c988c3f683e0eea38fe13ab25c1d2d7b41f"
+          "checksumValue": "f37ce4ba86f556a6b6fc3074d8a1ad4366f9a222"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-url.c-435",
-      "fileName": "repos/curl/lib/url.c",
+      "SPDXID": "SPDXRef-File-curl-addrinfo.h-432",
+      "fileName": "repos/curl/lib/curl_addrinfo.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f3b24c9de24e17eba9e0317f480d91ef8680dd45"
+          "checksumValue": "f464b5ed7898c5264b5833025c6d409e44c7fb4d"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vquic.h-436",
-      "fileName": "repos/curl/lib/vquic/vquic.h",
+      "SPDXID": "SPDXRef-File-tool-parsecfg.c-433",
+      "fileName": "repos/curl/src/tool_parsecfg.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "f5392eb04797f7f2d55d4120d6cc4d3c095f0d1e"
+          "checksumValue": "f5910f404e77a43a7f19f862e298e3cce0031e85"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-http-digest.c-437",
+      "SPDXID": "SPDXRef-File-http-digest.c-434",
       "fileName": "repos/curl/lib/http_digest.c",
       "checksums": [
         {
@@ -4547,7 +4517,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getinfo.h-438",
+      "SPDXID": "SPDXRef-File-getinfo.h-435",
       "fileName": "repos/curl/lib/getinfo.h",
       "checksums": [
         {
@@ -4557,12 +4527,42 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-threads.c-439",
+      "SPDXID": "SPDXRef-File-curl-threads.c-436",
       "fileName": "repos/curl/lib/curl_threads.c",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "f5fea9804693e1eee1faae8c48e1b2625e014730"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-tool-urlglob.c-437",
+      "fileName": "repos/curl/src/tool_urlglob.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f62d9738ec081a16f19fb34d68501aec22817bb2"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-vtls.c-438",
+      "fileName": "repos/curl/lib/vtls/vtls.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f7201d18d6507d9f7d076928385d1304bff16dd1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-urlapi.h-439",
+      "fileName": "repos/curl/lib/../include/curl/urlapi.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f7a42b3b9e0f526a36ae326f3ac3fc82a366de08"
         }
       ]
     },
@@ -4588,7 +4588,7 @@
     },
     {
       "SPDXID": "SPDXRef-File-curl-ntlm-core.h-442",
-      "fileName": "repos/curl/lib/vauth/../curl_ntlm_core.h",
+      "fileName": "repos/curl/lib/curl_ntlm_core.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4597,18 +4597,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tool-easysrc.h-443",
-      "fileName": "repos/curl/src/tool_easysrc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f9ddacfc3779d941303f0c6e8b4fe277ae4858ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-curl-endian.h-444",
-      "fileName": "repos/curl/lib/vauth/../curl_endian.h",
+      "SPDXID": "SPDXRef-File-curl-endian.h-443",
+      "fileName": "repos/curl/lib/curl_endian.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -4617,47 +4607,37 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curl-sha512-256.c-445",
-      "fileName": "repos/curl/lib/curl_sha512_256.c",
+      "SPDXID": "SPDXRef-File-cookie.h-444",
+      "fileName": "repos/curl/lib/cookie.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fa568b6b041ddb9cc2f7150cfdaef906f38c25ab"
+          "checksumValue": "fabd04d3989bb9fdb078ef57321f884ca7c699b4"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-urlapi-int.h-446",
-      "fileName": "repos/curl/lib/urlapi-int.h",
+      "SPDXID": "SPDXRef-File-basename.h-445",
+      "fileName": "repos/curl/lib/curlx/basename.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fbce1837ff94fb6c74d47847f687a53332edfeca"
+          "checksumValue": "fb79fed8053dac80b2a526801fce9d6e7cec43c1"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inet-pton.h-447",
-      "fileName": "repos/curl/lib/vtls/../curlx/inet_pton.h",
+      "SPDXID": "SPDXRef-File-tool-cb-hdr.c-446",
+      "fileName": "repos/curl/src/tool_cb_hdr.c",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fc3ae3d2bb2c20dd9beff7fc3c369addd15f9c94"
+          "checksumValue": "fc03cf143b95a8451c20f326fbdd338693833331"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cleartext.c-448",
-      "fileName": "repos/curl/lib/vauth/cleartext.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fc8a6ebd5102516803695f3bdd91cc94100eed3d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.c-449",
+      "SPDXID": "SPDXRef-File-dict.c-447",
       "fileName": "repos/curl/lib/dict.c",
       "checksums": [
         {
@@ -4667,32 +4647,32 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-getinfo.c-450",
-      "fileName": "repos/curl/lib/getinfo.c",
+      "SPDXID": "SPDXRef-File-schannel.h-448",
+      "fileName": "repos/curl/lib/../lib/vtls/schannel.h",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "fd0d483f0a1137a94b0eb6cd5e3bd5043f2a4333"
+          "checksumValue": "fe49e9a9d0fb50eedb38e6873df19d66e1f89634"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pop3.c-451",
-      "fileName": "repos/curl/lib/pop3.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fdb09f232097032e1e1dfab45c98eaa4501065b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-http-ntlm.h-452",
+      "SPDXID": "SPDXRef-File-http-ntlm.h-449",
       "fileName": "repos/curl/lib/http_ntlm.h",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "ff5218d89f6cd740ceb878a6cd7c1e21047f2cf9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-select.h-450",
+      "fileName": "repos/curl/lib/select.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ffcd44cfcfc773158bcc47a6d422ddfb962b39c1"
         }
       ]
     }
@@ -4761,132 +4741,132 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idn.c-12"
+      "relatedSpdxElement": "SPDXRef-File-smb.c-12"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-scache.c-13"
+      "relatedSpdxElement": "SPDXRef-File-cf-socket.h-13"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.c-14"
+      "relatedSpdxElement": "SPDXRef-File-keylog.c-14"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multiif.h-15"
+      "relatedSpdxElement": "SPDXRef-File-hmac.c-15"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rustls.c-16"
+      "relatedSpdxElement": "SPDXRef-File-inet-pton.h-16"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.h-17"
+      "relatedSpdxElement": "SPDXRef-File-multiif.h-17"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ldap.c-18"
+      "relatedSpdxElement": "SPDXRef-File-hsts.c-18"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transfer.h-19"
+      "relatedSpdxElement": "SPDXRef-File-curl-md5.h-19"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-md4.h-20"
+      "relatedSpdxElement": "SPDXRef-File-imap.c-20"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.h-21"
+      "relatedSpdxElement": "SPDXRef-File-transfer.h-21"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-if2ip.c-22"
+      "relatedSpdxElement": "SPDXRef-File-curl-md4.h-22"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-typecheck-gcc.h-23"
+      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.h-23"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.h-24"
+      "relatedSpdxElement": "SPDXRef-File-if2ip.c-24"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-range.c-25"
+      "relatedSpdxElement": "SPDXRef-File-rustls.c-25"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.h-26"
+      "relatedSpdxElement": "SPDXRef-File-netrc.h-26"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getpass.h-27"
+      "relatedSpdxElement": "SPDXRef-File-system.h-27"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlinfo.c-28"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.h-28"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-macos.h-29"
+      "relatedSpdxElement": "SPDXRef-File-connect.h-29"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha256.h-30"
+      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.h-30"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-ntop.c-31"
+      "relatedSpdxElement": "SPDXRef-File-llist.h-31"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.c-32"
+      "relatedSpdxElement": "SPDXRef-File-tool-getpass.h-32"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.c-33"
+      "relatedSpdxElement": "SPDXRef-File-curlinfo.c-33"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cram.c-34"
+      "relatedSpdxElement": "SPDXRef-File-macos.h-34"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doh.h-35"
+      "relatedSpdxElement": "SPDXRef-File-tool-filetime.c-35"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setopt.h-36"
+      "relatedSpdxElement": "SPDXRef-File-easy.h-36"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smb.c-37"
+      "relatedSpdxElement": "SPDXRef-File-strdup.h-37"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -4901,22 +4881,22 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-thrdd.c-40"
+      "relatedSpdxElement": "SPDXRef-File-llist.c-40"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llist.c-41"
+      "relatedSpdxElement": "SPDXRef-File-netrc.c-41"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base64.c-42"
+      "relatedSpdxElement": "SPDXRef-File-timediff.h-42"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-formparse.c-43"
+      "relatedSpdxElement": "SPDXRef-File-rtsp.c-43"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -4926,747 +4906,747 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http1.h-45"
+      "relatedSpdxElement": "SPDXRef-File-ntlm-sspi.c-45"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-spnego-sspi.c-46"
+      "relatedSpdxElement": "SPDXRef-File-tool-time.c-46"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn.h-47"
+      "relatedSpdxElement": "SPDXRef-File-if2ip.h-47"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-if2ip.h-48"
+      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.c-48"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ntfy.c-49"
+      "relatedSpdxElement": "SPDXRef-File-strparse.c-49"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noproxy.c-50"
+      "relatedSpdxElement": "SPDXRef-File-curl-ctype.h-50"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sendf.h-51"
+      "relatedSpdxElement": "SPDXRef-File-tool-time.h-51"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ctype.h-52"
+      "relatedSpdxElement": "SPDXRef-File-httpsrr.c-52"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-time.h-53"
+      "relatedSpdxElement": "SPDXRef-File-http.c-53"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libssh2.c-54"
+      "relatedSpdxElement": "SPDXRef-File-md4.c-54"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsts.c-55"
+      "relatedSpdxElement": "SPDXRef-File-ssh.h-55"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-md5.h-56"
+      "relatedSpdxElement": "SPDXRef-File-system-win32.c-56"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpsrr.c-57"
+      "relatedSpdxElement": "SPDXRef-File-file.c-57"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-pton.c-58"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.c-58"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-msgs.c-59"
+      "relatedSpdxElement": "SPDXRef-File-curl-sspi.c-59"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.h-60"
+      "relatedSpdxElement": "SPDXRef-File-strerror.c-60"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-doswin.c-61"
+      "relatedSpdxElement": "SPDXRef-File-vquic.c-61"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cookie.c-62"
+      "relatedSpdxElement": "SPDXRef-File-spnego-sspi.c-62"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ratelimit.c-63"
+      "relatedSpdxElement": "SPDXRef-File-cipher-suite.c-63"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic.c-64"
+      "relatedSpdxElement": "SPDXRef-File-curl.h-64"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.c-65"
+      "relatedSpdxElement": "SPDXRef-File-ftp.h-65"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sspi.c-66"
+      "relatedSpdxElement": "SPDXRef-File-config2setopts.c-66"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llist.h-67"
+      "relatedSpdxElement": "SPDXRef-File-tool-formparse.c-67"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.h-68"
+      "relatedSpdxElement": "SPDXRef-File-easyif.h-68"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strdup.h-69"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout.c-69"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerror.c-70"
+      "relatedSpdxElement": "SPDXRef-File-tool-ssls.c-70"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.h-71"
+      "relatedSpdxElement": "SPDXRef-File-uint-hash.c-71"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlx.h-72"
+      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.h-72"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-spack.c-73"
+      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.h-73"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-printf.h-74"
+      "relatedSpdxElement": "SPDXRef-File-hash.h-74"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyif.h-75"
+      "relatedSpdxElement": "SPDXRef-File-easygetopt.c-75"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks-gssapi.c-76"
+      "relatedSpdxElement": "SPDXRef-File-tool-findfile.c-76"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ssls.c-77"
+      "relatedSpdxElement": "SPDXRef-File-cfilters.c-77"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.c-78"
+      "relatedSpdxElement": "SPDXRef-File-altsvc.h-78"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smtp.c-79"
+      "relatedSpdxElement": "SPDXRef-File-version-win32.c-79"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.h-80"
+      "relatedSpdxElement": "SPDXRef-File-urlapi-int.h-80"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-pause.c-81"
+      "relatedSpdxElement": "SPDXRef-File-socketpair.h-81"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.h-82"
+      "relatedSpdxElement": "SPDXRef-File-sockaddr.h-82"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snprintf.h-83"
+      "relatedSpdxElement": "SPDXRef-File-mbedtls.c-83"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easygetopt.c-84"
+      "relatedSpdxElement": "SPDXRef-File-timediff.c-84"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-select.h-85"
+      "relatedSpdxElement": "SPDXRef-File-ratelimit.c-85"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multibyte.h-86"
+      "relatedSpdxElement": "SPDXRef-File-idn.c-86"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout.c-87"
+      "relatedSpdxElement": "SPDXRef-File-inet-ntop.h-87"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-findfile.c-88"
+      "relatedSpdxElement": "SPDXRef-File-base64.h-88"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basename.c-89"
+      "relatedSpdxElement": "SPDXRef-File-cf-socket.c-89"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basename.h-90"
+      "relatedSpdxElement": "SPDXRef-File-cshutdn.c-90"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-socket.h-91"
+      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.h-91"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-helpers.c-92"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.c-92"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-scache.h-93"
+      "relatedSpdxElement": "SPDXRef-File-slist-wc.h-93"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wait.c-94"
+      "relatedSpdxElement": "SPDXRef-File-macos.c-94"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socketpair.h-95"
+      "relatedSpdxElement": "SPDXRef-File-curl-share.c-95"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockaddr.h-96"
+      "relatedSpdxElement": "SPDXRef-File-pingpong.h-96"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.c-97"
+      "relatedSpdxElement": "SPDXRef-File-formdata.h-97"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynhds.h-98"
+      "relatedSpdxElement": "SPDXRef-File-fileinfo.c-98"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rustls.h-99"
+      "relatedSpdxElement": "SPDXRef-File-winapi.c-99"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base64.h-100"
+      "relatedSpdxElement": "SPDXRef-File-altsvc.c-100"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.h-101"
+      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.c-101"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ntlm-core.c-102"
+      "relatedSpdxElement": "SPDXRef-File-formdata.c-102"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-system-win32.c-103"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.h-103"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setopt.c-104"
+      "relatedSpdxElement": "SPDXRef-File-mime.c-104"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-var.c-105"
+      "relatedSpdxElement": "SPDXRef-File-uint-table.h-105"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vauth.h-106"
+      "relatedSpdxElement": "SPDXRef-File-smtp.h-106"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.h-107"
+      "relatedSpdxElement": "SPDXRef-File-libssh.c-107"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.c-108"
+      "relatedSpdxElement": "SPDXRef-File-curl-printf.h-108"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-arpa-telnet.h-109"
+      "relatedSpdxElement": "SPDXRef-File-strdup.c-109"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transfer.c-110"
+      "relatedSpdxElement": "SPDXRef-File-config2setopts.h-110"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-macos.c-111"
+      "relatedSpdxElement": "SPDXRef-File-warnless.h-111"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic-tls.c-112"
+      "relatedSpdxElement": "SPDXRef-File-vauth.h-112"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pingpong.h-113"
+      "relatedSpdxElement": "SPDXRef-File-doh.h-113"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fileinfo.c-114"
+      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.c-114"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcase.h-115"
+      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.c-115"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.h-116"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout.h-116"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mbedtls.h-117"
+      "relatedSpdxElement": "SPDXRef-File-websockets.h-117"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-request.h-118"
+      "relatedSpdxElement": "SPDXRef-File-schannel-verify.c-118"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http.c-119"
+      "relatedSpdxElement": "SPDXRef-File-rand.c-119"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smtp.h-120"
+      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.c-120"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config2setopts.h-121"
+      "relatedSpdxElement": "SPDXRef-File-tool-ssls.h-121"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.c-122"
+      "relatedSpdxElement": "SPDXRef-File-timeval.c-122"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-socket.c-123"
+      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.c-123"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mbedtls.c-124"
+      "relatedSpdxElement": "SPDXRef-File-strerr.h-124"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.c-125"
+      "relatedSpdxElement": "SPDXRef-File-vtls-spack.h-125"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.c-126"
+      "relatedSpdxElement": "SPDXRef-File-doh.c-126"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-table.h-127"
+      "relatedSpdxElement": "SPDXRef-File-asyn-base.c-127"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-share.h-128"
+      "relatedSpdxElement": "SPDXRef-File-oauth2.c-128"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-share.c-129"
+      "relatedSpdxElement": "SPDXRef-File-slist.h-129"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout.h-130"
+      "relatedSpdxElement": "SPDXRef-File-tool-stderr.h-130"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-websockets.h-131"
+      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.c-131"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-imap.c-132"
+      "relatedSpdxElement": "SPDXRef-File-vssh.h-132"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idn.h-133"
+      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.c-133"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ssls.h-134"
+      "relatedSpdxElement": "SPDXRef-File-curl-ntlm-core.c-134"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerr.h-135"
+      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.h-135"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mqtt.c-136"
+      "relatedSpdxElement": "SPDXRef-File-uint-spbset.h-136"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-filetime.c-137"
+      "relatedSpdxElement": "SPDXRef-File-curl-trc.c-137"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memdebug.c-138"
+      "relatedSpdxElement": "SPDXRef-File-strerror.h-138"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-ntop.h-139"
+      "relatedSpdxElement": "SPDXRef-File-easyoptions.c-139"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http2.c-140"
+      "relatedSpdxElement": "SPDXRef-File-asyn-ares.c-140"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-hmac.h-141"
+      "relatedSpdxElement": "SPDXRef-File-cookie.c-141"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist.h-142"
+      "relatedSpdxElement": "SPDXRef-File-tool-ca-embed.c-142"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-stderr.h-143"
+      "relatedSpdxElement": "SPDXRef-File-pingpong.c-143"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeval.h-144"
+      "relatedSpdxElement": "SPDXRef-File-curl-setup.h-144"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-spbset.h-145"
+      "relatedSpdxElement": "SPDXRef-File-openssl.c-145"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connect.c-146"
+      "relatedSpdxElement": "SPDXRef-File-tool-help.c-146"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerror.h-147"
+      "relatedSpdxElement": "SPDXRef-File-bufref.c-147"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyoptions.c-148"
+      "relatedSpdxElement": "SPDXRef-File-strparse.h-148"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.c-149"
+      "relatedSpdxElement": "SPDXRef-File-socks.h-149"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getparam.h-150"
+      "relatedSpdxElement": "SPDXRef-File-wait.c-150"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vssh.h-151"
+      "relatedSpdxElement": "SPDXRef-File-vquic.h-151"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ca-embed.c-152"
+      "relatedSpdxElement": "SPDXRef-File-request.h-152"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config2setopts.c-153"
+      "relatedSpdxElement": "SPDXRef-File-tool-sdecls.h-153"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufref.c-154"
+      "relatedSpdxElement": "SPDXRef-File-strcase.h-154"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftp.c-155"
+      "relatedSpdxElement": "SPDXRef-File-hostip.c-155"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel-verify.c-156"
+      "relatedSpdxElement": "SPDXRef-File-cw-pause.h-156"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.h-157"
+      "relatedSpdxElement": "SPDXRef-File-cw-out.c-157"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.c-158"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.h-158"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multibyte.c-159"
+      "relatedSpdxElement": "SPDXRef-File-uint-hash.h-159"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.h-160"
+      "relatedSpdxElement": "SPDXRef-File-amigaos.h-160"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doh.c-161"
+      "relatedSpdxElement": "SPDXRef-File-uint-spbset.c-161"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-pause.h-162"
+      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.c-162"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.h-163"
+      "relatedSpdxElement": "SPDXRef-File-headers.c-163"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-setup.h-164"
+      "relatedSpdxElement": "SPDXRef-File-urldata.h-164"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher-suite.c-165"
+      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.c-165"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-hash.h-166"
+      "relatedSpdxElement": "SPDXRef-File-digest.h-166"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amigaos.h-167"
+      "relatedSpdxElement": "SPDXRef-File-telnet.c-167"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-trc.h-168"
+      "relatedSpdxElement": "SPDXRef-File-curlver.h-168"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-spbset.c-169"
+      "relatedSpdxElement": "SPDXRef-File-bufref.h-169"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-memrchr.c-170"
+      "relatedSpdxElement": "SPDXRef-File-ftplistparser.h-170"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-headers.c-171"
+      "relatedSpdxElement": "SPDXRef-File-tool-version.h-171"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.c-172"
+      "relatedSpdxElement": "SPDXRef-File-curl-share.h-172"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy.h-173"
+      "relatedSpdxElement": "SPDXRef-File-uint-bset.c-173"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x509asn1.c-174"
+      "relatedSpdxElement": "SPDXRef-File-http-digest.h-174"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curlver.h-175"
+      "relatedSpdxElement": "SPDXRef-File-warnless.c-175"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufref.h-176"
+      "relatedSpdxElement": "SPDXRef-File-ws.c-176"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-quiche.c-177"
+      "relatedSpdxElement": "SPDXRef-File-ftp.c-177"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-version.h-178"
+      "relatedSpdxElement": "SPDXRef-File-smtp.c-178"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-splay.c-179"
+      "relatedSpdxElement": "SPDXRef-File-http1.c-179"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http2.h-180"
+      "relatedSpdxElement": "SPDXRef-File-tool-util.c-180"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mime.h-181"
+      "relatedSpdxElement": "SPDXRef-File-multi.c-181"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-bset.c-182"
+      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.h-182"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-digest.h-183"
+      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.c-183"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-util.c-184"
+      "relatedSpdxElement": "SPDXRef-File-tool-findfile.h-184"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operate.c-185"
+      "relatedSpdxElement": "SPDXRef-File-libssh2.c-185"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.h-186"
+      "relatedSpdxElement": "SPDXRef-File-tool-progress.c-186"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.c-187"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.c-187"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-findfile.h-188"
+      "relatedSpdxElement": "SPDXRef-File-schannel.c-188"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.h-189"
+      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.h-189"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-progress.c-190"
+      "relatedSpdxElement": "SPDXRef-File-request.c-190"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-altsvc.c-191"
+      "relatedSpdxElement": "SPDXRef-File-vtls-int.h-191"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ngtcp2.c-192"
+      "relatedSpdxElement": "SPDXRef-File-tool-xattr.h-192"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-xattr.h-193"
+      "relatedSpdxElement": "SPDXRef-File-vtls-scache.c-193"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5676,27 +5656,27 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.c-195"
+      "relatedSpdxElement": "SPDXRef-File-asyn.h-195"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version.c-196"
+      "relatedSpdxElement": "SPDXRef-File-tool-getpass.c-196"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timediff.c-197"
+      "relatedSpdxElement": "SPDXRef-File-multi-ev.c-197"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-help.h-198"
+      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.c-198"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-krb5-gssapi.c-199"
+      "relatedSpdxElement": "SPDXRef-File-tool-help.h-199"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5706,97 +5686,97 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-quiche.h-201"
+      "relatedSpdxElement": "SPDXRef-File-http-negotiate.h-201"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-negotiate.h-202"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.c-202"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.h-203"
+      "relatedSpdxElement": "SPDXRef-File-hostip.h-203"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ws.c-204"
+      "relatedSpdxElement": "SPDXRef-File-progress.c-204"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http.h-205"
+      "relatedSpdxElement": "SPDXRef-File-fopen.c-205"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynbuf.h-206"
+      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.h-206"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-config.h-207"
+      "relatedSpdxElement": "SPDXRef-File-transfer.c-207"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-content-encoding.c-208"
+      "relatedSpdxElement": "SPDXRef-File-dynbuf.h-208"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-vms.c-209"
+      "relatedSpdxElement": "SPDXRef-File-nonblock.c-209"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noproxy.h-210"
+      "relatedSpdxElement": "SPDXRef-File-dynbuf.c-210"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urldata.h-211"
+      "relatedSpdxElement": "SPDXRef-File-multibyte.c-211"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.h-212"
+      "relatedSpdxElement": "SPDXRef-File-noproxy.h-212"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gopher.c-213"
+      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.h-213"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.h-214"
+      "relatedSpdxElement": "SPDXRef-File-gopher.c-214"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeval.c-215"
+      "relatedSpdxElement": "SPDXRef-File-tool-writeout-json.h-215"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wolfssl.h-216"
+      "relatedSpdxElement": "SPDXRef-File-fileinfo.h-216"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fileinfo.h-217"
+      "relatedSpdxElement": "SPDXRef-File-dynhds.c-217"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynhds.c-218"
+      "relatedSpdxElement": "SPDXRef-File-uint-bset.h-218"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-bset.h-219"
+      "relatedSpdxElement": "SPDXRef-File-tool-vms.c-219"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5816,177 +5796,177 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.c-223"
+      "relatedSpdxElement": "SPDXRef-File-ws.h-223"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strdup.c-224"
+      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.c-224"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pop3.h-225"
+      "relatedSpdxElement": "SPDXRef-File-sendf.h-225"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.c-226"
+      "relatedSpdxElement": "SPDXRef-File-socketpair.c-226"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tftp.c-227"
+      "relatedSpdxElement": "SPDXRef-File-pop3.h-227"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ssh.h-228"
+      "relatedSpdxElement": "SPDXRef-File-curl-config.h-228"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cshutdn.h-229"
+      "relatedSpdxElement": "SPDXRef-File-cf-haproxy.c-229"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multihandle.h-230"
+      "relatedSpdxElement": "SPDXRef-File-connect.c-230"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-krb5-sspi.c-231"
+      "relatedSpdxElement": "SPDXRef-File-cleartext.c-231"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist-wc.h-232"
+      "relatedSpdxElement": "SPDXRef-File-curlx.h-232"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-ldap.h-233"
+      "relatedSpdxElement": "SPDXRef-File-multihandle.h-233"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apple.c-234"
+      "relatedSpdxElement": "SPDXRef-File-sha256.c-234"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-progress.c-235"
+      "relatedSpdxElement": "SPDXRef-File-curl-ldap.h-235"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-out.h-236"
+      "relatedSpdxElement": "SPDXRef-File-version.c-236"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel.c-237"
+      "relatedSpdxElement": "SPDXRef-File-cw-out.h-237"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mime.c-238"
+      "relatedSpdxElement": "SPDXRef-File-keylog.h-238"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socketpair.c-239"
+      "relatedSpdxElement": "SPDXRef-File-tool-operate.h-239"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-ares.c-240"
+      "relatedSpdxElement": "SPDXRef-File-parsedate.c-240"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-doswin.h-241"
+      "relatedSpdxElement": "SPDXRef-File-var.c-241"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options.h-242"
+      "relatedSpdxElement": "SPDXRef-File-inet-ntop.c-242"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openldap.c-243"
+      "relatedSpdxElement": "SPDXRef-File-hash.c-243"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sasl.h-244"
+      "relatedSpdxElement": "SPDXRef-File-tool-doswin.h-244"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.h-245"
+      "relatedSpdxElement": "SPDXRef-File-options.h-245"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cshutdn.c-246"
+      "relatedSpdxElement": "SPDXRef-File-setopt.c-246"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-get-line.c-247"
+      "relatedSpdxElement": "SPDXRef-File-tool-dirhie.h-247"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-altsvc.h-248"
+      "relatedSpdxElement": "SPDXRef-File-headers.h-248"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.h-249"
+      "relatedSpdxElement": "SPDXRef-File-curl-get-line.c-249"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-listhelp.c-250"
+      "relatedSpdxElement": "SPDXRef-File-header.h-250"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-endian.c-251"
+      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.h-251"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-spack.h-252"
+      "relatedSpdxElement": "SPDXRef-File-tool-listhelp.c-252"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conncache.c-253"
+      "relatedSpdxElement": "SPDXRef-File-curl-endian.c-253"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getparam.c-254"
+      "relatedSpdxElement": "SPDXRef-File-rand.h-254"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest-sspi.c-255"
+      "relatedSpdxElement": "SPDXRef-File-multibyte.h-255"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.h-256"
+      "relatedSpdxElement": "SPDXRef-File-functypes.h-256"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-vms.h-257"
+      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.h-257"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -5996,7 +5976,7 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnless.h-259"
+      "relatedSpdxElement": "SPDXRef-File-curl-sasl.h-259"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -6011,492 +5991,492 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.h-262"
+      "relatedSpdxElement": "SPDXRef-File-bufq.h-262"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnless.c-263"
+      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.c-263"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls.c-264"
+      "relatedSpdxElement": "SPDXRef-File-httpsrr.h-264"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.c-265"
+      "relatedSpdxElement": "SPDXRef-File-cshutdn.h-265"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mprintf.c-266"
+      "relatedSpdxElement": "SPDXRef-File-idn.h-266"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpsrr.h-267"
+      "relatedSpdxElement": "SPDXRef-File-strerr.c-267"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest.h-268"
+      "relatedSpdxElement": "SPDXRef-File-tftp.h-268"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-sdecls.h-269"
+      "relatedSpdxElement": "SPDXRef-File-mprintf.h-269"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hmac.c-270"
+      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.h-270"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tftp.h-271"
+      "relatedSpdxElement": "SPDXRef-File-rtsp.h-271"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mprintf.h-272"
+      "relatedSpdxElement": "SPDXRef-File-sendf.c-272"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.h-273"
+      "relatedSpdxElement": "SPDXRef-File-gsasl.c-273"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rtsp.h-274"
+      "relatedSpdxElement": "SPDXRef-File-openldap.c-274"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operate.h-275"
+      "relatedSpdxElement": "SPDXRef-File-digest.c-275"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.c-276"
+      "relatedSpdxElement": "SPDXRef-File-socks-gssapi.c-276"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock.c-277"
+      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.c-277"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostcheck.c-278"
+      "relatedSpdxElement": "SPDXRef-File-curl-range.h-278"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-range.h-279"
+      "relatedSpdxElement": "SPDXRef-File-psl.h-279"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-psl.h-280"
+      "relatedSpdxElement": "SPDXRef-File-tool-setup.h-280"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strequal.c-281"
+      "relatedSpdxElement": "SPDXRef-File-select.c-281"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-netrc.h-282"
+      "relatedSpdxElement": "SPDXRef-File-tool-operate.c-282"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-getpass.c-283"
+      "relatedSpdxElement": "SPDXRef-File-wait.h-283"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedate.c-284"
+      "relatedSpdxElement": "SPDXRef-File-curl-range.c-284"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-chunks.c-285"
+      "relatedSpdxElement": "SPDXRef-File-tool-msgs.c-285"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conncache.h-286"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.h-286"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cfgable.h-287"
+      "relatedSpdxElement": "SPDXRef-File-progress.h-287"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist.c-288"
+      "relatedSpdxElement": "SPDXRef-File-strcase.c-288"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-prg.h-289"
+      "relatedSpdxElement": "SPDXRef-File-escape.h-289"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-progress.h-290"
+      "relatedSpdxElement": "SPDXRef-File-vauth.c-290"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http1.c-291"
+      "relatedSpdxElement": "SPDXRef-File-gtls.c-291"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-splay.h-292"
+      "relatedSpdxElement": "SPDXRef-File-http2.h-292"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcase.c-293"
+      "relatedSpdxElement": "SPDXRef-File-tool-helpers.c-293"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cfilters.h-294"
+      "relatedSpdxElement": "SPDXRef-File-file.h-294"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.c-295"
+      "relatedSpdxElement": "SPDXRef-File-strequal.c-295"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.c-296"
+      "relatedSpdxElement": "SPDXRef-File-urlapi.c-296"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pingpong.c-297"
+      "relatedSpdxElement": "SPDXRef-File-gtls.h-297"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.h-298"
+      "relatedSpdxElement": "SPDXRef-File-apple.c-298"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ev.c-299"
+      "relatedSpdxElement": "SPDXRef-File-http-negotiate.c-299"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-select.c-300"
+      "relatedSpdxElement": "SPDXRef-File-base64.c-300"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-system.h-301"
+      "relatedSpdxElement": "SPDXRef-File-curl-trc.h-301"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libssh.c-302"
+      "relatedSpdxElement": "SPDXRef-File-conncache.c-302"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-win32.h-303"
+      "relatedSpdxElement": "SPDXRef-File-http-proxy.c-303"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openssl.c-304"
+      "relatedSpdxElement": "SPDXRef-File-getenv.c-304"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-negotiate.c-305"
+      "relatedSpdxElement": "SPDXRef-File-content-encoding.c-305"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedate.h-306"
+      "relatedSpdxElement": "SPDXRef-File-wolfssl.c-306"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-oauth2.c-307"
+      "relatedSpdxElement": "SPDXRef-File-tool-doswin.c-307"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.c-308"
+      "relatedSpdxElement": "SPDXRef-File-hostcheck.c-308"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sigpipe.h-309"
+      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.h-309"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getenv.c-310"
+      "relatedSpdxElement": "SPDXRef-File-multi.h-310"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynbuf.c-311"
+      "relatedSpdxElement": "SPDXRef-File-tool-paramhlp.h-311"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-win32.c-312"
+      "relatedSpdxElement": "SPDXRef-File-memdebug.c-312"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cw-out.c-313"
+      "relatedSpdxElement": "SPDXRef-File-spnego-gssapi.c-313"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keylog.c-314"
+      "relatedSpdxElement": "SPDXRef-File-wolfssl.h-314"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.h-315"
+      "relatedSpdxElement": "SPDXRef-File-curl-sasl.c-315"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-headers.h-316"
+      "relatedSpdxElement": "SPDXRef-File-tool-vms.h-316"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.c-317"
+      "relatedSpdxElement": "SPDXRef-File-sigpipe.h-317"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strparse.h-318"
+      "relatedSpdxElement": "SPDXRef-File-ntlm.c-318"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-request.c-319"
+      "relatedSpdxElement": "SPDXRef-File-dict.h-319"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openssl.h-320"
+      "relatedSpdxElement": "SPDXRef-File-arpa-telnet.h-320"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftplistparser.h-321"
+      "relatedSpdxElement": "SPDXRef-File-x509asn1.c-321"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.c-322"
+      "relatedSpdxElement": "SPDXRef-File-rustls.h-322"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-time.c-323"
+      "relatedSpdxElement": "SPDXRef-File-curl-fopen.c-323"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-spnego-gssapi.c-324"
+      "relatedSpdxElement": "SPDXRef-File-socks.c-324"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sasl.c-325"
+      "relatedSpdxElement": "SPDXRef-File-vtls.h-325"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy.c-326"
+      "relatedSpdxElement": "SPDXRef-File-uint-table.c-326"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.c-327"
+      "relatedSpdxElement": "SPDXRef-File-vtls-scache.h-327"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vssh.c-328"
+      "relatedSpdxElement": "SPDXRef-File-curl-hmac.h-328"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formdata.c-329"
+      "relatedSpdxElement": "SPDXRef-File-tool-main.c-329"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.h-330"
+      "relatedSpdxElement": "SPDXRef-File-var.h-330"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fopen.c-331"
+      "relatedSpdxElement": "SPDXRef-File-http.h-331"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fopen.c-332"
+      "relatedSpdxElement": "SPDXRef-File-tool-setopt.h-332"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gsasl.c-333"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha256.h-333"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-table.c-334"
+      "relatedSpdxElement": "SPDXRef-File-gopher.h-334"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-netrc.c-335"
+      "relatedSpdxElement": "SPDXRef-File-tool-setopt.c-335"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-main.c-336"
+      "relatedSpdxElement": "SPDXRef-File-curl-fopen.h-336"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-var.h-337"
+      "relatedSpdxElement": "SPDXRef-File-escape.c-337"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-trc.c-338"
+      "relatedSpdxElement": "SPDXRef-File-timeval.h-338"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gopher.h-339"
+      "relatedSpdxElement": "SPDXRef-File-krb5-sspi.c-339"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufq.h-340"
+      "relatedSpdxElement": "SPDXRef-File-curl-gssapi.c-340"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-fopen.h-341"
+      "relatedSpdxElement": "SPDXRef-File-telnet.h-341"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vauth.c-342"
+      "relatedSpdxElement": "SPDXRef-File-http-proxy.h-342"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls.h-343"
+      "relatedSpdxElement": "SPDXRef-File-http1.h-343"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.c-344"
+      "relatedSpdxElement": "SPDXRef-File-md5.c-344"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-hugehelp.c-345"
+      "relatedSpdxElement": "SPDXRef-File-asyn-thrdd.c-345"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha256.c-346"
+      "relatedSpdxElement": "SPDXRef-File-setopt.h-346"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-winapi.c-347"
+      "relatedSpdxElement": "SPDXRef-File-version-win32.h-347"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gssapi.c-348"
+      "relatedSpdxElement": "SPDXRef-File-url.h-348"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-telnet.h-349"
+      "relatedSpdxElement": "SPDXRef-File-http-ntlm.c-349"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wait.h-350"
+      "relatedSpdxElement": "SPDXRef-File-splay.h-350"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-proxy.h-351"
+      "relatedSpdxElement": "SPDXRef-File-mprintf.c-351"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vtls-int.h-352"
+      "relatedSpdxElement": "SPDXRef-File-slist.c-352"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-ntlm.c-353"
+      "relatedSpdxElement": "SPDXRef-File-snprintf.c-353"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-schannel.h-354"
+      "relatedSpdxElement": "SPDXRef-File-cfilters.h-354"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.h-355"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.c-355"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cookie.h-356"
+      "relatedSpdxElement": "SPDXRef-File-tool-ipfs.h-356"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-helpers.h-357"
+      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.c-357"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-xattr.c-358"
+      "relatedSpdxElement": "SPDXRef-File-tool-helpers.h-358"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formdata.h-359"
+      "relatedSpdxElement": "SPDXRef-File-tftp.c-359"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -6506,397 +6486,397 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easy-lock.h-361"
+      "relatedSpdxElement": "SPDXRef-File-tool-xattr.c-361"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostip.c-362"
+      "relatedSpdxElement": "SPDXRef-File-easy-lock.h-362"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-wrt.c-363"
+      "relatedSpdxElement": "SPDXRef-File-openssl.h-363"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wolfssl.c-364"
+      "relatedSpdxElement": "SPDXRef-File-easy.c-364"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ntlm.c-365"
+      "relatedSpdxElement": "SPDXRef-File-terminal.c-365"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rtsp.c-366"
+      "relatedSpdxElement": "SPDXRef-File-tool-formparse.h-366"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.c-367"
+      "relatedSpdxElement": "SPDXRef-File-tool-filetime.h-367"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-telnet.c-368"
+      "relatedSpdxElement": "SPDXRef-File-amigaos.c-368"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-formparse.h-369"
+      "relatedSpdxElement": "SPDXRef-File-basename.c-369"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fopen.h-370"
+      "relatedSpdxElement": "SPDXRef-File-tool-progress.h-370"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-filetime.h-371"
+      "relatedSpdxElement": "SPDXRef-File-winapi.h-371"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amigaos.c-372"
+      "relatedSpdxElement": "SPDXRef-File-smb.h-372"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-progress.h-373"
+      "relatedSpdxElement": "SPDXRef-File-inet-pton.c-373"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-winapi.h-374"
+      "relatedSpdxElement": "SPDXRef-File-cram.c-374"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-smb.h-375"
+      "relatedSpdxElement": "SPDXRef-File-vssh.c-375"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ws.h-376"
+      "relatedSpdxElement": "SPDXRef-File-snprintf.h-376"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gtls.c-377"
+      "relatedSpdxElement": "SPDXRef-File-strcopy.h-377"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostcheck.h-378"
+      "relatedSpdxElement": "SPDXRef-File-krb5-gssapi.c-378"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcopy.h-379"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.h-379"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi.c-380"
+      "relatedSpdxElement": "SPDXRef-File-conncache.h-380"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strcopy.c-381"
+      "relatedSpdxElement": "SPDXRef-File-apple.h-381"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-help.c-382"
+      "relatedSpdxElement": "SPDXRef-File-easyoptions.h-382"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-dbg.h-383"
+      "relatedSpdxElement": "SPDXRef-File-fopen.h-383"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-md4.c-384"
+      "relatedSpdxElement": "SPDXRef-File-mbedtls.h-384"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-easyoptions.h-385"
+      "relatedSpdxElement": "SPDXRef-File-fake-addrinfo.c-385"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-chunks.h-386"
+      "relatedSpdxElement": "SPDXRef-File-hostcheck.h-386"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h2-proxy.c-387"
+      "relatedSpdxElement": "SPDXRef-File-http-chunks.h-387"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strerr.c-388"
+      "relatedSpdxElement": "SPDXRef-File-curl-quiche.c-388"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi.h-389"
+      "relatedSpdxElement": "SPDXRef-File-vtls-spack.c-389"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cfilters.c-390"
+      "relatedSpdxElement": "SPDXRef-File-typecheck-gcc.h-390"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.h-391"
+      "relatedSpdxElement": "SPDXRef-File-strcopy.c-391"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic-int.h-392"
+      "relatedSpdxElement": "SPDXRef-File-http-chunks.c-392"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apple.h-393"
+      "relatedSpdxElement": "SPDXRef-File-terminal.h-393"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.h-394"
+      "relatedSpdxElement": "SPDXRef-File-splay.c-394"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi-ev.h-395"
+      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.h-395"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.h-396"
+      "relatedSpdxElement": "SPDXRef-File-multi-ev.h-396"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.h-397"
+      "relatedSpdxElement": "SPDXRef-File-tool-libinfo.h-397"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-functypes.h-398"
+      "relatedSpdxElement": "SPDXRef-File-curl-fnmatch.c-398"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ntlm-sspi.c-399"
+      "relatedSpdxElement": "SPDXRef-File-pop3.c-399"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.c-400"
+      "relatedSpdxElement": "SPDXRef-File-getinfo.c-400"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setup.h-401"
+      "relatedSpdxElement": "SPDXRef-File-cf-https-connect.h-401"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timediff.h-402"
+      "relatedSpdxElement": "SPDXRef-File-cf-ip-happy.c-402"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.c-403"
+      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.c-403"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uint-hash.c-404"
+      "relatedSpdxElement": "SPDXRef-File-hsts.h-404"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-psl.c-405"
+      "relatedSpdxElement": "SPDXRef-File-vquic-tls.c-405"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsts.h-406"
+      "relatedSpdxElement": "SPDXRef-File-http2.c-406"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.h-407"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.c-407"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cf-h1-proxy.h-408"
+      "relatedSpdxElement": "SPDXRef-File-ldap.c-408"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.h-409"
+      "relatedSpdxElement": "SPDXRef-File-psl.c-409"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-md5.c-410"
+      "relatedSpdxElement": "SPDXRef-File-dynhds.h-410"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setopt.c-411"
+      "relatedSpdxElement": "SPDXRef-File-tool-getparam.h-411"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hostip.h-412"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-see.h-412"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-header.h-413"
+      "relatedSpdxElement": "SPDXRef-File-curl-rtmp.h-413"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-content-encoding.h-414"
+      "relatedSpdxElement": "SPDXRef-File-mqtt.c-414"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.h-415"
+      "relatedSpdxElement": "SPDXRef-File-tool-getparam.c-415"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-setopt.h-416"
+      "relatedSpdxElement": "SPDXRef-File-content-encoding.h-416"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-proxy.c-417"
+      "relatedSpdxElement": "SPDXRef-File-mime.h-417"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-aws-sigv4.c-418"
+      "relatedSpdxElement": "SPDXRef-File-tool-operhlp.h-418"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-msgs.h-419"
+      "relatedSpdxElement": "SPDXRef-File-parsedate.h-419"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-digest.c-420"
+      "relatedSpdxElement": "SPDXRef-File-tool-msgs.h-420"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keylog.h-421"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-rea.c-421"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gtls.h-422"
+      "relatedSpdxElement": "SPDXRef-File-url.c-422"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock.h-423"
+      "relatedSpdxElement": "SPDXRef-File-cw-pause.c-423"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ftp.h-424"
+      "relatedSpdxElement": "SPDXRef-File-noproxy.c-424"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-cb-soc.h-425"
+      "relatedSpdxElement": "SPDXRef-File-nonblock.h-425"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strparse.c-426"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-soc.h-426"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl.h-427"
+      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.c-427"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-gethostname.c-428"
+      "relatedSpdxElement": "SPDXRef-File-imap.h-428"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-imap.h-429"
+      "relatedSpdxElement": "SPDXRef-File-digest-sspi.c-429"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.c-430"
+      "relatedSpdxElement": "SPDXRef-File-slist-wc.c-430"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connect.h-431"
+      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.h-431"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sendf.c-432"
+      "relatedSpdxElement": "SPDXRef-File-curl-addrinfo.h-432"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slist-wc.c-433"
+      "relatedSpdxElement": "SPDXRef-File-tool-parsecfg.c-433"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asyn-base.c-434"
+      "relatedSpdxElement": "SPDXRef-File-http-digest.c-434"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.c-435"
+      "relatedSpdxElement": "SPDXRef-File-getinfo.h-435"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vquic.h-436"
+      "relatedSpdxElement": "SPDXRef-File-curl-threads.c-436"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-digest.c-437"
+      "relatedSpdxElement": "SPDXRef-File-tool-urlglob.c-437"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getinfo.h-438"
+      "relatedSpdxElement": "SPDXRef-File-vtls.c-438"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-threads.c-439"
+      "relatedSpdxElement": "SPDXRef-File-urlapi.h-439"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
@@ -6916,52 +6896,42 @@
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tool-easysrc.h-443"
+      "relatedSpdxElement": "SPDXRef-File-curl-endian.h-443"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-endian.h-444"
+      "relatedSpdxElement": "SPDXRef-File-cookie.h-444"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curl-sha512-256.c-445"
+      "relatedSpdxElement": "SPDXRef-File-basename.h-445"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-urlapi-int.h-446"
+      "relatedSpdxElement": "SPDXRef-File-tool-cb-hdr.c-446"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inet-pton.h-447"
+      "relatedSpdxElement": "SPDXRef-File-dict.c-447"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cleartext.c-448"
+      "relatedSpdxElement": "SPDXRef-File-schannel.h-448"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.c-449"
+      "relatedSpdxElement": "SPDXRef-File-http-ntlm.h-449"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-getinfo.c-450"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pop3.c-451"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-http-ntlm.h-452"
+      "relatedSpdxElement": "SPDXRef-File-select.h-450"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Update curl golden SPDX files to match the pinned `curl-8_19_0` tag build. Previous golden files were built from `master` branch (build log `2026-03-19_2312`).

### Changes (user-reviewed and approved)

- **3 QUIC headers removed**: `curl-ngtcp2.h`, `curl-quiche.h`, `vquic-int.h`
- **1 source file added**: `snprintf.c`
- **Version**: `8.19.0-DEV` → `8.19.0` (intentional `-DEV` stripping)
- **Package rename**: `libcurl4` → `libcurl` (in `curl_build.spdx.json`)
- **Net CONTAINS relationships**: 441 → 439 (−3 removed, +1 added)

All 108 regression tests pass after update.
