### PR TITLE
feat(validator): refactor DependencyValidator for multi-distro (#103)

### DIFF
--- a/app/pipeline/facade.py
+++ b/app/pipeline/facade.py
@@ -43,7 +43,7 @@ class AnalysisPipeline:
         self.runner = runner or CommandRunner()
         self.validator = (
             validator
-            or DependencyValidator(self.runner)
+            or DependencyValidator()
         )
         self.cloner = cloner or RepoCloner(
             self.runner

--- a/app/pipeline/validator.py
+++ b/app/pipeline/validator.py
@@ -1,22 +1,28 @@
 """
 Dependency validation for OmniBOR Analysis.
 
-Checks that required apt packages are installed before
-attempting an instrumented build.
+Checks that required system packages are installed before
+attempting an instrumented build.  Uses the ``PackageResolver``
+abstraction so the check works on Debian/Ubuntu, RHEL/Fedora,
+and Alpine.
 """
-
-from app.runner import CommandRunner
 
 
 class DependencyValidator:
-    """Checks that required apt packages are installed before build.
+    """Checks that required packages are installed before build.
 
-    Reads the apt_deps list from a repo's config entry and
-    verifies each package is installed via dpkg-query.
+    Reads the ``apt_deps`` list from a repo's config entry and
+    verifies each package is installed using the injected
+    ``PackageResolver``.
     """
 
-    def __init__(self, runner=None):
-        self.runner = runner or CommandRunner()
+    def __init__(self, resolver=None):
+        if resolver is None:
+            from app.spdx.package_resolver import (
+                auto_detect_resolver,
+            )
+            resolver = auto_detect_resolver()
+        self._resolver = resolver
 
     def validate(self, repo_cfg):
         """Check all apt_deps are installed.
@@ -31,18 +37,11 @@ class DependencyValidator:
 
         missing = []
         for pkg in apt_deps:
-            rc = self.runner.run(
-                f"dpkg-query -W -f='${{Status}}' "
-                f"{pkg} 2>/dev/null "
-                "| grep -q 'install ok installed'",
-                description=(
-                    f"Checking dependency: {pkg}"
-                ),
-            )
-            if rc != 0:
+            if not self._resolver.is_package_installed(pkg):
                 missing.append(pkg)
 
         if missing:
+            hint = self._resolver.install_hint(missing)
             print(
                 f"\n[ERROR] Missing {len(missing)} "
                 "required package(s):"
@@ -50,17 +49,15 @@ class DependencyValidator:
             for pkg in missing:
                 print(f"  - {pkg}")
             print(
-                "\nInstall them with:\n"
-                f"  apt-get install -y "
-                f"{' '.join(missing)}\n"
-                "\nOr add them to the Dockerfile's "
-                "apt-get install list and rebuild "
-                "the image.\n"
+                f"\nInstall them with:\n"
+                f"  {hint}\n"
+                "\nOr add them to the Dockerfile and "
+                "rebuild the image.\n"
             )
             return False, missing
 
         print(
             f"[OK] All {len(apt_deps)} "
-            "apt dependencies verified"
+            "system dependencies verified"
         )
         return True, []

--- a/app/spdx/apk_resolver.py
+++ b/app/spdx/apk_resolver.py
@@ -202,6 +202,23 @@ class ApkResolver(PackageResolver):
         self._meta_cache[pkg_name] = result
         return result
 
+    def is_package_installed(self, pkg_name: str) -> bool:
+        """Check via ``apk info -e`` whether a package is installed."""
+        try:
+            subprocess.check_output(
+                ["apk", "info", "-e", pkg_name],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except (subprocess.CalledProcessError, OSError):
+            return False
+
+    def install_hint(self, packages: list) -> str:
+        """Return an ``apk add`` command."""
+        pkgs = " ".join(packages)
+        return f"apk add {pkgs}"
+
     @property
     def distro_version_qualifier(self) -> str:
         """Return distro version string for PURL qualifiers.

--- a/app/spdx/dpkg_resolver.py
+++ b/app/spdx/dpkg_resolver.py
@@ -142,6 +142,26 @@ class DpkgResolver(PackageResolver):
         self._meta_cache[pkg_name] = result
         return result
 
+    def is_package_installed(self, pkg_name: str) -> bool:
+        """Check via ``dpkg-query`` whether a package is installed."""
+        try:
+            out = subprocess.check_output(
+                [
+                    "dpkg-query", "-W",
+                    "-f=${Status}", pkg_name,
+                ],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+            return "install ok installed" in out
+        except (subprocess.CalledProcessError, OSError):
+            return False
+
+    def install_hint(self, packages: list) -> str:
+        """Return an ``apt-get install`` command."""
+        pkgs = " ".join(packages)
+        return f"apt-get install -y {pkgs}"
+
     @property
     def distro_version_qualifier(self) -> str:
         """Return distro version string for PURL qualifiers.

--- a/app/spdx/package_resolver.py
+++ b/app/spdx/package_resolver.py
@@ -51,12 +51,19 @@ class PackageResolver(ABC):
     """Resolves file paths to OS package metadata.
 
     Implementations must provide distro-specific mechanisms
-    for two operations:
+    for two core operations:
 
     1. ``resolve(file_path)`` — given an absolute file path,
        return the owning package's metadata or ``None``.
     2. ``purl_scheme()`` — return the PURL type and namespace
        prefix for this distro (e.g. ``pkg:deb/ubuntu``).
+
+    Optional operations (concrete defaults provided):
+
+    3. ``is_package_installed(pkg_name)`` — check whether a
+       named package is installed (for pre-build validation).
+    4. ``install_hint(packages)`` — return a distro-appropriate
+       install command string for missing packages.
 
     The interface is deliberately minimal (P4: Interface
     Segregation) so that adding a new distro requires only
@@ -88,6 +95,33 @@ class PackageResolver(ABC):
         The caller appends ``/{name}@{version}?qualifiers``
         to build the full PURL string.
         """
+
+    def is_package_installed(self, pkg_name: str) -> bool:
+        """Check whether a named package is installed.
+
+        Subclasses should override with the distro-appropriate
+        package query. The default returns ``True`` (assume
+        installed) so that callers degrade gracefully on
+        unsupported platforms.
+
+        Args:
+            pkg_name: Package name to check.
+
+        Returns:
+            True if installed, False otherwise.
+        """
+        return True
+
+    def install_hint(self, packages: list) -> str:
+        """Return a distro-appropriate install command hint.
+
+        Args:
+            packages: List of package names to install.
+
+        Returns:
+            A shell command string the user can run.
+        """
+        return "Install the missing packages manually."
 
     def make_purl(
         self, pkg_name: str, version: str,

--- a/app/spdx/rpm_resolver.py
+++ b/app/spdx/rpm_resolver.py
@@ -167,6 +167,23 @@ class RpmResolver(PackageResolver):
         self._meta_cache[pkg_name] = result
         return result
 
+    def is_package_installed(self, pkg_name: str) -> bool:
+        """Check via ``rpm -q`` whether a package is installed."""
+        try:
+            subprocess.check_output(
+                ["rpm", "-q", pkg_name],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except (subprocess.CalledProcessError, OSError):
+            return False
+
+    def install_hint(self, packages: list) -> str:
+        """Return a ``dnf install`` command."""
+        pkgs = " ".join(packages)
+        return f"dnf install -y {pkgs}"
+
     @property
     def distro_version_qualifier(self) -> str:
         """Return distro version string for PURL qualifiers.

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -25,6 +25,7 @@ from analyze import (
     _run_rust_pipeline,
     _validate_syft_spdx,
 )
+from app.spdx.package_resolver import PackageResolver
 
 
 # ============================================================
@@ -135,40 +136,60 @@ class TestCommandRunner(unittest.TestCase):
 # DependencyValidator
 # ============================================================
 
+class _FakeValidatorResolver(PackageResolver):
+    """Stub resolver for DependencyValidator tests."""
+
+    def __init__(self, installed=None):
+        self._installed = set(installed or [])
+
+    def resolve(self, file_path):
+        return None
+
+    def purl_scheme(self):
+        return "pkg:deb/ubuntu"
+
+    def is_package_installed(self, pkg_name):
+        return pkg_name in self._installed
+
+    def install_hint(self, packages):
+        pkgs = " ".join(packages)
+        return f"apt-get install -y {pkgs}"
+
+
 class TestDependencyValidator(unittest.TestCase):
     """Tests for DependencyValidator."""
 
     def test_no_apt_deps(self):
-        runner = MagicMock()
-        v = DependencyValidator(runner)
+        resolver = _FakeValidatorResolver()
+        v = DependencyValidator(resolver=resolver)
         ok, missing = v.validate({})
         self.assertTrue(ok)
         self.assertEqual(missing, [])
-        runner.run.assert_not_called()
 
     def test_empty_apt_deps(self):
-        runner = MagicMock()
-        v = DependencyValidator(runner)
+        resolver = _FakeValidatorResolver()
+        v = DependencyValidator(resolver=resolver)
         ok, missing = v.validate({"apt_deps": []})
         self.assertTrue(ok)
         self.assertEqual(missing, [])
 
     def test_all_installed(self):
-        runner = MagicMock()
-        runner.run.return_value = 0
-        v = DependencyValidator(runner)
+        resolver = _FakeValidatorResolver(
+            installed=["libssl-dev", "zlib1g-dev"]
+        )
+        v = DependencyValidator(resolver=resolver)
         with patch("builtins.print"):
             ok, missing = v.validate(
                 {"apt_deps": ["libssl-dev", "zlib1g-dev"]}
             )
         self.assertTrue(ok)
         self.assertEqual(missing, [])
-        self.assertEqual(runner.run.call_count, 2)
 
     def test_some_missing(self):
-        runner = MagicMock()
-        runner.run.side_effect = [0, 1, 0]
-        v = DependencyValidator(runner)
+        resolver = _FakeValidatorResolver(
+            installed=["libssl-dev", "zlib1g-dev"]
+        )
+        v = DependencyValidator(resolver=resolver)
         with patch("builtins.print"):
             ok, missing = v.validate(
                 {"apt_deps": [
@@ -180,9 +201,8 @@ class TestDependencyValidator(unittest.TestCase):
         self.assertEqual(missing, ["libpsl-dev"])
 
     def test_all_missing(self):
-        runner = MagicMock()
-        runner.run.return_value = 1
-        v = DependencyValidator(runner)
+        resolver = _FakeValidatorResolver()
+        v = DependencyValidator(resolver=resolver)
         with patch("builtins.print"):
             ok, missing = v.validate(
                 {"apt_deps": ["a", "b"]}
@@ -191,9 +211,8 @@ class TestDependencyValidator(unittest.TestCase):
         self.assertEqual(missing, ["a", "b"])
 
     def test_prints_install_hint(self):
-        runner = MagicMock()
-        runner.run.return_value = 1
-        v = DependencyValidator(runner)
+        resolver = _FakeValidatorResolver()
+        v = DependencyValidator(resolver=resolver)
         printed = []
         with patch(
             "builtins.print",
@@ -2374,6 +2393,15 @@ class TestClassifyReleaseBuild(unittest.TestCase):
 
 class TestAnalysisPipeline(unittest.TestCase):
     """Tests for AnalysisPipeline facade."""
+
+    def setUp(self):
+        patcher = patch(
+            "app.spdx.package_resolver"
+            ".auto_detect_resolver",
+            return_value=_FakeValidatorResolver(),
+        )
+        self._mock_resolver = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_default_construction(self):
         p = AnalysisPipeline()


### PR DESCRIPTION
## Summary

Implements **[A9] Refactor `pipeline/validator.py` for multi-distro** ([#103](https://github.com/tedg-dev/omnibor-analysis/issues/103)) — replaces hardcoded `dpkg-query` pre-build validation with `PackageResolver.is_package_installed()` and `install_hint()`.

## What Changed

### `app/spdx/package_resolver.py` (ABC extended)

- Added `is_package_installed(pkg_name)` — concrete default returns `True` (graceful degradation)
- Added `install_hint(packages)` — concrete default returns generic message

### `app/spdx/dpkg_resolver.py`

- `is_package_installed()` — uses `dpkg-query -W -f=${Status}` + checks for "install ok installed"
- `install_hint()` — returns `apt-get install -y ...`

### `app/spdx/rpm_resolver.py`

- `is_package_installed()` — uses `rpm -q`
- `install_hint()` — returns `dnf install -y ...`

### `app/spdx/apk_resolver.py`

- `is_package_installed()` — uses `apk info -e`
- `install_hint()` — returns `apk add ...`

### `app/pipeline/validator.py` (refactored)

- Replaced `CommandRunner` + hardcoded `dpkg-query` shell pipeline with `PackageResolver` DI
- `__init__` accepts optional `resolver`, defaults to `auto_detect_resolver()`
- Removed `from app.runner import CommandRunner` dependency
- Install hint is now distro-aware via `resolver.install_hint()`

### `app/pipeline/facade.py`

- `DependencyValidator()` no longer receives `self.runner` — uses its own resolver

### `tests/test_analyze.py` (updated)

- Added `_FakeValidatorResolver` with controllable `is_package_installed()` 
- All 6 `DependencyValidator` tests updated to use fake resolver
- `TestAnalysisPipeline.setUp` mocks `auto_detect_resolver` for default construction

## Regression Assessment

- **Pipeline impact:** Yes — modifies pre-build dependency validation
- **Reason:** Validation gates every build; wrong behavior = builds proceed with missing deps
- **Regression repos needed:** ALL repos (combined with #100/#101/#102)

## Verification

- 1017 passed + 15 skipped (zero regressions)
- Zero `dpkg` strings in `validator.py`
- **Container regression test needed** (combined with #100/#101/#102)

## Closes

Closes #103
