### PR TITLE
feat(docker): multi-stage Dockerfile with standalone + sidecar targets (#119)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,44 @@
-FROM ubuntu:22.04
+# ============================================================
+# Multi-stage Dockerfile for OmniBOR Analysis
+#
+# Targets:
+#   standalone — full image with toolchains + bomtrace (default)
+#   sidecar    — minimal image with analysis pipeline only
+#
+# Build:
+#   docker build --target standalone -t omnibor-env:standalone .
+#   docker build --target sidecar    -t omnibor-env:sidecar .
+# ============================================================
+
+# ============================================================
+# Stage: base — common OS, Python, utilities
+# ============================================================
+FROM ubuntu:22.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    wget \
+    curl \
+    ca-certificates \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python runtime dependencies for app scripts
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
+
+WORKDIR /workspace
+
+
+# ============================================================
+# Stage: standalone — full image with all toolchains + bomtrace
+# ============================================================
+FROM base AS standalone
 
 # ============================================================
 # Base build tools and libraries (C/C++)
@@ -23,12 +60,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     automake \
     libtool \
     pkg-config \
-    git \
-    wget \
-    curl \
-    ca-certificates \
-    python3 \
-    python3-pip \
     strace \
     # Utilities needed by bomsh scripts
     xxd \
@@ -66,18 +97,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     flex \
     bison \
     && rm -rf /var/lib/apt/lists/*
-
-# ============================================================
-# Python runtime dependencies for app scripts
-# ============================================================
-# WHY: analyze.py, compare.py, and add_repo.py all import pyyaml.
-# requirements.txt is the single source of truth for Python deps,
-# shared between local development (.venv) and this container.
-# If a new Python dependency is added, update requirements.txt —
-# do NOT add ad-hoc pip install commands here.
-COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
-    rm /tmp/requirements.txt
 
 # ============================================================
 # Install Syft (manifest-based SBOM generation)
@@ -260,5 +279,41 @@ COPY docker/bomtrace_go.conf /opt/bomsh/bin/bomtrace_go.conf
 # Working directory — repos are mounted here
 # ============================================================
 WORKDIR /workspace
+
+CMD ["/bin/bash"]
+
+
+# ============================================================
+# Stage: sidecar — minimal analysis image (no toolchains)
+# ============================================================
+# Use this when the build happens in a separate CI container
+# and this image only runs dep:tree + SPDX generation.
+# No SYS_PTRACE capability required.
+# ============================================================
+FROM base AS sidecar
+
+ENV OMNIBOR_MODE=sidecar
+
+# Only need bomsh scripts (no bomtrace binaries)
+RUN git clone --depth 1 \
+    https://github.com/omnibor/bomsh.git \
+    /opt/bomsh
+
+# Patch bomsh_create_bom_java.py (same as standalone)
+COPY docker/patches/bomsh_java_sourcefile.patch \
+    /tmp/bomsh_java.patch
+RUN cd /opt/bomsh && \
+    patch -p1 < /tmp/bomsh_java.patch && \
+    rm /tmp/bomsh_java.patch
+
+# Fast Java class reader (same as standalone)
+COPY docker/patches/bomsh_java_fast_classreader.py \
+    /opt/bomsh/scripts/bomsh_java_fast_classreader.py
+COPY docker/patches/apply_fast_javap.py \
+    /tmp/apply_fast_javap.py
+RUN python3 /tmp/apply_fast_javap.py && \
+    rm /tmp/apply_fast_javap.py
+
+ENV PATH="/opt/bomsh/bin:/opt/bomsh/scripts:${PATH}"
 
 CMD ["/bin/bash"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,20 +1,21 @@
 services:
-  omnibor-env:
+  # --------------------------------------------------------
+  # Standalone: full image with toolchains + bomtrace
+  # Usage: docker compose up omnibor-standalone
+  # --------------------------------------------------------
+  omnibor-standalone:
     # REQUIRED: bomtrace3 needs x86 (sys/reg.h). Uses QEMU on Apple Silicon.
     platform: linux/amd64
     build:
-      # Context is project root so Dockerfile can COPY requirements.txt
       context: ..
       dockerfile: docker/Dockerfile
+      target: standalone
+    image: omnibor-env:standalone
     container_name: omnibor-analysis
     volumes:
-      # Mount repos directory for cloned source code
       - ../repos:/workspace/repos
-      # Mount output directory for generated artifacts
       - ../output:/workspace/output
-      # Mount app scripts for orchestration
       - ../app:/workspace/app
-      # Mount docs for report generation
       - ../docs:/workspace/docs
     working_dir: /workspace
     stdin_open: true
@@ -24,3 +25,31 @@ services:
       - SYS_PTRACE
     security_opt:
       - seccomp:unconfined
+
+  # --------------------------------------------------------
+  # Sidecar: minimal image (no toolchains, no SYS_PTRACE)
+  # Usage: docker compose up omnibor-sidecar
+  # --------------------------------------------------------
+  omnibor-sidecar:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: sidecar
+    image: omnibor-env:sidecar
+    container_name: omnibor-sidecar
+    volumes:
+      - ../repos:/workspace/repos
+      - ../output:/workspace/output
+      - ../app:/workspace/app
+      - ../docs:/workspace/docs
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+
+  # --------------------------------------------------------
+  # Default (backward compatible alias for standalone)
+  # Usage: docker compose up omnibor-env
+  # --------------------------------------------------------
+  omnibor-env:
+    extends:
+      service: omnibor-standalone


### PR DESCRIPTION
## Summary

Multi-stage Dockerfile with `standalone` and `sidecar` build targets. Backward compatible — `omnibor-env` service extends `omnibor-standalone`.

## What Changed

### `docker/Dockerfile`
- **`base` stage** — Ubuntu 22.04 + Python + git/curl/wget (shared)
- **`standalone` stage** — full image: toolchains (GCC, Go, Rust, Java, Maven), bomtrace2/3, strace, Syft, all deps
- **`sidecar` stage** — minimal: bomsh scripts + patches only, no toolchains, no bomtrace, `OMNIBOR_MODE=sidecar` env

### `docker/docker-compose.yml`
- **`omnibor-standalone`** — builds standalone target, `SYS_PTRACE` + `seccomp:unconfined`
- **`omnibor-sidecar`** — builds sidecar target, no special capabilities
- **`omnibor-env`** — backward-compatible alias (`extends: omnibor-standalone`)

## Build Commands
```
docker build --target standalone -t omnibor-env:standalone -f docker/Dockerfile .
docker build --target sidecar    -t omnibor-env:sidecar    -f docker/Dockerfile .
```

## Acceptance Criteria
- [x] Two image tags buildable
- [x] Standalone image unchanged from current
- [x] `omnibor-env` alias preserves existing workflow
- [ ] Sidecar image < 300MB (verify on EC2)

## Verification
- 1156 passed + 15 skipped (no test changes)

## Closes

Closes #119
