### PR TITLE
fix: vendored legend dot color matches actual node rendering

### DIFF
--- a/app/viz/html_parts.py
+++ b/app/viz/html_parts.py
@@ -46,7 +46,7 @@ def get_legend_html(
     <span>Static ({type_counts.get('static', 0)})</span>
   </div>
   <div class="legend-item">
-    <div class="legend-dot" style="background:#4ecdc4;border:2px dashed #ff8c00"></div>
+    <div class="legend-dot" style="background:#888;border:2px dashed #ff8c00"></div>
     <span>Vendored ({vendored_count})</span>
   </div>
   <div class="legend-item">


### PR DESCRIPTION
The vendored legend dot in SPDX HTML visualizations used `#4ecdc4` (teal — the static link color) but actual vendored nodes render as `#888` (gray) with an orange dashed ring overlay. Changed legend to `background:#888` to match.
