### PR TITLE
feat(resolver): refactor collect_dynamic_libs.py to use PackageResolver (#101)

### DIFF
--- a/app/collect_dynamic_libs.py
+++ b/app/collect_dynamic_libs.py
@@ -2,8 +2,11 @@
 
 Runs inside the build container. Uses ldd and readelf to identify
 all dynamically linked libraries, distinguishes direct (NEEDED)
-from transitive, and resolves each to its dpkg package with
-full metadata.
+from transitive, and resolves each to its OS package with
+full metadata via the ``PackageResolver`` abstraction.
+
+Supports Debian/Ubuntu (dpkg), RHEL/CentOS/Fedora (rpm), and
+Alpine (apk).
 
 Outputs dynamic_libs.json alongside the treedb.
 """
@@ -13,7 +16,16 @@ import re
 import subprocess
 
 
-def main(binary_path, out_dir, project_bins=None):
+def main(
+    binary_path, out_dir,
+    project_bins=None, resolver=None,
+):
+    if resolver is None:
+        from app.spdx.package_resolver import (
+            auto_detect_resolver,
+        )
+        resolver = auto_detect_resolver()
+
     # Get ldd output
     ldd_out = subprocess.check_output(
         ["ldd", binary_path], text=True
@@ -66,50 +78,30 @@ def main(binary_path, out_dir, project_bins=None):
         f"transitive: {trans_count})"
     )
 
-    # Resolve each to dpkg package
-    fields = [
-        "Package", "Version", "Source",
-        "Maintainer", "Homepage", "Architecture",
-    ]
-    fmt = "|".join(
-        ["${" + f + "}" for f in fields]
-    )
-
+    # Resolve each library to its OS package
     results = {}
     for soname, info in sorted(libs.items()):
         real_path = os.path.realpath(info["path"])
-        pkg = None
+        result = None
         # Try real path first, then original path
         for try_path in [real_path, info["path"]]:
-            try:
-                dpkg_out = subprocess.check_output(
-                    ["dpkg", "-S", try_path],
-                    text=True,
-                    stderr=subprocess.DEVNULL,
-                ).strip()
-                pkg = (
-                    dpkg_out.split(":")[0]
-                    .split(",")[0].strip()
-                )
-                if pkg:
-                    break
-            except Exception:
-                continue
+            result = resolver.resolve(try_path)
+            if result:
+                break
 
+        pkg = result.name if result else None
         meta = {}
-        if pkg:
-            try:
-                out = subprocess.check_output(
-                    ["dpkg-query", "-W", "-f", fmt, pkg],
-                    text=True,
-                    stderr=subprocess.DEVNULL,
-                )
-                parts = out.split("|")
-                for i, f in enumerate(fields):
-                    if i < len(parts) and parts[i]:
-                        meta[f] = parts[i]
-            except Exception:
-                pass
+        if result:
+            meta["Package"] = result.name
+            meta["Version"] = result.version
+            if result.source:
+                meta["Source"] = result.source
+            if result.maintainer:
+                meta["Maintainer"] = result.maintainer
+            if result.homepage:
+                meta["Homepage"] = result.homepage
+            if result.architecture:
+                meta["Architecture"] = result.architecture
 
         source = meta.get("Source", pkg or soname)
         results[soname] = {
@@ -130,9 +122,9 @@ def main(binary_path, out_dir, project_bins=None):
     #    (e.g. libavcodec.so.62 from FFmpeg)
     # 2. NEEDED entries that match an output
     #    binary from the same repo, even when a
-    #    system dpkg package also provides the
-    #    soname (e.g. libcurl.so.4 when system
-    #    libcurl4 is installed)
+    #    system package also provides the soname
+    #    (e.g. libcurl.so.4 when system libcurl4
+    #    is installed)
     #
     # Build set of project .so base names from
     # output_binaries (e.g. "libcurl.so").
@@ -178,10 +170,10 @@ def main(binary_path, out_dir, project_bins=None):
             print(
                 f"  {soname:40s} {tag:12s} "
                 f"{name} (project-built, "
-                f"overriding dpkg)"
+                f"overriding system pkg)"
             )
 
-    # Remove project-built libs from dpkg results
+    # Remove project-built libs from system results
     for soname in proj_matched:
         del results[soname]
 

--- a/tests/test_collect_dynamic_libs.py
+++ b/tests/test_collect_dynamic_libs.py
@@ -1,21 +1,34 @@
 """Tests for collect_dynamic_libs.py.
 
 Focuses on the project_bins logic that identifies
-project-built .so files even when a system dpkg
-package provides the same soname.
+project-built .so files even when a system package
+provides the same soname.
 """
 import json
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Optional
 from unittest.mock import patch
 
-import sys
-sys.path.insert(
-    0, str(Path(__file__).resolve().parent.parent / "app")
+from app.collect_dynamic_libs import main
+from app.spdx.package_resolver import (
+    PackageResolver,
+    ResolvedPackage,
 )
 
-from collect_dynamic_libs import main  # noqa: E402
+
+class FakeResolver(PackageResolver):
+    """A test resolver that returns canned results."""
+
+    def __init__(self, path_map=None):
+        self._path_map = path_map or {}
+
+    def resolve(self, file_path: str) -> Optional[ResolvedPackage]:
+        return self._path_map.get(file_path)
+
+    def purl_scheme(self) -> str:
+        return "pkg:deb/ubuntu"
 
 
 class TestProjectBuiltDetection(unittest.TestCase):
@@ -51,38 +64,14 @@ class TestProjectBuiltDetection(unittest.TestCase):
             )
         return "\n".join(lines) + "\n"
 
-    def _mock_dpkg_s(self, path_to_pkg):
-        """Return a side_effect for dpkg -S calls."""
-        def side_effect(cmd, **kwargs):
-            if cmd[0] == "dpkg" and cmd[1] == "-S":
-                path = cmd[2]
-                if path in path_to_pkg:
-                    return path_to_pkg[path]
-                raise Exception("not found")
-            raise Exception("unexpected cmd")
-        return side_effect
-
-    def _mock_dpkg_query(self, pkg_to_meta):
-        """Return a side_effect for dpkg-query calls."""
-        def side_effect(cmd, **kwargs):
-            if cmd[0] == "dpkg-query":
-                pkg = cmd[4]
-                if pkg in pkg_to_meta:
-                    return pkg_to_meta[pkg]
-                raise Exception("not found")
-            raise Exception("unexpected cmd")
-        return side_effect
-
-    @patch("collect_dynamic_libs.subprocess.check_output")
-    @patch("collect_dynamic_libs.os.path.realpath")
-    def test_project_bins_overrides_dpkg(
+    @patch("app.collect_dynamic_libs.subprocess.check_output")
+    @patch("app.collect_dynamic_libs.os.path.realpath")
+    def test_project_bins_overrides_system_pkg(
         self, mock_realpath, mock_subproc,
     ):
         """When project_bins contains a .so, matching
         sonames should be moved to project_built_libs
         instead of dynamic_libs."""
-        # Simulate curl scenario: libcurl.so.4 resolves
-        # to system dpkg libcurl4 7.81.0
         needed = ["libcurl.so.4", "libc.so.6"]
         ldd_out = self._mock_ldd({
             "libcurl.so.4": "/lib/x86_64-linux-gnu/"
@@ -91,8 +80,6 @@ class TestProjectBuiltDetection(unittest.TestCase):
                          "libc.so.6",
         })
         readelf_out = self._mock_readelf(needed)
-
-        # realpath returns itself for simplicity
         mock_realpath.side_effect = lambda p: p
 
         def subproc_side_effect(cmd, **kwargs):
@@ -100,32 +87,31 @@ class TestProjectBuiltDetection(unittest.TestCase):
                 return ldd_out
             if cmd[0] == "readelf":
                 return readelf_out
-            if cmd[0] == "dpkg" and cmd[1] == "-S":
-                path = cmd[2]
-                if "libcurl" in path:
-                    return "libcurl4: " + path
-                if "libc" in path:
-                    return "libc6: " + path
-                raise Exception("not found")
-            if cmd[0] == "dpkg-query":
-                pkg = cmd[4]
-                if pkg == "libcurl4":
-                    return (
-                        "libcurl4|7.81.0-1ubuntu1.23"
-                        "|curl|Ubuntu Dev|"
-                        "https://curl.haxx.se|amd64"
-                    )
-                if pkg == "libc6":
-                    return (
-                        "libc6|2.35-0ubuntu3|glibc"
-                        "|Ubuntu Dev|"
-                        "https://www.gnu.org/software"
-                        "/libc/libc.html|amd64"
-                    )
-                raise Exception("not found")
             raise Exception(f"unexpected: {cmd}")
 
         mock_subproc.side_effect = subproc_side_effect
+
+        resolver = FakeResolver({
+            "/lib/x86_64-linux-gnu/libcurl.so.4":
+                ResolvedPackage(
+                    name="libcurl4",
+                    version="7.81.0-1ubuntu1.23",
+                    source="curl",
+                    maintainer="Ubuntu Dev",
+                    homepage="https://curl.haxx.se",
+                    architecture="amd64",
+                ),
+            "/lib/x86_64-linux-gnu/libc.so.6":
+                ResolvedPackage(
+                    name="libc6",
+                    version="2.35-0ubuntu3",
+                    source="glibc",
+                    maintainer="Ubuntu Dev",
+                    homepage="https://www.gnu.org/"
+                             "software/libc/libc.html",
+                    architecture="amd64",
+                ),
+        })
 
         with tempfile.TemporaryDirectory() as td:
             with patch("builtins.print"):
@@ -135,6 +121,7 @@ class TestProjectBuiltDetection(unittest.TestCase):
                         "src/.libs/curl",
                         "lib/.libs/libcurl.so",
                     ],
+                    resolver=resolver,
                 )
 
             out = json.loads(
@@ -165,9 +152,9 @@ class TestProjectBuiltDetection(unittest.TestCase):
                 "libc.so.6", out["dynamic_libs"],
             )
 
-    @patch("collect_dynamic_libs.subprocess.check_output")
-    @patch("collect_dynamic_libs.os.path.realpath")
-    def test_no_project_bins_keeps_dpkg(
+    @patch("app.collect_dynamic_libs.subprocess.check_output")
+    @patch("app.collect_dynamic_libs.os.path.realpath")
+    def test_no_project_bins_keeps_resolved(
         self, mock_realpath, mock_subproc,
     ):
         """Without project_bins, all libs stay in
@@ -185,28 +172,34 @@ class TestProjectBuiltDetection(unittest.TestCase):
                 return ldd_out
             if cmd[0] == "readelf":
                 return readelf_out
-            if cmd[0] == "dpkg" and cmd[1] == "-S":
-                return "libcurl4: " + cmd[2]
-            if cmd[0] == "dpkg-query":
-                return (
-                    "libcurl4|7.81.0|curl|Dev|"
-                    "https://curl.haxx.se|amd64"
-                )
             raise Exception(f"unexpected: {cmd}")
 
         mock_subproc.side_effect = subproc_side_effect
 
+        resolver = FakeResolver({
+            "/lib/x86_64-linux-gnu/libcurl.so.4":
+                ResolvedPackage(
+                    name="libcurl4",
+                    version="7.81.0",
+                    source="curl",
+                    maintainer="Dev",
+                    homepage="https://curl.haxx.se",
+                    architecture="amd64",
+                ),
+        })
+
         with tempfile.TemporaryDirectory() as td:
             with patch("builtins.print"):
-                main("/fake/curl", td)
+                main(
+                    "/fake/curl", td,
+                    resolver=resolver,
+                )
 
             out = json.loads(
                 (Path(td) / "dynamic_libs.json")
                 .read_text()
             )
 
-            # Without project_bins, libcurl stays in
-            # dynamic_libs
             self.assertIn(
                 "libcurl.so.4", out["dynamic_libs"],
             )
@@ -214,8 +207,8 @@ class TestProjectBuiltDetection(unittest.TestCase):
                 out["project_built_libs"], {},
             )
 
-    @patch("collect_dynamic_libs.subprocess.check_output")
-    @patch("collect_dynamic_libs.os.path.realpath")
+    @patch("app.collect_dynamic_libs.subprocess.check_output")
+    @patch("app.collect_dynamic_libs.os.path.realpath")
     def test_not_found_still_project_built(
         self, mock_realpath, mock_subproc,
     ):
@@ -237,18 +230,21 @@ class TestProjectBuiltDetection(unittest.TestCase):
                 return ldd_out
             if cmd[0] == "readelf":
                 return readelf_out
-            if cmd[0] == "dpkg" and cmd[1] == "-S":
-                if "libc" in cmd[2]:
-                    return "libc6: " + cmd[2]
-                raise Exception("not found")
-            if cmd[0] == "dpkg-query":
-                return (
-                    "libc6|2.35|glibc|Dev|"
-                    "https://gnu.org|amd64"
-                )
             raise Exception(f"unexpected: {cmd}")
 
         mock_subproc.side_effect = subproc_side_effect
+
+        resolver = FakeResolver({
+            "/lib/x86_64-linux-gnu/libc.so.6":
+                ResolvedPackage(
+                    name="libc6",
+                    version="2.35",
+                    source="glibc",
+                    maintainer="Dev",
+                    homepage="https://gnu.org",
+                    architecture="amd64",
+                ),
+        })
 
         with tempfile.TemporaryDirectory() as td:
             with patch("builtins.print"):
@@ -258,6 +254,7 @@ class TestProjectBuiltDetection(unittest.TestCase):
                         "ffmpeg",
                         "libavcodec/libavcodec.so",
                     ],
+                    resolver=resolver,
                 )
 
             out = json.loads(
@@ -265,7 +262,6 @@ class TestProjectBuiltDetection(unittest.TestCase):
                 .read_text()
             )
 
-            # not-found lib is project_built
             self.assertIn(
                 "libavcodec.so.62",
                 out["project_built_libs"],
@@ -276,8 +272,8 @@ class TestProjectBuiltDetection(unittest.TestCase):
             self.assertEqual(pb["name"], "libavcodec")
             self.assertTrue(pb["project_built"])
 
-    @patch("collect_dynamic_libs.subprocess.check_output")
-    @patch("collect_dynamic_libs.os.path.realpath")
+    @patch("app.collect_dynamic_libs.subprocess.check_output")
+    @patch("app.collect_dynamic_libs.os.path.realpath")
     def test_non_so_project_bins_ignored(
         self, mock_realpath, mock_subproc,
     ):
@@ -296,16 +292,21 @@ class TestProjectBuiltDetection(unittest.TestCase):
                 return ldd_out
             if cmd[0] == "readelf":
                 return readelf_out
-            if cmd[0] == "dpkg" and cmd[1] == "-S":
-                return "libc6: " + cmd[2]
-            if cmd[0] == "dpkg-query":
-                return (
-                    "libc6|2.35|glibc|Dev|"
-                    "https://gnu.org|amd64"
-                )
             raise Exception(f"unexpected: {cmd}")
 
         mock_subproc.side_effect = subproc_side_effect
+
+        resolver = FakeResolver({
+            "/lib/x86_64-linux-gnu/libc.so.6":
+                ResolvedPackage(
+                    name="libc6",
+                    version="2.35",
+                    source="glibc",
+                    maintainer="Dev",
+                    homepage="https://gnu.org",
+                    architecture="amd64",
+                ),
+        })
 
         with tempfile.TemporaryDirectory() as td:
             with patch("builtins.print"):
@@ -315,6 +316,7 @@ class TestProjectBuiltDetection(unittest.TestCase):
                         "src/redis-server",
                         "src/redis-cli",
                     ],
+                    resolver=resolver,
                 )
 
             out = json.loads(
@@ -322,7 +324,6 @@ class TestProjectBuiltDetection(unittest.TestCase):
                 .read_text()
             )
 
-            # No .so in project_bins, so no overrides
             self.assertIn(
                 "libc.so.6", out["dynamic_libs"],
             )


### PR DESCRIPTION
## Summary

Implements **[A7] Refactor `collect_dynamic_libs.py` to use PackageResolver** ([#101](https://github.com/tedg-dev/omnibor-analysis/issues/101)) — replaces hardcoded `dpkg -S` and `dpkg-query -W` subprocess calls with the `PackageResolver` abstraction via dependency injection.

## What Changed

### `app/collect_dynamic_libs.py` (refactored)

- **Dependency injection** — `main()` accepts optional `resolver` parameter; defaults to `auto_detect_resolver()`
- **Replaced `dpkg -S` block** (lines 83-97) with `resolver.resolve(try_path)`
- **Replaced `dpkg-query -W` block** (lines 99-112) with `ResolvedPackage` field mapping
- **Updated comments** — replaced dpkg-specific references with generic package terms
- **Output key `dpkg_package`** — kept for downstream compatibility (`resolver.py`, `emitter.py` consume it)
- `subprocess` kept for `ldd` and `readelf` (not package manager calls)

### `tests/test_collect_dynamic_libs.py` (updated — 4 tests)

- Replaced `sys.path` manipulation with proper `app.` imports
- Replaced dpkg subprocess mocks with `FakeResolver` + `ResolvedPackage`
- Removed unused `_mock_dpkg_s` and `_mock_dpkg_query` helpers
- All 4 existing tests updated and passing

## Regression Assessment

- **Pipeline impact:** **Yes** — modifies dynamic library metadata collection
- **Reason:** `dynamic_libs.json` feeds SPDX generation for system dependencies
- **Regression repos needed:** ALL repos (combined with #100 regression run)

## Verification

- 1017 passed + 15 skipped (zero regressions)
- **Container regression test needed** (combined with #100)

## Closes

Closes #101
