### PR TITLE
chore: document .gitkeep requirement when adding new languages

### DIFF
--- a/.windsurf/rules/project/supported-languages.md
+++ b/.windsurf/rules/project/supported-languages.md
@@ -54,3 +54,14 @@ When OmniBOR/bomsh adds support for a new language:
 1. Update the tables above
 2. Update `app/pipeline/language_validator.py` with the new mapping
 3. Update the version comment (e.g., "bomsh v2026.2")
+4. Create language subdirectories with `.gitkeep` under **all** output
+   categories to preserve the directory skeleton on fresh clone:
+   ```
+   output/binaries/<lang>/.gitkeep
+   output/binary-scan/<lang>/.gitkeep
+   output/build-logs/<lang>/.gitkeep
+   output/omnibor/<lang>/.gitkeep
+   output/runtime/<lang>/.gitkeep
+   output/spdx/<lang>/.gitkeep
+   ```
+5. Commit the `.gitkeep` files (they are allowed through `.gitignore`)

--- a/.windsurf/workflows/add-repo.md
+++ b/.windsurf/workflows/add-repo.md
@@ -42,6 +42,16 @@ Once the user approves:
 
 This writes the entry to `app/config.yaml` and creates output directories.
 
+If this is a **new language** (not an existing one like c-cpp, rust, go, java),
+also create `.gitkeep` files under all output categories:
+
+```bash
+for dir in binaries binary-scan build-logs omnibor runtime spdx; do
+  touch output/$dir/<new-lang>/.gitkeep
+done
+git add output/**/<new-lang>/.gitkeep
+```
+
 ## 4. Add missing Dockerfile packages (if any)
 
 If the script reports missing apt packages, add them to `docker/Dockerfile`

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -175,9 +175,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 docker-compose -f docker/docker-compose.yml build
 ```
 
-### 4. Create output and docs directories
+### 4. Create output directories
 
-Directories are created automatically by `analyze.py` using the `{lang}/{repo}/{ts}/` convention. No manual setup needed.
+Per-run directories (`{lang}/{repo}/{ts}/`) are created automatically by
+`analyze.py`. However, if you are adding a **new language** (not just a new
+repo for an existing language), you must create the language-level skeleton
+with `.gitkeep` files so the directory structure is preserved on fresh clone:
+
+```bash
+for dir in binaries binary-scan build-logs omnibor runtime spdx; do
+  touch output/$dir/<new-lang>/.gitkeep
+done
+git add output/**/<new-lang>/.gitkeep
+```
 
 ### 5. Test the build manually first
 


### PR DESCRIPTION
Document the requirement to create `.gitkeep` files under all 6 output categories when adding a new language to the pipeline.

## Files Changed (3)

| File | Change |
|---|---|
| `.windsurf/rules/project/supported-languages.md` | Added steps 4-5 to "Updating This File" section |
| `docs/guides/CONTRIBUTING.md` | Rewrote step 4 with `.gitkeep` instructions for new languages |
| `.windsurf/workflows/add-repo.md` | Added conditional `.gitkeep` note in step 3 |

Follows up on PR #89 which added the `.gitkeep` skeleton.
