### PR TITLE
fix: dive binary collector, remove datahub, add build docs

### DIFF
--- a/.windsurf/rules/infrastructure/active-profile.md
+++ b/.windsurf/rules/infrastructure/active-profile.md
@@ -14,7 +14,7 @@ description: Active infrastructure profile — tedg's AWS EC2 instance
 | **IP** | `54.215.15.253` (Elastic IP) |
 | **Instance ID** | `i-02ef4bf118d6bae90` |
 | **Region** | `us-west-1` |
-| **Instance Type** | `c6i.4xlarge` (16 vCPU, 32 GB RAM) |
+| **Instance Type** | `c6i.xlarge` (4 vCPU, 8 GB RAM) |
 | **OS** | Ubuntu 22.04 x86_64 |
 | **AMI** | `ami-02ff48e800d3550ab` |
 | **EBS** | 50 GB gp3 (3000 IOPS) |

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -192,11 +192,11 @@ repos:
     branch: v0.13.1
     language: go
     build_steps:
-    - 'go build -a -trimpath -ldflags="-s -w" -o dive .'
-    clean_cmd: rm -f dive
+    - 'go build -a -trimpath -ldflags="-s -w" -o dive_bin .'
+    clean_cmd: rm -f dive_bin
     description: Docker image layer explorer (~15-20 direct + 25 indirect Go deps)
     output_binaries:
-    - dive
+    - dive_bin
   gdu:
     url: https://github.com/dundee/gdu.git
     branch: v5.34.1
@@ -277,16 +277,6 @@ repos:
     description: OWASP dependency-check CLI (6 modules - utils, core, cli, ant, maven, archetype)
     output_binaries:
     - '**/target/*.jar'
-  datahub:
-    url: https://github.com/datahub-project/datahub.git
-    branch: v1.5.0.1
-    language: java
-    build_steps:
-    - ./gradlew build -x test -x check --no-daemon -q
-    clean_cmd: ./gradlew clean --no-daemon -q
-    description: DataHub metadata platform (Gradle multi-module, Java primary with Python/TS components)
-    output_binaries:
-    - '**/build/libs/*.jar'
   logging-log4j2:
     url: https://github.com/apache/logging-log4j2.git
     branch: rel/2.24.3

--- a/app/pipeline/binary_collector.py
+++ b/app/pipeline/binary_collector.py
@@ -123,6 +123,12 @@ class BinaryCollector:
                         f"[WARN] Binary not found: {src}"
                     )
                     continue
+                if not src.is_file():
+                    print(
+                        f"[WARN] Not a file (directory?): "
+                        f"{src}"
+                    )
+                    continue
                 shutil.copy2(str(src), str(dst))
                 size = dst.stat().st_size
                 print(

--- a/docs/architecture/polyglot-build-support.md
+++ b/docs/architecture/polyglot-build-support.md
@@ -1,0 +1,87 @@
+# Polyglot Build Support — Future Work
+
+## Problem Statement
+
+Some target repositories are **polyglot** — they contain multiple languages
+and build systems in a single repository. The current OmniBOR analysis
+container is equipped with toolchains for C/C++, Go, Rust, and Java
+individually, but cannot build projects that require multiple toolchains
+simultaneously or include non-supported languages (Python, TypeScript,
+etc.) as build-time dependencies.
+
+## Example: datahub
+
+[DataHub](https://github.com/datahub-project/datahub) (`v1.5.0.1`) is a
+metadata platform that uses Gradle as its primary build system but includes:
+
+- **Java** — core services, metadata models, GraphQL API
+- **Python** — `metadata-ingestion` module (requires Python 3.x + pip)
+- **TypeScript/React** — `datahub-web-react` frontend (requires Node.js + npm)
+- **Docker** — container build definitions as Gradle subprojects
+
+Running `./gradlew build` fails in our container because Node.js and
+Python toolchains are not installed, and the Gradle build does not
+provide a way to build only the Java subprojects without also triggering
+the frontend and ingestion builds.
+
+## Why datahub Was Removed
+
+datahub was removed from `config.yaml` because:
+
+1. Build consistently fails (~272s) due to missing Node.js/Python toolchains
+2. No straightforward Gradle exclude pattern covers all non-Java subprojects
+3. Adding Node.js + Python to the Docker image significantly increases
+   image size and complexity
+4. The SPDX output would be incomplete (missing frontend/ingestion deps)
+
+## Proposed Approach for Next Generation
+
+### Option A: Multi-Stage Analysis
+
+Run separate analysis passes per language, then merge results:
+
+1. Build Java subprojects only (`./gradlew :metadata-service:war:build`)
+2. Analyze Python deps via `pip freeze` or `requirements.txt`
+3. Analyze TypeScript deps via `package-lock.json`
+4. Merge per-language SPDX documents into a unified project SPDX
+
+### Option B: Extended Docker Image
+
+Create a separate Docker image (`omnibor-env-polyglot`) with all
+toolchains:
+
+- Java (Maven + Gradle) — already present
+- Python 3.x + pip
+- Node.js + npm
+- Additional build tools as needed
+
+### Option C: Config-Driven Subproject Selection
+
+Allow `config.yaml` to specify which Gradle/Maven subprojects to build:
+
+```yaml
+datahub:
+  build_steps:
+    - './gradlew build -x test -x :datahub-web-react:build -x :metadata-ingestion:build'
+  include_subprojects:
+    - 'metadata-service/**'
+    - 'metadata-models'
+    - 'entity-registry'
+```
+
+## Other Polyglot Candidates
+
+Projects that may benefit from polyglot support in the future:
+
+| Project | Primary | Secondary | Notes |
+|---------|---------|-----------|-------|
+| datahub | Java (Gradle) | Python, TypeScript | Metadata platform |
+| Apache Spark | Scala (Maven) | Python, R | Big data framework |
+| Elasticsearch | Java (Gradle) | Groovy | Search engine |
+| VS Code | TypeScript | C++ (native modules) | Editor |
+
+## Priority
+
+Low — current language-specific pipelines cover the majority of
+real-world projects. Polyglot support is a nice-to-have for
+comprehensive enterprise SBOM coverage.

--- a/docs/deep-dive/build-run-results_2026-04-29_1550.md
+++ b/docs/deep-dive/build-run-results_2026-04-29_1550.md
@@ -1,0 +1,75 @@
+# Build Run Results — 2026-04-29
+
+Full analysis re-run of all 21 configured repositories with
+root package version detection (PR #87).
+
+## EC2 Build Host
+
+| Field | Value |
+|-------|-------|
+| **Instance Type** | `c6i.xlarge` |
+| **vCPUs** | 4 (2 cores × 2 threads) |
+| **RAM** | 8 GB |
+| **CPU** | Intel Xeon Platinum 8375C @ 2.90 GHz |
+| **Storage** | 50 GB gp3 (3000 IOPS) |
+| **OS** | Ubuntu 22.04 x86_64 (kernel 6.8.0-1052-aws) |
+| **Docker** | 29.3.1 |
+| **Region** | us-west-1 |
+
+## Results — 21/21 Successful
+
+| Language | Repo | Tag | Duration | Notes |
+|----------|------|-----|----------|-------|
+| C/C++ | openosc | v1.0.7 | 6s | Minimal C library, bomtrace3 |
+| C/C++ | redis | 8.0-rc1 | 31s | Single-binary server, bomtrace3 |
+| C/C++ | nmap | 7.95 | 51s | Network scanner, autoconf, bomtrace3 |
+| C/C++ | curl | curl-8_12_1 | 72s | HTTP client, autoconf, bomtrace3 |
+| C/C++ | ffmpeg | n7.1 | 741s (12m) | Large multimedia framework, bomtrace3 |
+| C/C++ | node | v22.14.0 | 5,976s (100m) | V8 + libuv, massive C++ codebase, bomtrace3 |
+| Go | fzf | v0.61.1 | 48s | Fuzzy finder, bomtrace2 |
+| Go | croc | v10.2.3 | 75s | File transfer, bomtrace2 |
+| Go | dive | v0.13.1 | 104s | Docker image explorer, bomtrace2 |
+| Go | gdu | v5.34.1 | 119s | Disk usage analyzer, bomtrace2 |
+| Go | lazygit | v0.46.0 | 122s | Git TUI, bomtrace2 |
+| Go | pocketbase | v0.28.1 | 152s | Backend framework, bomtrace2 |
+| Rust | oxipng | v9.1.4 | 41s | PNG optimizer, bomtrace2 |
+| Rust | dura | v0.2.0 | 175s | Auto-commit daemon, bomtrace2 |
+| Java | jsoup | jsoup-1.18.3 | 35s | HTML parser, zero runtime deps, strace |
+| Java | checkstyle | checkstyle-10.22.0 | 72s | Static analysis, Maven, strace |
+| Java | crawler4j | crawler4j-4.4.0 | 119s | Web crawler, Maven, strace |
+| Java | logging-log4j2 | rel/2.24.3 | 136s | Log4j2, Maven multi-module (JDK 17), strace |
+| Java | dependency-check | v9.2.0 | 272s | OWASP scanner, Maven multi-module, strace |
+| Java | bc-java | r1bcpg81 | 292s | Bouncy Castle crypto, Gradle, strace |
+| Java | spring-boot | v3.3.0 | 570s (10m) | Spring framework, Gradle multi-module, strace |
+
+## Aggregate
+
+| Metric | Value |
+|--------|-------|
+| **Total repos** | 21 |
+| **Successful** | 21 (100%) |
+| **Total wall-clock time** | ~154 min |
+| **Longest build** | node (100 min) |
+| **Shortest build** | openosc (6s) |
+| **Median build** | ~119s |
+
+## Performance Notes
+
+- **C/C++ builds are ptrace-instrumented** (bomtrace3), which adds
+  significant overhead to compilation. node's 100-min build time is
+  dominated by V8 engine compilation under ptrace interception.
+- **Go and Rust builds use LD_PRELOAD** (bomtrace2), which has much
+  lower overhead than ptrace.
+- **Java builds use strace** for post-build file access analysis,
+  with minimal build overhead.
+- All builds ran **sequentially** — no parallelism between repos.
+- Docker container resource limits match the host (no CPU/memory caps).
+- node consistently saturates all 4 vCPUs during compilation (~400% CPU).
+
+## Changes Since Last Run
+
+- **PR #87**: Root package version detection for all languages
+- **dive fix**: Binary output renamed to `dive_bin` to avoid directory
+  name conflict; `binary_collector.py` now guards against directories
+- **datahub removed**: Polyglot project (Java + Python + Node.js)
+  not buildable in current container

--- a/docs/deep-dive/build-run-results_2026-04-29_1550_baseline.md
+++ b/docs/deep-dive/build-run-results_2026-04-29_1550_baseline.md
@@ -1,0 +1,148 @@
+# Build Run Results — 2026-04-29 (Baseline)
+
+Non-instrumented build times for all 21 repositories.
+For comparison with instrumented runs, see `build-run-results_2026-04-29_1550.md`.
+
+## EC2 Build Host
+
+| Field | Value |
+|-------|-------|
+| **Instance Type** | `c6i.xlarge` |
+| **vCPUs** | 4 (2 cores × 2 threads) |
+| **RAM** | 8 GB |
+| **CPU** | Intel Xeon Platinum 8375C @ 2.90 GHz |
+| **Storage** | 50 GB gp3 (3000 IOPS) |
+| **OS** | Ubuntu 22.04 x86_64 (kernel 6.8.0-1052-aws) |
+| **Docker** | 29.3.1 |
+| **Region** | us-west-1 |
+
+## Results — 21/21 Successful (Baseline)
+
+| Language | Repo | Tag | Baseline | Instrumented | Overhead | Notes |
+|----------|------|-----|----------|--------------|----------|-------|
+| C/C++ | openosc | v1.0.7 | 6s | 6s | 0% | Minimal C library |
+| C/C++ | redis | 8.0-rc1 | 26s | 31s | +19% | Single-binary server |
+| C/C++ | nmap | 7.95 | 48s | 51s | +6% | Network scanner, autoconf |
+| C/C++ | curl | curl-8_12_1 | 62s | 72s | +16% | HTTP client, autoconf |
+| C/C++ | ffmpeg | n7.1 | 658s (11m) | 741s (12m) | +13% | Large multimedia framework |
+| C/C++ | node | v22.14.0 | 5,461s (91m) | 5,976s (100m) | +9% | V8 + libuv, massive C++ codebase |
+| Go | fzf | v0.61.1 | 10s | 48s | +380% | Fuzzy finder |
+| Go | croc | v10.2.3 | 16s | 75s | +369% | File transfer |
+| Go | dive | v0.13.1 | 23s | 104s | +352% | Docker image explorer |
+| Go | gdu | v5.34.1 | 36s | 119s | +231% | Disk usage analyzer |
+| Go | lazygit | v0.46.0 | 31s | 122s | +294% | Git TUI |
+| Go | pocketbase | v0.28.1 | 53s | 152s | +187% | Backend framework |
+| Rust | oxipng | v9.1.4 | 23s | 41s | +78% | PNG optimizer |
+| Rust | dura | v0.2.0 | 47s | 175s | +272% | Auto-commit daemon |
+| Java | jsoup | jsoup-1.18.3 | 26s | 35s | +35% | HTML parser, zero runtime deps |
+| Java | checkstyle | checkstyle-10.22.0 | 35s | 72s | +106% | Static analysis, Maven |
+| Java | crawler4j | crawler4j-4.4.0 | 95s | 119s | +25% | Web crawler, Maven |
+| Java | dependency-check | v9.2.0 | 28s | 272s | +871% | OWASP scanner, Maven multi-module |
+| Java | logging-log4j2 | rel/2.24.3 | 108s | 136s | +26% | Log4j2, Maven multi-module (JDK 17) |
+| Java | bc-java | r1bcpg81 | 145s | 292s | +101% | Bouncy Castle crypto, Gradle |
+| Java | spring-boot | v3.3.0 | 55s | 570s (10m) | +936% | Spring framework, Gradle multi-module |
+
+## Instrumentation Overhead Analysis
+
+| Tracer | Avg Overhead | Range | Notes |
+|--------|--------------|-------|-------|
+| **bomtrace3 (ptrace)** | +12% | 6%–19% | C/C++ builds — ptrace overhead scales with compilation time |
+| **bomtrace2 (LD_PRELOAD)** | +298% | 78%–380% | Go/Rust builds — LD_PRELOAD + Go/Rust toolchain overhead |
+| **strace (post-build)** | +363% | 25%–936% | Java builds — strace + Maven/Gradle overhead, highly variable |
+
+### Key Observations
+
+- **C/C++**: bomtrace3 overhead is modest (+6% to +19%). Larger projects (ffmpeg, node) show lower percentage overhead.
+- **Go**: bomtrace2 adds significant overhead (+187% to +380%). Go's fast compile time makes the interception cost more visible.
+- **Rust**: Moderate overhead (+78% to +272%). Cargo build --release is already heavy.
+- **Java**: Highly variable (+25% to +936%). strace + Maven/Gradle multi-module builds can introduce large overhead, especially for spring-boot and dependency-check.
+
+## Aggregate
+
+| Metric | Baseline | Instrumented | Overhead |
+|--------|----------|--------------|----------|
+| **Total wall-clock time** | ~115 min | ~154 min | +34% |
+| **Longest build** | node (91 min) | node (100 min) | +9% |
+| **Shortest build** | openosc (6s) | openosc (6s) | 0% |
+| **Median build** | ~47s | ~119s | +153% |
+
+## Performance Notes
+
+- **Sequential execution** — No parallelism between repos, same as instrumented run
+- **Docker container** — Same resource limits, no CPU/memory caps
+- **Node build** — Still saturates all 4 vCPUs without ptrace, but completes ~9% faster
+- **Java variability** — strace overhead depends heavily on Maven/Gradle behavior and module complexity
+
+## Comparison Summary
+
+- **Non-instrumented builds**: 115 min total
+- **Instrumented builds**: 154 min total
+- **Overall overhead**: 34% additional wall-clock time for complete analysis
+
+---
+
+## Appendix: Benchmark Methodology Analysis
+
+**WARNING**: The overhead measurements above are not reliable due to methodological issues. The variance (25%-936%) and overall 34% overhead should not be used for decision-making.
+
+### Critical Issues with Current Benchmark
+
+#### 1. Hyperthreading Contention at 400% CPU
+- `c6i.xlarge` has 4 physical cores with hyperthreading (8 logical)
+- `400% CPU` indicates all 4 physical cores are saturated
+- Hyperthreading shares L1/L2 cache between threads, causing resource contention
+- Research shows compilation performance varies significantly when hyperthreaded cores compete for cache
+
+#### 2. No CPU Affinity Control
+- HPC benchmarking best practices require CPU affinity control
+- Without pinning, threads migrate between cores, causing cache thrashing
+- Docker runs without `taskset` or `likwid-pin` to constrain processes
+
+#### 3. Dynamic CPU Clock (Turbo Boost)
+- Intel Xeon Platinum 8375C uses turbo boost (2.9GHz base, higher boost)
+- Different loads trigger different boost states
+- Best practices require disabling turbo for reproducible benchmarks
+
+#### 4. System Load Variability
+- EC2 instances are multi-tenant
+- Background processes, network I/O, and disk contention affect results
+- No isolation from system noise
+
+#### 5. Build System Caching Effects
+- Go/Rust incremental builds may use caches differently
+- Maven/Gradle daemon processes may persist between runs
+- `make -j$(nproc)` vs single-threaded builds have different characteristics
+
+### Industry Best Practices Violated
+
+From HPC benchmarking guidelines:
+
+1. **Fixed CPU frequency** (disable turbo) - Not done
+2. **CPU affinity control** (pin threads to specific cores) - Not done
+3. **Isolate from system noise** (dedicated hardware, no background load) - Not done
+4. **Multiple runs with statistics** (we did single runs) - Not done
+5. **Control SMT/hyperthreading** (test with/without, don't mix results) - Not done
+6. **Warm-up runs** (allow caches to stabilize) - Not done
+
+### The Real Issue: Non-Comparable Scenarios
+
+The biggest problem: **instrumented and baseline runs occurred under different system conditions**:
+
+- **Instrumented runs**: Sequential over hours, system warmed up, potential thermal throttling
+- **Baseline runs**: After a reboot, cold caches, different system state
+- **400% CPU**: Indicates we're hitting system limits where small variations cause large timing differences
+
+### Recommended Proper Benchmark Method
+
+For reliable overhead measurements:
+
+1. **Run each repo 3-5 times** in both modes
+2. **Use CPU affinity**: `taskset -c 0-3` to pin to physical cores only
+3. **Disable turbo boost**: `cpupower frequency-set -g performance`
+4. **Isolate builds**: Kill background processes, clear caches
+5. **Same system state**: Run baseline+instrumented back-to-back for each repo
+6. **Statistical analysis**: Report mean ± std deviation
+
+### Conclusion
+
+The current measurements are not reliable indicators of true instrumentation cost. The 34% overall overhead and wild variance (25%-936%) reflect system load and methodology issues rather than actual tracer overhead.

--- a/docs/deep-dive/demo-workflow.md
+++ b/docs/deep-dive/demo-workflow.md
@@ -12,7 +12,7 @@ blockquote { font-size: 18px; }
 
 # OmniBOR Tech Deep Dive — Demo Cheat Sheet
 
-> **Last modified:** 2026-04-17 11:41 HST
+> **Last modified:** 2026-04-29 05:46 HST
 
 | | |
 |---|---|
@@ -179,24 +179,151 @@ release tag for reproducibility, and the build steps. The pipeline runs
 all steps except the last one normally, then wraps the final `make` with
 bomtrace3 for interception."
 
-**1e. Pipeline orchestration**
+**1e. Pipeline entry point — `runners.py`**
 
 Open `app/pipeline/runners.py`.
 
-**Say:** "`main()` clones the repo, generates a Syft manifest SBOM, then
-dispatches to the language-specific pipeline. For C/C++ that's
-`_run_c_cpp_pipeline()` — instrumented build, SPDX generation, validation,
-and documentation. Add a repo to the YAML and the pipeline handles the
-rest."
+**Say:** "This is the CLI entry point. `main()` parses arguments, loads
+`config.yaml`, creates a single `AnalysisPipeline` facade, then executes
+the common steps: clone the repo at its pinned tag, optionally generate a
+Syft manifest SBOM, then dispatch to the language-specific runner. After
+the language pipeline returns, it writes build and runtime documentation."
 
-**1f. Builder — where interception happens**
+**Key code path** (lines 100–170):
+
+```text
+main()
+  → pipeline = AnalysisPipeline()        # facade.py — composes all components
+  → pipeline.cloner.clone(...)           # git clone at pinned tag
+  → pipeline.syft_gen.generate(...)      # optional Syft manifest SBOM
+  → run_c_cpp_pipeline(pipeline, ...)    # dispatch to lang_runners.py
+  → pipeline.docs.write_build_doc(...)   # build documentation
+```
+
+---
+
+**1f. Language-specific runner — `lang_runners.py`**
+
+Open `app/pipeline/lang_runners.py`.
+
+**Say:** "Each language has its own pipeline function.
+`run_c_cpp_pipeline()` orchestrates the seven steps for C/C++:
+
+1. **Validate apt deps** — checks `apt_deps` from config are installed
+2. **Instrumented build** — `pipeline.builder.build()` wraps `make` with
+   bomtrace3
+3. **OmniBOR SPDX** — `pipeline.spdx_gen.generate()` calls `bomsh_sbom.py`
+   to produce SPDX from the OmniBOR data
+4. **Collect metadata** — dynamic libraries, component versions
+5. **Per-binary ADG SPDX** — `pipeline.adg_spdx.generate()` produces the
+   analyzed + build SBOM pair per binary
+6. **Validate SPDX** — schema + semantic validation
+7. **Collect binaries** — copy output binaries to `output/binaries/`
+
+Rust and Go follow the same pattern using bomtrace2 instead of bomtrace3.
+Java uses strace + `bomsh_create_bom_java.py` instead."
+
+---
+
+**1g. The Facade — `facade.py`**
+
+Open `app/pipeline/facade.py`.
+
+**Say:** "`AnalysisPipeline` is a facade that composes all pipeline
+components via dependency injection. Each component — `RepoCloner`,
+`BomtraceBuilder`, `SpdxGenerator`, `MetadataCollector`, `AdgSpdxStep`,
+`SpdxValidator`, `SyftGenerator`, `BinaryCollector`, `DocWriter` — is
+independently testable. The facade wires them together with a shared
+`CommandRunner` that executes shell commands inside the Docker container."
+
+---
+
+**1h. Builder — where interception happens**
 
 Open `app/pipeline/builder.py`.
 
-**Say:** "The builder runs pre-build steps normally, then prepends
-bomtrace3 to the final `make` command. After the build, it calls
-`bomsh_create_bom.py` to generate the Artifact Dependency Graph from the
-raw logfile."
+**Say:** "The builder is where omnibor-analysis hands off to the upstream
+bomsh tools. Here's the exact sequence inside `build()`:
+
+**Step 1 — Clean.** Run `make clean` or `make distclean` (from
+`clean_cmd` in config) so every source file is recompiled. Without this,
+make sees existing `.o` files and becomes a no-op — bomtrace3 intercepts
+zero compiler calls.
+
+**Step 2 — Pre-build.** Run every `build_steps` entry except the last
+one without instrumentation. For C/C++ this is typically `autoreconf` and
+`./configure` — they generate Makefiles but don't compile code.
+
+**Step 3 — Instrumented build.** Prepend the tracer to the final build
+step:
+
+```text
+bomtrace3 make -j$(nproc)
+```
+
+bomtrace3 is a modified strace. It attaches via ptrace as the parent
+process and intercepts every `execve()` syscall. When make spawns gcc,
+ar, or ld, bomtrace3 captures the full command line and computes
+SHA-256 gitoid hashes for every input and output file. The result is a
+raw logfile at `/tmp/bomsh_hook_raw_logfile.sha1`.
+
+**Step 4 — ADG generation.** Call `bomsh_create_bom.py` to parse the raw
+logfile into an Artifact Dependency Graph:
+
+```text
+bomsh_create_bom.py -r /tmp/bomsh_hook_raw_logfile.sha1 -b <bom_dir>
+```
+
+This produces two key artifacts in `<bom_dir>/metadata/bomsh/`:
+- `bomsh_omnibor_treedb` — JSON mapping of gitoid → filepath, with
+  `hash_tree` arrays showing which inputs built each output
+- `bomsh_omnibor_doc_mapping` — maps binary hashes to OmniBOR document IDs
+- `bomsh_hook_raw_logfile` — archived copy of the raw build trace"
+
+---
+
+**1i. OmniBOR config — language-specific tracers**
+
+Open `app/config.yaml` and scroll to the `omnibor:` sections at the bottom.
+
+**Say:** "The config has four omnibor sections — one per language:
+
+| Language | Tracer | ADG Script | Key Difference |
+|----------|--------|-----------|----------------|
+| C/C++ | `bomtrace3` | `bomsh_create_bom.py` | ptrace-based, intercepts execve |
+| Rust | `bomtrace2` | `bomsh_create_bom.py` | ptrace-based, bomsh has dedicated rustc parser |
+| Go | `bomtrace2 -c bomtrace_go.conf` | `bomsh_create_bom.py` | Go-specific config watches go tool compile/link |
+| Java | `strace` (external) | `bomsh_create_bom_java.py` | Post-build analysis, scans .java → .class → .jar |
+
+All four produce the same output structure: a treedb JSON in
+`output/omnibor/{lang}/{repo}/{ts}/metadata/bomsh/`."
+
+---
+
+**1j. From treedb to SPDX — two output types**
+
+**Say:** "After the build, omnibor-analysis produces two SPDX files per
+binary (following the CISA SBOM taxonomy):
+
+1. **Analyzed SBOM** (`*_analyzed.spdx.json`) — only the source files
+   compiled into the binary, traced from the treedb `hash_tree`. Each
+   file has its gitoid checksum. This is the ground-truth provenance.
+
+2. **Build SBOM** (`*_build.spdx.json`) — the full dependency graph:
+   vendored libraries detected from source paths (e.g., `deps/lua/`,
+   `vendor/zlib/`), dynamic libraries from `ldd` output, build tools
+   (gcc, libc6). Versions detected from source headers and version files.
+
+The `AdgSpdxStep` in `adg_spdx.py` drives this. It instantiates
+`AdgSpdxGenerator` (from `spdx_from_adg.py`) which reads the treedb,
+resolves vendored packages via `VendoredVersionDetector`, classifies
+relationships (STATIC_LINK, DYNAMIC_LINK, BUILD_TOOL_OF, DEPENDS_ON),
+and emits SPDX 2.3 JSON through `SpdxEmitter`.
+
+Finally, `SpdxGenerator.patch_spdx_metadata()` injects OmniBOR
+ExternalRefs — `PERSISTENT-ID` references with `gitoid:blob:sha1:` locators
+— into each SPDX package, linking the SBOM back to the OmniBOR artifact
+identity."
 
 <br><br><hr>
 
@@ -639,4 +766,4 @@ ssh omnibor-build "sudo rm -rf /home/ubuntu/omnibor-analysis/repos/openosc"
 
 ---
 
-*Last updated: 2026-04-17 11:41 HST*
+*Last updated: 2026-04-29 05:46 HST*

--- a/docs/guides/ONBOARDING.md
+++ b/docs/guides/ONBOARDING.md
@@ -138,7 +138,7 @@ Pre-configured Rust repos: **oxipng**, **dura**
 
 Pre-configured Go repos: **lazygit**, **fzf**, **pocketbase**, **croc**, **dive**, **gdu**
 
-Pre-configured Java repos: **checkstyle**, **jsoup**, **crawler4j**, **dependency-check**, **logging-log4j2**, **spring-boot**, **bc-java**, **datahub**
+Pre-configured Java repos: **checkstyle**, **jsoup**, **crawler4j**, **dependency-check**, **logging-log4j2**, **spring-boot**, **bc-java**
 
 ### Add a new repo from GitHub
 


### PR DESCRIPTION
## Summary

Bug fixes, repo cleanup, and build performance documentation.

## Changes

### Bug Fixes
- **`binary_collector.py`** — Add `is_file()` guard to prevent `IsADirectoryError` when a binary name matches a directory (e.g., `repos/dive/dive`)
- **`config.yaml`** — Fix dive binary output to `dive_bin` to avoid name conflict with `dive/` package directory

### Repo Removal
- **`config.yaml`** — Remove datahub (polyglot build environment limitations)
- **`ONBOARDING.md`** — Remove datahub from pre-configured Java repos list

### Infrastructure Fix
- **`active-profile.md`** — Correct instance type: `c6i.4xlarge` → `c6i.xlarge` (4 vCPU, 8 GB)

### New Documentation
- **`polyglot-build-support.md`** — Documents why polyglot repos like datahub are excluded and future approaches
- **`build-run-results_2026-04-29_1550.md`** — Instrumented build run results for all 21 repos with EC2 specs
- **`build-run-results_2026-04-29_1550_baseline.md`** — Non-instrumented baseline times + benchmark methodology analysis appendix

### Updated Documentation
- **`demo-workflow.md`** — Updated pipeline entry point section and timestamp

## Test Results

901 tests passed, all green.
