### PR TITLE
feat(resolver): implement ApkResolver (#98)

### DIFF
--- a/app/spdx/apk_resolver.py
+++ b/app/spdx/apk_resolver.py
@@ -1,0 +1,230 @@
+"""Alpine apk package resolver.
+
+Resolves file paths to OS package metadata using
+``apk info --who-owns`` (file-to-package lookup) and
+``apk info`` / ``apk info --webpage`` / ``apk info --size``
+(package metadata query). This is the concrete
+``PackageResolver`` implementation for Alpine Linux.
+
+Alpine apk reference:
+    https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper
+"""
+
+import subprocess
+from typing import Optional
+
+from app.spdx.package_resolver import (
+    PackageResolver,
+    ResolvedPackage,
+    detect_distro_id,
+    detect_distro_version,
+    purl_namespace_for_distro,
+)
+
+
+def _parse_apk_info(output: str) -> dict:
+    """Parse ``apk info -a <pkg>`` output into a dict.
+
+    apk info outputs key-value lines like::
+
+        <pkg>-<ver> description:
+        <description text>
+
+        <pkg>-<ver> webpage:
+        https://example.com
+
+        <pkg>-<ver> installed size:
+        1234
+
+    We extract: description, webpage, installed size, license.
+    """
+    meta = {}
+    lines = output.strip().splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if " description:" in line:
+            if i + 1 < len(lines):
+                meta["description"] = lines[i + 1].strip()
+            i += 2
+        elif " webpage:" in line:
+            if i + 1 < len(lines):
+                meta["webpage"] = lines[i + 1].strip()
+            i += 2
+        elif " license:" in line:
+            if i + 1 < len(lines):
+                meta["license"] = lines[i + 1].strip()
+            i += 2
+        elif " origin:" in line:
+            if i + 1 < len(lines):
+                meta["origin"] = lines[i + 1].strip()
+            i += 2
+        elif " maintainer:" in line:
+            if i + 1 < len(lines):
+                meta["maintainer"] = lines[i + 1].strip()
+            i += 2
+        else:
+            i += 1
+    return meta
+
+
+def _parse_apk_version(pkg_name: str, output: str) -> str:
+    """Extract version from ``apk info -v <pkg>`` output.
+
+    Output is ``<pkg>-<version>\\n``. We strip the package name
+    prefix to get just the version.
+
+    Example: ``musl-1.2.4-r2`` → ``1.2.4-r2``
+    """
+    line = output.strip()
+    prefix = pkg_name + "-"
+    if line.startswith(prefix):
+        return line[len(prefix):]
+    return line
+
+
+class ApkResolver(PackageResolver):
+    """Alpine Linux package resolver using apk.
+
+    Uses:
+
+    1. ``apk info --who-owns <path>`` — find owning package
+    2. ``apk info -v <pkg>`` — get version
+    3. ``apk info -a <pkg>`` — get full metadata
+
+    Caches metadata per package name to avoid redundant
+    ``apk info`` calls.
+    """
+
+    def __init__(self):
+        self._distro_id = detect_distro_id()
+        self._distro_version = detect_distro_version()
+        self._namespace = purl_namespace_for_distro(
+            self._distro_id
+        )
+        self._meta_cache = {}
+
+    def purl_scheme(self) -> str:
+        """Return ``pkg:apk/alpine`` for this distro."""
+        return f"pkg:apk/{self._namespace}"
+
+    def resolve(
+        self, file_path: str,
+    ) -> Optional[ResolvedPackage]:
+        """Resolve a file path to its apk package metadata.
+
+        Args:
+            file_path: Absolute path to a file on disk.
+
+        Returns:
+            A ``ResolvedPackage`` with apk metadata, or
+            ``None`` if the file is not owned by any package.
+        """
+        pkg_name = self._file_to_package(file_path)
+        if not pkg_name:
+            return None
+        return self._query_metadata(pkg_name)
+
+    def _file_to_package(self, file_path: str) -> Optional[str]:
+        """Run ``apk info --who-owns <path>``.
+
+        Output format: ``<path> is owned by <pkg>-<ver>``
+        We extract the package name (without version).
+
+        Returns the package name, or None.
+        """
+        try:
+            out = subprocess.check_output(
+                ["apk", "info", "--who-owns", file_path],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            # Format: "/usr/lib/libssl.so.3 is owned by libssl3-3.1.4-r2"
+            if "is owned by" in out:
+                owned_part = out.split("is owned by")[-1].strip()
+                # Strip version: find last hyphen before a digit
+                # e.g. "libssl3-3.1.4-r2" → "libssl3"
+                return _strip_apk_version(owned_part)
+            return None
+        except (subprocess.CalledProcessError, OSError):
+            return None
+
+    def _query_metadata(
+        self, pkg_name: str,
+    ) -> Optional[ResolvedPackage]:
+        """Query apk for package metadata, with caching."""
+        if pkg_name in self._meta_cache:
+            return self._meta_cache[pkg_name]
+
+        # Get version
+        version = ""
+        try:
+            out = subprocess.check_output(
+                ["apk", "info", "-v", pkg_name],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            version = _parse_apk_version(pkg_name, out)
+        except (subprocess.CalledProcessError, OSError):
+            pass
+
+        # Get full metadata
+        meta = {}
+        try:
+            out = subprocess.check_output(
+                ["apk", "info", "-a", pkg_name],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            meta = _parse_apk_info(out)
+        except (subprocess.CalledProcessError, OSError):
+            pass
+
+        if not version and not meta:
+            self._meta_cache[pkg_name] = None
+            return None
+
+        result = ResolvedPackage(
+            name=pkg_name,
+            version=version,
+            source=meta.get("origin", ""),
+            architecture="",
+            maintainer=meta.get("maintainer", ""),
+            homepage=meta.get("webpage", ""),
+            section="",
+            extra={
+                k: v for k, v in meta.items()
+                if k not in {
+                    "origin", "maintainer", "webpage",
+                }
+            },
+        )
+        self._meta_cache[pkg_name] = result
+        return result
+
+    @property
+    def distro_version_qualifier(self) -> str:
+        """Return distro version string for PURL qualifiers.
+
+        Example: ``"alpine-3.18"``.
+        """
+        if self._distro_version:
+            return f"{self._distro_id}-{self._distro_version}"
+        return self._distro_id
+
+
+def _strip_apk_version(name_version: str) -> str:
+    """Strip version suffix from an apk package-version string.
+
+    ``libssl3-3.1.4-r2`` → ``libssl3``
+    ``musl-1.2.4-r2`` → ``musl``
+    ``busybox-1.36.1-r6`` → ``busybox``
+
+    Alpine versions start with a digit after a hyphen.
+    We find the first ``-`` followed by a digit and split there.
+    """
+    for i, ch in enumerate(name_version):
+        if ch == "-" and i + 1 < len(name_version):
+            if name_version[i + 1].isdigit():
+                return name_version[:i]
+    return name_version

--- a/tests/test_apk_resolver.py
+++ b/tests/test_apk_resolver.py
@@ -1,0 +1,326 @@
+"""Tests for ApkResolver — Alpine Linux package resolver.
+
+All subprocess calls are mocked. No actual apk commands run.
+
+Covers:
+- purl_scheme() returns correct apk namespace
+- resolve() for files owned by a package
+- resolve() for unowned files
+- resolve() when apk info fails
+- _parse_apk_info() output parsing
+- _parse_apk_version() extraction
+- _strip_apk_version() name/version splitting
+- Metadata caching
+- distro_version_qualifier property
+- make_purl() integration
+"""
+
+import subprocess
+from unittest.mock import patch
+
+from app.spdx.apk_resolver import (
+    ApkResolver,
+    _parse_apk_info,
+    _parse_apk_version,
+    _strip_apk_version,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────
+
+
+def _make_resolver(
+    distro_id="alpine", distro_version="3.18",
+):
+    """Create an ApkResolver with mocked distro detection."""
+    with patch(
+        "app.spdx.apk_resolver.detect_distro_id",
+        return_value=distro_id,
+    ), patch(
+        "app.spdx.apk_resolver.detect_distro_version",
+        return_value=distro_version,
+    ):
+        return ApkResolver()
+
+
+# ── _strip_apk_version() ──────────────────────────────────
+
+
+class TestStripApkVersion:
+    """Tests for version stripping from apk name-version."""
+
+    def test_standard(self):
+        assert _strip_apk_version("libssl3-3.1.4-r2") == "libssl3"
+
+    def test_musl(self):
+        assert _strip_apk_version("musl-1.2.4-r2") == "musl"
+
+    def test_busybox(self):
+        assert _strip_apk_version("busybox-1.36.1-r6") == "busybox"
+
+    def test_no_version(self):
+        assert _strip_apk_version("libssl3") == "libssl3"
+
+    def test_hyphenated_name(self):
+        assert _strip_apk_version(
+            "ca-certificates-20230506-r0"
+        ) == "ca-certificates"
+
+
+# ── _parse_apk_version() ──────────────────────────────────
+
+
+class TestParseApkVersion:
+    """Tests for version extraction from apk info -v."""
+
+    def test_standard(self):
+        assert _parse_apk_version(
+            "musl", "musl-1.2.4-r2"
+        ) == "1.2.4-r2"
+
+    def test_no_prefix_match(self):
+        assert _parse_apk_version(
+            "other", "musl-1.2.4-r2"
+        ) == "musl-1.2.4-r2"
+
+    def test_empty(self):
+        assert _parse_apk_version("pkg", "") == ""
+
+
+# ── _parse_apk_info() ─────────────────────────────────────
+
+
+class TestParseApkInfo:
+    """Tests for parsing apk info -a output."""
+
+    def test_full_output(self):
+        output = (
+            "musl-1.2.4-r2 description:\n"
+            "the musl c library\n"
+            "\n"
+            "musl-1.2.4-r2 webpage:\n"
+            "https://musl.libc.org/\n"
+            "\n"
+            "musl-1.2.4-r2 license:\n"
+            "MIT\n"
+            "\n"
+            "musl-1.2.4-r2 origin:\n"
+            "musl\n"
+            "\n"
+            "musl-1.2.4-r2 maintainer:\n"
+            "Timo Teras <timo.teras@iki.fi>\n"
+        )
+        meta = _parse_apk_info(output)
+        assert meta["description"] == "the musl c library"
+        assert meta["webpage"] == "https://musl.libc.org/"
+        assert meta["license"] == "MIT"
+        assert meta["origin"] == "musl"
+        assert meta["maintainer"] == (
+            "Timo Teras <timo.teras@iki.fi>"
+        )
+
+    def test_partial_output(self):
+        output = (
+            "pkg-1.0-r0 description:\n"
+            "some package\n"
+            "\n"
+            "pkg-1.0-r0 webpage:\n"
+            "https://example.com\n"
+        )
+        meta = _parse_apk_info(output)
+        assert meta["description"] == "some package"
+        assert meta["webpage"] == "https://example.com"
+        assert "license" not in meta
+
+    def test_empty_output(self):
+        assert _parse_apk_info("") == {}
+
+
+# ── purl_scheme() ─────────────────────────────────────────
+
+
+class TestApkResolverPurlScheme:
+
+    def test_alpine(self):
+        r = _make_resolver("alpine", "3.18")
+        assert r.purl_scheme() == "pkg:apk/alpine"
+
+
+# ── resolve() success ──────────────────────────────────────
+
+
+class TestApkResolverResolve:
+
+    @patch("subprocess.check_output")
+    def test_resolves_known_file(self, mock_subproc):
+        r = _make_resolver()
+        path = "/usr/lib/libssl.so.3"
+
+        def side_effect(cmd, **kwargs):
+            if "--who-owns" in cmd:
+                return (
+                    f"{path} is owned by libssl3-3.1.4-r2"
+                )
+            if "-v" in cmd:
+                return "libssl3-3.1.4-r2"
+            if "-a" in cmd:
+                return (
+                    "libssl3-3.1.4-r2 description:\n"
+                    "SSL shared libraries\n"
+                    "\n"
+                    "libssl3-3.1.4-r2 webpage:\n"
+                    "https://www.openssl.org/\n"
+                    "\n"
+                    "libssl3-3.1.4-r2 origin:\n"
+                    "openssl\n"
+                    "\n"
+                    "libssl3-3.1.4-r2 maintainer:\n"
+                    "Alpine Team\n"
+                )
+            raise ValueError(f"Unexpected cmd: {cmd}")
+
+        mock_subproc.side_effect = side_effect
+        result = r.resolve(path)
+
+        assert result is not None
+        assert result.name == "libssl3"
+        assert result.version == "3.1.4-r2"
+        assert result.source == "openssl"
+        assert result.homepage == "https://www.openssl.org/"
+        assert result.maintainer == "Alpine Team"
+        assert result.extra.get("description") == (
+            "SSL shared libraries"
+        )
+
+
+# ── resolve() failure ──────────────────────────────────────
+
+
+class TestApkResolverResolveFailure:
+
+    @patch("subprocess.check_output")
+    def test_unowned_file_returns_none(self, mock_subproc):
+        r = _make_resolver()
+        mock_subproc.side_effect = subprocess.CalledProcessError(
+            1, "apk"
+        )
+        assert r.resolve("/tmp/random/file") is None
+
+    @patch("subprocess.check_output")
+    def test_no_owned_by_message(self, mock_subproc):
+        r = _make_resolver()
+        mock_subproc.return_value = (
+            "ERROR: /tmp/foo: Could not find owner package"
+        )
+        assert r.resolve("/tmp/foo") is None
+
+    @patch("subprocess.check_output")
+    def test_version_and_info_both_fail(self, mock_subproc):
+        """File is owned but all metadata queries fail."""
+        r = _make_resolver()
+
+        def side_effect(cmd, **kwargs):
+            if "--who-owns" in cmd:
+                return "/some/file is owned by pkg-1.0-r0"
+            raise subprocess.CalledProcessError(1, "apk")
+
+        mock_subproc.side_effect = side_effect
+        assert r.resolve("/some/file") is None
+
+    @patch("subprocess.check_output")
+    def test_oserror_returns_none(self, mock_subproc):
+        r = _make_resolver()
+        mock_subproc.side_effect = OSError("not found")
+        assert r.resolve("/usr/lib/libfoo.so") is None
+
+
+# ── Caching ────────────────────────────────────────────────
+
+
+class TestApkResolverCaching:
+
+    @patch("subprocess.check_output")
+    def test_second_resolve_uses_cache(self, mock_subproc):
+        r = _make_resolver()
+
+        def side_effect(cmd, **kwargs):
+            if "--who-owns" in cmd:
+                return "/x is owned by musl-1.2.4-r2"
+            if "-v" in cmd:
+                return "musl-1.2.4-r2"
+            if "-a" in cmd:
+                return (
+                    "musl-1.2.4-r2 origin:\nmusl\n"
+                )
+            raise ValueError(f"Unexpected: {cmd}")
+
+        mock_subproc.side_effect = side_effect
+
+        r.resolve("/usr/lib/ld-musl-x86_64.so.1")
+        r.resolve("/usr/lib/libc.musl-x86_64.so.1")
+
+        # apk info -v should only be called once (cached)
+        info_v_calls = [
+            c for c in mock_subproc.call_args_list
+            if "-v" in c[0][0]
+        ]
+        assert len(info_v_calls) == 1
+
+    @patch("subprocess.check_output")
+    def test_failed_lookup_cached(self, mock_subproc):
+        r = _make_resolver()
+
+        def side_effect(cmd, **kwargs):
+            if "--who-owns" in cmd:
+                return "/x is owned by badpkg-1.0-r0"
+            raise subprocess.CalledProcessError(1, "apk")
+
+        mock_subproc.side_effect = side_effect
+
+        assert r.resolve("/some/path") is None
+        assert r.resolve("/other/path") is None
+
+        info_calls = [
+            c for c in mock_subproc.call_args_list
+            if "-v" in c[0][0] or "-a" in c[0][0]
+        ]
+        # Only the first resolve should attempt metadata queries
+        # (2 calls: -v and -a), second is cached
+        assert len(info_calls) == 2
+
+
+# ── distro_version_qualifier ───────────────────────────────
+
+
+class TestApkDistroVersionQualifier:
+
+    def test_with_version(self):
+        r = _make_resolver("alpine", "3.18")
+        assert r.distro_version_qualifier == "alpine-3.18"
+
+    def test_without_version(self):
+        r = _make_resolver("alpine", "")
+        assert r.distro_version_qualifier == "alpine"
+
+
+# ── make_purl() integration ────────────────────────────────
+
+
+class TestApkResolverMakePurl:
+
+    def test_full_purl(self):
+        r = _make_resolver("alpine", "3.18")
+        purl = r.make_purl(
+            "libssl3", "3.1.4-r2",
+            arch="x86_64",
+            distro_version="alpine-3.18",
+        )
+        assert purl == (
+            "pkg:apk/alpine/libssl3@3.1.4-r2"
+            "?arch=x86_64&distro=alpine-3.18"
+        )
+
+    def test_minimal_purl(self):
+        r = _make_resolver("alpine", "3.18")
+        purl = r.make_purl("musl", "1.2.4-r2")
+        assert purl == "pkg:apk/alpine/musl@1.2.4-r2"

--- a/tests/test_package_resolver.py
+++ b/tests/test_package_resolver.py
@@ -322,13 +322,11 @@ class TestAutoDetectResolver:
             resolver = auto_detect_resolver()
             assert isinstance(resolver, RpmResolver)
 
-    def test_apk_family_imports_apk(self):
+    def test_apk_family_returns_apk_resolver(self):
         with patch(
             "app.spdx.package_resolver.detect_distro_id",
             return_value="alpine",
         ):
-            with pytest.raises(
-                (ImportError, ModuleNotFoundError),
-            ):
-                # ApkResolver module doesn't exist yet (#98)
-                auto_detect_resolver()
+            from app.spdx.apk_resolver import ApkResolver
+            resolver = auto_detect_resolver()
+            assert isinstance(resolver, ApkResolver)


### PR DESCRIPTION
## Summary

Implements **[A4] Implement ApkResolver** ([#98](https://github.com/tedg-dev/omnibor-analysis/issues/98)) — the Alpine Linux concrete `PackageResolver` using `apk info --who-owns` and `apk info -v/-a`.

## What Changed

### `app/spdx/apk_resolver.py` (new — 230 lines)

- **`ApkResolver(PackageResolver)`** — resolves file paths to Alpine apk package metadata
- **`resolve(file_path)`** — runs `apk info --who-owns`, `apk info -v`, `apk info -a`
- **`purl_scheme()`** — returns `pkg:apk/alpine`
- **`_parse_apk_info()`** — parses `apk info -a` output (description, webpage, license, origin, maintainer)
- **`_parse_apk_version()`** — extracts version from `apk info -v` output
- **`_strip_apk_version()`** — splits `name-version` strings (e.g. `libssl3-3.1.4-r2` → `libssl3`)
- **Metadata caching** and **`distro_version_qualifier`**

### `tests/test_apk_resolver.py` (new — 23 tests)

- `_strip_apk_version()` for standard, hyphenated, no-version cases
- `_parse_apk_version()` extraction
- `_parse_apk_info()` full, partial, and empty output
- `purl_scheme()` for Alpine
- `resolve()` success with full metadata verification
- `resolve()` failure: unowned, error message, both queries fail, OSError
- Metadata caching: hit and miss cached
- `distro_version_qualifier`, `make_purl()` integration

### `tests/test_package_resolver.py` (updated)

- `test_apk_family_imports_apk` → `test_apk_family_returns_apk_resolver`

## Regression Assessment

- **Pipeline impact:** No
- **Reason:** New file with no consumers in the existing pipeline
- **Regression repos needed:** None

## Verification

- 1002 tests pass (979 existing + 23 new, zero regressions)
- **100% coverage** on new file

## Closes

Closes #98
