### PR TITLE
feat(resolver): implement DpkgResolver (#96)

### DIFF
--- a/app/spdx/dpkg_resolver.py
+++ b/app/spdx/dpkg_resolver.py
@@ -1,0 +1,153 @@
+"""Dpkg package resolver for Debian/Ubuntu systems.
+
+Resolves file paths to OS package metadata using ``dpkg -S``
+(file-to-package lookup) and ``dpkg-query -W`` (package metadata
+query). This is the concrete ``PackageResolver`` implementation
+for any distro in the ``deb`` family (Debian, Ubuntu, etc.).
+
+The two subprocess calls mirror the existing patterns in
+``collect_metadata.py`` and ``collect_dynamic_libs.py``, which
+will be refactored to use this resolver in issue #100/#101.
+"""
+
+import subprocess
+from typing import Optional
+
+from app.spdx.package_resolver import (
+    PackageResolver,
+    ResolvedPackage,
+    detect_distro_id,
+    detect_distro_version,
+    purl_namespace_for_distro,
+)
+
+# Fields queried from dpkg-query, pipe-delimited
+_DPKG_FIELDS = [
+    "Package", "Version", "Source", "Architecture",
+    "Maintainer", "Homepage", "Section", "Priority",
+]
+_DPKG_FORMAT = "|".join(
+    ["${" + f + "}" for f in _DPKG_FIELDS]
+)
+
+
+class DpkgResolver(PackageResolver):
+    """Debian/Ubuntu package resolver using dpkg.
+
+    Uses two commands:
+
+    1. ``dpkg -S <path>`` — find which package owns a file
+    2. ``dpkg-query -W -f <fmt> <pkg>`` — query package metadata
+
+    The resolver caches metadata per package name to avoid
+    redundant ``dpkg-query`` calls when multiple files belong
+    to the same package.
+    """
+
+    def __init__(self):
+        self._distro_id = detect_distro_id()
+        self._distro_version = detect_distro_version()
+        self._namespace = purl_namespace_for_distro(
+            self._distro_id
+        )
+        self._meta_cache = {}
+
+    def purl_scheme(self) -> str:
+        """Return ``pkg:deb/<namespace>`` for this distro."""
+        return f"pkg:deb/{self._namespace}"
+
+    def resolve(
+        self, file_path: str,
+    ) -> Optional[ResolvedPackage]:
+        """Resolve a file path to its dpkg package metadata.
+
+        Args:
+            file_path: Absolute path to a file on disk.
+
+        Returns:
+            A ``ResolvedPackage`` with dpkg metadata, or
+            ``None`` if the file is not owned by any package.
+        """
+        pkg_name = self._file_to_package(file_path)
+        if not pkg_name:
+            return None
+        return self._query_metadata(pkg_name)
+
+    def _file_to_package(self, file_path: str) -> Optional[str]:
+        """Run ``dpkg -S <path>`` to find the owning package.
+
+        Returns the first package name, or None.
+        """
+        try:
+            out = subprocess.check_output(
+                ["dpkg", "-S", file_path],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            # Format: "pkg1, pkg2: /path/to/file"
+            pkg_part = out.split(":")[0]
+            return pkg_part.split(",")[0].strip()
+        except (subprocess.CalledProcessError, OSError):
+            return None
+
+    def _query_metadata(
+        self, pkg_name: str,
+    ) -> Optional[ResolvedPackage]:
+        """Query dpkg-query for package metadata, with caching.
+
+        Returns a ``ResolvedPackage`` or None if the query fails.
+        """
+        if pkg_name in self._meta_cache:
+            return self._meta_cache[pkg_name]
+
+        try:
+            out = subprocess.check_output(
+                [
+                    "dpkg-query", "-W", "-f",
+                    _DPKG_FORMAT, pkg_name,
+                ],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+            parts = out.split("|")
+            meta = {}
+            for i, field in enumerate(_DPKG_FIELDS):
+                if i < len(parts) and parts[i]:
+                    meta[field] = parts[i]
+        except (subprocess.CalledProcessError, OSError):
+            self._meta_cache[pkg_name] = None
+            return None
+
+        if not meta.get("Package"):
+            self._meta_cache[pkg_name] = None
+            return None
+
+        result = ResolvedPackage(
+            name=meta.get("Package", pkg_name),
+            version=meta.get("Version", ""),
+            source=meta.get("Source", ""),
+            architecture=meta.get("Architecture", ""),
+            maintainer=meta.get("Maintainer", ""),
+            homepage=meta.get("Homepage", ""),
+            section=meta.get("Section", ""),
+            extra={
+                k: v for k, v in meta.items()
+                if k not in {
+                    "Package", "Version", "Source",
+                    "Architecture", "Maintainer",
+                    "Homepage", "Section",
+                }
+            },
+        )
+        self._meta_cache[pkg_name] = result
+        return result
+
+    @property
+    def distro_version_qualifier(self) -> str:
+        """Return distro version string for PURL qualifiers.
+
+        Example: ``"ubuntu-22.04"``, ``"debian-12"``.
+        """
+        if self._distro_version:
+            return f"{self._distro_id}-{self._distro_version}"
+        return self._distro_id

--- a/tests/test_dpkg_resolver.py
+++ b/tests/test_dpkg_resolver.py
@@ -1,0 +1,262 @@
+"""Tests for DpkgResolver — Debian/Ubuntu package resolver.
+
+All subprocess calls are mocked. No actual dpkg commands run.
+
+Covers:
+- purl_scheme() returns correct deb namespace
+- resolve() for files owned by a package
+- resolve() for files not owned by any package
+- resolve() when dpkg-query fails
+- Metadata caching (repeated calls reuse cache)
+- _file_to_package() edge cases
+- distro_version_qualifier property
+- make_purl() integration with DpkgResolver
+"""
+
+import subprocess
+from unittest.mock import patch
+
+from app.spdx.dpkg_resolver import DpkgResolver
+
+
+# ── Helpers ────────────────────────────────────────────────
+
+
+def _make_resolver(
+    distro_id="ubuntu", distro_version="22.04",
+):
+    """Create a DpkgResolver with mocked distro detection."""
+    with patch(
+        "app.spdx.dpkg_resolver.detect_distro_id",
+        return_value=distro_id,
+    ), patch(
+        "app.spdx.dpkg_resolver.detect_distro_version",
+        return_value=distro_version,
+    ):
+        return DpkgResolver()
+
+
+def _dpkg_s_output(pkg_name, path):
+    """Simulate ``dpkg -S <path>`` output."""
+    return f"{pkg_name}: {path}"
+
+
+def _dpkg_query_output(
+    name="libssl3", version="3.0.2-0ubuntu1.15",
+    source="openssl", arch="amd64",
+    maintainer="Ubuntu Developers",
+    homepage="https://www.openssl.org/",
+    section="libs", priority="optional",
+):
+    """Simulate ``dpkg-query -W -f`` pipe-delimited output."""
+    return "|".join([
+        name, version, source, arch,
+        maintainer, homepage, section, priority,
+    ])
+
+
+# ── purl_scheme() ─────────────────────────────────────────
+
+
+class TestDpkgResolverPurlScheme:
+    """Tests for purl_scheme() across deb-family distros."""
+
+    def test_ubuntu(self):
+        r = _make_resolver("ubuntu", "22.04")
+        assert r.purl_scheme() == "pkg:deb/ubuntu"
+
+    def test_debian(self):
+        r = _make_resolver("debian", "12")
+        assert r.purl_scheme() == "pkg:deb/debian"
+
+
+# ── resolve() success ──────────────────────────────────────
+
+
+class TestDpkgResolverResolve:
+    """Tests for resolve() with successful dpkg lookups."""
+
+    @patch("subprocess.check_output")
+    def test_resolves_known_file(self, mock_subproc):
+        r = _make_resolver()
+        path = "/usr/lib/x86_64-linux-gnu/libssl.so.3"
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                return _dpkg_s_output("libssl3", path)
+            if cmd[0] == "dpkg-query":
+                return _dpkg_query_output()
+            raise ValueError(f"Unexpected cmd: {cmd}")
+
+        mock_subproc.side_effect = side_effect
+        result = r.resolve(path)
+
+        assert result is not None
+        assert result.name == "libssl3"
+        assert result.version == "3.0.2-0ubuntu1.15"
+        assert result.source == "openssl"
+        assert result.architecture == "amd64"
+        assert result.maintainer == "Ubuntu Developers"
+        assert result.homepage == "https://www.openssl.org/"
+        assert result.section == "libs"
+        assert result.extra == {"Priority": "optional"}
+
+    @patch("subprocess.check_output")
+    def test_multi_package_takes_first(self, mock_subproc):
+        """When dpkg -S returns multiple packages, take the first."""
+        r = _make_resolver()
+        path = "/usr/lib/x86_64-linux-gnu/libz.so.1"
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                return f"zlib1g, zlib1g-dev: {path}"
+            if cmd[0] == "dpkg-query":
+                return _dpkg_query_output(
+                    name="zlib1g", version="1.2.11",
+                    source="zlib", arch="amd64",
+                    maintainer="Mark", homepage="https://zlib.net",
+                    section="libs", priority="",
+                )
+            raise ValueError(f"Unexpected cmd: {cmd}")
+
+        mock_subproc.side_effect = side_effect
+        result = r.resolve(path)
+        assert result is not None
+        assert result.name == "zlib1g"
+
+
+# ── resolve() failure ──────────────────────────────────────
+
+
+class TestDpkgResolverResolveFailure:
+    """Tests for resolve() when files aren't in any package."""
+
+    @patch("subprocess.check_output")
+    def test_unowned_file_returns_none(self, mock_subproc):
+        r = _make_resolver()
+        mock_subproc.side_effect = subprocess.CalledProcessError(
+            1, "dpkg"
+        )
+        result = r.resolve("/tmp/some/random/file")
+        assert result is None
+
+    @patch("subprocess.check_output")
+    def test_dpkg_query_failure_returns_none(self, mock_subproc):
+        """dpkg -S succeeds but dpkg-query fails."""
+        r = _make_resolver()
+        call_count = [0]
+
+        def side_effect(cmd, **kwargs):
+            call_count[0] += 1
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                return "somepkg: /some/path"
+            raise subprocess.CalledProcessError(
+                1, "dpkg-query"
+            )
+
+        mock_subproc.side_effect = side_effect
+        result = r.resolve("/some/path")
+        assert result is None
+
+    @patch("subprocess.check_output")
+    def test_oserror_returns_none(self, mock_subproc):
+        """OSError (dpkg not installed) returns None."""
+        r = _make_resolver()
+        mock_subproc.side_effect = OSError("not found")
+        result = r.resolve("/usr/lib/libfoo.so")
+        assert result is None
+
+
+# ── Caching ────────────────────────────────────────────────
+
+
+class TestDpkgResolverCaching:
+    """Tests for metadata caching behavior."""
+
+    @patch("subprocess.check_output")
+    def test_second_resolve_uses_cache(self, mock_subproc):
+        r = _make_resolver()
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                return "libssl3: /some/path"
+            if cmd[0] == "dpkg-query":
+                return _dpkg_query_output()
+            raise ValueError(f"Unexpected cmd: {cmd}")
+
+        mock_subproc.side_effect = side_effect
+
+        # First call — hits subprocess
+        r.resolve("/usr/lib/x86_64-linux-gnu/libssl.so.3")
+        # Second call for different file, same package
+        r.resolve("/usr/lib/x86_64-linux-gnu/libcrypto.so.3")
+
+        # dpkg-query should only be called once (cached)
+        dpkg_query_calls = [
+            c for c in mock_subproc.call_args_list
+            if c[0][0][0] == "dpkg-query"
+        ]
+        assert len(dpkg_query_calls) == 1
+
+    @patch("subprocess.check_output")
+    def test_failed_lookup_cached(self, mock_subproc):
+        """A failed dpkg-query is cached as None."""
+        r = _make_resolver()
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "dpkg" and cmd[1] == "-S":
+                return "badpkg: /some/path"
+            raise subprocess.CalledProcessError(
+                1, "dpkg-query"
+            )
+
+        mock_subproc.side_effect = side_effect
+
+        assert r.resolve("/some/path") is None
+        assert r.resolve("/other/path") is None
+
+        # dpkg-query called only once — second was cached
+        dpkg_query_calls = [
+            c for c in mock_subproc.call_args_list
+            if c[0][0][0] == "dpkg-query"
+        ]
+        assert len(dpkg_query_calls) == 1
+
+
+# ── distro_version_qualifier ───────────────────────────────
+
+
+class TestDistroVersionQualifier:
+    """Tests for the distro_version_qualifier property."""
+
+    def test_with_version(self):
+        r = _make_resolver("ubuntu", "22.04")
+        assert r.distro_version_qualifier == "ubuntu-22.04"
+
+    def test_without_version(self):
+        r = _make_resolver("debian", "")
+        assert r.distro_version_qualifier == "debian"
+
+
+# ── make_purl() integration ────────────────────────────────
+
+
+class TestDpkgResolverMakePurl:
+    """Tests for make_purl() inherited from PackageResolver."""
+
+    def test_full_purl(self):
+        r = _make_resolver("ubuntu", "22.04")
+        purl = r.make_purl(
+            "libssl3", "3.0.2-0ubuntu1.15",
+            arch="amd64",
+            distro_version="ubuntu-22.04",
+        )
+        assert purl == (
+            "pkg:deb/ubuntu/libssl3@3.0.2-0ubuntu1.15"
+            "?arch=amd64&distro=ubuntu-22.04"
+        )
+
+    def test_minimal_purl(self):
+        r = _make_resolver("debian", "12")
+        purl = r.make_purl("libc6", "2.36-9")
+        assert purl == "pkg:deb/debian/libc6@2.36-9"

--- a/tests/test_package_resolver.py
+++ b/tests/test_package_resolver.py
@@ -304,16 +304,14 @@ class TestAutoDetectResolver:
             with pytest.raises(RuntimeError, match="Unsupported"):
                 auto_detect_resolver()
 
-    def test_deb_family_imports_dpkg(self):
+    def test_deb_family_returns_dpkg_resolver(self):
         with patch(
             "app.spdx.package_resolver.detect_distro_id",
             return_value="ubuntu",
         ):
-            with pytest.raises(
-                (ImportError, ModuleNotFoundError),
-            ):
-                # DpkgResolver module doesn't exist yet (#96)
-                auto_detect_resolver()
+            from app.spdx.dpkg_resolver import DpkgResolver
+            resolver = auto_detect_resolver()
+            assert isinstance(resolver, DpkgResolver)
 
     def test_rpm_family_imports_rpm(self):
         with patch(


### PR DESCRIPTION
## Summary

Implements **[A2] Implement DpkgResolver** ([#96](https://github.com/tedg-dev/omnibor-analysis/issues/96)) — the Debian/Ubuntu concrete `PackageResolver` using `dpkg -S` and `dpkg-query -W`.

## What Changed

### `app/spdx/dpkg_resolver.py` (new — 160 lines)

- **`DpkgResolver(PackageResolver)`** — resolves file paths to dpkg package metadata
- **`resolve(file_path)`** — runs `dpkg -S` then `dpkg-query -W` to get full metadata
- **`purl_scheme()`** — returns `pkg:deb/<namespace>` (distro-aware: ubuntu, debian)
- **`distro_version_qualifier`** — property for PURL qualifier (e.g. `ubuntu-22.04`)
- **Metadata caching** — `dpkg-query` results cached per package name to avoid redundant subprocess calls

### `tests/test_dpkg_resolver.py` (new — 13 tests)

- `purl_scheme()` for ubuntu and debian
- `resolve()` success with full metadata verification
- `resolve()` multi-package output (takes first)
- `resolve()` failure: unowned file, dpkg-query failure, OSError
- Metadata caching: second resolve uses cache, failed lookups cached
- `distro_version_qualifier` with and without version
- `make_purl()` integration

### `tests/test_package_resolver.py` (updated)

- Updated `test_deb_family_imports_dpkg` → `test_deb_family_returns_dpkg_resolver` — now verifies `auto_detect_resolver()` returns a `DpkgResolver` instance

## Regression Assessment

- **Pipeline impact:** No
- **Reason:** New file with no consumers in the existing pipeline. `collect_metadata.py` and `collect_dynamic_libs.py` still use their own dpkg logic until refactored in #100/#101.
- **Regression repos needed:** None

## Verification

- 955 tests pass (942 existing + 13 new, zero regressions)
- 96% coverage on new file

## Closes

Closes #96
