### PR TITLE
docs: add 4 missing Java repos to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,11 @@ Go modules are classified as direct or indirect from `go.mod`. Each gets a `pkg:
 | [checkstyle](https://github.com/checkstyle/checkstyle) | 10 | 21 | Static analysis, deep Maven tree |
 | [jsoup](https://github.com/jhy/jsoup) | 0 | 0 | HTML parser, zero runtime deps |
 | [crawler4j](https://github.com/yasserg/crawler4j) | 6 | 16 | Web crawler, Apache HttpComponents |
-| [dependency-check](https://github.com/jeremylong/DependencyCheck) | ~20 | ~80 | OWASP vulnerability scanner, multi-module |
+| [dependency-check](https://github.com/jeremylong/DependencyCheck) | ~20 | ~80 | OWASP vulnerability scanner, Maven multi-module |
+| [logging-log4j2](https://github.com/apache/logging-log4j2) | ~10 | ~20 | Apache Log4j2 logging framework, Maven multi-module |
+| [spring-boot](https://github.com/spring-projects/spring-boot) | ~50 | ~70 | Spring Boot framework, Gradle multi-module |
+| [bc-java](https://github.com/bcgit/bc-java) | ~10 | ~5 | Bouncy Castle crypto library, Gradle multi-module |
+| [datahub](https://github.com/datahub-project/datahub) | ~30 | ~60 | DataHub metadata platform, Gradle multi-module |
 
 Java uses strace-based post-build analysis instead of bomtrace. Maven dependencies are classified as direct (depth 1) or transitive (depth 2+) via BFS.
 


### PR DESCRIPTION
Add 4 missing Java repos to README target repositories table: logging-log4j2, spring-boot, bc-java, datahub. All 23 config.yaml repos are now listed.
