### PR TITLE
feat(java): wire dep:tree strategies into pipeline (#109)

### DIFF
--- a/app/pipeline/lang_runners.py
+++ b/app/pipeline/lang_runners.py
@@ -164,31 +164,70 @@ def run_rust_pipeline(
 # Java pipeline
 # ============================================================
 
+def _select_java_strategy(
+    repo_name, repo_cfg, paths_cfg, mode,
+):
+    """Select interception strategy for Java builds.
+
+    In sidecar mode, uses dep:tree strategies that avoid
+    strace entirely.  Detects Maven vs Gradle from the
+    repo's build configuration.
+
+    In standalone mode, returns None (legacy strace path).
+    """
+    if mode != "sidecar":
+        return None
+
+    from app.spdx.gradle_parser import is_gradle_project
+
+    repo_dir = (
+        Path(paths_cfg["repos_dir"]) / repo_name
+    )
+    if is_gradle_project(str(repo_dir)):
+        from app.pipeline.interception import (
+            GradleDepTreeStrategy,
+        )
+        return GradleDepTreeStrategy()
+
+    from app.pipeline.interception import (
+        MavenDepTreeStrategy,
+    )
+    return MavenDepTreeStrategy()
+
+
 def run_java_pipeline(
     pipeline, repo_name, repo_cfg,
     paths_cfg, omnibor_java_cfg, run_ts,
+    mode="standalone",
 ):
-    """Java pipeline: strace-instrumented Maven build,
-    bomsh_create_bom_java.py for OmniBOR ADG, SPDX generation,
-    metadata, ADG SPDX, validation, JAR collection.
+    """Java pipeline: build + SPDX generation.
 
-    Java uses a different approach than C/C++/Rust/Go:
-    1. Build with strace to capture file I/O
-    2. Run bomsh_create_bom_java.py with strace log
-       to create the OmniBOR treedb
-
-    See: https://github.com/omnibor/bomsh
-    #software-vulnerability-cve-search-for-java-packages
+    In standalone mode (default): strace + bomsh_create_bom_java.py.
+    In sidecar mode: dep:tree strategy (no strace needed).
 
     Returns (success, duration_sec).
     """
-    # Step 4: Instrumented build (strace + Maven)
-    start = time.time()
-    success = pipeline.builder.build_java(
-        repo_name, repo_cfg,
-        paths_cfg, omnibor_java_cfg,
-        run_ts=run_ts,
+    strategy = _select_java_strategy(
+        repo_name, repo_cfg, paths_cfg, mode,
     )
+
+    # Step 4: Build (strace or sidecar)
+    start = time.time()
+    if strategy:
+        # Sidecar: use builder.build() with strategy
+        success = pipeline.builder.build(
+            repo_name, repo_cfg,
+            paths_cfg, omnibor_java_cfg,
+            run_ts=run_ts,
+            strategy=strategy,
+        )
+    else:
+        # Standalone: legacy strace path
+        success = pipeline.builder.build_java(
+            repo_name, repo_cfg,
+            paths_cfg, omnibor_java_cfg,
+            run_ts=run_ts,
+        )
     duration = time.time() - start
 
     # Step 5a: Generate SPDX from OmniBOR

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -167,9 +167,11 @@ def main():
             paths_cfg, omnibor_cfg, run_ts,
         )
     elif lang == "java":
+        mode = config.get("mode", DEFAULT_MODE)
         success, duration = run_java_pipeline(
             pipeline, args.repo, repo_cfg,
             paths_cfg, omnibor_cfg, run_ts,
+            mode=mode,
         )
     else:
         success, duration = run_go_pipeline(

--- a/tests/test_java_pipeline_wire.py
+++ b/tests/test_java_pipeline_wire.py
@@ -1,0 +1,200 @@
+"""
+Tests for Java pipeline strategy wiring (#109 B4).
+
+Verifies that _select_java_strategy returns the correct
+strategy based on mode and build system (Maven vs Gradle).
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from app.pipeline.lang_runners import (
+    _select_java_strategy,
+    run_java_pipeline,
+)
+from app.pipeline.interception import (
+    MavenDepTreeStrategy,
+    GradleDepTreeStrategy,
+)
+
+
+class TestSelectJavaStrategy(unittest.TestCase):
+    """Tests for _select_java_strategy()."""
+
+    def _paths(self):
+        return {"repos_dir": "/workspace/repos"}
+
+    def _repo_cfg(self):
+        return {
+            "url": "https://github.com/example/app.git",
+            "language": "java",
+            "build_steps": ["mvn package"],
+        }
+
+    def test_standalone_returns_none(self):
+        result = _select_java_strategy(
+            "myapp", self._repo_cfg(),
+            self._paths(), "standalone",
+        )
+        self.assertIsNone(result)
+
+    def test_default_mode_returns_none(self):
+        result = _select_java_strategy(
+            "myapp", self._repo_cfg(),
+            self._paths(), "standalone",
+        )
+        self.assertIsNone(result)
+
+    @patch(
+        "app.spdx.gradle_parser"
+        ".is_gradle_project",
+        return_value=False,
+    )
+    def test_sidecar_maven(self, mock_is_gradle):
+        result = _select_java_strategy(
+            "jsoup", self._repo_cfg(),
+            self._paths(), "sidecar",
+        )
+        self.assertIsInstance(
+            result, MavenDepTreeStrategy,
+        )
+        mock_is_gradle.assert_called_once_with(
+            "/workspace/repos/jsoup",
+        )
+
+    @patch(
+        "app.spdx.gradle_parser"
+        ".is_gradle_project",
+        return_value=True,
+    )
+    def test_sidecar_gradle(self, mock_is_gradle):
+        result = _select_java_strategy(
+            "checkstyle", self._repo_cfg(),
+            self._paths(), "sidecar",
+        )
+        self.assertIsInstance(
+            result, GradleDepTreeStrategy,
+        )
+
+    def test_non_sidecar_skips_detection(self):
+        # Should not import or call is_gradle_project
+        result = _select_java_strategy(
+            "myapp", self._repo_cfg(),
+            self._paths(), "standalone",
+        )
+        self.assertIsNone(result)
+
+
+class TestRunJavaPipelineMode(unittest.TestCase):
+    """Tests for run_java_pipeline mode dispatch."""
+
+    def _setup(self):
+        pipeline = MagicMock()
+        pipeline.builder.build_java.return_value = True
+        pipeline.builder.build.return_value = True
+        pipeline.spdx_gen.generate_java.return_value = (
+            "/out/spdx.json"
+        )
+        pipeline.metadata_collector.collect\
+            .return_value = None
+        pipeline.spdx_validator.validate\
+            .return_value = None
+        pipeline.binary_collector.collect\
+            .return_value = None
+        return pipeline
+
+    def _repo_cfg(self):
+        return {
+            "url": "https://github.com/example/app",
+            "language": "java",
+            "build_steps": ["mvn package"],
+            "output_binaries": ["target/app.jar"],
+        }
+
+    def _omnibor(self):
+        return {
+            "strace_opts": "-f -e trace=openat",
+            "strace_logfile": "/tmp/strace.log",
+            "create_bom_script": "bomsh_java.py",
+        }
+
+    def _paths(self):
+        return {
+            "repos_dir": "/workspace/repos",
+            "output_dir": "/workspace/output",
+        }
+
+    @patch(
+        "app.pipeline.lang_runners"
+        ".generate_java_adg_spdx",
+        return_value=[],
+    )
+    def test_standalone_uses_build_java(self, _):
+        pipeline = self._setup()
+        with patch("builtins.print"):
+            success, dur = run_java_pipeline(
+                pipeline, "jsoup",
+                self._repo_cfg(), self._paths(),
+                self._omnibor(), "2024-01-01",
+                mode="standalone",
+            )
+        self.assertTrue(success)
+        pipeline.builder.build_java\
+            .assert_called_once()
+        pipeline.builder.build\
+            .assert_not_called()
+
+    @patch(
+        "app.pipeline.lang_runners"
+        ".generate_java_adg_spdx",
+        return_value=[],
+    )
+    @patch(
+        "app.spdx.gradle_parser"
+        ".is_gradle_project",
+        return_value=False,
+    )
+    def test_sidecar_uses_build_with_strategy(
+        self, _, __,
+    ):
+        pipeline = self._setup()
+        with patch("builtins.print"):
+            success, dur = run_java_pipeline(
+                pipeline, "jsoup",
+                self._repo_cfg(), self._paths(),
+                self._omnibor(), "2024-01-01",
+                mode="sidecar",
+            )
+        self.assertTrue(success)
+        pipeline.builder.build\
+            .assert_called_once()
+        # Verify strategy was passed
+        call_kw = pipeline.builder.build\
+            .call_args[1]
+        self.assertIsInstance(
+            call_kw["strategy"],
+            MavenDepTreeStrategy,
+        )
+        pipeline.builder.build_java\
+            .assert_not_called()
+
+    @patch(
+        "app.pipeline.lang_runners"
+        ".generate_java_adg_spdx",
+        return_value=[],
+    )
+    def test_default_mode_is_standalone(self, _):
+        pipeline = self._setup()
+        with patch("builtins.print"):
+            success, dur = run_java_pipeline(
+                pipeline, "jsoup",
+                self._repo_cfg(), self._paths(),
+                self._omnibor(), "2024-01-01",
+            )
+        # Default mode=standalone -> build_java
+        pipeline.builder.build_java\
+            .assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wires dep:tree strategies (B1–B3) into the Java pipeline via mode selection (C2/C6). `--mode sidecar` now uses `MavenDepTreeStrategy` or `GradleDepTreeStrategy` instead of strace. `--mode standalone` (default) is unchanged.

## What Changed

### `app/pipeline/lang_runners.py`
- **`_select_java_strategy()`** — returns `MavenDepTreeStrategy` or `GradleDepTreeStrategy` in sidecar mode, `None` in standalone
- **`run_java_pipeline()`** — accepts `mode=` parameter; dispatches to `build()` with strategy (sidecar) or `build_java()` (standalone)

### `app/pipeline/runners.py`
- Passes `config["mode"]` to `run_java_pipeline()`

### `tests/test_java_pipeline_wire.py` (new)
- 8 tests covering strategy selection (Maven/Gradle detection) and pipeline dispatch

## Regression Assessment

- **Pipeline impact:** Standalone mode unchanged — `build_java()` path identical
- **Sidecar mode:** New code path, not yet exercised in production
- **Regression repos needed:** jsoup (Maven), checkstyle (Gradle) on EC2

## Verification

- 1156 passed + 15 skipped (8 new tests, zero regressions)

## Closes

Closes #109
