### PR TITLE
feat(resolver): refactor resolver.py PURL generation for multi-distro (#102)

### DIFF
--- a/app/spdx/resolver.py
+++ b/app/spdx/resolver.py
@@ -15,11 +15,17 @@ class ComponentResolver:
     to identify runtime dependencies with full metadata.
     """
 
-    def __init__(self, metadata_path):
+    def __init__(self, metadata_path, resolver=None):
         self.metadata = json.loads(
             Path(metadata_path).read_text()
         )
         self._dynamic_libs = None
+        if resolver is None:
+            from app.spdx.package_resolver import (
+                auto_detect_resolver,
+            )
+            resolver = auto_detect_resolver()
+        self._resolver = resolver
 
     @property
     def distro(self):
@@ -27,12 +33,19 @@ class ComponentResolver:
 
     @property
     def distro_codename(self):
-        """Extract distro version for PURL qualifier."""
+        """Extract distro version for PURL qualifier.
+
+        Delegates to the resolver's ``distro_version_qualifier``
+        when available, falls back to parsing the distro string.
+        """
+        qualifier = getattr(
+            self._resolver, "distro_version_qualifier", None
+        )
+        if qualifier:
+            return qualifier
         d = self.distro.lower()
-        # "Ubuntu 22.04.5 LTS" -> "ubuntu-22.04"
         m = re.search(r"ubuntu\s+([\d.]+)", d)
         if m:
-            # Use major.minor only
             parts = m.group(1).split(".")
             ver = ".".join(parts[:2])
             return f"ubuntu-{ver}"
@@ -162,26 +175,40 @@ class ComponentResolver:
         return components
 
     def _clean_version(self, version):
-        """Strip epoch, dfsg, ubuntu suffixes for CPE."""
+        """Strip distro-specific suffixes for CPE.
+
+        Handles:
+        - Epoch prefix (``1:1.2.11`` → ``1.2.11``)
+        - Debian/Ubuntu: dfsg, ubuntu, build suffixes
+        - RPM: release suffix (``3.0.7-24.el9`` → ``3.0.7``)
+        - Alpine: ``-rN`` suffix (``3.1.4-r2`` → ``3.1.4``)
+        """
         v = version
         # Remove epoch (e.g. "1:1.2.11...")
         if ":" in v:
             v = v.split(":", 1)[1]
-        # Remove dfsg suffix
+        # Remove dfsg suffix (Debian)
         v = re.sub(r"[.+]dfsg.*", "", v)
-        # Remove ubuntu/build suffix
+        # Remove ubuntu/build suffix (Ubuntu)
         v = re.sub(r"-\d+ubuntu.*", "", v)
         v = re.sub(r"-\d+build.*", "", v)
+        # Remove RPM release (e.g. -24.el9, -1.fc39)
+        v = re.sub(r"-\d+\.el\d+.*", "", v)
+        v = re.sub(r"-\d+\.fc\d+.*", "", v)
+        v = re.sub(r"-\d+\.amzn\d+.*", "", v)
+        # Remove Alpine -rN suffix
+        v = re.sub(r"-r\d+$", "", v)
+        # Generic trailing release number
         v = re.sub(r"-\d+$", "", v)
         return v
 
-    def _make_purl(self, dpkg_pkg, version, arch):
-        """Generate Package URL."""
+    def _make_purl(self, pkg_name, version, arch):
+        """Generate Package URL using the resolver's scheme."""
         distro = self.distro_codename
-        return (
-            f"pkg:deb/ubuntu/{dpkg_pkg}"
-            f"@{version}"
-            f"?arch={arch}&distro={distro}"
+        return self._resolver.make_purl(
+            pkg_name, version,
+            arch=arch,
+            distro_version=distro,
         )
 
     def _make_cpe(self, source, version):

--- a/tests/test_spdx_from_adg.py
+++ b/tests/test_spdx_from_adg.py
@@ -34,6 +34,27 @@ from app.version_detection.strategies import (
 from app.version_detection.patterns import (
     name_prefixes,
 )
+from app.spdx.package_resolver import (
+    PackageResolver,
+)
+
+
+class _FakeDpkgResolver(PackageResolver):
+    """Stub resolver for testing ComponentResolver on macOS."""
+
+    def resolve(self, file_path):
+        return None
+
+    def purl_scheme(self):
+        return "pkg:deb/ubuntu"
+
+    @property
+    def distro_version_qualifier(self):
+        return "ubuntu-22.04"
+
+
+def _fake_dpkg_resolver():
+    return _FakeDpkgResolver()
 
 
 class TestAdgParser(unittest.TestCase):
@@ -569,7 +590,7 @@ class TestComponentResolver(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
 
             dynlib_path = Path(td) / "dynamic_libs.json"
             dynlib_path.write_text(
@@ -588,7 +609,7 @@ class TestComponentResolver(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
 
             dynlib_path = Path(td) / "dynamic_libs.json"
             dynlib_path.write_text(
@@ -608,7 +629,7 @@ class TestComponentResolver(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
 
             dynlib_path = Path(td) / "dynamic_libs.json"
             dynlib_path.write_text(
@@ -627,7 +648,7 @@ class TestComponentResolver(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
 
             dynlib_path = Path(td) / "dynamic_libs.json"
             dynlib_path.write_text(
@@ -646,7 +667,7 @@ class TestComponentResolver(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
 
             dynlib_path = Path(td) / "dynamic_libs.json"
             dynlib_path.write_text(
@@ -668,7 +689,7 @@ class TestComponentResolver(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
 
             # Epoch removal
             self.assertEqual(
@@ -694,7 +715,7 @@ class TestComponentResolver(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
             self.assertEqual(
                 resolver.distro_codename,
                 "ubuntu-22.04",
@@ -704,7 +725,7 @@ class TestComponentResolver(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
             # Don't load dynamic libs
             components = (
                 resolver.resolve_dynamic_components()
@@ -715,7 +736,7 @@ class TestComponentResolver(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
 
             dynlibs = {
                 "binary": "/curl",
@@ -1965,6 +1986,16 @@ class TestComponentResolverEdgeCases(
     """Edge-case tests for ComponentResolver."""
 
     def test_non_ubuntu_distro_fallback(self):
+        """When resolver has no qualifier and distro
+        is not Ubuntu, falls back to 'linux'."""
+
+        class _NoQualResolver(PackageResolver):
+            def resolve(self, file_path):
+                return None
+
+            def purl_scheme(self):
+                return "pkg:deb/debian"
+
         with tempfile.TemporaryDirectory() as td:
             meta = {
                 "distro": "Debian GNU/Linux 12",
@@ -1976,7 +2007,10 @@ class TestComponentResolverEdgeCases(
             }
             path = Path(td) / "meta.json"
             path.write_text(json.dumps(meta))
-            resolver = ComponentResolver(str(path))
+            resolver = ComponentResolver(
+                str(path),
+                resolver=_NoQualResolver(),
+            )
             self.assertEqual(
                 resolver.distro_codename, "linux"
             )
@@ -1984,6 +2018,14 @@ class TestComponentResolverEdgeCases(
 
 class TestAdgSpdxGenerator(unittest.TestCase):
     """Tests for AdgSpdxGenerator facade."""
+
+    def setUp(self):
+        patcher = patch(
+            "app.spdx.package_resolver.auto_detect_resolver",
+            return_value=_fake_dpkg_resolver(),
+        )
+        self._mock_resolver = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def _setup_full(self, td):
         """Create a complete test environment."""
@@ -2172,6 +2214,14 @@ class TestAdgSpdxGenerator(unittest.TestCase):
 class TestCli(unittest.TestCase):
     """Tests for CLI main() function."""
 
+    def setUp(self):
+        patcher = patch(
+            "app.spdx.package_resolver.auto_detect_resolver",
+            return_value=_fake_dpkg_resolver(),
+        )
+        self._mock_resolver = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_main_success(self):
         from spdx_from_adg import main
         with tempfile.TemporaryDirectory() as td:
@@ -2289,7 +2339,7 @@ class TestProjectBuiltLibs(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             meta = self._base_metadata()
             path = self._write_metadata(td, meta)
-            resolver = ComponentResolver(path)
+            resolver = ComponentResolver(path, resolver=_fake_dpkg_resolver())
 
             dynlibs = {
                 "binary": "/repos/ffmpeg/ffmpeg",
@@ -2620,6 +2670,14 @@ class TestGenerateMissingDynlibs(unittest.TestCase):
     """Test generate() when dynamic_libs.json is
     missing (lines 1312-1317)."""
 
+    def setUp(self):
+        patcher = patch(
+            "app.spdx.package_resolver.auto_detect_resolver",
+            return_value=_fake_dpkg_resolver(),
+        )
+        self._mock_resolver = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_missing_dynlib_returns_none(self):
         """generate() returns None if dynlib not found."""
         with tempfile.TemporaryDirectory() as td:
@@ -2671,6 +2729,14 @@ class TestGenerateMissingDynlibs(unittest.TestCase):
 class TestVisualizationFailure(unittest.TestCase):
     """Test HTML visualization failure handling
     (lines 1384-1385)."""
+
+    def setUp(self):
+        patcher = patch(
+            "app.spdx.package_resolver.auto_detect_resolver",
+            return_value=_fake_dpkg_resolver(),
+        )
+        self._mock_resolver = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_visualization_exception_caught(self):
         """generate() succeeds even when visualization


### PR DESCRIPTION
## Summary

Implements **[A8] Refactor `resolver.py` PURL generation for multi-distro** ([#102](https://github.com/tedg-dev/omnibor-analysis/issues/102)) — replaces hardcoded `pkg:deb/ubuntu/` PURL prefix with `resolver.make_purl()`, and makes version cleaning and distro codename resolution multi-distro aware.

## What Changed

### `app/spdx/resolver.py` (refactored)

- **Dependency injection** — `ComponentResolver.__init__()` accepts optional `resolver` parameter; defaults to `auto_detect_resolver()`
- **`_make_purl()`** — now delegates to `resolver.make_purl()` instead of hardcoding `pkg:deb/ubuntu/`
- **`distro_codename`** — delegates to `resolver.distro_version_qualifier` when available, falls back to Ubuntu-specific parsing
- **`_clean_version()`** — extended to handle RPM (`-24.el9`, `-1.fc39`), Alpine (`-r2`), and Amazon Linux (`-1.amzn2`) suffixes in addition to existing Debian/Ubuntu patterns
- **Zero `pkg:deb` strings** in executable code

### `tests/test_spdx_from_adg.py` (updated)

- Added `_FakeDpkgResolver` class and `_fake_dpkg_resolver()` factory for test isolation
- All `ComponentResolver(path)` calls → `ComponentResolver(path, resolver=_fake_dpkg_resolver())`
- Added `setUp` + mock `auto_detect_resolver` for 4 test classes that use `AdgSpdxGenerator` internally
- Edge-case test for non-Ubuntu distro fallback uses `_NoQualResolver` (no `distro_version_qualifier` property)
- All 147 existing tests passing with identical assertions

## Regression Assessment

- **Pipeline impact:** **Yes** — directly affects PURL strings in SPDX external references
- **Reason:** `_make_purl()` generates PURLs for every system dependency in every SPDX file
- **Regression repos needed:** ALL repos (combined with #100/#101 regression run)

## Verification

- 1017 passed + 15 skipped (zero regressions)
- PURL format unchanged on Ubuntu (same `pkg:deb/ubuntu/{pkg}@{version}?arch=...&distro=...`)
- **Container regression test needed** (combined with #100/#101)

## Closes

Closes #102
