### PR TITLE
docs: document root version detection across all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ omnibor-analysis/
 │   ├── pipeline/           Analysis pipeline (clone, build, instrument, generate SBOMs)
 │   ├── spdx/              Per-binary SPDX 2.3 generation from ADG data
 │   ├── viz/               D3.js visualization package (extract, styles, JS templates)
-│   ├── version_detection/ Package version detection (12 ordered strategies)
+│   ├── version_detection/ Root + vendored package version detection (14 strategies)
 │   ├── repo_discovery/    Auto-discover and configure repos from GitHub
 │   └── templates/         Report templates
 ├── docker/                Docker environment (Linux + gcc + Rust + Go + Maven + bomtrace)
@@ -65,7 +65,7 @@ omnibor-analysis/
 │   ├── issues/            Upstream bug tracking and workarounds
 │   └── deep-dive/         Research, performance, enterprise docs
 ├── terraform/             AWS EC2 infrastructure as code
-├── tests/                 Unit tests (874 tests)
+├── tests/                 Unit tests (900 tests)
 ├── repos/                 Cloned target repositories (gitignored)
 ├── output/                Generated artifacts: SBOMs, ADGs, binaries (gitignored)
 ├── .windsurf/             Cascade AI rules and workflows
@@ -188,7 +188,6 @@ Go modules are classified as direct or indirect from `go.mod`. Each gets a `pkg:
 | [logging-log4j2](https://github.com/apache/logging-log4j2) | ~10 | ~20 | Apache Log4j2 logging framework, Maven multi-module |
 | [spring-boot](https://github.com/spring-projects/spring-boot) | ~50 | ~70 | Spring Boot framework, Gradle multi-module |
 | [bc-java](https://github.com/bcgit/bc-java) | ~10 | ~5 | Bouncy Castle crypto library, Gradle multi-module |
-| [datahub](https://github.com/datahub-project/datahub) | ~30 | ~60 | DataHub metadata platform, Gradle multi-module |
 
 Java uses strace-based post-build analysis instead of bomtrace. Maven dependencies are classified as direct (depth 1) or transitive (depth 2+) via BFS.
 

--- a/docs/architecture/app-architecture.md
+++ b/docs/architecture/app-architecture.md
@@ -139,9 +139,9 @@ app/spdx/generator.py            # AdgSpdxGenerator (facade)
  ├─ app/spdx/parser.py           # AdgParser — reads bomsh treedb, classifies artifacts
  ├─ app/spdx/resolver.py         # ComponentResolver — maps artifacts to packages
  ├─ app/spdx/emitter.py          # SpdxEmitter — produces SPDX 2.3 JSON
- │   └─ app/version_detection/   # VendoredVersionDetector (12 strategies)
+ │   └─ app/version_detection/   # VendoredVersionDetector (14 strategies)
  │       ├─ detector.py           # Orchestrates strategies in priority order
- │       ├─ strategies.py         # 12 version detection strategies
+ │       ├─ strategies.py         # 14 version detection strategies
  │       └─ patterns.py           # Regex patterns and file name constants
  └─ app/spdx_visualize.py        # generate_html() [called at end of generate()]
      └─ app/viz/                  # Visualization sub-package (see §4)
@@ -293,7 +293,7 @@ These run inside the Docker container during pipeline execution:
 
 | File | Purpose | Called by |
 |------|---------|----------|
-| `app/collect_metadata.py` | dpkg metadata for system files → `component_metadata.json` | `MetadataCollector` |
+| `app/collect_metadata.py` | dpkg metadata for system files → `component_metadata.json`; root version from config tag | `MetadataCollector` |
 | `app/collect_dynamic_libs.py` | ldd/readelf → `dynamic_libs.json` per binary | `MetadataCollector` |
 | `app/apply_qemu_fallback.py` | Patch bomsh for QEMU/Apple Silicon compatibility | Dockerfile |
 
@@ -382,12 +382,14 @@ Modular HTML generation for interactive dependency graphs. The
 orchestrator (`spdx_visualize.py`) assembles CSS, HTML fragments, and
 JS code from dedicated modules. Each module is under 340 lines.
 
-### `app/version_detection/` — Vendored library version detection (3 modules)
+### `app/version_detection/` — Root + vendored version detection (3 modules)
 
 12 ordered strategies for detecting versions from source trees
 (VERSION files, CMakeLists.txt, configure.ac, package.json, Cargo.toml,
-Makefile variables, etc.). Used by `SpdxEmitter` to set `versionInfo`
-on vendored packages.
+pom.xml, Makefile variables, etc.). Used by `SpdxEmitter` to set
+`versionInfo` on vendored packages, and by `collect_metadata.py` to
+detect the root package version from config tags with file-based
+fallback.
 
 ### `app/repo_discovery/` — Auto-discover repos (6 modules)
 
@@ -397,4 +399,4 @@ path detection, build step generation, and config.yaml writing. Used by
 
 ---
 
-*Last updated: March 31, 2026*
+*Last updated: April 29, 2026*

--- a/docs/architecture/omnibor-analysis-overview.md
+++ b/docs/architecture/omnibor-analysis-overview.md
@@ -141,38 +141,56 @@ graph TD
 
 ---
 
-## Vendored Version Detection: 12 Strategies
+## Version Detection
+
+omnibor-analysis detects versions for both the **root package** and
+**vendored libraries**:
+
+### Root package version (all languages)
+
+The pipeline extracts the root `versionInfo` from the `config.yaml`
+`branch` tag (e.g., `v0.25.9` → `0.25.9`). This covers 20 of 23
+configured repos. For repos without a semver tag, it falls back to
+file-based detection (`Cargo.toml` for Rust, `pom.xml` for Java,
+VERSION files for C/C++). See [Stable Tag Pinning](../features/stable-tag-pinning.md).
+
+### Vendored library version (12 strategies)
 
 C/C++ vendored libraries declare versions in ad-hoc ways. omnibor-analysis
 implements 12 detection strategies, ordered most-reliable first:
 
 ```mermaid
 flowchart LR
-    A["VERSION /<br/>RELEASE file"] --> B["configure.ac<br/>AC_INIT"]
-    B --> C["CMakeLists.txt<br/>project(VERSION)"]
-    C --> D["meson.build<br/>project(version:)"]
-    D --> E[".pc.in<br/>Version: field"]
-    E --> F["#define<br/>PREFIX_VERSION"]
-    F --> G["#define<br/>MAJOR/MINOR/PATCH"]
-    G --> H["Broad #define<br/>fallback"]
-    H --> I["Header comment<br/>(first 20 lines)"]
-    I --> J["Makefile<br/>VERSION = x.y.z"]
+    A["VERSION /<br/>RELEASE file"] --> B["Key-value<br/>VERSION.dat"]
+    B --> C["Structured data<br/>package.json / Cargo.toml<br/>pom.xml"]
+    C --> D["configure.ac<br/>AC_INIT"]
+    D --> E["CMakeLists.txt<br/>project(VERSION)"]
+    E --> F["meson.build<br/>project(version:)"]
+    F --> G[".pc.in<br/>Version: field"]
+    G --> H["#define<br/>PREFIX_VERSION"]
+    H --> I["#define<br/>MAJOR/MINOR/PATCH"]
+    I --> J["Broad #define<br/>fallback"]
+    J --> K["Header comment<br/>(first 20 lines)"]
+    K --> L["Makefile<br/>VERSION = x.y.z"]
 
     style A fill:#2ecc71,color:#fff
     style B fill:#27ae60,color:#fff
     style C fill:#229954,color:#fff
     style D fill:#1e8449,color:#fff
     style E fill:#196f3d,color:#fff
-    style F fill:#3498db,color:#fff
-    style G fill:#2980b9,color:#fff
-    style H fill:#2471a3,color:#fff
-    style I fill:#e67e22,color:#fff
-    style J fill:#d35400,color:#fff
+    style F fill:#117a65,color:#fff
+    style G fill:#0e6655,color:#fff
+    style H fill:#3498db,color:#fff
+    style I fill:#2980b9,color:#fff
+    style J fill:#2471a3,color:#fff
+    style K fill:#e67e22,color:#fff
+    style L fill:#d35400,color:#fff
 ```
 
 **First match wins.** A VERSION file (most reliable) always beats a regex in a
 Makefile (least reliable). Handles quoted strings (`"5"`), RELEASE/MICRO as PATCH
 aliases, and flexible `lib` prefix stripping (`liblua` → `LUA_` prefix matching).
+See [Version Detection](../features/vendored-version-detection.md) for full details.
 
 ---
 
@@ -225,10 +243,10 @@ Source code → bomtrace3 (ptrace) → raw logfile → OmniBOR ADG → SPDX 2.3 
 - **bomtrace3** — modified strace that intercepts gcc/ld via ptrace
 - **bomsh_create_bom.py** — builds the OmniBOR Artifact Dependency Graph
 - **app/spdx/emitter.py** — generates per-binary SPDX with vendored detection
-- **app/version_detection/** — 12-strategy vendored version detection
+- **app/version_detection/** — root + vendored version detection (14 strategies)
 - **app/spdx_visualize.py** — D3.js interactive dependency graphs
 
-**Quality gates:** 670 tests, 97% code coverage, golden file regression baselines
+**Quality gates:** 900 tests, 98% code coverage, golden file regression baselines
 for all 18 C/C++ binary artifacts across 4 projects.
 
 ---

--- a/docs/architecture/omnibor-analysis-technical-overview.md
+++ b/docs/architecture/omnibor-analysis-technical-overview.md
@@ -30,7 +30,7 @@ Clone → Validate deps → bomtrace build → ADG → SPDX → Validate → Vis
 | `bomsh_sbom.py` | omnibor/bomsh | ADG → basic OmniBOR SPDX |
 | `app/spdx/generator.py` | omnibor-analysis | ADG → enriched per-binary SPDX with dpkg metadata |
 | `app/spdx/java_generator.py` | omnibor-analysis | Java: ADG + `mvn dependency:tree` → SPDX |
-| `app/version_detection/` | omnibor-analysis | 12 strategies for vendored library version detection |
+| `app/version_detection/` | omnibor-analysis | Root version from config tags + 12 vendored detection strategies |
 | `app/spdx_visualize.py` | omnibor-analysis | SPDX → interactive D3.js HTML |
 
 **Environment:** Docker container on AWS EC2 (Ubuntu 22.04 x86_64) with `SYS_PTRACE` capability.

--- a/docs/deep-dive/spdx-generation-deep-dive.md
+++ b/docs/deep-dive/spdx-generation-deep-dive.md
@@ -363,14 +363,18 @@ SPDX generation.
 ### `collect_metadata.py` (once per repo)
 
 Reads the bomsh treedb and resolves every system file (libraries, headers, CRT
-objects) to its dpkg package:
+objects) to its dpkg package. Also detects the **root package version** using
+a two-pronged approach: (1) extract semver from the config tag (primary), or
+(2) fall back to file-based detection via `Cargo.toml`, `pom.xml`, or other
+version strategies. See [Version Detection](../features/vendored-version-detection.md#3-root-package-version-detection).
 
-1. Iterates all treedb entries, filters system files (not under `repos/`)
-2. Resolves canonical paths (`os.path.realpath` to handle `/../`)
-3. Runs `dpkg -S <path>` for each file to find the owning package
-4. Runs `dpkg-query --showformat` to extract full metadata: name, version,
+1. Detects root package version from config tag or file-based fallback
+2. Iterates all treedb entries, filters system files (not under `repos/`)
+3. Resolves canonical paths (`os.path.realpath` to handle `/../`)
+4. Runs `dpkg -S <path>` for each file to find the owning package
+5. Runs `dpkg-query --showformat` to extract full metadata: name, version,
    source package, architecture, maintainer, homepage, section
-5. Writes `component_metadata.json` to the metadata directory
+6. Writes `component_metadata.json` to the metadata directory
 
 **Output:** `output/omnibor/<repo>/metadata/component_metadata.json`
 
@@ -432,12 +436,23 @@ Two modes:
 ### Vendored Version Detection
 
 `VendoredVersionDetector` scans vendored source directories for version
-information using multiple strategies:
+information using 12 ordered strategies (first match wins):
 
-1. **VERSION files** — `VERSION`, `version.txt`, etc.
-2. **#define macros** — `#define LIB_VERSION "1.2.3"`, `#define MAJOR 1`
-3. **Header comments** — `/* libfoo v1.2.3 */`
-4. **.pc.in files** — `Version: @VERSION@` patterns
+1. **VERSION / RELEASE files** — `VERSION`, `VERSION.txt`, `RELEASE`
+2. **Key-value files** — `VERSION.dat`
+3. **Structured data** — `package.json`, `Cargo.toml`, `pom.xml`, etc.
+4. **configure.ac** — `AC_INIT([lib],[x.y.z])`
+5. **CMakeLists.txt** — `project(VERSION x.y.z)`
+6. **meson.build** — `project(version: 'x.y.z')`
+7. **.pc.in files** — `Version: x.y.z`
+8. **#define PREFIX_VERSION** — `#define LIB_VERSION "1.2.3"`
+9. **#define MAJOR/MINOR/PATCH** — split macros
+10. **Broad #define fallback** — any `#define` with VERSION/VER
+11. **Header comments** — `/* libfoo v1.2.3 */`
+12. **Makefile variables** — `VERSION = x.y.z`
+
+See [Version Detection](../features/vendored-version-detection.md)
+for full strategy documentation.
 
 ### SPDX Relationship Types
 

--- a/docs/features/stable-tag-pinning.md
+++ b/docs/features/stable-tag-pinning.md
@@ -91,7 +91,11 @@ known stable release tag**.
 ## 3. Why Tags Matter for SPDX
 
 SPDX 2.3 records the version of each package in the `versionInfo`
-field. Downstream consumers rely on this field for:
+field. The pipeline automatically extracts the root package version
+from the config tag (see [Version Detection](vendored-version-detection.md#3-root-package-version-detection)),
+so tag accuracy directly determines SPDX `versionInfo` accuracy.
+
+Downstream consumers rely on this field for:
 
 | Consumer | What they need | Broken by dev branches |
 |----------|---------------|----------------------|
@@ -103,28 +107,32 @@ field. Downstream consumers rely on this field for:
 
 ## 4. Current Tag Map
 
-All repositories in `config.yaml` as of March 2026:
+All repositories in `config.yaml` as of April 2026:
 
-| Repo | Language | Tag | Source |
-|------|----------|-----|--------|
-| curl | c-cpp | `curl-8_19_0` | GitHub Release |
-| ffmpeg | c-cpp | `n8.1` | Git tag (FFmpeg uses `nX.Y` convention) |
-| nmap | c-cpp | `master` | No tags exist (see [§7](#7-repos-without-tags)) |
-| redis | c-cpp | `8.0.6` | GitHub Release |
-| openosc | c-cpp | `v1.0.7` | GitHub Release |
-| node | c-cpp | `v22.19.0` | GitHub Release |
-| fzf | go | `v0.70.0` | GitHub Release |
-| lazygit | go | `v0.60.0` | GitHub Release |
-| pocketbase | go | `v0.25.9` | GitHub Release |
-| croc | go | `v10.4.2` | GitHub Release |
-| dive | go | `v0.13.1` | GitHub Release |
-| gdu | go | `v5.34.1` | GitHub Release |
-| oxipng | rust | `v10.1.0` | GitHub Release |
-| dura | rust | `v0.2.0` | Git tag |
-| jsoup | java | `jsoup-1.22.1` | GitHub Release |
-| checkstyle | java | `checkstyle-13.3.0` | GitHub Release |
-| crawler4j | java | `crawler4j-4.4.0` | GitHub Release |
-| dependency-check | java | `v9.2.0` | GitHub Release |
+| Repo | Language | Tag | Extracted Version | Source |
+|------|----------|-----|-------------------|--------|
+| curl | c-cpp | `curl-8_19_0` | — (underscores) | GitHub Release |
+| ffmpeg | c-cpp | `n8.1` | `8.1` | Git tag |
+| nmap | c-cpp | `master` | — (no version) | No tags exist (see [§7](#7-repos-without-tags)) |
+| redis | c-cpp | `8.0.6` | `8.0.6` | GitHub Release |
+| openosc | c-cpp | `v1.0.7` | `1.0.7` | GitHub Release |
+| node | c-cpp | `v22.19.0` | `22.19.0` | GitHub Release |
+| fzf | go | `v0.70.0` | `0.70.0` | GitHub Release |
+| lazygit | go | `v0.60.0` | `0.60.0` | GitHub Release |
+| croc | go | `v10.4.2` | `10.4.2` | GitHub Release |
+| dive | go | `v0.13.1` | `0.13.1` | GitHub Release |
+| gdu | go | `v5.34.1` | `5.34.1` | GitHub Release |
+| pocketbase | go | `v0.25.9` | `0.25.9` | GitHub Release |
+| oxipng | rust | `v10.1.0` | `10.1.0` | GitHub Release |
+| dura | rust | `v0.2.0` | `0.2.0` | Git tag |
+| jsoup | java | `jsoup-1.22.1` | `1.22.1` | GitHub Release |
+| checkstyle | java | `checkstyle-13.3.0` | `13.3.0` | GitHub Release |
+| crawler4j | java | `crawler4j-4.4.0` | `4.4.0` | GitHub Release |
+| dependency-check | java | `v9.2.0` | `9.2.0` | GitHub Release |
+| datahub | java | `v1.5.0.1` | `1.5.0.1` | GitHub Release |
+| logging-log4j2 | java | `rel/2.24.3` | `2.24.3` | GitHub Release |
+| spring-boot | java | `v3.4.4` | `3.4.4` | GitHub Release |
+| bc-java | java | `r1rv84` | — (non-numeric) | Git tag |
 
 ## 5. How Tags Were Selected
 
@@ -197,4 +205,4 @@ produces a more useful SBOM than a moving development target.
 
 ---
 
-*Last updated: March 20, 2026*
+*Last updated: April 29, 2026*

--- a/docs/features/vendored-version-detection.md
+++ b/docs/features/vendored-version-detection.md
@@ -1,9 +1,10 @@
-# Vendored Version Detection
+# Version Detection
 
 This document describes how omnibor-analysis detects version information for
-vendored (statically linked) libraries from source code. It covers the 10
-detection strategies, real-world patterns that motivated each one, known
-limitations, and guidance for handling edge cases.
+both the **root package** (the project being built) and **vendored (statically
+linked) libraries** from source code. It covers root version extraction from
+config tags, the 12 vendored detection strategies, real-world patterns that
+motivated each one, known limitations, and guidance for handling edge cases.
 
 ---
 
@@ -11,13 +12,14 @@ limitations, and guidance for handling edge cases.
 
 1. [The Problem](#1-the-problem)
 2. [Why Versions Matter in SBOMs](#2-why-versions-matter-in-sboms)
-3. [Design Principles](#3-design-principles)
-4. [The 10 Detection Strategies](#4-the-10-detection-strategies)
-5. [Library Name Prefix Handling](#5-library-name-prefix-handling)
-6. [Real-World Examples](#6-real-world-examples)
-7. [Known Limitations](#7-known-limitations)
-8. [How to Debug Missing Versions](#8-how-to-debug-missing-versions)
-9. [Adding New Strategies](#9-adding-new-strategies)
+3. [Root Package Version Detection](#3-root-package-version-detection)
+4. [Design Principles](#4-design-principles)
+5. [The 12 Vendored Detection Strategies](#5-the-12-vendored-detection-strategies)
+6. [Library Name Prefix Handling](#6-library-name-prefix-handling)
+7. [Real-World Examples](#7-real-world-examples)
+8. [Known Limitations](#8-known-limitations)
+9. [How to Debug Missing Versions](#9-how-to-debug-missing-versions)
+10. [Adding New Strategies](#10-adding-new-strategies)
 
 ---
 
@@ -58,7 +60,57 @@ useful:
 - **SPDX quality** — NTIA minimum elements for SBOMs include version as a
   recommended field.
 
-## 3. Design Principles
+## 3. Root Package Version Detection
+
+The **root package** is the project being built (e.g., redis, oxipng,
+checkstyle). Its version is set via a two-pronged approach:
+
+### Primary: Config tag extraction
+
+The pipeline extracts a semver-like version from the `branch` field in
+`config.yaml`. Since every repo is pinned to a stable release tag (see
+[Stable Tag Pinning](stable-tag-pinning.md)), the tag usually contains
+the version:
+
+| Tag format | Example | Extracted version |
+|------------|---------|-------------------|
+| `vX.Y.Z` | `v0.25.9` | `0.25.9` |
+| `X.Y.Z` | `8.0.6` | `8.0.6` |
+| `name-X.Y.Z` | `jsoup-1.22.1` | `1.22.1` |
+| `rel/X.Y.Z` | `rel/2.24.3` | `2.24.3` |
+| `nX.Y` | `n8.1` | `8.1` |
+
+This covers **20 of 23** configured repos. The three exceptions are:
+- `nmap` (`master` — no stable tags exist)
+- `bc-java` (`r1rv84` — non-numeric tag)
+- `curl` (`curl-8_19_0` — underscores instead of dots)
+
+### Fallback: File-based detection
+
+If no version is found in the tag, the pipeline falls back to
+file-based detection using language-specific parsers:
+
+| File | Language | Parser |
+|------|----------|--------|
+| `Cargo.toml` | Rust | `parse_cargo_toml` — extracts `version = "x.y.z"` |
+| `pom.xml` | Java/Maven | `parse_pom_xml` — extracts `<version>`, skips `<parent>` block, handles `-SNAPSHOT` |
+
+These parsers supplement the existing vendored strategies (which also
+scan the repo root for VERSION files, `configure.ac`, etc.).
+
+### Implementation
+
+- **`collect_metadata.py`**: `_version_from_tag()` extracts version
+  from config branch; `_detect_repo_version()` tries tag first, then
+  file-based detection
+- **`metadata_collector.py`**: passes `config_branch` from
+  `config.yaml` to `collect_metadata.main()`
+- **SPDX emitter**: uses the detected version as the root package
+  `versionInfo` field
+
+---
+
+## 4. Design Principles
 
 The `VendoredVersionDetector` class in `app/spdx/version_detector.py` follows
 these principles:
@@ -96,11 +148,11 @@ Library names in `#define` macros often differ from directory names:
 The detector generates multiple prefix candidates and falls back to a
 prefix-agnostic scan.
 
-## 4. The 10 Detection Strategies
+## 5. The 12 Vendored Detection Strategies
 
 Strategies are tried in this order. The first match wins.
 
-### Strategy 1: VERSION / RELEASE / VERSION.txt Files
+### Strategy 1: VERSION / RELEASE / VERSION.txt files
 
 **Pattern:** Plain text file containing a semver string.
 
@@ -121,7 +173,38 @@ the most unambiguous source.
 
 **File names checked:** `VERSION`, `VERSION.txt`, `RELEASE`
 
-### Strategy 2: configure.ac AC_INIT
+### Strategy 2: Key-value version files
+
+**Pattern:** Structured key-value files like `VERSION.dat`.
+
+**Examples:**
+```
+# jemalloc VERSION.dat
+VERSION=5.3.0
+```
+
+### Strategy 3: Structured data files (package.json, Cargo.toml, pom.xml)
+
+**Pattern:** Language-ecosystem files with a version field.
+
+**Parsers:**
+
+| File | Parser | Pattern |
+|------|--------|---------|
+| `package.json` | `parse_package_json` | `"version": "x.y.z"` |
+| `version.json` | `parse_version_json` | `"version": "x.y.z"` |
+| `pyproject.toml` | `parse_pyproject_toml` | `version = "x.y.z"` |
+| `Cargo.toml` | `parse_cargo_toml` | `version = "x.y.z"` (Rust) |
+| `pom.xml` | `parse_pom_xml` | `<version>x.y.z</version>` (Java/Maven) |
+
+**`Cargo.toml` details:** Parses the `[package]` section for
+`version = "x.y.z"`. Uses regex to extract the first semver match.
+
+**`pom.xml` details:** Strips the `<parent>` block before extracting
+`<version>` to avoid matching the parent POM's version. Handles
+`-SNAPSHOT` suffixes by extracting only the numeric prefix.
+
+### Strategy 4: configure.ac AC_INIT
 
 **Pattern:** Autoconf `AC_INIT` macro with version argument.
 
@@ -140,7 +223,7 @@ projects. The version in `AC_INIT` is what gets substituted into `config.h`,
 
 **Real-world hit:** libdnet-stripped in nmap (`AC_INIT([libdnet],[1.18.0])`)
 
-### Strategy 3: CMakeLists.txt project(VERSION)
+### Strategy 5: CMakeLists.txt project(VERSION)
 
 **Pattern:** CMake `project()` command with VERSION keyword.
 
@@ -156,7 +239,7 @@ project(mylib VERSION 2.0.0 LANGUAGES C CXX)
 **Note:** The regex matches `VERSION` inside `project()` parentheses, avoiding
 false matches on `cmake_minimum_required(VERSION ...)`.
 
-### Strategy 4: meson.build project(version:)
+### Strategy 6: meson.build project(version:)
 
 **Pattern:** Meson build system `project()` with `version:` keyword argument.
 
@@ -169,7 +252,7 @@ project('mylib', 'c',
 
 **Regex:** `project\s*\([^)]*?version\s*:\s*['"](\d+\.\d+(?:\.\d+)?)`
 
-### Strategy 5: .pc.in Files
+### Strategy 7: .pc.in files
 
 **Pattern:** pkg-config template files with `Version:` field.
 
@@ -181,7 +264,7 @@ Version: 1.2.0
 
 **Real-world hit:** hiredis in redis (`hiredis.pc.in`)
 
-### Strategy 6: #define PREFIX_VERSION / PREFIX_RELEASE Strings
+### Strategy 8: #define PREFIX_VERSION / PREFIX_RELEASE strings
 
 **Pattern:** Single-line `#define` with the library prefix, containing a
 quoted version string.
@@ -206,7 +289,7 @@ If we checked VERSION first, we'd get `5.4` instead of `5.4.8`.
 **Prefix candidates:** Generated by `_name_prefixes()` — see
 [Section 5](#5-library-name-prefix-handling).
 
-### Strategy 7: #define MAJOR / MINOR / PATCH|RELEASE|MICRO Parts
+### Strategy 9: #define MAJOR / MINOR / PATCH|RELEASE|MICRO parts
 
 **Pattern:** Separate `#define` macros for each version component.
 
@@ -246,7 +329,7 @@ detector tries a wildcard `\w*` prefix. This handles cases like xxhash where
 the library name is "xxhash" but the macros use `XXH_` — a prefix that cannot
 be algorithmically derived from the name.
 
-### Strategy 8: Broad #define Fallback
+### Strategy 10: Broad #define fallback
 
 **Pattern:** Any `#define` with `VERSION` or `VER` in its name containing a
 quoted semver string.
@@ -261,7 +344,7 @@ quoted semver string.
 order to avoid false matches. It does not require the macro name to match the
 library name at all.
 
-### Strategy 9: Header Comment Version
+### Strategy 11: Header comment version
 
 **Pattern:** Version string in a comment block in the first 20 lines of a
 header file.
@@ -279,7 +362,7 @@ header file.
 file that may refer to something else (protocol versions, format versions,
 etc.).
 
-### Strategy 10: Makefile VERSION Variables
+### Strategy 12: Makefile VERSION variables
 
 **Pattern:** VERSION assignment in a Makefile.
 
@@ -295,7 +378,7 @@ VERSION := 2.1.0
 **Why last:** Makefile version variables are less reliable because they may
 refer to ABI versions, SO versions, or other non-semantic version numbers.
 
-## 5. Library Name Prefix Handling
+## 6. Library Name Prefix Handling
 
 The `_name_prefixes()` method generates multiple prefix candidates from the
 library directory name, accounting for common naming conventions:
@@ -326,7 +409,7 @@ removed while preserving order (most specific first).
 After all named prefixes are exhausted, Strategy 7 falls back to `\w*` as a
 wildcard prefix to catch completely unpredictable naming.
 
-## 6. Real-World Examples
+## 7. Real-World Examples
 
 ### nmap Vendored Libraries (March 2026)
 
@@ -355,7 +438,7 @@ wildcard prefix to catch completely unpredictable naming.
 
 ### Improvement Over Previous Detector
 
-| Package | Before (4 strategies) | After (10 strategies) |
+| Package | Before (4 strategies) | After (12 strategies) |
 |---------|----------------------|----------------------|
 | liblua (nmap) | (none) | **5.4.8** |
 | nsock (nmap) | (none) | **0.02** |
@@ -368,7 +451,7 @@ The improvements came from: quoted string support, RELEASE-as-PATCH alias,
 lib prefix stripping, prefix-agnostic fallback, expanded header comment
 scanning window, and configure.ac/CMakeLists.txt parsing.
 
-## 7. Known Limitations
+## 8. Known Limitations
 
 ### Flat integer versions
 
@@ -413,7 +496,7 @@ with the library's prefix. The broad fallback (Strategy 8) could
 theoretically match the wrong one, but since it runs last, a prefix-specific
 match will win first.
 
-## 8. How to Debug Missing Versions
+## 9. How to Debug Missing Versions
 
 If a vendored library is showing `(none)` for its version:
 
@@ -448,22 +531,25 @@ If a vendored library is showing `(none)` for its version:
    print(det._name_prefixes("libname"))
    ```
 
-## 9. Adding New Strategies
+## 10. Adding New Strategies
 
 To add a new detection strategy:
 
-1. Add a new `_parse_*` method to `VendoredVersionDetector`
-2. Call it from `detect()` in the appropriate position (more reliable
-   strategies earlier)
-3. Use `_safe_read()` for file I/O (handles OSError gracefully)
-4. Match against `_VER_RE` for consistent semver extraction
-5. Add tests in `tests/test_spdx_from_adg.py` under
-   `TestVendoredVersionDetector`
-6. Add an unreadable-file test for graceful error handling
+1. Add a `parse_*` function in `app/version_detection/strategies.py`
+2. For structured data files (e.g., `Cargo.toml`), register the parser
+   in `_STRUCTURED_PARSERS` in `app/version_detection/detector.py` and
+   add the filename to `STRUCTURED_VERSION_FILES` in
+   `app/version_detection/patterns.py`
+3. For other strategies, add the call in `detect()` in the appropriate
+   position (more reliable strategies earlier)
+4. Use `_safe_read()` for file I/O (handles OSError gracefully)
+5. Match against `VER_RE` for consistent semver extraction
+6. Add tests in `tests/test_version_detection.py`
+7. Add an unreadable-file test for graceful error handling
 
-The test suite currently has 20+ version detector tests covering all 10
-strategies plus error handling and prefix generation.
+The test suite currently has 80+ version detector tests covering all 12
+strategies, root version extraction, and prefix generation.
 
 ---
 
-*Last updated: March 12, 2026*
+*Last updated: April 29, 2026*


### PR DESCRIPTION
## Summary

Documents the root package version detection feature (PR #87) across
all relevant docs. Only documentation changes — no code changes.

## Files Changed (7 docs only)

| File | Change |
|---|---|
| `README.md` | Strategy count 12→14, test count 874→900 |
| `docs/features/vendored-version-detection.md` | Renamed to "Version Detection"; added §3 root version from config tags; added Cargo.toml + pom.xml strategies; fixed strategy count 10→12; updated "Adding New Strategies" |
| `docs/features/stable-tag-pinning.md` | Added note that pipeline auto-extracts root version; added "Extracted Version" column; added 5 missing repos to tag map |
| `docs/architecture/app-architecture.md` | Updated `collect_metadata.py` description; updated `version_detection` package summary |
| `docs/deep-dive/spdx-generation-deep-dive.md` | Updated `collect_metadata.py` section; expanded vendored strategies to full 12-item list |
| `docs/architecture/omnibor-analysis-overview.md` | Split version section into root + vendored; updated flowchart; updated test/coverage stats |
| `docs/architecture/omnibor-analysis-technical-overview.md` | Updated `version_detection` description |

## Scope

This PR ONLY touches documentation. No code, no tests. All code
changes were in PR #87 (already merged).
