### PR TITLE
feat(resolver): startup logging + integration tests (#99)

### DIFF
--- a/app/spdx/package_resolver.py
+++ b/app/spdx/package_resolver.py
@@ -14,9 +14,12 @@ to select the correct implementation at runtime.
 Design reference: sidecar-implementation-design.md Section 4.3
 """
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -221,19 +224,35 @@ def auto_detect_resolver() -> PackageResolver:
             corresponding resolver is not yet implemented.
     """
     distro_id = detect_distro_id()
+    distro_ver = detect_distro_version()
     family = _DISTRO_FAMILIES.get(distro_id)
 
     if family == "deb":
         from app.spdx.dpkg_resolver import DpkgResolver
-        return DpkgResolver()
+        resolver = DpkgResolver()
+        logger.info(
+            "Detected distro: %s %s → DpkgResolver",
+            distro_id, distro_ver,
+        )
+        return resolver
 
     if family == "rpm":
         from app.spdx.rpm_resolver import RpmResolver
-        return RpmResolver()
+        resolver = RpmResolver()
+        logger.info(
+            "Detected distro: %s %s → RpmResolver",
+            distro_id, distro_ver,
+        )
+        return resolver
 
     if family == "apk":
         from app.spdx.apk_resolver import ApkResolver
-        return ApkResolver()
+        resolver = ApkResolver()
+        logger.info(
+            "Detected distro: %s %s → ApkResolver",
+            distro_id, distro_ver,
+        )
+        return resolver
 
     raise RuntimeError(
         f"Unsupported distro '{distro_id}'. "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared pytest configuration and custom markers."""
+
+import shutil
+
+
+def pytest_configure(config):
+    """Register custom markers for integration tests."""
+    config.addinivalue_line(
+        "markers",
+        "integration: marks tests that require real OS "
+        "package manager binaries (deselect with '-m "
+        "\"not integration\"')",
+    )
+    config.addinivalue_line(
+        "markers",
+        "requires_dpkg: marks tests that need dpkg/dpkg-query",
+    )
+    config.addinivalue_line(
+        "markers",
+        "requires_rpm: marks tests that need rpm",
+    )
+    config.addinivalue_line(
+        "markers",
+        "requires_apk: marks tests that need apk",
+    )
+
+
+def has_binary(name: str) -> bool:
+    """Check if a binary is available on PATH."""
+    return shutil.which(name) is not None

--- a/tests/test_package_resolver.py
+++ b/tests/test_package_resolver.py
@@ -330,3 +330,17 @@ class TestAutoDetectResolver:
             from app.spdx.apk_resolver import ApkResolver
             resolver = auto_detect_resolver()
             assert isinstance(resolver, ApkResolver)
+
+    def test_logs_detected_distro(self, caplog):
+        import logging
+        with patch(
+            "app.spdx.package_resolver.detect_distro_id",
+            return_value="ubuntu",
+        ), patch(
+            "app.spdx.package_resolver.detect_distro_version",
+            return_value="22.04",
+        ):
+            with caplog.at_level(logging.INFO):
+                auto_detect_resolver()
+            assert "Detected distro: ubuntu 22.04" in caplog.text
+            assert "DpkgResolver" in caplog.text

--- a/tests/test_resolver_integration.py
+++ b/tests/test_resolver_integration.py
@@ -1,0 +1,242 @@
+"""Integration tests for package resolvers against real binaries.
+
+These tests run against the actual dpkg, rpm, or apk binaries
+installed on the host. They are skipped automatically when the
+required binary is not available.
+
+Run all integration tests::
+
+    pytest tests/test_resolver_integration.py -v
+
+Run only dpkg tests (inside Ubuntu/Debian container)::
+
+    pytest tests/test_resolver_integration.py -v -m requires_dpkg
+
+Skip integration tests entirely::
+
+    pytest tests/ -m "not integration"
+"""
+
+import logging
+import shutil
+
+import pytest
+
+from app.spdx.package_resolver import (
+    auto_detect_resolver,
+    detect_distro_id,
+)
+
+# ── Skip conditions ────────────────────────────────────────
+
+has_dpkg = shutil.which("dpkg") is not None
+has_rpm = shutil.which("rpm") is not None
+has_apk = shutil.which("apk") is not None
+
+skip_no_dpkg = pytest.mark.skipif(
+    not has_dpkg,
+    reason="dpkg/dpkg-query not available on this host",
+)
+skip_no_rpm = pytest.mark.skipif(
+    not has_rpm,
+    reason="rpm not available on this host",
+)
+skip_no_apk = pytest.mark.skipif(
+    not has_apk,
+    reason="apk not available on this host",
+)
+
+
+# ── DpkgResolver integration ──────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.requires_dpkg
+@skip_no_dpkg
+class TestDpkgResolverIntegration:
+    """Tests that run DpkgResolver against real dpkg."""
+
+    def _make_resolver(self):
+        from app.spdx.dpkg_resolver import DpkgResolver
+        return DpkgResolver()
+
+    def test_resolve_libc(self):
+        """libc is present on every Debian/Ubuntu system."""
+        r = self._make_resolver()
+        # /lib/x86_64-linux-gnu/libc.so.6 or similar
+        result = r.resolve("/usr/bin/dpkg")
+        assert result is not None
+        assert result.name == "dpkg"
+        assert result.version != ""
+
+    def test_resolve_nonexistent_returns_none(self):
+        r = self._make_resolver()
+        result = r.resolve(
+            "/nonexistent/path/that/no/package/owns"
+        )
+        assert result is None
+
+    def test_purl_scheme_matches_host(self):
+        r = self._make_resolver()
+        distro = detect_distro_id()
+        scheme = r.purl_scheme()
+        assert scheme.startswith("pkg:deb/")
+        if distro == "ubuntu":
+            assert scheme == "pkg:deb/ubuntu"
+        elif distro == "debian":
+            assert scheme == "pkg:deb/debian"
+
+    def test_make_purl_from_resolved(self):
+        """End-to-end: resolve a file → build a PURL."""
+        r = self._make_resolver()
+        result = r.resolve("/usr/bin/dpkg")
+        if result is None:
+            pytest.skip("dpkg binary not owned by dpkg package")
+        purl = r.make_purl(
+            result.name, result.version,
+            arch=result.architecture,
+            distro_version=r.distro_version_qualifier,
+        )
+        assert purl.startswith("pkg:deb/")
+        assert "dpkg@" in purl
+        assert "arch=" in purl
+        assert "distro=" in purl
+
+    def test_caching_real_packages(self):
+        """Verify caching works with real dpkg queries."""
+        r = self._make_resolver()
+        r.resolve("/usr/bin/dpkg")
+        r.resolve("/usr/bin/dpkg")
+        # Should have exactly 1 entry in cache
+        assert len(r._meta_cache) >= 1
+
+
+# ── RpmResolver integration ───────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.requires_rpm
+@skip_no_rpm
+class TestRpmResolverIntegration:
+    """Tests that run RpmResolver against real rpm."""
+
+    def _make_resolver(self):
+        from app.spdx.rpm_resolver import RpmResolver
+        return RpmResolver()
+
+    def test_resolve_rpm_binary(self):
+        """rpm itself is always installed on rpm-based hosts."""
+        r = self._make_resolver()
+        result = r.resolve("/usr/bin/rpm")
+        assert result is not None
+        assert result.name == "rpm"
+        assert result.version != ""
+
+    def test_resolve_nonexistent_returns_none(self):
+        r = self._make_resolver()
+        result = r.resolve(
+            "/nonexistent/path/that/no/package/owns"
+        )
+        assert result is None
+
+    def test_purl_scheme_matches_host(self):
+        r = self._make_resolver()
+        scheme = r.purl_scheme()
+        assert scheme.startswith("pkg:rpm/")
+
+    def test_make_purl_from_resolved(self):
+        r = self._make_resolver()
+        result = r.resolve("/usr/bin/rpm")
+        if result is None:
+            pytest.skip("rpm binary not owned by rpm package")
+        purl = r.make_purl(
+            result.name, result.version,
+            arch=result.architecture,
+            distro_version=r.distro_version_qualifier,
+        )
+        assert purl.startswith("pkg:rpm/")
+        assert "rpm@" in purl
+
+
+# ── ApkResolver integration ───────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.requires_apk
+@skip_no_apk
+class TestApkResolverIntegration:
+    """Tests that run ApkResolver against real apk."""
+
+    def _make_resolver(self):
+        from app.spdx.apk_resolver import ApkResolver
+        return ApkResolver()
+
+    def test_resolve_apk_binary(self):
+        """apk itself is always installed on Alpine."""
+        r = self._make_resolver()
+        result = r.resolve("/sbin/apk")
+        assert result is not None
+        assert "apk" in result.name.lower()
+        assert result.version != ""
+
+    def test_resolve_nonexistent_returns_none(self):
+        r = self._make_resolver()
+        result = r.resolve(
+            "/nonexistent/path/that/no/package/owns"
+        )
+        assert result is None
+
+    def test_purl_scheme_is_apk_alpine(self):
+        r = self._make_resolver()
+        assert r.purl_scheme() == "pkg:apk/alpine"
+
+    def test_make_purl_from_resolved(self):
+        r = self._make_resolver()
+        result = r.resolve("/sbin/apk")
+        if result is None:
+            pytest.skip("apk binary not resolvable")
+        purl = r.make_purl(
+            result.name, result.version,
+            distro_version=r.distro_version_qualifier,
+        )
+        assert purl.startswith("pkg:apk/alpine/")
+
+
+# ── auto_detect_resolver() integration ─────────────────────
+
+
+@pytest.mark.integration
+class TestAutoDetectResolverIntegration:
+    """Test that auto_detect_resolver() works on the real host."""
+
+    def test_returns_resolver_on_known_distro(self):
+        """On any supported distro, should return a resolver."""
+        distro = detect_distro_id()
+        if distro == "unknown":
+            pytest.skip("Not running on a recognized Linux distro")
+        # macOS doesn't have /etc/os-release — will be "unknown"
+        if distro not in (
+            "ubuntu", "debian",
+            "rhel", "centos", "fedora",
+            "rocky", "almalinux", "ol",
+            "alpine",
+        ):
+            pytest.skip(f"Unsupported distro: {distro}")
+        resolver = auto_detect_resolver()
+        assert resolver is not None
+
+    def test_logs_detected_distro(self, caplog):
+        """auto_detect_resolver() should log the detected distro."""
+        distro = detect_distro_id()
+        if distro == "unknown":
+            pytest.skip("Not running on a recognized Linux distro")
+        if distro not in (
+            "ubuntu", "debian",
+            "rhel", "centos", "fedora",
+            "rocky", "almalinux", "ol",
+            "alpine",
+        ):
+            pytest.skip(f"Unsupported distro: {distro}")
+        with caplog.at_level(logging.INFO):
+            auto_detect_resolver()
+        assert "Detected distro:" in caplog.text


### PR DESCRIPTION
## Summary

Implements **[A5] Wire `auto_detect_resolver()` + integration tests** ([#99](https://github.com/tedg-dev/omnibor-analysis/issues/99)) — adds startup logging to `auto_detect_resolver()` and creates multi-distro integration tests that run resolvers against real package manager binaries.

## What Changed

### `app/spdx/package_resolver.py` (updated)

- **Startup logging** — `auto_detect_resolver()` now logs `"Detected distro: ubuntu 22.04 → DpkgResolver"` (or equivalent) at INFO level when selecting a resolver
- Added `logging` import and module-level logger

### `tests/conftest.py` (new)

- Registers custom pytest markers: `integration`, `requires_dpkg`, `requires_rpm`, `requires_apk`
- `has_binary()` helper for runtime binary detection

### `tests/test_resolver_integration.py` (new — 15 tests)

Integration tests that exercise resolvers against **real** dpkg/rpm/apk binaries. Auto-skip when the binary isn't available:

- **`TestDpkgResolverIntegration`** (5 tests) — resolve `/usr/bin/dpkg`, nonexistent file, PURL scheme, end-to-end PURL, caching
- **`TestRpmResolverIntegration`** (4 tests) — resolve `/usr/bin/rpm`, nonexistent file, PURL scheme, end-to-end PURL
- **`TestApkResolverIntegration`** (4 tests) — resolve `/sbin/apk`, nonexistent file, PURL scheme, end-to-end PURL
- **`TestAutoDetectResolverIntegration`** (2 tests) — factory returns resolver on known distro, logs detected distro

### `tests/test_package_resolver.py` (updated)

- New `test_logs_detected_distro` — verifies the log message content with mocked distro detection

## How to Run

```bash
# All tests (integration tests auto-skip on macOS):
pytest tests/ -x -q

# Only integration tests (inside container):
pytest tests/test_resolver_integration.py -v

# Skip integration tests:
pytest tests/ -m "not integration"

# Only dpkg tests (Ubuntu/Debian):
pytest -m requires_dpkg -v
```

## Regression Assessment

- **Pipeline impact:** No
- **Reason:** Logging is additive. Integration tests are new files. No pipeline consumers modified.
- **Regression repos needed:** None

## Verification

- 1003 passed + 15 skipped (macOS — no dpkg/rpm/apk) = 1018 total
- **100% coverage** on `package_resolver.py`

## Closes

Closes #99
