### PR TITLE
feat(resolver): create PackageResolver ABC (#95)

### DIFF
--- a/.windsurf/rules/workflow/regression-gate.md
+++ b/.windsurf/rules/workflow/regression-gate.md
@@ -1,0 +1,71 @@
+# Issue Regression Gate
+
+## Rule
+
+**Before implementing** any GitHub issue, evaluate whether the change
+could affect pipeline output (SPDX, metadata, dynamic libs, PURL
+generation, build steps, or config resolution). If yes, a system-level
+regression run is required **after** implementation passes all unit
+tests and before the PR is declared ready.
+
+Report the regression assessment to the user during issue research,
+**before** writing any code.
+
+## When to Require a Regression Run
+
+A regression run is required if the change touches or could affect:
+
+- SPDX generation or emission (`emitter.py`, `generator.py`,
+  `java_generator.py`, any `*_generator.py`)
+- Dependency parsing (`parser.py`, `lang_parsers.py`,
+  `maven_parser.py`, `gradle_parser.py`)
+- Package resolution or PURL generation (`resolver.py`,
+  `package_resolver.py`, `collect_metadata.py`,
+  `collect_dynamic_libs.py`)
+- Build pipeline (`builder.py`, `runners.py`, `lang_runners.py`,
+  `facade.py`)
+- Config schema or path resolution (`config.py`, `config.yaml`)
+- Interception strategy (`interception.py`, `CommandRunner`)
+- Visualization extraction logic (`extract.py`)
+- Relationship type mapping (`relationships.py`)
+- Vendored detection (`vendored.py`)
+- Docker image changes (`Dockerfile`, `docker-compose.yml`)
+
+A regression run is **not** required for:
+
+- Pure documentation changes
+- New ABC/interface definitions with no consumers yet
+- Test-only changes
+- Rule file changes
+- New modules that are not wired into the pipeline
+
+## Regression Test Repos
+
+Run at least one repo per supported language. These repos were chosen
+to exercise the widest set of pipeline code paths:
+
+| Language | Repo | Why |
+|----------|------|-----|
+| C/C++ | `redis` | Pure make, 8 vendored libs under deps/, 2 binaries, STATIC_LINK + DYNAMIC_LINK |
+| Go | `fzf` | Clean Go build, vendored module detection, fast turnaround |
+| Rust | `dura` | Largest Rust dep tree (42 direct + 35 transitive), git bindings |
+| Java | `dependency-check` | Multi-module, shade plugin, deepest dep hierarchy |
+
+## Regression Run Procedure
+
+1. Ensure EC2 is running and code is synced
+2. Run each regression repo: `analyze.py --repo <name>`
+3. Compare SPDX output against the most recent golden/baseline run
+4. Report any differences to the user per golden-file-policy
+5. Only declare the issue complete if regression output matches
+
+## Assessment Format
+
+When evaluating an issue, report to the user:
+
+```
+### Regression Assessment: #<issue> [<title>]
+- **Pipeline impact:** Yes/No
+- **Reason:** <why it does or does not affect output>
+- **Regression repos needed:** <list or "None">
+```

--- a/app/spdx/package_resolver.py
+++ b/app/spdx/package_resolver.py
@@ -1,0 +1,242 @@
+"""Package resolver abstraction for multi-distro support.
+
+Provides a common interface for resolving file paths to OS package
+metadata across different Linux distributions. Each concrete
+resolver implements the distro-specific query mechanism:
+
+- ``DpkgResolver`` — Debian/Ubuntu (``dpkg-query -S``)
+- ``RpmResolver``  — RHEL/CentOS/Fedora (``rpm -qf``)
+- ``ApkResolver``  — Alpine (``apk info --who-owns``)
+
+The ``auto_detect_resolver()`` factory reads ``/etc/os-release``
+to select the correct implementation at runtime.
+
+Design reference: sidecar-implementation-design.md Section 4.3
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class ResolvedPackage:
+    """Metadata for a resolved OS package.
+
+    Attributes:
+        name: Binary package name (e.g. ``libssl3``).
+        version: Full package version string.
+        source: Source package name (e.g. ``openssl``).
+        architecture: Package architecture (e.g. ``amd64``).
+        maintainer: Package maintainer string.
+        homepage: Upstream homepage URL.
+        section: Package section/group (e.g. ``libs``).
+        extra: Additional distro-specific metadata fields.
+    """
+
+    name: str
+    version: str
+    source: str = ""
+    architecture: str = ""
+    maintainer: str = ""
+    homepage: str = ""
+    section: str = ""
+    extra: dict = field(default_factory=dict)
+
+
+class PackageResolver(ABC):
+    """Resolves file paths to OS package metadata.
+
+    Implementations must provide distro-specific mechanisms
+    for two operations:
+
+    1. ``resolve(file_path)`` — given an absolute file path,
+       return the owning package's metadata or ``None``.
+    2. ``purl_scheme()`` — return the PURL type and namespace
+       prefix for this distro (e.g. ``pkg:deb/ubuntu``).
+
+    The interface is deliberately minimal (P4: Interface
+    Segregation) so that adding a new distro requires only
+    two method implementations.
+    """
+
+    @abstractmethod
+    def resolve(self, file_path: str) -> Optional[ResolvedPackage]:
+        """Return package metadata for a file, or None.
+
+        Args:
+            file_path: Absolute path to a file on disk.
+
+        Returns:
+            A ``ResolvedPackage`` with the owning package's
+            metadata, or ``None`` if the file does not belong
+            to any installed package.
+        """
+
+    @abstractmethod
+    def purl_scheme(self) -> str:
+        """Return the PURL type+namespace prefix for this distro.
+
+        Examples:
+            - ``"pkg:deb/ubuntu"`` for Debian/Ubuntu
+            - ``"pkg:rpm/rhel"`` for RHEL/CentOS
+            - ``"pkg:apk/alpine"`` for Alpine
+
+        The caller appends ``/{name}@{version}?qualifiers``
+        to build the full PURL string.
+        """
+
+    def make_purl(
+        self, pkg_name: str, version: str,
+        arch: str = "", distro_version: str = "",
+    ) -> str:
+        """Build a complete PURL from package metadata.
+
+        Args:
+            pkg_name: Binary package name.
+            version: Package version string.
+            arch: Package architecture (optional qualifier).
+            distro_version: Distro version (optional qualifier).
+
+        Returns:
+            A valid Package URL string.
+        """
+        purl = f"{self.purl_scheme()}/{pkg_name}@{version}"
+        qualifiers = []
+        if arch:
+            qualifiers.append(f"arch={arch}")
+        if distro_version:
+            qualifiers.append(f"distro={distro_version}")
+        if qualifiers:
+            purl += "?" + "&".join(qualifiers)
+        return purl
+
+
+def detect_distro_id() -> str:
+    """Read distro ID from ``/etc/os-release``.
+
+    Returns:
+        Lowercase distro identifier (e.g. ``"ubuntu"``,
+        ``"rhel"``, ``"alpine"``). Returns ``"unknown"``
+        if detection fails.
+    """
+    try:
+        with open("/etc/os-release", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("ID="):
+                    return (
+                        line.split("=", 1)[1]
+                        .strip()
+                        .strip('"')
+                        .lower()
+                    )
+    except OSError:
+        pass
+    return "unknown"
+
+
+def detect_distro_version() -> str:
+    """Read distro version from ``/etc/os-release``.
+
+    Returns:
+        Version string (e.g. ``"22.04"``, ``"9.3"``,
+        ``"3.18"``). Returns ``""`` if detection fails.
+    """
+    try:
+        with open("/etc/os-release", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("VERSION_ID="):
+                    return (
+                        line.split("=", 1)[1]
+                        .strip()
+                        .strip('"')
+                    )
+    except OSError:
+        pass
+    return ""
+
+
+# Distro ID → PURL family mapping
+_DISTRO_FAMILIES = {
+    "ubuntu": "deb",
+    "debian": "deb",
+    "rhel": "rpm",
+    "centos": "rpm",
+    "fedora": "rpm",
+    "rocky": "rpm",
+    "almalinux": "rpm",
+    "ol": "rpm",
+    "alpine": "apk",
+}
+
+# PURL family → distro namespace mapping
+_PURL_NAMESPACES = {
+    "deb": {
+        "ubuntu": "ubuntu",
+        "debian": "debian",
+    },
+    "rpm": {
+        "rhel": "rhel",
+        "centos": "centos",
+        "fedora": "fedora",
+        "rocky": "rocky",
+        "almalinux": "almalinux",
+        "ol": "oracle",
+    },
+    "apk": {
+        "alpine": "alpine",
+    },
+}
+
+
+def purl_namespace_for_distro(distro_id: str) -> str:
+    """Return the PURL namespace for a distro ID.
+
+    Args:
+        distro_id: Lowercase distro identifier from
+            ``/etc/os-release`` ``ID=`` field.
+
+    Returns:
+        PURL namespace string (e.g. ``"ubuntu"``, ``"rhel"``).
+        Falls back to the distro ID itself if unknown.
+    """
+    family = _DISTRO_FAMILIES.get(distro_id)
+    if family:
+        ns_map = _PURL_NAMESPACES.get(family, {})
+        return ns_map.get(distro_id, distro_id)
+    return distro_id
+
+
+def auto_detect_resolver() -> PackageResolver:
+    """Detect the host distro and return the appropriate resolver.
+
+    Reads ``/etc/os-release`` to determine the package manager,
+    then instantiates the matching ``PackageResolver`` subclass.
+
+    Returns:
+        A concrete ``PackageResolver`` for the detected distro.
+
+    Raises:
+        RuntimeError: If the distro is unrecognized or the
+            corresponding resolver is not yet implemented.
+    """
+    distro_id = detect_distro_id()
+    family = _DISTRO_FAMILIES.get(distro_id)
+
+    if family == "deb":
+        from app.spdx.dpkg_resolver import DpkgResolver
+        return DpkgResolver()
+
+    if family == "rpm":
+        from app.spdx.rpm_resolver import RpmResolver
+        return RpmResolver()
+
+    if family == "apk":
+        from app.spdx.apk_resolver import ApkResolver
+        return ApkResolver()
+
+    raise RuntimeError(
+        f"Unsupported distro '{distro_id}'. "
+        f"No PackageResolver available. "
+        f"Supported families: deb, rpm, apk."
+    )

--- a/tests/test_package_resolver.py
+++ b/tests/test_package_resolver.py
@@ -1,0 +1,338 @@
+"""Tests for PackageResolver ABC and helper functions.
+
+Covers:
+- ResolvedPackage dataclass construction
+- PackageResolver ABC contract enforcement
+- make_purl() helper method
+- detect_distro_id() with mocked /etc/os-release
+- detect_distro_version() with mocked /etc/os-release
+- purl_namespace_for_distro() mapping
+- auto_detect_resolver() factory with mocked distro detection
+"""
+
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from app.spdx.package_resolver import (
+    PackageResolver,
+    ResolvedPackage,
+    auto_detect_resolver,
+    detect_distro_id,
+    detect_distro_version,
+    purl_namespace_for_distro,
+)
+
+
+# ── ResolvedPackage dataclass ──────────────────────────────
+
+
+class TestResolvedPackage:
+    """Tests for the ResolvedPackage dataclass."""
+
+    def test_minimal_construction(self):
+        pkg = ResolvedPackage(name="libssl3", version="3.0.2")
+        assert pkg.name == "libssl3"
+        assert pkg.version == "3.0.2"
+        assert pkg.source == ""
+        assert pkg.architecture == ""
+        assert pkg.maintainer == ""
+        assert pkg.homepage == ""
+        assert pkg.section == ""
+        assert pkg.extra == {}
+
+    def test_full_construction(self):
+        pkg = ResolvedPackage(
+            name="libssl3",
+            version="3.0.2-0ubuntu1.15",
+            source="openssl",
+            architecture="amd64",
+            maintainer="Ubuntu Developers",
+            homepage="https://www.openssl.org/",
+            section="libs",
+            extra={"Priority": "optional"},
+        )
+        assert pkg.name == "libssl3"
+        assert pkg.source == "openssl"
+        assert pkg.architecture == "amd64"
+        assert pkg.extra == {"Priority": "optional"}
+
+    def test_extra_defaults_to_empty_dict(self):
+        pkg1 = ResolvedPackage(name="a", version="1")
+        pkg2 = ResolvedPackage(name="b", version="2")
+        # Verify each instance gets its own dict (no shared mutable default)
+        pkg1.extra["key"] = "val"
+        assert pkg2.extra == {}
+
+
+# ── PackageResolver ABC contract ───────────────────────────
+
+
+class TestPackageResolverABC:
+    """Tests for the PackageResolver abstract base class."""
+
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError):
+            PackageResolver()
+
+    def test_subclass_must_implement_resolve(self):
+        class Incomplete(PackageResolver):
+            def purl_scheme(self):
+                return "pkg:test/test"
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_subclass_must_implement_purl_scheme(self):
+        class Incomplete(PackageResolver):
+            def resolve(self, file_path):
+                return None
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_complete_subclass_instantiates(self):
+        class Complete(PackageResolver):
+            def resolve(self, file_path):
+                return None
+
+            def purl_scheme(self):
+                return "pkg:test/test"
+
+        resolver = Complete()
+        assert resolver.resolve("/usr/lib/libfoo.so") is None
+        assert resolver.purl_scheme() == "pkg:test/test"
+
+
+# ── make_purl() ────────────────────────────────────────────
+
+
+class TestMakePurl:
+    """Tests for the make_purl() helper on PackageResolver."""
+
+    def _make_resolver(self, scheme):
+        """Create a minimal concrete resolver for testing."""
+
+        class Stub(PackageResolver):
+            def resolve(self, file_path):
+                return None
+
+            def purl_scheme(self):
+                return scheme
+
+        return Stub()
+
+    def test_basic_purl(self):
+        r = self._make_resolver("pkg:deb/ubuntu")
+        purl = r.make_purl("libssl3", "3.0.2")
+        assert purl == "pkg:deb/ubuntu/libssl3@3.0.2"
+
+    def test_purl_with_arch(self):
+        r = self._make_resolver("pkg:deb/ubuntu")
+        purl = r.make_purl("libssl3", "3.0.2", arch="amd64")
+        assert purl == (
+            "pkg:deb/ubuntu/libssl3@3.0.2?arch=amd64"
+        )
+
+    def test_purl_with_distro_version(self):
+        r = self._make_resolver("pkg:rpm/rhel")
+        purl = r.make_purl(
+            "openssl-libs", "3.0.7-24.el9",
+            distro_version="rhel-9.3",
+        )
+        assert purl == (
+            "pkg:rpm/rhel/openssl-libs@3.0.7-24.el9"
+            "?distro=rhel-9.3"
+        )
+
+    def test_purl_with_all_qualifiers(self):
+        r = self._make_resolver("pkg:apk/alpine")
+        purl = r.make_purl(
+            "libssl3", "3.1.4-r2",
+            arch="x86_64", distro_version="alpine-3.18",
+        )
+        assert purl == (
+            "pkg:apk/alpine/libssl3@3.1.4-r2"
+            "?arch=x86_64&distro=alpine-3.18"
+        )
+
+    def test_purl_no_qualifiers(self):
+        r = self._make_resolver("pkg:deb/debian")
+        purl = r.make_purl("libc6", "2.36-9")
+        assert purl == "pkg:deb/debian/libc6@2.36-9"
+
+
+# ── detect_distro_id() ─────────────────────────────────────
+
+
+class TestDetectDistroId:
+    """Tests for detect_distro_id() with mocked os-release."""
+
+    def test_ubuntu(self):
+        content = (
+            'NAME="Ubuntu"\n'
+            'VERSION="22.04.3 LTS"\n'
+            'ID=ubuntu\n'
+        )
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_id() == "ubuntu"
+
+    def test_rhel(self):
+        content = (
+            'NAME="Red Hat Enterprise Linux"\n'
+            'ID="rhel"\n'
+            'VERSION_ID="9.3"\n'
+        )
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_id() == "rhel"
+
+    def test_alpine(self):
+        content = 'ID=alpine\nVERSION_ID=3.18.4\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_id() == "alpine"
+
+    def test_centos(self):
+        content = 'ID="centos"\nVERSION_ID="8"\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_id() == "centos"
+
+    def test_fedora(self):
+        content = 'ID=fedora\nVERSION_ID=39\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_id() == "fedora"
+
+    def test_rocky(self):
+        content = 'ID="rocky"\nVERSION_ID="9.3"\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_id() == "rocky"
+
+    def test_missing_file(self):
+        with patch("builtins.open", side_effect=OSError):
+            assert detect_distro_id() == "unknown"
+
+    def test_no_id_line(self):
+        content = 'NAME="Some Linux"\nVERSION="1.0"\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_id() == "unknown"
+
+    def test_quoted_id(self):
+        content = 'ID="debian"\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_id() == "debian"
+
+
+# ── detect_distro_version() ────────────────────────────────
+
+
+class TestDetectDistroVersion:
+    """Tests for detect_distro_version() with mocked os-release."""
+
+    def test_ubuntu(self):
+        content = 'ID=ubuntu\nVERSION_ID="22.04"\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_version() == "22.04"
+
+    def test_rhel(self):
+        content = 'ID="rhel"\nVERSION_ID="9.3"\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_version() == "9.3"
+
+    def test_alpine_unquoted(self):
+        content = 'ID=alpine\nVERSION_ID=3.18.4\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_version() == "3.18.4"
+
+    def test_missing_file(self):
+        with patch("builtins.open", side_effect=OSError):
+            assert detect_distro_version() == ""
+
+    def test_no_version_line(self):
+        content = 'ID=ubuntu\nNAME="Ubuntu"\n'
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert detect_distro_version() == ""
+
+
+# ── purl_namespace_for_distro() ────────────────────────────
+
+
+class TestPurlNamespaceForDistro:
+    """Tests for the distro ID to PURL namespace mapping."""
+
+    @pytest.mark.parametrize(
+        "distro_id,expected",
+        [
+            ("ubuntu", "ubuntu"),
+            ("debian", "debian"),
+            ("rhel", "rhel"),
+            ("centos", "centos"),
+            ("fedora", "fedora"),
+            ("rocky", "rocky"),
+            ("almalinux", "almalinux"),
+            ("ol", "oracle"),
+            ("alpine", "alpine"),
+        ],
+    )
+    def test_known_distros(self, distro_id, expected):
+        assert purl_namespace_for_distro(distro_id) == expected
+
+    def test_unknown_distro_returns_id(self):
+        assert purl_namespace_for_distro("nixos") == "nixos"
+
+    def test_empty_string(self):
+        assert purl_namespace_for_distro("") == ""
+
+
+# ── auto_detect_resolver() ─────────────────────────────────
+
+
+class TestAutoDetectResolver:
+    """Tests for the auto_detect_resolver() factory."""
+
+    def test_unsupported_distro_raises(self):
+        with patch(
+            "app.spdx.package_resolver.detect_distro_id",
+            return_value="nixos",
+        ):
+            with pytest.raises(RuntimeError, match="Unsupported"):
+                auto_detect_resolver()
+
+    def test_unknown_distro_raises(self):
+        with patch(
+            "app.spdx.package_resolver.detect_distro_id",
+            return_value="unknown",
+        ):
+            with pytest.raises(RuntimeError, match="Unsupported"):
+                auto_detect_resolver()
+
+    def test_deb_family_imports_dpkg(self):
+        with patch(
+            "app.spdx.package_resolver.detect_distro_id",
+            return_value="ubuntu",
+        ):
+            with pytest.raises(
+                (ImportError, ModuleNotFoundError),
+            ):
+                # DpkgResolver module doesn't exist yet (#96)
+                auto_detect_resolver()
+
+    def test_rpm_family_imports_rpm(self):
+        with patch(
+            "app.spdx.package_resolver.detect_distro_id",
+            return_value="rhel",
+        ):
+            with pytest.raises(
+                (ImportError, ModuleNotFoundError),
+            ):
+                # RpmResolver module doesn't exist yet (#97)
+                auto_detect_resolver()
+
+    def test_apk_family_imports_apk(self):
+        with patch(
+            "app.spdx.package_resolver.detect_distro_id",
+            return_value="alpine",
+        ):
+            with pytest.raises(
+                (ImportError, ModuleNotFoundError),
+            ):
+                # ApkResolver module doesn't exist yet (#98)
+                auto_detect_resolver()


### PR DESCRIPTION
## Summary

Implements **[A1] Create PackageResolver ABC** ([#95](https://github.com/tedg-dev/omnibor-analysis/issues/95)) — the foundation for multi-distro package resolution.

Also adds the **regression-gate rule** (`.windsurf/rules/workflow/regression-gate.md`) for evaluating pipeline regression risk on every issue.

## What Changed

### `app/spdx/package_resolver.py` (new — 240 lines)

- **`ResolvedPackage`** dataclass — structured return type with `name`, `version`, `source`, `architecture`, `maintainer`, `homepage`, `section`, `extra`
- **`PackageResolver`** ABC — two abstract methods (`resolve()`, `purl_scheme()`) + concrete `make_purl()` helper
- **`detect_distro_id()`** / **`detect_distro_version()`** — read `/etc/os-release`
- **`purl_namespace_for_distro()`** — maps 9 distro IDs to PURL namespaces (ubuntu, debian, rhel, centos, fedora, rocky, almalinux, ol/oracle, alpine)
- **`auto_detect_resolver()`** — factory with lazy imports for `DpkgResolver`/`RpmResolver`/`ApkResolver` (modules created in #96/#97/#98)

### `tests/test_package_resolver.py` (new — 42 tests)

- ABC contract enforcement (cannot instantiate, must implement both methods)
- `make_purl()` with all qualifier combinations
- `detect_distro_id()` for 7 distros + edge cases
- `detect_distro_version()` for 3 distros + edge cases
- `purl_namespace_for_distro()` parametrized across all 9 mappings
- `auto_detect_resolver()` for unsupported/unknown distros and each family

### `.windsurf/rules/workflow/regression-gate.md` (new)

Defines when system-level regression runs are required per issue, with designated repos: `redis` (C/C++), `fzf` (Go), `dura` (Rust), `dependency-check` (Java).

## Regression Assessment

- **Pipeline impact:** No
- **Reason:** Pure ABC with no consumers in the existing pipeline
- **Regression repos needed:** None

## Verification

- 942 tests pass (900 existing + 42 new, zero regressions)
- 96% coverage on new file (3 uncovered lines are lazy imports for not-yet-created resolver modules)

## Closes

Closes #95

## Track A Roadmap

This is the first issue in the Package Resolver track ([epic #129](https://github.com/tedg-dev/omnibor-analysis/issues/129)). Next: #96 (DpkgResolver), #97 (RpmResolver), #98 (ApkResolver).
