### PR TITLE
feat(java): InterceptionStrategy + Maven/Gradle dep:tree + shade detection (#106/#107/#108)

### DIFF
--- a/app/pipeline/gradle_dep_tree_parser.py
+++ b/app/pipeline/gradle_dep_tree_parser.py
@@ -1,0 +1,217 @@
+"""
+Gradle dependency tree parser for pipeline use.
+
+Wraps ``app.spdx.gradle_parser`` with multi-project
+support and output format compatible with the Maven
+DOT parser (``maven_dep_tree_parser.py``).
+
+Gradle tree format::
+
+    +--- group:artifact:version
+    |    +--- group:artifact:version
+    |    \\--- group:artifact:declared -> resolved (*)
+
+Version conflict notation: ``declared -> resolved``
+indicates Gradle resolved to a different version.
+``(*)`` means the subtree was already listed.
+"""
+
+import subprocess
+from pathlib import Path
+from typing import List
+
+from app.spdx.gradle_parser import (
+    parse_gradle_dep_tree,
+)
+
+
+def run_gradle_dep_tree(
+    repo_dir, project=None, runner=None,
+):
+    """Run ``./gradlew dependencies`` for a project.
+
+    Args:
+        repo_dir: Path to the repository root.
+        project: Optional Gradle subproject name.
+        runner: Optional ``CommandRunner`` (unused,
+            kept for API consistency).
+
+    Returns:
+        Raw stdout string, or None on failure.
+    """
+    repo_path = Path(repo_dir)
+    gradlew = repo_path / "gradlew"
+    if not gradlew.exists():
+        print(
+            f"[WARN] No gradlew found in {repo_dir}"
+        )
+        return None
+
+    task = "dependencies"
+    if project:
+        task = f"{project}:dependencies"
+
+    try:
+        result = subprocess.run(
+            [
+                str(gradlew), task,
+                "--configuration", "runtimeClasspath",
+                "--no-daemon", "-q",
+            ],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        if result.returncode != 0:
+            print(
+                "[WARN] Gradle dependencies failed: "
+                f"{result.stderr[:200]}"
+            )
+            return None
+        return result.stdout
+    except subprocess.TimeoutExpired:
+        print(
+            "[WARN] Gradle dependencies timed out "
+            "(120s)"
+        )
+        return None
+    except FileNotFoundError:
+        print("[WARN] gradlew not found on PATH")
+        return None
+
+
+def parse_gradle_output(output):
+    """Parse Gradle dependency tree into structured dicts.
+
+    Delegates to ``gradle_parser.parse_gradle_dep_tree()``
+    and normalises the output to match the Maven DOT
+    parser format (adds ``is_test``, ``module``,
+    ``packaging`` fields).
+
+    Args:
+        output: Raw stdout from ``./gradlew dependencies``.
+
+    Returns:
+        List of dependency dicts with keys matching
+        ``maven_dep_tree_parser.parse_dot_output()``.
+    """
+    raw_deps = parse_gradle_dep_tree(output)
+    deps = []
+    for d in raw_deps:
+        scope = d.get("scope", "compile")
+        deps.append({
+            "groupId": d["groupId"],
+            "artifactId": d["artifactId"],
+            "version": d["version"],
+            "scope": scope,
+            "packaging": "jar",
+            "direct": d.get("direct", False),
+            "parent": d.get("parent"),
+            "is_test": scope == "test",
+            "module": None,
+        })
+    return deps
+
+
+def find_gradle_subprojects(repo_dir):
+    """Discover Gradle subprojects from settings.gradle.
+
+    Parses ``settings.gradle`` or ``settings.gradle.kts``
+    for ``include`` directives.
+
+    Args:
+        repo_dir: Path to the repository root.
+
+    Returns:
+        List of subproject names (e.g. ``[":core", ":web"]``).
+    """
+    repo_path = Path(repo_dir)
+    for name in (
+        "settings.gradle", "settings.gradle.kts",
+    ):
+        settings = repo_path / name
+        if settings.exists():
+            return _parse_settings(settings)
+    return []
+
+
+def _parse_settings(settings_path):
+    """Extract ``include`` directives from settings file."""
+    projects = []
+    try:
+        content = settings_path.read_text(
+            encoding="utf-8",
+        )
+    except OSError:
+        return projects
+
+    import re
+    # Match: include 'project1', 'project2'
+    # Match: include("project1", "project2")
+    for match in re.finditer(
+        r"""include\s*\(?\s*['"]([^'"]+)['"]""",
+        content,
+    ):
+        projects.append(match.group(1))
+
+    # Also match comma-separated in same include
+    for match in re.finditer(
+        r""",\s*['"]([^'"]+)['"]""",
+        content,
+    ):
+        val = match.group(1)
+        if val.startswith(":"):
+            projects.append(val)
+
+    return projects
+
+
+def get_all_gradle_deps(
+    repo_dir: str,
+    include_subprojects: bool = True,
+) -> List[dict]:
+    """Get dependencies from all Gradle subprojects.
+
+    Args:
+        repo_dir: Path to the repository root.
+        include_subprojects: If True, iterate over
+            subprojects discovered from settings.gradle.
+
+    Returns:
+        Combined deduplicated dependency list.
+    """
+    all_deps = []
+    seen = set()
+
+    # Root project
+    output = run_gradle_dep_tree(repo_dir)
+    if output:
+        deps = parse_gradle_output(output)
+        for d in deps:
+            key = (d["groupId"], d["artifactId"])
+            if key not in seen:
+                seen.add(key)
+                all_deps.append(d)
+
+    # Subprojects
+    if include_subprojects:
+        subprojects = find_gradle_subprojects(repo_dir)
+        for proj in subprojects:
+            output = run_gradle_dep_tree(
+                repo_dir, project=proj,
+            )
+            if output:
+                deps = parse_gradle_output(output)
+                for d in deps:
+                    d["module"] = proj
+                    key = (
+                        d["groupId"],
+                        d["artifactId"],
+                    )
+                    if key not in seen:
+                        seen.add(key)
+                        all_deps.append(d)
+
+    return all_deps

--- a/app/pipeline/interception.py
+++ b/app/pipeline/interception.py
@@ -128,3 +128,66 @@ class MavenDepTreeStrategy(InterceptionStrategy):
             f"{len(deps)} dependencies → {out_file}"
         )
         return True
+
+
+class GradleDepTreeStrategy(InterceptionStrategy):
+    """Java Gradle: ``./gradlew dependencies`` instead of strace.
+
+    Like ``MavenDepTreeStrategy``, this avoids ``SYS_PTRACE``
+    for Gradle-based Java builds:
+
+    1. Runs the build command unmodified.
+    2. Runs ``./gradlew dependencies`` per subproject.
+    3. Parses the indented tree output into structured data.
+
+    Handles multi-project builds by iterating subprojects
+    discovered from ``settings.gradle``.
+    """
+
+    def __init__(self, runner=None):
+        from app.runner import CommandRunner
+        self._runner = runner or CommandRunner()
+
+    def instrument_command(self, build_cmd, repo_dir):
+        """Return the build command unmodified — no strace.
+
+        Returns:
+            ``(build_cmd, {})`` — no env vars needed.
+        """
+        return build_cmd, {}
+
+    def generate_adg(self, repo_dir, bom_dir, omnibor_cfg):
+        """Run ``./gradlew dependencies`` and parse output.
+
+        Writes parsed dependency data to
+        ``{bom_dir}/gradle_deps.json``.
+
+        Returns:
+            True on success, False on failure.
+        """
+        import json
+        from pathlib import Path
+
+        from app.pipeline.gradle_dep_tree_parser import (
+            get_all_gradle_deps,
+        )
+
+        bom_path = Path(bom_dir)
+        bom_path.mkdir(parents=True, exist_ok=True)
+
+        deps = get_all_gradle_deps(repo_dir)
+        if not deps:
+            print(
+                "[WARN] No dependencies found in "
+                "Gradle dependency tree"
+            )
+
+        out_file = bom_path / "gradle_deps.json"
+        with open(out_file, "w", encoding="utf-8") as f:
+            json.dump(deps, f, indent=2)
+
+        print(
+            f"[OK] Gradle dep:tree: "
+            f"{len(deps)} dependencies → {out_file}"
+        )
+        return True

--- a/app/pipeline/interception.py
+++ b/app/pipeline/interception.py
@@ -1,0 +1,130 @@
+"""
+Build interception strategies for OmniBOR Analysis.
+
+Defines the ``InterceptionStrategy`` ABC and concrete
+implementations for different build interception methods.
+
+Each strategy provides two operations:
+
+1. ``instrument_command()`` — modify a build command to
+   enable OmniBOR tracing (e.g. prepend bomtrace3, set
+   environment variables, or pass through unmodified).
+2. ``generate_adg()`` — produce the OmniBOR Artifact
+   Dependency Graph from tracer output or build-tool
+   dependency information.
+
+Design reference:
+    Implementation Design §4.4 — Interception Strategy
+"""
+
+from abc import ABC, abstractmethod
+
+
+class InterceptionStrategy(ABC):
+    """Defines how a build is instrumented for OmniBOR tracing.
+
+    Concrete strategies implement distro-specific or
+    language-specific instrumentation. The pipeline
+    selects a strategy based on ``config.yaml`` settings.
+    """
+
+    @abstractmethod
+    def instrument_command(self, build_cmd, repo_dir):
+        """Modify a build command for OmniBOR tracing.
+
+        Args:
+            build_cmd: The original build command string.
+            repo_dir: Path to the repository root.
+
+        Returns:
+            A ``(command, env)`` tuple where *command* is
+            the (possibly modified) build command string
+            and *env* is a dict of environment variables
+            to set during the build (empty dict if none).
+        """
+
+    @abstractmethod
+    def generate_adg(self, repo_dir, bom_dir, omnibor_cfg):
+        """Generate the OmniBOR Artifact Dependency Graph.
+
+        Args:
+            repo_dir: Path to the repository root.
+            bom_dir: Path to the OmniBOR output directory.
+            omnibor_cfg: The ``omnibor`` config section.
+
+        Returns:
+            True on success, False on failure.
+        """
+
+
+class MavenDepTreeStrategy(InterceptionStrategy):
+    """Java Maven: ``mvn dependency:tree`` instead of strace.
+
+    In sidecar mode, Java builds do not need ``SYS_PTRACE``.
+    Instead of intercepting file I/O via strace, this strategy:
+
+    1. Runs the build command unmodified (no strace prefix).
+    2. Runs ``mvn dependency:tree -DoutputType=dot`` to
+       capture the declared dependency graph.
+    3. Parses the DOT output into treedb-compatible format.
+
+    Accuracy caveat: ``mvn dependency:tree`` reports the
+    *declared* dependency graph, which may diverge from the
+    *actual* runtime classpath when shade/assembly plugins
+    repackage transitive dependencies.
+    """
+
+    def __init__(self, runner=None):
+        from app.runner import CommandRunner
+        self._runner = runner or CommandRunner()
+
+    def instrument_command(self, build_cmd, repo_dir):
+        """Return the build command unmodified — no strace.
+
+        Returns:
+            ``(build_cmd, {})`` — no env vars needed.
+        """
+        return build_cmd, {}
+
+    def generate_adg(self, repo_dir, bom_dir, omnibor_cfg):
+        """Run ``mvn dependency:tree -DoutputType=dot`` and parse.
+
+        Writes parsed dependency data to
+        ``{bom_dir}/maven_deps.json``.
+
+        Returns:
+            True on success, False on failure.
+        """
+        import json
+        from pathlib import Path
+
+        from app.pipeline.maven_dep_tree_parser import (
+            parse_dot_output,
+            run_maven_dep_tree,
+        )
+
+        bom_path = Path(bom_dir)
+        bom_path.mkdir(parents=True, exist_ok=True)
+
+        dot_output = run_maven_dep_tree(
+            repo_dir, runner=self._runner,
+        )
+        if dot_output is None:
+            return False
+
+        deps = parse_dot_output(dot_output)
+        if not deps:
+            print(
+                "[WARN] No dependencies found in "
+                "mvn dependency:tree output"
+            )
+
+        out_file = bom_path / "maven_deps.json"
+        with open(out_file, "w", encoding="utf-8") as f:
+            json.dump(deps, f, indent=2)
+
+        print(
+            f"[OK] Maven dep:tree: "
+            f"{len(deps)} dependencies → {out_file}"
+        )
+        return True

--- a/app/pipeline/maven_dep_tree_parser.py
+++ b/app/pipeline/maven_dep_tree_parser.py
@@ -1,0 +1,260 @@
+"""
+Maven ``dependency:tree`` DOT format parser.
+
+Parses the output of ``mvn dependency:tree -DoutputType=dot``
+into structured dependency metadata.
+
+DOT output format::
+
+    digraph "com.example:app:jar:1.0" {
+        "com.example:app:jar:1.0" ->
+            "org.apache:commons-lang3:jar:3.12.0:compile" ;
+        "org.apache:commons-lang3:jar:3.12.0:compile" ->
+            "org.apache:commons-text:jar:1.10.0:compile" ;
+    }
+
+Each node uses the Maven coordinate format:
+``groupId:artifactId:packaging:version[:scope]``
+
+The root node (project itself) has no scope suffix.
+Dependency nodes have a scope suffix (compile, runtime,
+provided, test, system, import).
+
+Multi-module projects produce multiple ``digraph`` blocks,
+one per module.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+
+# Maven dependency scopes that appear in production artifacts.
+# Test-scope dependencies are excluded from production SPDX.
+_PRODUCTION_SCOPES = frozenset({
+    "compile", "runtime", "provided", "system",
+})
+
+# Regex for DOT edge lines:
+#   "group:artifact:type:ver:scope" -> "group:artifact:type:ver:scope" ;
+_EDGE_RE = re.compile(
+    r'"([^"]+)"\s*->\s*"([^"]+)"\s*;'
+)
+
+# Regex for DOT digraph header:
+#   digraph "group:artifact:type:ver" {
+_DIGRAPH_RE = re.compile(
+    r'digraph\s+"([^"]+)"\s*\{'
+)
+
+
+def parse_maven_coordinate(coord):
+    """Parse a Maven coordinate string into a dict.
+
+    Handles two formats:
+
+    - ``groupId:artifactId:packaging:version`` (root node)
+    - ``groupId:artifactId:packaging:version:scope`` (dep)
+
+    Args:
+        coord: Maven coordinate string.
+
+    Returns:
+        A dict with keys: ``groupId``, ``artifactId``,
+        ``packaging``, ``version``, ``scope``.
+        Returns None if the coordinate is malformed.
+    """
+    parts = coord.split(":")
+    if len(parts) == 4:
+        return {
+            "groupId": parts[0],
+            "artifactId": parts[1],
+            "packaging": parts[2],
+            "version": parts[3],
+            "scope": "",
+        }
+    if len(parts) == 5:
+        return {
+            "groupId": parts[0],
+            "artifactId": parts[1],
+            "packaging": parts[2],
+            "version": parts[3],
+            "scope": parts[4],
+        }
+    return None
+
+
+def parse_dot_output(dot_text):
+    """Parse ``mvn dependency:tree -DoutputType=dot`` output.
+
+    Extracts all dependency edges from the DOT graph and
+    builds a list of dependency dicts. The root project node
+    is identified as the digraph name and excluded from the
+    dependency list.
+
+    Handles multi-module projects (multiple digraph blocks).
+
+    Args:
+        dot_text: Raw stdout from ``mvn dependency:tree
+            -DoutputType=dot``, possibly including Maven
+            ``[INFO]`` log prefix lines.
+
+    Returns:
+        A list of dicts, each with keys:
+
+        - ``groupId``, ``artifactId``, ``version``, ``scope``
+        - ``packaging`` (jar, pom, war, etc.)
+        - ``direct`` (bool) — True if the parent is the
+          project root
+        - ``parent`` — the parent artifactId, or None for
+          direct deps
+        - ``is_test`` (bool) — True if scope is ``test``
+        - ``module`` — the module coordinate that owns this
+          dependency (for multi-module projects)
+    """
+    # Strip Maven [INFO] prefixes if present
+    lines = []
+    for raw_line in dot_text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("[INFO] "):
+            line = line[7:]
+        lines.append(line)
+    clean_text = "\n".join(lines)
+
+    # Collect root nodes per digraph block
+    roots = set()
+    for match in _DIGRAPH_RE.finditer(clean_text):
+        roots.add(match.group(1))
+
+    # Parse all edges
+    seen = set()
+    deps = []
+    for match in _EDGE_RE.finditer(clean_text):
+        parent_coord = match.group(1)
+        child_coord = match.group(2)
+
+        child = parse_maven_coordinate(child_coord)
+        if child is None:
+            continue
+
+        parent = parse_maven_coordinate(parent_coord)
+        if parent is None:
+            continue
+
+        # Deduplicate by (groupId, artifactId) — Maven
+        # resolves one version per artifact, so the first
+        # occurrence (nearest/managed) wins.
+        dep_key = (
+            child["groupId"],
+            child["artifactId"],
+        )
+        if dep_key in seen:
+            continue
+        seen.add(dep_key)
+
+        # Direct dependency = parent is a root node
+        is_direct = parent_coord in roots
+
+        scope = child.get("scope", "compile") or "compile"
+
+        deps.append({
+            "groupId": child["groupId"],
+            "artifactId": child["artifactId"],
+            "version": child["version"],
+            "scope": scope,
+            "packaging": child.get("packaging", "jar"),
+            "direct": is_direct,
+            "parent": (
+                None if is_direct
+                else parent["artifactId"]
+            ),
+            "is_test": scope == "test",
+            "module": parent_coord if is_direct else None,
+        })
+
+    return deps
+
+
+def filter_production_deps(deps):
+    """Filter dependency list to production-only scopes.
+
+    Removes test-scope dependencies from the list.
+
+    Args:
+        deps: List of dependency dicts from
+            ``parse_dot_output()``.
+
+    Returns:
+        A new list containing only dependencies with
+        production scopes (compile, runtime, provided,
+        system).
+    """
+    return [
+        d for d in deps
+        if d.get("scope", "compile") in _PRODUCTION_SCOPES
+    ]
+
+
+def classify_scopes(deps):
+    """Classify dependencies by scope.
+
+    Args:
+        deps: List of dependency dicts.
+
+    Returns:
+        A dict mapping scope names to lists of deps.
+    """
+    result = {}
+    for dep in deps:
+        scope = dep.get("scope", "compile")
+        result.setdefault(scope, []).append(dep)
+    return result
+
+
+def run_maven_dep_tree(repo_dir, runner=None):
+    """Run ``mvn dependency:tree -DoutputType=dot``.
+
+    Args:
+        repo_dir: Path to the repository root (must
+            contain ``pom.xml``).
+        runner: Optional ``CommandRunner`` for logging.
+            If None, uses subprocess directly.
+
+    Returns:
+        The raw stdout string, or None on failure.
+    """
+    repo_path = Path(repo_dir)
+    pom_path = repo_path / "pom.xml"
+    if not pom_path.exists():
+        print(
+            f"[WARN] No pom.xml found in {repo_dir}"
+        )
+        return None
+
+    try:
+        result = subprocess.run(
+            [
+                "mvn", "dependency:tree",
+                "-DoutputType=dot",
+            ],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            print(
+                "[WARN] mvn dependency:tree failed: "
+                f"{result.stderr[:200]}"
+            )
+            return None
+        return result.stdout
+    except subprocess.TimeoutExpired:
+        print(
+            "[WARN] mvn dependency:tree timed out "
+            "(120s)"
+        )
+        return None
+    except FileNotFoundError:
+        print("[WARN] mvn not found on PATH")
+        return None

--- a/app/pipeline/maven_plugin_detector.py
+++ b/app/pipeline/maven_plugin_detector.py
@@ -1,0 +1,270 @@
+"""
+Maven shade/assembly plugin detector.
+
+Scans ``pom.xml`` files for ``maven-shade-plugin`` and
+``maven-assembly-plugin`` configurations that repackage
+transitive dependencies into uber-JARs.  When detected,
+``mvn dependency:tree`` may not reflect the actual JAR
+contents (shaded deps are inlined, not declared).
+
+Used by the Java pipeline to annotate SPDX documents
+with accuracy caveats.
+"""
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+
+# Known repackaging plugins that affect dep:tree accuracy
+_REPACKAGING_PLUGINS = {
+    "maven-shade-plugin": {
+        "group_id": "org.apache.maven.plugins",
+        "warning": (
+            "maven-shade-plugin detected — uber-JAR "
+            "may contain shaded transitive dependencies "
+            "not listed in dependency:tree"
+        ),
+    },
+    "maven-assembly-plugin": {
+        "group_id": "org.apache.maven.plugins",
+        "warning": (
+            "maven-assembly-plugin detected — "
+            "assembled archive may bundle dependencies "
+            "not listed in dependency:tree"
+        ),
+    },
+    "spring-boot-maven-plugin": {
+        "group_id": "org.springframework.boot",
+        "warning": (
+            "spring-boot-maven-plugin detected — "
+            "fat JAR bundles all runtime dependencies; "
+            "dependency:tree is accurate for this case"
+        ),
+    },
+}
+
+
+@dataclass
+class PluginDetection:
+    """Result of scanning a pom.xml for repackaging plugins.
+
+    Attributes:
+        plugin_id: The Maven artifactId of the plugin.
+        group_id: The Maven groupId of the plugin.
+        warning: Human-readable warning message.
+        pom_path: Path to the pom.xml where detected.
+        has_filters: Whether the shade config includes
+            artifact filters (reduces false positives).
+    """
+    plugin_id: str
+    group_id: str
+    warning: str
+    pom_path: str
+    has_filters: bool = False
+
+
+@dataclass
+class DetectionResult:
+    """Aggregated result from scanning all pom.xml files.
+
+    Attributes:
+        detections: List of individual plugin detections.
+        spdx_comment: Pre-formatted comment for SPDX
+            ``creationInfo`` annotation.
+        is_uber_jar: True if any shading/assembly plugin
+            was detected.
+    """
+    detections: List[PluginDetection] = field(
+        default_factory=list,
+    )
+
+    @property
+    def is_uber_jar(self) -> bool:
+        """True if any repackaging plugin was detected."""
+        return len(self.detections) > 0
+
+    @property
+    def spdx_comment(self) -> str:
+        """SPDX creationInfo comment annotation.
+
+        Returns empty string if no plugins detected.
+        """
+        if not self.detections:
+            return ""
+        lines = []
+        for d in self.detections:
+            lines.append(d.warning)
+        return "; ".join(lines)
+
+    @property
+    def plugin_ids(self) -> List[str]:
+        """List of detected plugin artifactIds."""
+        return [d.plugin_id for d in self.detections]
+
+
+def detect_repackaging_plugins(
+    repo_dir: str,
+    pom_subpath: Optional[str] = None,
+) -> DetectionResult:
+    """Scan pom.xml files for repackaging plugins.
+
+    Searches the root ``pom.xml`` and, for multi-module
+    projects, each module's ``pom.xml``.
+
+    Args:
+        repo_dir: Path to the repository root.
+        pom_subpath: Optional relative path to a specific
+            ``pom.xml`` (e.g. ``"core/pom.xml"``).  If
+            None, scans root + all modules listed in the
+            root POM.
+
+    Returns:
+        A ``DetectionResult`` with all findings.
+    """
+    result = DetectionResult()
+    repo_path = Path(repo_dir)
+
+    if pom_subpath:
+        pom_paths = [repo_path / pom_subpath]
+    else:
+        root_pom = repo_path / "pom.xml"
+        if not root_pom.exists():
+            return result
+        pom_paths = [root_pom]
+        # Add module POMs for multi-module projects
+        modules = _find_modules(root_pom)
+        for mod in modules:
+            mod_pom = repo_path / mod / "pom.xml"
+            if mod_pom.exists():
+                pom_paths.append(mod_pom)
+
+    for pom in pom_paths:
+        detections = _scan_pom(pom)
+        result.detections.extend(detections)
+
+    return result
+
+
+def _find_modules(pom_path: Path) -> List[str]:
+    """Extract ``<modules><module>`` list from a POM."""
+    try:
+        tree = ET.parse(pom_path)
+        root = tree.getroot()
+        ns = _maven_ns(root)
+
+        if ns:
+            modules_elem = root.find("m:modules", ns)
+        else:
+            modules_elem = root.find("modules")
+
+        if modules_elem is None:
+            return []
+
+        result = []
+        for mod in modules_elem:
+            if mod.text:
+                result.append(mod.text.strip())
+        return result
+    except ET.ParseError:
+        return []
+
+
+def _scan_pom(pom_path: Path) -> List[PluginDetection]:
+    """Scan a single pom.xml for repackaging plugins."""
+    try:
+        tree = ET.parse(pom_path)
+        root = tree.getroot()
+    except ET.ParseError:
+        return []
+
+    ns = _maven_ns(root)
+    detections = []
+
+    # Search both build/plugins and build/pluginManagement
+    plugin_paths = [
+        ".//m:build/m:plugins/m:plugin" if ns
+        else ".//build/plugins/plugin",
+        ".//m:build/m:pluginManagement/m:plugins/m:plugin"
+        if ns else
+        ".//build/pluginManagement/plugins/plugin",
+    ]
+
+    for xpath in plugin_paths:
+        plugins = root.findall(xpath, ns) if ns else (
+            root.findall(xpath)
+        )
+        for plugin in plugins:
+            detection = _check_plugin(
+                plugin, ns, str(pom_path),
+            )
+            if detection:
+                detections.append(detection)
+
+    return detections
+
+
+def _check_plugin(
+    plugin_elem, ns, pom_path: str,
+) -> Optional[PluginDetection]:
+    """Check if a ``<plugin>`` element is a repackaging plugin."""
+    if ns:
+        artifact_elem = plugin_elem.find(
+            "m:artifactId", ns,
+        )
+        group_elem = plugin_elem.find(
+            "m:groupId", ns,
+        )
+    else:
+        artifact_elem = plugin_elem.find("artifactId")
+        group_elem = plugin_elem.find("groupId")
+
+    if artifact_elem is None or not artifact_elem.text:
+        return None
+
+    artifact_id = artifact_elem.text.strip()
+    group_id = (
+        group_elem.text.strip()
+        if group_elem is not None and group_elem.text
+        else "org.apache.maven.plugins"
+    )
+
+    if artifact_id not in _REPACKAGING_PLUGINS:
+        return None
+
+    info = _REPACKAGING_PLUGINS[artifact_id]
+
+    # Check for artifact filters (shade plugin)
+    has_filters = _has_shade_filters(
+        plugin_elem, ns,
+    )
+
+    return PluginDetection(
+        plugin_id=artifact_id,
+        group_id=group_id,
+        warning=info["warning"],
+        pom_path=pom_path,
+        has_filters=has_filters,
+    )
+
+
+def _has_shade_filters(plugin_elem, ns) -> bool:
+    """Check if shade plugin has ``<artifactSet>`` filters."""
+    if ns:
+        filters = plugin_elem.find(
+            ".//m:configuration/m:artifactSet", ns,
+        )
+    else:
+        filters = plugin_elem.find(
+            ".//configuration/artifactSet",
+        )
+    return filters is not None
+
+
+def _maven_ns(root) -> dict:
+    """Extract Maven XML namespace from root element."""
+    if root.tag.startswith("{"):
+        ns_uri = root.tag.split("}")[0] + "}"
+        return {"m": ns_uri[1:-1]}
+    return {}

--- a/tests/test_gradle_dep_tree_parser.py
+++ b/tests/test_gradle_dep_tree_parser.py
@@ -1,0 +1,339 @@
+"""
+Tests for app/pipeline/gradle_dep_tree_parser.py.
+
+Tests the Gradle dependency tree parser wrapper and
+GradleDepTreeStrategy with realistic fixture data.
+"""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from app.pipeline.gradle_dep_tree_parser import (
+    parse_gradle_output,
+    run_gradle_dep_tree,
+    find_gradle_subprojects,
+)
+
+
+# ============================================================
+# Fixture: single-project Gradle output
+# ============================================================
+
+_SINGLE_PROJECT_OUTPUT = """\
+runtimeClasspath - Runtime classpath of source set 'main'.
++--- org.slf4j:slf4j-api:2.0.7
++--- com.google.guava:guava:32.1.3-jre
+|    +--- com.google.guava:failureaccess:1.0.1
+|    \\--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
++--- org.apache.commons:commons-lang3:3.14.0
+\\--- com.fasterxml.jackson.core:jackson-databind:2.16.0
+     +--- com.fasterxml.jackson.core:jackson-core:2.16.0
+     \\--- com.fasterxml.jackson.core:jackson-annotations:2.16.0
+"""
+
+# ============================================================
+# Fixture: version conflict
+# ============================================================
+
+_VERSION_CONFLICT_OUTPUT = """\
+runtimeClasspath - Runtime classpath of source set 'main'.
++--- org.slf4j:slf4j-api:2.0.7
++--- com.example:lib-a:1.0.0
+|    \\--- org.slf4j:slf4j-api:1.7.36 -> 2.0.7 (*)
+\\--- com.example:lib-b:2.0.0
+     \\--- org.slf4j:slf4j-api:2.0.0 -> 2.0.7 (*)
+"""
+
+# ============================================================
+# Fixture: empty output
+# ============================================================
+
+_EMPTY_OUTPUT = """\
+runtimeClasspath - Runtime classpath of source set 'main'.
+No dependencies
+"""
+
+
+# ============================================================
+# Tests: parse_gradle_output
+# ============================================================
+
+class TestParseGradleOutput(unittest.TestCase):
+    """Tests for parse_gradle_output()."""
+
+    def test_single_project_deps(self):
+        deps = parse_gradle_output(
+            _SINGLE_PROJECT_OUTPUT,
+        )
+        names = {d["artifactId"] for d in deps}
+        self.assertIn("slf4j-api", names)
+        self.assertIn("guava", names)
+        self.assertIn("commons-lang3", names)
+        self.assertIn("jackson-databind", names)
+
+    def test_transitive_deps(self):
+        deps = parse_gradle_output(
+            _SINGLE_PROJECT_OUTPUT,
+        )
+        transitive = [
+            d for d in deps if not d["direct"]
+        ]
+        names = {d["artifactId"] for d in transitive}
+        self.assertIn("failureaccess", names)
+        self.assertIn("jackson-core", names)
+
+    def test_direct_deps(self):
+        deps = parse_gradle_output(
+            _SINGLE_PROJECT_OUTPUT,
+        )
+        direct = [d for d in deps if d["direct"]]
+        self.assertEqual(len(direct), 4)
+
+    def test_output_format_has_required_keys(self):
+        deps = parse_gradle_output(
+            _SINGLE_PROJECT_OUTPUT,
+        )
+        required = {
+            "groupId", "artifactId", "version",
+            "scope", "packaging", "direct",
+            "parent", "is_test", "module",
+        }
+        for d in deps:
+            self.assertTrue(
+                required.issubset(d.keys()),
+                f"Missing keys in {d}",
+            )
+
+    def test_packaging_defaults_to_jar(self):
+        deps = parse_gradle_output(
+            _SINGLE_PROJECT_OUTPUT,
+        )
+        for d in deps:
+            self.assertEqual(d["packaging"], "jar")
+
+    def test_version_conflict_resolved(self):
+        deps = parse_gradle_output(
+            _VERSION_CONFLICT_OUTPUT,
+        )
+        slf4j = [
+            d for d in deps
+            if d["artifactId"] == "slf4j-api"
+        ]
+        self.assertEqual(len(slf4j), 1)
+        self.assertEqual(slf4j[0]["version"], "2.0.7")
+
+    def test_empty_output(self):
+        deps = parse_gradle_output(_EMPTY_OUTPUT)
+        self.assertEqual(deps, [])
+
+    def test_empty_string(self):
+        deps = parse_gradle_output("")
+        self.assertEqual(deps, [])
+
+    def test_scope_is_compile(self):
+        deps = parse_gradle_output(
+            _SINGLE_PROJECT_OUTPUT,
+        )
+        for d in deps:
+            self.assertEqual(d["scope"], "compile")
+
+    def test_not_test_scope(self):
+        deps = parse_gradle_output(
+            _SINGLE_PROJECT_OUTPUT,
+        )
+        for d in deps:
+            self.assertFalse(d["is_test"])
+
+
+# ============================================================
+# Tests: run_gradle_dep_tree
+# ============================================================
+
+class TestRunGradleDepTree(unittest.TestCase):
+    """Tests for run_gradle_dep_tree()."""
+
+    def test_no_gradlew_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            with patch("builtins.print"):
+                result = run_gradle_dep_tree(td)
+            self.assertIsNone(result)
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".subprocess.run"
+    )
+    def test_success(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=_SINGLE_PROJECT_OUTPUT,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "gradlew").touch()
+            result = run_gradle_dep_tree(td)
+        self.assertEqual(
+            result, _SINGLE_PROJECT_OUTPUT,
+        )
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".subprocess.run"
+    )
+    def test_failure_returns_none(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="BUILD FAILED",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "gradlew").touch()
+            with patch("builtins.print"):
+                result = run_gradle_dep_tree(td)
+            self.assertIsNone(result)
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".subprocess.run"
+    )
+    def test_timeout_returns_none(self, mock_run):
+        mock_run.side_effect = (
+            subprocess.TimeoutExpired("gradlew", 120)
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "gradlew").touch()
+            with patch("builtins.print"):
+                result = run_gradle_dep_tree(td)
+            self.assertIsNone(result)
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".subprocess.run"
+    )
+    def test_subproject(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=_SINGLE_PROJECT_OUTPUT,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "gradlew").touch()
+            run_gradle_dep_tree(
+                td, project=":core",
+            )
+        call_args = mock_run.call_args[0][0]
+        self.assertIn(":core:dependencies", call_args)
+
+
+# ============================================================
+# Tests: find_gradle_subprojects
+# ============================================================
+
+class TestFindGradleSubprojects(unittest.TestCase):
+    """Tests for find_gradle_subprojects()."""
+
+    def test_no_settings_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = find_gradle_subprojects(td)
+        self.assertEqual(result, [])
+
+    def test_groovy_settings(self):
+        with tempfile.TemporaryDirectory() as td:
+            settings = Path(td) / "settings.gradle"
+            settings.write_text(
+                "include ':core'\n"
+                "include ':web'\n",
+                encoding="utf-8",
+            )
+            result = find_gradle_subprojects(td)
+        self.assertIn(":core", result)
+        self.assertIn(":web", result)
+
+    def test_kotlin_settings(self):
+        with tempfile.TemporaryDirectory() as td:
+            settings = (
+                Path(td) / "settings.gradle.kts"
+            )
+            settings.write_text(
+                'include(":core")\n'
+                'include(":web")\n',
+                encoding="utf-8",
+            )
+            result = find_gradle_subprojects(td)
+        self.assertIn(":core", result)
+        self.assertIn(":web", result)
+
+
+# ============================================================
+# Tests: GradleDepTreeStrategy
+# ============================================================
+
+class TestGradleDepTreeStrategy(unittest.TestCase):
+    """Tests for GradleDepTreeStrategy."""
+
+    def test_instrument_command_passthrough(self):
+        from app.pipeline.interception import (
+            GradleDepTreeStrategy,
+        )
+        strategy = GradleDepTreeStrategy()
+        cmd, env = strategy.instrument_command(
+            "./gradlew build", "/repo",
+        )
+        self.assertEqual(cmd, "./gradlew build")
+        self.assertEqual(env, {})
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".run_gradle_dep_tree"
+    )
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".find_gradle_subprojects"
+    )
+    def test_generate_adg_success(
+        self, mock_subs, mock_run,
+    ):
+        from app.pipeline.interception import (
+            GradleDepTreeStrategy,
+        )
+        mock_subs.return_value = []
+        mock_run.return_value = _SINGLE_PROJECT_OUTPUT
+        strategy = GradleDepTreeStrategy()
+        with tempfile.TemporaryDirectory() as td:
+            bom_dir = Path(td) / "bom"
+            with patch("builtins.print"):
+                ok = strategy.generate_adg(
+                    "/repo", str(bom_dir), {},
+                )
+            self.assertTrue(ok)
+            self.assertTrue(
+                (bom_dir / "gradle_deps.json").exists()
+            )
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".run_gradle_dep_tree"
+    )
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".find_gradle_subprojects"
+    )
+    def test_generate_adg_no_deps(
+        self, mock_subs, mock_run,
+    ):
+        from app.pipeline.interception import (
+            GradleDepTreeStrategy,
+        )
+        mock_subs.return_value = []
+        mock_run.return_value = None
+        strategy = GradleDepTreeStrategy()
+        with tempfile.TemporaryDirectory() as td:
+            bom_dir = Path(td) / "bom"
+            with patch("builtins.print"):
+                ok = strategy.generate_adg(
+                    "/repo", str(bom_dir), {},
+                )
+            self.assertTrue(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_maven_dep_tree_parser.py
+++ b/tests/test_maven_dep_tree_parser.py
@@ -1,0 +1,459 @@
+"""
+Tests for app/pipeline/maven_dep_tree_parser.py.
+
+Tests the Maven ``dependency:tree`` DOT format parser
+with realistic fixture data from real Maven projects.
+"""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from app.pipeline.maven_dep_tree_parser import (
+    parse_maven_coordinate,
+    parse_dot_output,
+    filter_production_deps,
+    classify_scopes,
+    run_maven_dep_tree,
+)
+
+
+# ============================================================
+# Fixture: single-module project DOT output
+# ============================================================
+
+# Simplified output from dependency-check-core
+_SINGLE_MODULE_DOT = """\
+[INFO] --- dependency:3.6.1:tree (default-cli) @ dependency-check-core ---
+[INFO] digraph "org.owasp:dependency-check-core:jar:9.0.9" {
+[INFO]    "org.owasp:dependency-check-core:jar:9.0.9" -> "org.slf4j:slf4j-api:jar:2.0.7:compile" ;
+[INFO]    "org.owasp:dependency-check-core:jar:9.0.9" -> "commons-io:commons-io:jar:2.15.1:compile" ;
+[INFO]    "org.owasp:dependency-check-core:jar:9.0.9" -> "org.apache.commons:commons-lang3:jar:3.14.0:compile" ;
+[INFO]    "org.owasp:dependency-check-core:jar:9.0.9" -> "org.junit.jupiter:junit-jupiter:jar:5.10.1:test" ;
+[INFO]    "org.apache.commons:commons-lang3:jar:3.14.0:compile" -> "org.apache.commons:commons-text:jar:1.11.0:compile" ;
+[INFO]    "org.junit.jupiter:junit-jupiter:jar:5.10.1:test" -> "org.junit.jupiter:junit-jupiter-api:jar:5.10.1:test" ;
+[INFO]    "org.junit.jupiter:junit-jupiter-api:jar:5.10.1:test" -> "org.opentest4j:opentest4j:jar:1.3.0:test" ;
+[INFO] }
+"""
+
+# ============================================================
+# Fixture: multi-module project DOT output
+# ============================================================
+
+_MULTI_MODULE_DOT = """\
+[INFO] --- dependency:3.6.1:tree (default-cli) @ parent ---
+[INFO] digraph "com.example:parent:pom:1.0.0" {
+[INFO] }
+[INFO]
+[INFO] --- dependency:3.6.1:tree (default-cli) @ core ---
+[INFO] digraph "com.example:core:jar:1.0.0" {
+[INFO]    "com.example:core:jar:1.0.0" -> "org.slf4j:slf4j-api:jar:2.0.7:compile" ;
+[INFO]    "com.example:core:jar:1.0.0" -> "com.google.guava:guava:jar:32.1.3-jre:compile" ;
+[INFO] }
+[INFO]
+[INFO] --- dependency:3.6.1:tree (default-cli) @ web ---
+[INFO] digraph "com.example:web:war:1.0.0" {
+[INFO]    "com.example:web:war:1.0.0" -> "com.example:core:jar:1.0.0:compile" ;
+[INFO]    "com.example:web:war:1.0.0" -> "javax.servlet:javax.servlet-api:jar:4.0.1:provided" ;
+[INFO]    "com.example:web:war:1.0.0" -> "org.mockito:mockito-core:jar:5.8.0:test" ;
+[INFO]    "org.mockito:mockito-core:jar:5.8.0:test" -> "net.bytebuddy:byte-buddy:jar:1.14.10:test" ;
+[INFO] }
+"""
+
+# ============================================================
+# Fixture: no-scope root node (DOT format edge case)
+# ============================================================
+
+_ROOT_ONLY_DOT = """\
+digraph "com.example:app:jar:2.0.0" {
+}
+"""
+
+# ============================================================
+# Fixture: version conflict (managed version wins)
+# ============================================================
+
+_VERSION_CONFLICT_DOT = """\
+digraph "com.example:app:jar:1.0.0" {
+    "com.example:app:jar:1.0.0" -> "org.apache:commons-lang3:jar:3.14.0:compile" ;
+    "com.example:app:jar:1.0.0" -> "com.foo:bar:jar:1.0.0:compile" ;
+    "com.foo:bar:jar:1.0.0:compile" -> "org.apache:commons-lang3:jar:3.12.0:compile" ;
+}
+"""
+
+# ============================================================
+# Fixture: optional and system scope
+# ============================================================
+
+_SCOPES_DOT = """\
+digraph "com.example:app:jar:1.0.0" {
+    "com.example:app:jar:1.0.0" -> "com.oracle:ojdbc8:jar:21.9.0:system" ;
+    "com.example:app:jar:1.0.0" -> "org.slf4j:slf4j-api:jar:2.0.7:runtime" ;
+    "com.example:app:jar:1.0.0" -> "org.projectlombok:lombok:jar:1.18.30:provided" ;
+    "com.example:app:jar:1.0.0" -> "org.junit:junit:jar:4.13.2:test" ;
+}
+"""
+
+
+# ============================================================
+# Tests: parse_maven_coordinate
+# ============================================================
+
+class TestParseMavenCoordinate(unittest.TestCase):
+    """Tests for parse_maven_coordinate()."""
+
+    def test_four_part_root(self):
+        result = parse_maven_coordinate(
+            "com.example:app:jar:1.0.0"
+        )
+        self.assertEqual(result["groupId"], "com.example")
+        self.assertEqual(result["artifactId"], "app")
+        self.assertEqual(result["packaging"], "jar")
+        self.assertEqual(result["version"], "1.0.0")
+        self.assertEqual(result["scope"], "")
+
+    def test_five_part_with_scope(self):
+        result = parse_maven_coordinate(
+            "org.slf4j:slf4j-api:jar:2.0.7:compile"
+        )
+        self.assertEqual(result["groupId"], "org.slf4j")
+        self.assertEqual(result["artifactId"], "slf4j-api")
+        self.assertEqual(result["packaging"], "jar")
+        self.assertEqual(result["version"], "2.0.7")
+        self.assertEqual(result["scope"], "compile")
+
+    def test_test_scope(self):
+        result = parse_maven_coordinate(
+            "org.junit:junit:jar:4.13.2:test"
+        )
+        self.assertEqual(result["scope"], "test")
+
+    def test_war_packaging(self):
+        result = parse_maven_coordinate(
+            "com.example:web:war:1.0.0"
+        )
+        self.assertEqual(result["packaging"], "war")
+
+    def test_malformed_too_few_parts(self):
+        self.assertIsNone(
+            parse_maven_coordinate("com.example:app")
+        )
+
+    def test_malformed_too_many_parts(self):
+        self.assertIsNone(
+            parse_maven_coordinate(
+                "a:b:c:d:e:f"
+            )
+        )
+
+    def test_empty_string(self):
+        self.assertIsNone(parse_maven_coordinate(""))
+
+    def test_jre_classifier_in_version(self):
+        result = parse_maven_coordinate(
+            "com.google.guava:guava:jar:"
+            "32.1.3-jre:compile"
+        )
+        self.assertEqual(result["version"], "32.1.3-jre")
+
+
+# ============================================================
+# Tests: parse_dot_output
+# ============================================================
+
+class TestParseDotOutput(unittest.TestCase):
+    """Tests for parse_dot_output()."""
+
+    def test_single_module_direct_deps(self):
+        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+        direct = [d for d in deps if d["direct"]]
+        self.assertEqual(len(direct), 4)
+        names = {d["artifactId"] for d in direct}
+        self.assertIn("slf4j-api", names)
+        self.assertIn("commons-io", names)
+        self.assertIn("commons-lang3", names)
+        self.assertIn("junit-jupiter", names)
+
+    def test_single_module_transitive_deps(self):
+        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+        transitive = [d for d in deps if not d["direct"]]
+        self.assertEqual(len(transitive), 3)
+        names = {d["artifactId"] for d in transitive}
+        self.assertIn("commons-text", names)
+        self.assertIn("junit-jupiter-api", names)
+        self.assertIn("opentest4j", names)
+
+    def test_transitive_parent_set(self):
+        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+        text = next(
+            d for d in deps
+            if d["artifactId"] == "commons-text"
+        )
+        self.assertEqual(text["parent"], "commons-lang3")
+        self.assertFalse(text["direct"])
+
+    def test_direct_parent_is_none(self):
+        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+        slf4j = next(
+            d for d in deps
+            if d["artifactId"] == "slf4j-api"
+        )
+        self.assertIsNone(slf4j["parent"])
+        self.assertTrue(slf4j["direct"])
+
+    def test_test_scope_flagged(self):
+        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+        test_deps = [d for d in deps if d["is_test"]]
+        self.assertTrue(len(test_deps) >= 1)
+        names = {d["artifactId"] for d in test_deps}
+        self.assertIn("junit-jupiter", names)
+
+    def test_compile_scope_not_test(self):
+        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+        slf4j = next(
+            d for d in deps
+            if d["artifactId"] == "slf4j-api"
+        )
+        self.assertFalse(slf4j["is_test"])
+        self.assertEqual(slf4j["scope"], "compile")
+
+    def test_multi_module_all_deps(self):
+        deps = parse_dot_output(_MULTI_MODULE_DOT)
+        names = {d["artifactId"] for d in deps}
+        self.assertIn("slf4j-api", names)
+        self.assertIn("guava", names)
+        self.assertIn("javax.servlet-api", names)
+        self.assertIn("mockito-core", names)
+        self.assertIn("byte-buddy", names)
+        # core is a sibling module dependency
+        self.assertIn("core", names)
+
+    def test_multi_module_provided_scope(self):
+        deps = parse_dot_output(_MULTI_MODULE_DOT)
+        servlet = next(
+            d for d in deps
+            if d["artifactId"] == "javax.servlet-api"
+        )
+        self.assertEqual(servlet["scope"], "provided")
+
+    def test_empty_digraph(self):
+        deps = parse_dot_output(_ROOT_ONLY_DOT)
+        self.assertEqual(deps, [])
+
+    def test_version_conflict_dedup(self):
+        deps = parse_dot_output(_VERSION_CONFLICT_DOT)
+        lang3 = [
+            d for d in deps
+            if d["artifactId"] == "commons-lang3"
+        ]
+        # First occurrence wins (direct dep at 3.14.0)
+        self.assertEqual(len(lang3), 1)
+        self.assertEqual(lang3[0]["version"], "3.14.0")
+
+    def test_no_info_prefix(self):
+        """Works with raw DOT (no [INFO] prefixes)."""
+        raw = (
+            'digraph "a:b:jar:1.0" {\n'
+            '  "a:b:jar:1.0" -> '
+            '"c:d:jar:2.0:compile" ;\n'
+            '}\n'
+        )
+        deps = parse_dot_output(raw)
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["artifactId"], "d")
+
+    def test_empty_string(self):
+        self.assertEqual(parse_dot_output(""), [])
+
+    def test_garbage_input(self):
+        self.assertEqual(
+            parse_dot_output("not a dot graph"), []
+        )
+
+
+# ============================================================
+# Tests: filter_production_deps
+# ============================================================
+
+class TestFilterProductionDeps(unittest.TestCase):
+    """Tests for filter_production_deps()."""
+
+    def test_removes_test_scope(self):
+        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+        prod = filter_production_deps(deps)
+        test_deps = [d for d in prod if d["is_test"]]
+        self.assertEqual(test_deps, [])
+
+    def test_keeps_compile_scope(self):
+        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+        prod = filter_production_deps(deps)
+        names = {d["artifactId"] for d in prod}
+        self.assertIn("slf4j-api", names)
+        self.assertIn("commons-io", names)
+
+    def test_keeps_provided_scope(self):
+        deps = parse_dot_output(_SCOPES_DOT)
+        prod = filter_production_deps(deps)
+        names = {d["artifactId"] for d in prod}
+        self.assertIn("lombok", names)
+
+    def test_keeps_system_scope(self):
+        deps = parse_dot_output(_SCOPES_DOT)
+        prod = filter_production_deps(deps)
+        names = {d["artifactId"] for d in prod}
+        self.assertIn("ojdbc8", names)
+
+    def test_keeps_runtime_scope(self):
+        deps = parse_dot_output(_SCOPES_DOT)
+        prod = filter_production_deps(deps)
+        names = {d["artifactId"] for d in prod}
+        self.assertIn("slf4j-api", names)
+
+    def test_empty_list(self):
+        self.assertEqual(filter_production_deps([]), [])
+
+
+# ============================================================
+# Tests: classify_scopes
+# ============================================================
+
+class TestClassifyScopes(unittest.TestCase):
+    """Tests for classify_scopes()."""
+
+    def test_scopes_classified(self):
+        deps = parse_dot_output(_SCOPES_DOT)
+        by_scope = classify_scopes(deps)
+        self.assertIn("system", by_scope)
+        self.assertIn("runtime", by_scope)
+        self.assertIn("provided", by_scope)
+        self.assertIn("test", by_scope)
+
+    def test_counts(self):
+        deps = parse_dot_output(_SCOPES_DOT)
+        by_scope = classify_scopes(deps)
+        self.assertEqual(len(by_scope["system"]), 1)
+        self.assertEqual(len(by_scope["test"]), 1)
+
+    def test_empty_list(self):
+        self.assertEqual(classify_scopes([]), {})
+
+
+# ============================================================
+# Tests: run_maven_dep_tree
+# ============================================================
+
+class TestRunMavenDepTree(unittest.TestCase):
+    """Tests for run_maven_dep_tree()."""
+
+    def test_no_pom_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            with patch("builtins.print"):
+                result = run_maven_dep_tree(td)
+            self.assertIsNone(result)
+
+    @patch("app.pipeline.maven_dep_tree_parser"
+           ".subprocess.run")
+    def test_success(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=_SINGLE_MODULE_DOT,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "pom.xml").touch()
+            result = run_maven_dep_tree(td)
+        self.assertEqual(result, _SINGLE_MODULE_DOT)
+
+    @patch("app.pipeline.maven_dep_tree_parser"
+           ".subprocess.run")
+    def test_failure_returns_none(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="BUILD FAILURE",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "pom.xml").touch()
+            with patch("builtins.print"):
+                result = run_maven_dep_tree(td)
+            self.assertIsNone(result)
+
+    @patch("app.pipeline.maven_dep_tree_parser"
+           ".subprocess.run")
+    def test_timeout_returns_none(self, mock_run):
+        mock_run.side_effect = (
+            subprocess.TimeoutExpired("mvn", 120)
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "pom.xml").touch()
+            with patch("builtins.print"):
+                result = run_maven_dep_tree(td)
+            self.assertIsNone(result)
+
+    @patch("app.pipeline.maven_dep_tree_parser"
+           ".subprocess.run")
+    def test_mvn_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError()
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "pom.xml").touch()
+            with patch("builtins.print"):
+                result = run_maven_dep_tree(td)
+            self.assertIsNone(result)
+
+
+# ============================================================
+# Tests: InterceptionStrategy / MavenDepTreeStrategy
+# ============================================================
+
+class TestMavenDepTreeStrategy(unittest.TestCase):
+    """Tests for MavenDepTreeStrategy."""
+
+    def test_instrument_command_passthrough(self):
+        from app.pipeline.interception import (
+            MavenDepTreeStrategy,
+        )
+        strategy = MavenDepTreeStrategy()
+        cmd, env = strategy.instrument_command(
+            "mvn package -DskipTests", "/repo"
+        )
+        self.assertEqual(
+            cmd, "mvn package -DskipTests"
+        )
+        self.assertEqual(env, {})
+
+    @patch("app.pipeline.maven_dep_tree_parser"
+           ".run_maven_dep_tree")
+    def test_generate_adg_success(self, mock_run):
+        from app.pipeline.interception import (
+            MavenDepTreeStrategy,
+        )
+        mock_run.return_value = _SINGLE_MODULE_DOT
+        strategy = MavenDepTreeStrategy()
+        with tempfile.TemporaryDirectory() as td:
+            bom_dir = Path(td) / "bom"
+            with patch("builtins.print"):
+                ok = strategy.generate_adg(
+                    "/repo", str(bom_dir), {},
+                )
+            self.assertTrue(ok)
+            self.assertTrue(
+                (bom_dir / "maven_deps.json").exists()
+            )
+
+    @patch("app.pipeline.maven_dep_tree_parser"
+           ".run_maven_dep_tree")
+    def test_generate_adg_failure(self, mock_run):
+        from app.pipeline.interception import (
+            MavenDepTreeStrategy,
+        )
+        mock_run.return_value = None
+        strategy = MavenDepTreeStrategy()
+        with tempfile.TemporaryDirectory() as td:
+            ok = strategy.generate_adg(
+                "/repo", str(Path(td) / "bom"), {},
+            )
+            self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_maven_plugin_detector.py
+++ b/tests/test_maven_plugin_detector.py
@@ -1,0 +1,393 @@
+"""
+Tests for app/pipeline/maven_plugin_detector.py.
+
+Uses fixture pom.xml content to test shade/assembly
+plugin detection without requiring Maven or real repos.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.pipeline.maven_plugin_detector import (
+    detect_repackaging_plugins,
+    DetectionResult,
+    PluginDetection,
+)
+
+
+# ============================================================
+# Fixture POM fragments
+# ============================================================
+
+_POM_WITH_SHADE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0.0</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+"""
+
+_POM_WITH_SHADE_FILTERS = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0.0</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <artifactSet>
+            <includes>
+              <include>org.apache.commons:*</include>
+            </includes>
+          </artifactSet>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+"""
+
+_POM_WITH_ASSEMBLY = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0.0</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.6.0</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+"""
+
+_POM_SPRING_BOOT = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0.0</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+"""
+
+_POM_NO_PLUGINS = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.7</version>
+    </dependency>
+  </dependencies>
+</project>
+"""
+
+_POM_NO_NAMESPACE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0.0</version>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+"""
+
+_POM_PLUGIN_MANAGEMENT = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.5.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>
+"""
+
+_POM_MULTI_MODULE_PARENT = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>core</module>
+    <module>cli</module>
+  </modules>
+</project>
+"""
+
+
+# ============================================================
+# Tests: detect_repackaging_plugins
+# ============================================================
+
+class TestDetectRepackagingPlugins(unittest.TestCase):
+    """Tests for detect_repackaging_plugins()."""
+
+    def _write_pom(self, td, content, subdir=None):
+        """Write a pom.xml in the temp directory."""
+        if subdir:
+            d = Path(td) / subdir
+            d.mkdir(parents=True, exist_ok=True)
+            pom = d / "pom.xml"
+        else:
+            pom = Path(td) / "pom.xml"
+        pom.write_text(content, encoding="utf-8")
+        return pom
+
+    def test_shade_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(td, _POM_WITH_SHADE)
+            result = detect_repackaging_plugins(td)
+        self.assertTrue(result.is_uber_jar)
+        self.assertEqual(len(result.detections), 1)
+        self.assertEqual(
+            result.detections[0].plugin_id,
+            "maven-shade-plugin",
+        )
+
+    def test_shade_warning_message(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(td, _POM_WITH_SHADE)
+            result = detect_repackaging_plugins(td)
+        self.assertIn(
+            "shade", result.detections[0].warning,
+        )
+
+    def test_shade_with_filters(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(td, _POM_WITH_SHADE_FILTERS)
+            result = detect_repackaging_plugins(td)
+        self.assertTrue(result.is_uber_jar)
+        self.assertTrue(result.detections[0].has_filters)
+
+    def test_shade_without_filters(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(td, _POM_WITH_SHADE)
+            result = detect_repackaging_plugins(td)
+        self.assertFalse(result.detections[0].has_filters)
+
+    def test_assembly_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(td, _POM_WITH_ASSEMBLY)
+            result = detect_repackaging_plugins(td)
+        self.assertTrue(result.is_uber_jar)
+        self.assertEqual(
+            result.detections[0].plugin_id,
+            "maven-assembly-plugin",
+        )
+
+    def test_spring_boot_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(td, _POM_SPRING_BOOT)
+            result = detect_repackaging_plugins(td)
+        self.assertTrue(result.is_uber_jar)
+        self.assertEqual(
+            result.detections[0].plugin_id,
+            "spring-boot-maven-plugin",
+        )
+
+    def test_no_plugins_clean(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(td, _POM_NO_PLUGINS)
+            result = detect_repackaging_plugins(td)
+        self.assertFalse(result.is_uber_jar)
+        self.assertEqual(len(result.detections), 0)
+
+    def test_no_pom_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = detect_repackaging_plugins(td)
+        self.assertFalse(result.is_uber_jar)
+
+    def test_no_namespace_pom(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(td, _POM_NO_NAMESPACE)
+            result = detect_repackaging_plugins(td)
+        self.assertTrue(result.is_uber_jar)
+        self.assertEqual(
+            result.detections[0].plugin_id,
+            "maven-shade-plugin",
+        )
+
+    def test_plugin_management(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(td, _POM_PLUGIN_MANAGEMENT)
+            result = detect_repackaging_plugins(td)
+        self.assertTrue(result.is_uber_jar)
+
+    def test_multi_module_scans_children(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(
+                td, _POM_MULTI_MODULE_PARENT,
+            )
+            self._write_pom(
+                td, _POM_NO_PLUGINS, subdir="core",
+            )
+            self._write_pom(
+                td, _POM_WITH_SHADE, subdir="cli",
+            )
+            result = detect_repackaging_plugins(td)
+        self.assertTrue(result.is_uber_jar)
+        self.assertEqual(len(result.detections), 1)
+        self.assertIn(
+            "cli", result.detections[0].pom_path,
+        )
+
+    def test_specific_pom_subpath(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write_pom(
+                td, _POM_WITH_SHADE, subdir="sub",
+            )
+            result = detect_repackaging_plugins(
+                td, pom_subpath="sub/pom.xml",
+            )
+        self.assertTrue(result.is_uber_jar)
+
+    def test_malformed_pom(self):
+        with tempfile.TemporaryDirectory() as td:
+            pom = Path(td) / "pom.xml"
+            pom.write_text(
+                "<not valid xml",
+                encoding="utf-8",
+            )
+            result = detect_repackaging_plugins(td)
+        self.assertFalse(result.is_uber_jar)
+
+
+# ============================================================
+# Tests: DetectionResult
+# ============================================================
+
+class TestDetectionResult(unittest.TestCase):
+    """Tests for DetectionResult dataclass."""
+
+    def test_empty_result(self):
+        r = DetectionResult()
+        self.assertFalse(r.is_uber_jar)
+        self.assertEqual(r.spdx_comment, "")
+        self.assertEqual(r.plugin_ids, [])
+
+    def test_spdx_comment_single(self):
+        r = DetectionResult(detections=[
+            PluginDetection(
+                plugin_id="maven-shade-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="shade detected",
+                pom_path="/pom.xml",
+            ),
+        ])
+        self.assertEqual(r.spdx_comment, "shade detected")
+
+    def test_spdx_comment_multiple(self):
+        r = DetectionResult(detections=[
+            PluginDetection(
+                plugin_id="maven-shade-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="shade",
+                pom_path="/pom.xml",
+            ),
+            PluginDetection(
+                plugin_id="maven-assembly-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="assembly",
+                pom_path="/pom.xml",
+            ),
+        ])
+        self.assertEqual(
+            r.spdx_comment, "shade; assembly",
+        )
+
+    def test_plugin_ids(self):
+        r = DetectionResult(detections=[
+            PluginDetection(
+                plugin_id="maven-shade-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="shade",
+                pom_path="/pom.xml",
+            ),
+        ])
+        self.assertEqual(
+            r.plugin_ids, ["maven-shade-plugin"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements Track B issues **B1** (#106), **B2** (#107), **B3** (#108) — the complete Java `dep:tree` optimization foundation: `InterceptionStrategy` ABC, Maven and Gradle `dep:tree` strategies/parsers, and Maven shade/assembly plugin detection.

## What Changed

### `app/pipeline/interception.py` (new)

- **`InterceptionStrategy` ABC** — `instrument_command()` + `generate_adg()` interface
- **`MavenDepTreeStrategy`** — runs `mvn dependency:tree -DoutputType=dot`, parses DOT output
- **`GradleDepTreeStrategy`** — runs `./gradlew dependencies`, parses tree output, handles multi-project builds

### `app/pipeline/maven_dep_tree_parser.py` (new)

- **`parse_dot_output()`** — full DOT graph parser: `[INFO]` stripping, multi-module, direct/transitive, scope extraction, version conflict dedup (`groupId:artifactId` key)
- **`filter_production_deps()`** / **`classify_scopes()`** — scope utilities
- **`run_maven_dep_tree()`** — subprocess wrapper with timeout + error handling

### `app/pipeline/maven_plugin_detector.py` (new)

- **`detect_repackaging_plugins()`** — scans `pom.xml` for `maven-shade-plugin`, `maven-assembly-plugin`, `spring-boot-maven-plugin`
- Handles multi-module projects, `pluginManagement`, namespace/no-namespace POMs
- **`DetectionResult`** with `is_uber_jar`, `spdx_comment`, `plugin_ids` properties
- Detects shade `artifactSet` filters

### `app/pipeline/gradle_dep_tree_parser.py` (new)

- Wraps `app.spdx.gradle_parser` with Maven-compatible output format (`is_test`, `module`, `packaging` fields)
- **`find_gradle_subprojects()`** — parses `settings.gradle`/`.kts` for `include` directives
- **`get_all_gradle_deps()`** — iterates all subprojects, deduplicates

### Tests (76 new tests total)

- `test_maven_dep_tree_parser.py` — 38 tests (coordinate parsing, DOT format, scopes, dedup, multi-module)
- `test_maven_plugin_detector.py` — 17 tests (shade, assembly, spring-boot, filters, multi-module, malformed)
- `test_gradle_dep_tree_parser.py` — 21 tests (tree format, version conflicts, subprojects, strategy)

## Regression Assessment

- **Pipeline impact:** No — all new modules, not wired into pipeline
- **Reason:** Integration comes in #109 [B4]
- **Regression repos needed:** None

## Verification

- 1093 passed + 15 skipped (76 new tests, zero regressions)

## Closes

Closes #106, closes #107, closes #108
