### PR TITLE
chore: expand markdown formatting rules and fix underscore rendering

### DIFF
--- a/.windsurf/rules/code-standards/markdown-formatting.md
+++ b/.windsurf/rules/code-standards/markdown-formatting.md
@@ -1,18 +1,21 @@
 ---
-description: Markdown formatting rule for lists and code blocks after colons
+description: Comprehensive markdown formatting rules for all generated .md files
 ---
 
-# Markdown Formatting Rule
+# Markdown Formatting Rules
 
-When generating markdown documents, **always add a blank line after any line ending with ":**"** before lists, code blocks, or other formatted content.
+All rules below apply to every markdown file Cascade generates or edits.
+Violations break rendering in GitHub, VS Code preview, and other standard markdown viewers.
 
-## Why This Matters
+---
 
-Without a blank line after ":**", the subsequent list or code block will not render correctly in most markdown parsers.
+## Rule 1: Blank Line After Colon Lines
 
-## Examples
+**Always add a blank line after any line ending with `:**`** before lists, code blocks, or other formatted content.
 
-### Incorrect (no newline):
+Without a blank line, the subsequent content will not render correctly.
+
+**Incorrect:**
 
 ```markdown
 **What it captures:**
@@ -20,7 +23,7 @@ Without a blank line after ":**", the subsequent list or code block will not ren
 - Item 2
 ```
 
-### Correct (with newline):
+**Correct:**
 
 ```markdown
 **What it captures:**
@@ -29,13 +32,239 @@ Without a blank line after ":**", the subsequent list or code block will not ren
 - Item 2
 ```
 
-## Rule Application
+---
+
+## Rule 2: Code Fences MUST Have a Language Identifier
+
+**NEVER use bare triple-backtick fences.** Every fenced code block must specify a language.
+
+**Incorrect:**
+
+````markdown
+```
+some content here
+```
+````
+
+**Correct — use the appropriate language:**
+
+- `bash` — shell commands, scripts
+- `c` — C source code
+- `python` — Python source code
+- `yaml` — YAML config files
+- `json` — JSON data
+- `text` — plain text output, logs, syscall lists, or anything that is not code
+- `toml`, `sql`, `html`, `css`, `js`, etc. — use the matching language
+
+If the content is not code but also not prose (e.g., a list of syscall names, log output, file paths), use `text`.
+
+---
+
+## Rule 3: NO ASCII Art Diagrams in Markdown
+
+**NEVER use box-drawing characters** (e.g., `┌`, `│`, `└`, `─`, `▼`, `├`) to create diagrams in markdown files. They render incorrectly in most viewers due to font width inconsistencies.
+
+**Instead, use one of:**
+
+- **Markdown tables** — for structured data, flows, property lists
+- **Numbered/bulleted lists** — for sequential steps or hierarchies
+- **Draw.io `.drawio` files** — for actual visual diagrams (per the Draw.io rule)
+
+**Incorrect:**
+
+````markdown
+```
+┌──────────┐     ┌──────────┐
+│  Step 1  │────▶│  Step 2  │
+└──────────┘     └──────────┘
+```
+````
+
+**Correct — use a table:**
+
+```markdown
+| Step | Action | Output |
+|------|--------|--------|
+| 1 | Compile | main.o |
+| 2 | Link | binary |
+```
+
+---
+
+## Rule 4: Prefer Tables Over Code Blocks for Structured Data
+
+When presenting structured information (comparisons, property/value pairs, sequential data with columns), **always use markdown tables** instead of formatted code blocks.
+
+Tables are searchable, render consistently, and are easier to update.
+
+**Incorrect:**
+
+````markdown
+```
+Starting overhead:     40pp
+After cache:           31pp
+After seccomp:         14pp
+```
+````
+
+**Correct:**
+
+```markdown
+| Step | Strategy | Running Total |
+|------|----------|---------------|
+| Start | — | **40pp** |
+| +1 | Pre-Hash Cache | **31pp** |
+| +2 | seccomp-bpf | **14pp** |
+```
+
+---
+
+## Rule 5: Metadata Blocks Use Headerless Tables
+
+Document metadata (audience, author, date, status) must use a **headerless 2-column table**, not blockquotes. Blockquotes merge consecutive lines into a single paragraph in most markdown renderers.
+
+**Incorrect (renders as one line):**
+
+```markdown
+> **Audience:** Engineering teams
+> **Status:** Draft
+> **Last updated:** April 2026
+```
+
+**Correct:**
+
+```markdown
+| | |
+|---|---|
+| **Audience** | Engineering teams |
+| **Status** | Draft |
+| **Last updated** | April 2026 |
+```
+
+---
+
+## Rule 6: Architectural Diagrams as Draw.io + Embedded PNG
+
+When a document needs a **visual diagram** (data flows, architecture, component relationships, anything with boxes and arrows), create a `.drawio` file and embed the exported PNG in the markdown.
+
+**Steps:**
+
+1. Create `<name>.drawio` in the same directory as the markdown file
+2. Export to PNG: `/Applications/draw.io.app/Contents/MacOS/draw.io --export --format png --scale 2 --border 10 --output <name>.png <name>.drawio`
+3. Embed as a **clickable thumbnail** that opens the full-size image on click:
+
+```markdown
+<a href="diagram-name.png"><img src="diagram-name.png" width="600" alt="Diagram Title — click to enlarge"></a>
+
+*Click image to enlarge. Source: [diagram-name.drawio](diagram-name.drawio)*
+```
+
+The `width="600"` displays a readable thumbnail inline. Clicking opens the full 2x-scale PNG. On GitHub, this opens in a lightbox; locally it opens the image file.
+
+**When to use Draw.io diagrams:**
+
+- Architecture overviews with multiple components and data flow arrows
+- Sequence/interaction diagrams
+- Anything that would otherwise tempt you to use ASCII art
+
+**When NOT to use Draw.io diagrams (use markdown tables instead):**
+
+- Tabular data (comparisons, metrics, property/value lists)
+- Sequential steps without branching
+- Anything readers may need to search, copy, or diff
+
+---
+
+## Rule 7: Tables Stay as Markdown (Never Images)
+
+**NEVER convert markdown tables to images.** Tables must remain as native markdown because:
+
+- They are **searchable** (Ctrl+F works)
+- They are **diff-friendly** (git shows line-level changes)
+- They are **editable** without re-exporting
+- They **render natively** on GitHub, VS Code, and all markdown viewers
+- They **adapt** to dark/light themes automatically
+
+Draw.io images lose all of these properties. Use Draw.io only for diagrams with flows, arrows, and spatial relationships — not for data tables.
+
+---
+
+## Rule 8: Backtick-Wrap Identifiers Containing Underscores (HIGH PRIORITY)
+
+**Any technical identifier containing underscores MUST be wrapped in backticks** when it appears in prose outside a fenced code block. Bare underscores in markdown are interpreted as italic markers — `_text_` renders as _text_, silently corrupting filenames, variable names, and constants.
 
 This rule applies to:
 
-- Lines ending with ":**" followed by bullet lists
-- Lines ending with ":**" followed by numbered lists
-- Lines ending with ":**" followed by code blocks
-- Lines ending with ":**" followed by any other formatted content
+- **Filenames:** `bomsh_hook_raw_logfile`, `openosc_package_info.c`, `redis-server_build.spdx.json`
+- **Function/variable names:** `hash_tree`, `_run_c_cpp_pipeline()`
+- **Constants/enums:** `STATIC_LINK`, `DEPENDS_ON`, `GENERATED_FROM`
+- **Config keys:** `build_steps`, `output_binaries`, `apt_deps`
 
-Always ensure there is a blank line between the colon and the subsequent content.
+**Incorrect — underscores create false italics:**
+
+```markdown
+The bomsh_hook_raw_logfile contains STATIC_LINK relationships.
+```
+
+Renders as: "The bomsh*hook*raw\_logfile contains STATIC*LINK relationships."
+
+**Correct — backticks prevent italic interpretation:**
+
+```markdown
+The `bomsh_hook_raw_logfile` contains `STATIC_LINK` relationships.
+```
+
+**Why not backslash-escape?** Backslash escaping (`\_`) works but is fragile and ugly in raw markdown. Backticks are preferred because they also apply monospace formatting, which is semantically correct for technical identifiers.
+
+**Never escape underscores inside code blocks or backticks.** Fenced code blocks (` ``` `) and inline backticks (`` ` ``) are literal contexts — markdown does not interpret underscores inside them. Escaping with `\_` inside code produces a visible backslash in the rendered output.
+
+**Self-check:** Before finishing any markdown edit, scan all prose lines (outside code fences and backticks) for bare underscores. If a word contains `_` and is not inside backticks or a code fence, wrap it in backticks.
+
+---
+
+## Rule 9: Consecutive Lines Need Blank Line Separators
+
+**Consecutive lines that are not separated by a blank line render as a single paragraph** in standard markdown. This is especially problematic for metadata-style blocks like:
+
+**Incorrect (renders as one long line):**
+
+```markdown
+**Impact:** -11pp (40% → 29%)
+**Complexity:** Low
+**Target budget category:** SHA-256 file hashing
+```
+
+**Correct — add a blank line between each line:**
+
+```markdown
+**Impact:** -11pp (40% → 29%)
+
+**Complexity:** Low
+
+**Target budget category:** SHA-256 file hashing
+```
+
+**Do NOT use trailing `\` for line breaks.** While `\` is valid CommonMark, it renders as a literal backslash in many viewers (Webex, some GitHub contexts, VS Code preview). Blank lines are the only universally reliable separator.
+
+**When this applies:**
+
+- Strategy/feature metadata blocks (Impact, Complexity, Target)
+- Any group of short bold lines meant to display vertically
+- Consecutive `**Key:** value` lines outside a table
+
+**Alternative:** Use a headerless table (Rule 5) if there are more than 3 lines.
+
+---
+
+## Summary of Violations
+
+| Violation | Fix |
+|-----------|-----|
+| Bare ` ``` ` code fence | Add language: ` ```bash `, ` ```c `, ` ```text `, etc. |
+| ASCII art box diagrams | Create `.drawio` + export PNG + embed in markdown |
+| Structured data in code blocks | Convert to markdown tables |
+| No blank line after `:**` | Add blank line before list/code/content |
+| Diagram needed in markdown | Create `.drawio`, export PNG, embed with `![](name.png)` |
+| Table converted to image | Revert to markdown table — tables must stay as text |
+| Bare underscores in prose identifiers | Wrap in backticks: `bomsh_hook_raw_logfile` |
+| Consecutive bold lines merge into one | Add blank line between each line (never use `\`) |

--- a/.windsurf/rules/infrastructure/ec2-operations.md
+++ b/.windsurf/rules/infrastructure/ec2-operations.md
@@ -38,8 +38,10 @@ the project root:
 ## AWS session management
 
 - `duo-sso` sessions expire every 1 hour
-- If any `aws` command fails with `RequestExpired`, tell the user to re-auth
-- After re-auth, fix the credentials profile name:
+- If any `aws` command fails with `RequestExpired` or `ExpiredToken`,
+  **immediately run** `duo-sso --profile ted-admin` (interactive Chrome mode).
+  Do NOT just print instructions — always execute the command.
+- After duo-sso completes, fix the credentials profile name:
   `sed -i '' 's/^\[default\]/[ted-admin]/' ~/.aws/credentials`
 
 ## EC2 instance power management

--- a/docs/architecture/app-architecture.md
+++ b/docs/architecture/app-architecture.md
@@ -120,7 +120,7 @@ app/pipeline/runners.py          # CLI main() + language-specific runners
          └─ app/config.py
 ```
 
-## 3. SPDX Generation (spdx_from_adg.py)
+## 3. SPDX Generation (`spdx_from_adg.py`)
 
 `spdx_from_adg.py` is a backward-compatibility **shim** that re-exports
 everything from the refactored `app/spdx/` package. New code should
@@ -178,7 +178,7 @@ and appear in the sibling's own SPDX file instead.
 | `cli.py` | `main()` | Standalone CLI for `python3 -m app.spdx_from_adg` |
 | `version_detector.py` | — | Backward-compat shim → `app.version_detection` |
 
-## 4. Visualization (spdx_visualize.py)
+## 4. Visualization (`spdx_visualize.py`)
 
 `spdx_visualize.py` is the **orchestrator** that reads an SPDX JSON
 document and assembles a standalone HTML file from modular parts in
@@ -254,7 +254,7 @@ app/compare.py
  └─ ComparisonPipeline  # Facade orchestrating the above
 ```
 
-## 6. Repo Discovery (add_repo.py)
+## 6. Repo Discovery (`add_repo.py`)
 
 `add_repo.py` auto-discovers build system, dependencies, and output
 binaries for a GitHub repository and generates a `config.yaml` entry.

--- a/docs/summary/spdx-generation-deep-dive.md
+++ b/docs/summary/spdx-generation-deep-dive.md
@@ -160,7 +160,7 @@ f"{tracer} {make_cmd}"  # e.g., "bomtrace3 make -j$(nproc)"
 
 ---
 
-## 3. Stage 2: ADG Generation with bomsh_create_bom.py
+## 3. Stage 2: ADG Generation with `bomsh_create_bom.py`
 
 ### What is the ADG?
 
@@ -176,7 +176,7 @@ The ADG provides **complete cryptographic provenance** — for any output binary
 can trace back through every intermediate object file to every source file that
 contributed to it.
 
-### How bomsh_create_bom.py works
+### How `bomsh_create_bom.py` works
 
 The script is invoked as:
 ```bash
@@ -233,7 +233,7 @@ output/omnibor/curl/
                 └── ...                      ← list of files that have OmniBOR docs
 ```
 
-### The bomsh_omnibor_doc_mapping file
+### The `bomsh_omnibor_doc_mapping` file
 
 This is the most important intermediate artifact. It is a JSON file with the structure:
 
@@ -253,7 +253,7 @@ This mapping is what connects a specific binary file to its complete build prove
 
 ---
 
-## 4. Stage 3: SPDX Generation with bomsh_sbom.py
+## 4. Stage 3: SPDX Generation with `bomsh_sbom.py`
 
 ### Overview
 
@@ -360,7 +360,7 @@ After the build, `MetadataCollector` (in `analyze.py`) runs two collection scrip
 to gather dpkg package metadata and dynamic library information needed for rich
 SPDX generation.
 
-### collect_metadata.py (once per repo)
+### `collect_metadata.py` (once per repo)
 
 Reads the bomsh treedb and resolves every system file (libraries, headers, CRT
 objects) to its dpkg package:
@@ -374,7 +374,7 @@ objects) to its dpkg package:
 
 **Output:** `output/omnibor/<repo>/metadata/component_metadata.json`
 
-### collect_dynamic_libs.py (per binary)
+### `collect_dynamic_libs.py` (per binary)
 
 For each output binary, identifies dynamically linked libraries:
 
@@ -450,7 +450,7 @@ Each component becomes an SPDX package with a relationship to the root binary:
 | `BUILD_TOOL_OF` | Compiler/toolchain | gcc version from build |
 | `CONTAINS` | Source file belongs to package | Treedb artifact classification |
 
-### direct_only Mode
+### `direct_only` Mode
 
 When a project produces both executables and shared libraries (e.g., curl +
 libcurl.so), the executable's SBOM uses `direct_only=True` to avoid duplicating
@@ -493,8 +493,8 @@ Every ADG SPDX output automatically generates an interactive HTML dependency
 graph using `spdx_visualize.py`:
 
 - **D3.js force-directed layout** — packages are nodes, relationships are edges
-- **Color-coded by type**: purple (root), teal (STATIC_LINK), red (DYNAMIC_LINK),
-  yellow (BUILD_TOOL_OF)
+- **Color-coded by type**: purple (root), teal (`STATIC_LINK`), red (`DYNAMIC_LINK`),
+  yellow (`BUILD_TOOL_OF`)
 - **Node size** scales by source file count
 - **Interactive**: drag nodes, zoom/pan, hover for tooltips (version, purpose,
   file count, comments)
@@ -709,6 +709,7 @@ actually happened during compilation:
 ## 14. Configured Repositories
 
 **C/C++ (bomtrace3):**
+
 | Repo | Binaries | Vendored Libs | Dynamic Libs | Build Time | Notes |
 |---|---|---|---|---|---|
 | **curl** | curl, libcurl.so | — (uses /deps/) | ~10 | ~5 min | Reference target; autoconf + make |
@@ -717,18 +718,21 @@ actually happened during compilation:
 | **nmap** | nmap, ncat, nping | 7 (liblua, libssh2, libdnet, ...) | 14 | ~3.3 min | Uses vendored_dirs config for top-level lib detection |
 
 **Go (bomtrace2):**
+
 | Repo | Binaries | Direct Deps | Indirect Deps | Build Time | Notes |
 |---|---|---|---|---|---|
 | **lazygit** | lazygit | 33 | 29 | ~2 min | Terminal UI; stdlib + direct/indirect grouping |
 | **pocketbase** | pocketbase | 4 | — | ~1 min | Backend-as-a-service |
 
 **Rust (bomtrace2):**
+
 | Repo | Binaries | Crate Deps | Build Time | Notes |
 |---|---|---|---|---|
-| **oxipng** | oxipng | 44 | ~1 min | All crates use STATIC_LINK |
+| **oxipng** | oxipng | 44 | ~1 min | All crates use `STATIC_LINK` |
 | **dura** | dura | 150+ | ~3 min | Large dependency tree |
 
-**Java (strace + bomsh_create_bom_java.py):**
+**Java (strace + `bomsh_create_bom_java.py`):**
+
 | Repo | Binaries | Direct Deps | Transitive Deps | Build Time | Notes |
 |---|---|---|---|---|---|
 | **checkstyle** | checkstyle.jar | 10 | 21 | ~1 min | Single module |


### PR DESCRIPTION
## Summary

Expand markdown formatting rules from 1 rule to 9, and fix underscore rendering issues across documentation files.

## Changes

### Rules
- **`markdown-formatting.md`** — Expanded from a single "blank line after colon" rule to 9 comprehensive rules:
  1. Blank line after `:**`
  2. Code fences must have language identifiers
  3. No ASCII art diagrams (use Draw.io)
  4. Prefer tables over code blocks for structured data
  5. Metadata blocks use headerless tables
  6. Draw.io diagram workflow
  7. Tables stay as markdown (never images)
  8. Backtick-wrap identifiers with underscores (HIGH PRIORITY)
  9. Consecutive lines need blank line separators

- **`ec2-operations.md`** — Fix duo-sso rule: Cascade must **run** the command automatically, not just print instructions. Fixed `--profile` flag syntax.

### Documentation fixes
- **`app-architecture.md`** — Backtick-wrap filenames with underscores in headings (`spdx_from_adg.py`, `spdx_visualize.py`, `add_repo.py`)
- **`spdx-generation-deep-dive.md`** — Backtick-wrap identifiers in headings and prose, revert accidental `\_` escapes inside fenced code blocks, add blank lines before tables

## Testing
- 732 tests pass, no code changes
