### PR TITLE
fix: replace contaminated lazygit + stale oxipng golden files

### DIFF
--- a/.windsurf/rules/CRITICAL.md
+++ b/.windsurf/rules/CRITICAL.md
@@ -60,11 +60,16 @@ Violating any rule marked NEVER is a critical failure.
 ## Before Every Golden File Comparison
 
 - [ ] **NEVER** update golden files without explicit user approval.
+- [ ] **NEVER** suggest updating golden files — no reason is valid.
+  The user reviews diffs and decides. Period.
 - [ ] **NEVER** dismiss differences with "likely upstream" or "within
   tolerance" — report EVERY difference.
 - [ ] **ALWAYS** report: exact counts (old → new), added/removed entries,
   version changes, structural changes.
 - [ ] **ALWAYS** stop and wait for user approval if any diffs exist.
+- [ ] **ALWAYS** clean bomtrace3 treedb between sequential repo runs
+  (`rm -f /tmp/bomsh_hook_raw_logfile* /tmp/bomsh_createbom* /tmp/treedb_*`
+  but PRESERVE `/tmp/bomsh_hook2.py`).
 
 ---
 

--- a/.windsurf/rules/cascade/golden-file-policy.md
+++ b/.windsurf/rules/cascade/golden-file-policy.md
@@ -1,55 +1,72 @@
 ---
-description: Golden file / baseline approval policy — NEVER update without user approval
+description: Golden file / baseline policy — immutable baselines, user decides ALL updates
 trigger: always_on
 priority: critical
 ---
 
 # Golden File / Baseline Policy
 
-Applies to any project that uses known-good output files (golden files,
-snapshots, baselines) for regression testing.
+Golden SPDX files are **immutable baselines**. They exist solely to detect
+changes caused by our code. They are NOT tracking upstream repos.
 
-## Rule: ALL Differences Require User Review
+## Absolute Rule: Cascade NEVER Updates Golden Files
 
-When comparing new output against golden files or previous runs:
+No code change, upstream change, bomsh update, or any other reason
+justifies Cascade updating a golden file. The user makes ALL update
+decisions — no exceptions.
+
+## When Diffs Are Found
 
 1. **Report EVERY difference** — no matter how small (counts, names,
    versions, types, structural changes)
-2. **Do NOT assume** any difference is benign, expected, or caused by
-   upstream changes
-3. **Do NOT update golden files** until the user has reviewed all diffs
-   and explicitly approved
-4. **Do NOT dismiss** differences with phrases like "likely upstream"
-   or "within tolerance"
+2. Report exact paths to both golden and proposed files
+3. Report ALL diffs: package counts, versions, relationships,
+   added/removed packages
+4. **STOP and wait for user review**
+5. The **user decides** whether to update — not Cascade
 
-## What to Report
+## What Is NOT a Valid Reason to Suggest Updating Golden Files
 
-For each file compared, provide:
+- Upstream repo released a new version
+- Upstream added/removed dependencies
+- bomsh/bomtrace upstream changed behavior
+- Our SPDX emission code changed
+- Re-running on a new date or new container
+- Docker image rebuild
+- **Any other reason — there are NO exceptions**
 
-- Exact metric changes (old → new) for all key counts
-- Any added, removed, or changed entries
-- Any changed versions, checksums, or metadata
-- Side-by-side summary of what specifically changed
+## Pinned Repos Requirement
 
-## Workflow
+All repos in `config.yaml` MUST use pinned release tags (or commit
+SHAs for repos without tags). Golden files are generated from pinned
+versions and must remain stable. The `--skip-clone` flag must not
+bypass the pinned version.
 
-1. Run regression tests
-2. If tests pass with zero diffs → report "identical, no changes"
-3. If ANY diffs exist → **STOP and report all diffs to user**
-4. Wait for explicit user approval before updating golden files
-5. Only after approval: copy new output to golden folder and re-run tests
+## Treedb Contamination Prevention
+
+bomtrace3 treedb persists in `/tmp/` between builds. When running
+multiple repos sequentially, clean treedb between each run:
+
+```bash
+rm -f /tmp/bomsh_hook_raw_logfile* /tmp/bomsh_createbom* /tmp/treedb_*
+# PRESERVE /tmp/bomsh_hook2.py — required by bomtrace3
+```
+
+Failure to clean between runs causes cross-repo package leakage
+in SPDX output (e.g., Rust crates appearing in C builds).
 
 ## Violations
 
-- Updating golden files without user approval is a **critical violation**
-- Dismissing or minimizing differences without investigation is a
-  **critical violation**
+- Updating golden files without explicit user approval = **critical failure**
+- Suggesting golden file updates as routine = **critical failure**
+- Dismissing diffs for any reason = **critical failure**
+- Running multiple repos without treedb cleanup = **critical failure**
 
 ## Applicability
 
 This policy applies to:
 
-- SPDX SBOM golden files
+- SPDX SBOM golden files (`tests/golden/spdx/{lang}/{repo}/`)
 - API response snapshots
 - CLI output baselines
 - Configuration template baselines

--- a/tests/golden/spdx/go/lazygit/lazygit_analyzed.spdx.json
+++ b/tests/golden/spdx/go/lazygit/lazygit_analyzed.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "lazygit",
-  "documentNamespace": "https://omnibor.io/omnibor-analysis/lazygit-cf1baff0-b821-467f-abbb-45ecfa811c67",
+  "documentNamespace": "https://omnibor.io/omnibor-analysis/lazygit-a1233265-3d00-47d4-adb0-62bc8edb9798",
   "creationInfo": {
-    "created": "2026-05-04T22:15:55Z",
+    "created": "2026-05-05T16:27:38Z",
     "creators": [
       "Tool: bomtrace3-unknown",
       "Tool: bomsh-unknown",
@@ -20,7 +20,7 @@
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": true,
       "primaryPackagePurpose": "APPLICATION",
-      "builtDate": "2026-05-04T22:15:55Z",
+      "builtDate": "2026-05-05T16:27:38Z",
       "externalRefs": [],
       "checksums": [],
       "comment": "Built on Ubuntu 22.04.5 LTS with gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
@@ -63,28 +63,7 @@
       "versionInfo": "1.0.1"
     },
     {
-      "SPDXID": "SPDXRef-fast-float-5",
-      "name": "fast_float",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/fast_float/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-fpconv-6",
-      "name": "fpconv",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/fpconv/. Source compiled into static archive and linked.",
-      "versionInfo": "1.0"
-    },
-    {
-      "SPDXID": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "SPDXID": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "name": "github.com/ProtonMail/go-crypto",
       "downloadLocation": "https://pkg.go.dev/github.com/ProtonMail/go-crypto",
       "filesAnalyzed": true,
@@ -101,7 +80,7 @@
       "versionInfo": "1.1.6"
     },
     {
-      "SPDXID": "SPDXRef-github.com-adrg-xdg-8",
+      "SPDXID": "SPDXRef-github.com-adrg-xdg-6",
       "name": "github.com/adrg/xdg",
       "downloadLocation": "https://pkg.go.dev/github.com/adrg/xdg",
       "filesAnalyzed": true,
@@ -118,7 +97,7 @@
       "versionInfo": "0.4.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-atotto-clipboard-9",
+      "SPDXID": "SPDXRef-github.com-atotto-clipboard-7",
       "name": "github.com/atotto/clipboard",
       "downloadLocation": "https://pkg.go.dev/github.com/atotto/clipboard",
       "filesAnalyzed": true,
@@ -135,7 +114,7 @@
       "versionInfo": "0.1.4"
     },
     {
-      "SPDXID": "SPDXRef-github.com-aybabtme-humanlog-10",
+      "SPDXID": "SPDXRef-github.com-aybabtme-humanlog-8",
       "name": "github.com/aybabtme/humanlog",
       "downloadLocation": "https://pkg.go.dev/github.com/aybabtme/humanlog",
       "filesAnalyzed": true,
@@ -152,7 +131,7 @@
       "versionInfo": "0.4.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-bahlo-generic-list-go-11",
+      "SPDXID": "SPDXRef-github.com-bahlo-generic-list-go-9",
       "name": "github.com/bahlo/generic-list-go",
       "downloadLocation": "https://pkg.go.dev/github.com/bahlo/generic-list-go",
       "filesAnalyzed": true,
@@ -169,7 +148,7 @@
       "versionInfo": "0.2.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-buger-jsonparser-12",
+      "SPDXID": "SPDXRef-github.com-buger-jsonparser-10",
       "name": "github.com/buger/jsonparser",
       "downloadLocation": "https://pkg.go.dev/github.com/buger/jsonparser",
       "filesAnalyzed": true,
@@ -186,7 +165,7 @@
       "versionInfo": "1.1.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-cloudflare-circl-13",
+      "SPDXID": "SPDXRef-github.com-cloudflare-circl-11",
       "name": "github.com/cloudflare/circl",
       "downloadLocation": "https://pkg.go.dev/github.com/cloudflare/circl",
       "filesAnalyzed": true,
@@ -203,7 +182,7 @@
       "versionInfo": "1.6.3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-cloudfoundry-jibber-jabber-14",
+      "SPDXID": "SPDXRef-github.com-cloudfoundry-jibber-jabber-12",
       "name": "github.com/cloudfoundry/jibber_jabber",
       "downloadLocation": "https://pkg.go.dev/github.com/cloudfoundry/jibber_jabber",
       "filesAnalyzed": true,
@@ -220,7 +199,7 @@
       "versionInfo": "0.0.0-20151120183258-bcc4c8345a21"
     },
     {
-      "SPDXID": "SPDXRef-github.com-creack-pty-15",
+      "SPDXID": "SPDXRef-github.com-creack-pty-13",
       "name": "github.com/creack/pty",
       "downloadLocation": "https://pkg.go.dev/github.com/creack/pty",
       "filesAnalyzed": true,
@@ -237,7 +216,7 @@
       "versionInfo": "1.1.11"
     },
     {
-      "SPDXID": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
+      "SPDXID": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "name": "github.com/cyphar/filepath-securejoin",
       "downloadLocation": "https://pkg.go.dev/github.com/cyphar/filepath-securejoin",
       "filesAnalyzed": true,
@@ -254,7 +233,7 @@
       "versionInfo": "0.4.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-emirpasic-gods-17",
+      "SPDXID": "SPDXRef-github.com-emirpasic-gods-15",
       "name": "github.com/emirpasic/gods",
       "downloadLocation": "https://pkg.go.dev/github.com/emirpasic/gods",
       "filesAnalyzed": true,
@@ -271,7 +250,7 @@
       "versionInfo": "1.18.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-fatih-color-18",
+      "SPDXID": "SPDXRef-github.com-fatih-color-16",
       "name": "github.com/fatih/color",
       "downloadLocation": "https://pkg.go.dev/github.com/fatih/color",
       "filesAnalyzed": true,
@@ -288,7 +267,7 @@
       "versionInfo": "1.9.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-gdamore-encoding-19",
+      "SPDXID": "SPDXRef-github.com-gdamore-encoding-17",
       "name": "github.com/gdamore/encoding",
       "downloadLocation": "https://pkg.go.dev/github.com/gdamore/encoding",
       "filesAnalyzed": true,
@@ -305,7 +284,7 @@
       "versionInfo": "1.0.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "SPDXID": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "name": "github.com/gdamore/tcell/v2",
       "downloadLocation": "https://pkg.go.dev/github.com/gdamore/tcell/v2",
       "filesAnalyzed": true,
@@ -322,7 +301,7 @@
       "versionInfo": "2.13.8"
     },
     {
-      "SPDXID": "SPDXRef-github.com-go-errors-errors-21",
+      "SPDXID": "SPDXRef-github.com-go-errors-errors-19",
       "name": "github.com/go-errors/errors",
       "downloadLocation": "https://pkg.go.dev/github.com/go-errors/errors",
       "filesAnalyzed": true,
@@ -339,7 +318,7 @@
       "versionInfo": "1.5.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-go-git-gcfg-22",
+      "SPDXID": "SPDXRef-github.com-go-git-gcfg-20",
       "name": "github.com/go-git/gcfg",
       "downloadLocation": "https://pkg.go.dev/github.com/go-git/gcfg",
       "filesAnalyzed": true,
@@ -356,7 +335,7 @@
       "versionInfo": "1.5.1-0.20230307220236-3a3c6141e376"
     },
     {
-      "SPDXID": "SPDXRef-github.com-go-git-go-billy-v5-23",
+      "SPDXID": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "name": "github.com/go-git/go-billy/v5",
       "downloadLocation": "https://pkg.go.dev/github.com/go-git/go-billy/v5",
       "filesAnalyzed": true,
@@ -373,7 +352,7 @@
       "versionInfo": "5.6.2"
     },
     {
-      "SPDXID": "SPDXRef-github.com-go-logfmt-logfmt-24",
+      "SPDXID": "SPDXRef-github.com-go-logfmt-logfmt-22",
       "name": "github.com/go-logfmt/logfmt",
       "downloadLocation": "https://pkg.go.dev/github.com/go-logfmt/logfmt",
       "filesAnalyzed": true,
@@ -390,7 +369,7 @@
       "versionInfo": "0.5.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-golang-groupcache-25",
+      "SPDXID": "SPDXRef-github.com-golang-groupcache-23",
       "name": "github.com/golang/groupcache",
       "downloadLocation": "https://pkg.go.dev/github.com/golang/groupcache",
       "filesAnalyzed": true,
@@ -407,7 +386,7 @@
       "versionInfo": "0.0.0-20241129210726-2c02b8208cf8"
     },
     {
-      "SPDXID": "SPDXRef-github.com-gookit-color-26",
+      "SPDXID": "SPDXRef-github.com-gookit-color-24",
       "name": "github.com/gookit/color",
       "downloadLocation": "https://pkg.go.dev/github.com/gookit/color",
       "filesAnalyzed": true,
@@ -424,7 +403,7 @@
       "versionInfo": "1.4.2"
     },
     {
-      "SPDXID": "SPDXRef-github.com-integrii-flaggy-27",
+      "SPDXID": "SPDXRef-github.com-integrii-flaggy-25",
       "name": "github.com/integrii/flaggy",
       "downloadLocation": "https://pkg.go.dev/github.com/integrii/flaggy",
       "filesAnalyzed": true,
@@ -441,7 +420,7 @@
       "versionInfo": "1.4.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jbenet-go-context-28",
+      "SPDXID": "SPDXRef-github.com-jbenet-go-context-26",
       "name": "github.com/jbenet/go-context",
       "downloadLocation": "https://pkg.go.dev/github.com/jbenet/go-context",
       "filesAnalyzed": true,
@@ -458,7 +437,7 @@
       "versionInfo": "0.0.0-20150711004518-d14ea06fba99"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jesseduffield-generics-29",
+      "SPDXID": "SPDXRef-github.com-jesseduffield-generics-27",
       "name": "github.com/jesseduffield/generics",
       "downloadLocation": "https://pkg.go.dev/github.com/jesseduffield/generics",
       "filesAnalyzed": true,
@@ -475,7 +454,7 @@
       "versionInfo": "0.0.0-20250517122708-b0b4a53a6f5c"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "SPDXID": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "name": "github.com/jesseduffield/go-git/v5",
       "downloadLocation": "https://pkg.go.dev/github.com/jesseduffield/go-git/v5",
       "filesAnalyzed": true,
@@ -492,7 +471,7 @@
       "versionInfo": "5.14.1-0.20250407170251-e1a013310ccd"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "SPDXID": "SPDXRef-github.com-jesseduffield-gocui-29",
       "name": "github.com/jesseduffield/gocui",
       "downloadLocation": "https://pkg.go.dev/github.com/jesseduffield/gocui",
       "filesAnalyzed": true,
@@ -509,7 +488,7 @@
       "versionInfo": "0.3.1-0.20260308162933-5e45e57b5564"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jesseduffield-lazycore-32",
+      "SPDXID": "SPDXRef-github.com-jesseduffield-lazycore-30",
       "name": "github.com/jesseduffield/lazycore",
       "downloadLocation": "https://pkg.go.dev/github.com/jesseduffield/lazycore",
       "filesAnalyzed": true,
@@ -526,7 +505,7 @@
       "versionInfo": "0.0.0-20221012050358-03d2e40243c5"
     },
     {
-      "SPDXID": "SPDXRef-github.com-kardianos-osext-33",
+      "SPDXID": "SPDXRef-github.com-kardianos-osext-31",
       "name": "github.com/kardianos/osext",
       "downloadLocation": "https://pkg.go.dev/github.com/kardianos/osext",
       "filesAnalyzed": true,
@@ -543,7 +522,7 @@
       "versionInfo": "0.0.0-20190222173326-2bc1f35cddc0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-karimkhaleel-jsonschema-34",
+      "SPDXID": "SPDXRef-github.com-karimkhaleel-jsonschema-32",
       "name": "github.com/karimkhaleel/jsonschema",
       "downloadLocation": "https://pkg.go.dev/github.com/karimkhaleel/jsonschema",
       "filesAnalyzed": true,
@@ -560,7 +539,7 @@
       "versionInfo": "0.0.0-20231001195015-d933f0d94ea3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-kevinburke-ssh-config-35",
+      "SPDXID": "SPDXRef-github.com-kevinburke-ssh-config-33",
       "name": "github.com/kevinburke/ssh_config",
       "downloadLocation": "https://pkg.go.dev/github.com/kevinburke/ssh_config",
       "filesAnalyzed": true,
@@ -577,7 +556,7 @@
       "versionInfo": "1.2.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-kr-logfmt-36",
+      "SPDXID": "SPDXRef-github.com-kr-logfmt-34",
       "name": "github.com/kr/logfmt",
       "downloadLocation": "https://pkg.go.dev/github.com/kr/logfmt",
       "filesAnalyzed": true,
@@ -594,7 +573,7 @@
       "versionInfo": "0.0.0-20140226030751-b84e30acd515"
     },
     {
-      "SPDXID": "SPDXRef-github.com-kyokomi-emoji-v2-37",
+      "SPDXID": "SPDXRef-github.com-kyokomi-emoji-v2-35",
       "name": "github.com/kyokomi/emoji/v2",
       "downloadLocation": "https://pkg.go.dev/github.com/kyokomi/emoji/v2",
       "filesAnalyzed": true,
@@ -611,7 +590,7 @@
       "versionInfo": "2.2.8"
     },
     {
-      "SPDXID": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
+      "SPDXID": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "name": "github.com/lucasb-eyer/go-colorful",
       "downloadLocation": "https://pkg.go.dev/github.com/lucasb-eyer/go-colorful",
       "filesAnalyzed": true,
@@ -628,7 +607,7 @@
       "versionInfo": "1.3.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-mailru-easyjson-39",
+      "SPDXID": "SPDXRef-github.com-mailru-easyjson-37",
       "name": "github.com/mailru/easyjson",
       "downloadLocation": "https://pkg.go.dev/github.com/mailru/easyjson",
       "filesAnalyzed": true,
@@ -645,7 +624,7 @@
       "versionInfo": "0.7.7"
     },
     {
-      "SPDXID": "SPDXRef-github.com-mattn-go-colorable-40",
+      "SPDXID": "SPDXRef-github.com-mattn-go-colorable-38",
       "name": "github.com/mattn/go-colorable",
       "downloadLocation": "https://pkg.go.dev/github.com/mattn/go-colorable",
       "filesAnalyzed": true,
@@ -662,7 +641,7 @@
       "versionInfo": "0.1.11"
     },
     {
-      "SPDXID": "SPDXRef-github.com-mattn-go-isatty-41",
+      "SPDXID": "SPDXRef-github.com-mattn-go-isatty-39",
       "name": "github.com/mattn/go-isatty",
       "downloadLocation": "https://pkg.go.dev/github.com/mattn/go-isatty",
       "filesAnalyzed": true,
@@ -679,7 +658,7 @@
       "versionInfo": "0.0.14"
     },
     {
-      "SPDXID": "SPDXRef-github.com-mgutz-str-42",
+      "SPDXID": "SPDXRef-github.com-mgutz-str-40",
       "name": "github.com/mgutz/str",
       "downloadLocation": "https://pkg.go.dev/github.com/mgutz/str",
       "filesAnalyzed": true,
@@ -696,7 +675,7 @@
       "versionInfo": "1.2.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-petermattis-goid-43",
+      "SPDXID": "SPDXRef-github.com-petermattis-goid-41",
       "name": "github.com/petermattis/goid",
       "downloadLocation": "https://pkg.go.dev/github.com/petermattis/goid",
       "filesAnalyzed": true,
@@ -713,7 +692,7 @@
       "versionInfo": "0.0.0-20250813065127-a731cc31b4fe"
     },
     {
-      "SPDXID": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "SPDXID": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "name": "github.com/pjbgf/sha1cd",
       "downloadLocation": "https://pkg.go.dev/github.com/pjbgf/sha1cd",
       "filesAnalyzed": true,
@@ -730,7 +709,7 @@
       "versionInfo": "0.3.2"
     },
     {
-      "SPDXID": "SPDXRef-github.com-rivo-uniseg-45",
+      "SPDXID": "SPDXRef-github.com-rivo-uniseg-43",
       "name": "github.com/rivo/uniseg",
       "downloadLocation": "https://pkg.go.dev/github.com/rivo/uniseg",
       "filesAnalyzed": true,
@@ -747,7 +726,7 @@
       "versionInfo": "0.4.7"
     },
     {
-      "SPDXID": "SPDXRef-github.com-sahilm-fuzzy-46",
+      "SPDXID": "SPDXRef-github.com-sahilm-fuzzy-44",
       "name": "github.com/sahilm/fuzzy",
       "downloadLocation": "https://pkg.go.dev/github.com/sahilm/fuzzy",
       "filesAnalyzed": true,
@@ -764,7 +743,7 @@
       "versionInfo": "0.1.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-samber-lo-47",
+      "SPDXID": "SPDXRef-github.com-samber-lo-45",
       "name": "github.com/samber/lo",
       "downloadLocation": "https://pkg.go.dev/github.com/samber/lo",
       "filesAnalyzed": true,
@@ -781,7 +760,7 @@
       "versionInfo": "1.31.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-sasha-s-go-deadlock-48",
+      "SPDXID": "SPDXRef-github.com-sasha-s-go-deadlock-46",
       "name": "github.com/sasha-s/go-deadlock",
       "downloadLocation": "https://pkg.go.dev/github.com/sasha-s/go-deadlock",
       "filesAnalyzed": true,
@@ -798,7 +777,7 @@
       "versionInfo": "0.3.6"
     },
     {
-      "SPDXID": "SPDXRef-github.com-sergi-go-diff-49",
+      "SPDXID": "SPDXRef-github.com-sergi-go-diff-47",
       "name": "github.com/sergi/go-diff",
       "downloadLocation": "https://pkg.go.dev/github.com/sergi/go-diff",
       "filesAnalyzed": true,
@@ -815,7 +794,7 @@
       "versionInfo": "1.3.2-0.20230802210424-5b0b94c5c0d3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-sirupsen-logrus-50",
+      "SPDXID": "SPDXRef-github.com-sirupsen-logrus-48",
       "name": "github.com/sirupsen/logrus",
       "downloadLocation": "https://pkg.go.dev/github.com/sirupsen/logrus",
       "filesAnalyzed": true,
@@ -832,7 +811,7 @@
       "versionInfo": "1.9.3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-skeema-knownhosts-51",
+      "SPDXID": "SPDXRef-github.com-skeema-knownhosts-49",
       "name": "github.com/skeema/knownhosts",
       "downloadLocation": "https://pkg.go.dev/github.com/skeema/knownhosts",
       "filesAnalyzed": true,
@@ -849,7 +828,7 @@
       "versionInfo": "1.3.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-spf13-afero-52",
+      "SPDXID": "SPDXRef-github.com-spf13-afero-50",
       "name": "github.com/spf13/afero",
       "downloadLocation": "https://pkg.go.dev/github.com/spf13/afero",
       "filesAnalyzed": true,
@@ -866,7 +845,7 @@
       "versionInfo": "1.9.5"
     },
     {
-      "SPDXID": "SPDXRef-github.com-spkg-bom-53",
+      "SPDXID": "SPDXRef-github.com-spkg-bom-51",
       "name": "github.com/spkg/bom",
       "downloadLocation": "https://pkg.go.dev/github.com/spkg/bom",
       "filesAnalyzed": true,
@@ -883,7 +862,7 @@
       "versionInfo": "0.0.0-20160624110644-59b7046e48ad"
     },
     {
-      "SPDXID": "SPDXRef-github.com-stefanhaller-git-todo-parser-54",
+      "SPDXID": "SPDXRef-github.com-stefanhaller-git-todo-parser-52",
       "name": "github.com/stefanhaller/git-todo-parser",
       "downloadLocation": "https://pkg.go.dev/github.com/stefanhaller/git-todo-parser",
       "filesAnalyzed": true,
@@ -900,7 +879,7 @@
       "versionInfo": "0.0.7-0.20250905083220-c50528f08304"
     },
     {
-      "SPDXID": "SPDXRef-github.com-wk8-go-ordered-map-v2-55",
+      "SPDXID": "SPDXRef-github.com-wk8-go-ordered-map-v2-53",
       "name": "github.com/wk8/go-ordered-map/v2",
       "downloadLocation": "https://pkg.go.dev/github.com/wk8/go-ordered-map/v2",
       "filesAnalyzed": true,
@@ -917,7 +896,7 @@
       "versionInfo": "2.1.8"
     },
     {
-      "SPDXID": "SPDXRef-github.com-xanzy-ssh-agent-56",
+      "SPDXID": "SPDXRef-github.com-xanzy-ssh-agent-54",
       "name": "github.com/xanzy/ssh-agent",
       "downloadLocation": "https://pkg.go.dev/github.com/xanzy/ssh-agent",
       "filesAnalyzed": true,
@@ -934,7 +913,7 @@
       "versionInfo": "0.3.3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-xo-terminfo-57",
+      "SPDXID": "SPDXRef-github.com-xo-terminfo-55",
       "name": "github.com/xo/terminfo",
       "downloadLocation": "https://pkg.go.dev/github.com/xo/terminfo",
       "filesAnalyzed": true,
@@ -951,7 +930,7 @@
       "versionInfo": "0.0.0-20210125001918-ca9a967f8778"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-crypto-58",
+      "SPDXID": "SPDXRef-golang.org-x-crypto-56",
       "name": "golang.org/x/crypto",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/crypto",
       "filesAnalyzed": true,
@@ -968,7 +947,7 @@
       "versionInfo": "0.45.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-exp-59",
+      "SPDXID": "SPDXRef-golang.org-x-exp-57",
       "name": "golang.org/x/exp",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/exp",
       "filesAnalyzed": true,
@@ -985,7 +964,7 @@
       "versionInfo": "0.0.0-20240719175910-8a7402abbf56"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-net-60",
+      "SPDXID": "SPDXRef-golang.org-x-net-58",
       "name": "golang.org/x/net",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/net",
       "filesAnalyzed": true,
@@ -1002,7 +981,7 @@
       "versionInfo": "0.47.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-sync-61",
+      "SPDXID": "SPDXRef-golang.org-x-sync-59",
       "name": "golang.org/x/sync",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/sync",
       "filesAnalyzed": true,
@@ -1019,7 +998,7 @@
       "versionInfo": "0.19.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-sys-62",
+      "SPDXID": "SPDXRef-golang.org-x-sys-60",
       "name": "golang.org/x/sys",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/sys",
       "filesAnalyzed": true,
@@ -1036,7 +1015,7 @@
       "versionInfo": "0.42.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-term-63",
+      "SPDXID": "SPDXRef-golang.org-x-term-61",
       "name": "golang.org/x/term",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/term",
       "filesAnalyzed": true,
@@ -1053,7 +1032,7 @@
       "versionInfo": "0.40.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-text-64",
+      "SPDXID": "SPDXRef-golang.org-x-text-62",
       "name": "golang.org/x/text",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/text",
       "filesAnalyzed": true,
@@ -1070,7 +1049,7 @@
       "versionInfo": "0.34.0"
     },
     {
-      "SPDXID": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-65",
+      "SPDXID": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-63",
       "name": "gopkg.in/ozeidan/fuzzy-patricia.v3",
       "downloadLocation": "https://pkg.go.dev/gopkg.in/ozeidan/fuzzy-patricia.v3",
       "filesAnalyzed": true,
@@ -1087,7 +1066,7 @@
       "versionInfo": "3.0.0"
     },
     {
-      "SPDXID": "SPDXRef-gopkg.in-warnings.v0-66",
+      "SPDXID": "SPDXRef-gopkg.in-warnings.v0-64",
       "name": "gopkg.in/warnings.v0",
       "downloadLocation": "https://pkg.go.dev/gopkg.in/warnings.v0",
       "filesAnalyzed": true,
@@ -1104,7 +1083,7 @@
       "versionInfo": "0.1.2"
     },
     {
-      "SPDXID": "SPDXRef-gopkg.in-yaml.v3-67",
+      "SPDXID": "SPDXRef-gopkg.in-yaml.v3-65",
       "name": "gopkg.in/yaml.v3",
       "downloadLocation": "https://pkg.go.dev/gopkg.in/yaml.v3",
       "filesAnalyzed": true,
@@ -1119,85 +1098,11 @@
       "comment": "Go module (direct). 13 source files compiled into lazygit",
       "packageSourceInfo": "Vendored via go mod vendor. Source at vendor/gopkg.in/yaml.v3/.",
       "versionInfo": "3.0.1"
-    },
-    {
-      "SPDXID": "SPDXRef-hdr-histogram-68",
-      "name": "hdr_histogram",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/hdr_histogram/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-hiredis-69",
-      "name": "hiredis",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 6 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/hiredis/. Source compiled into static archive and linked.",
-      "versionInfo": "1.2.0"
-    },
-    {
-      "SPDXID": "SPDXRef-jemalloc-70",
-      "name": "jemalloc",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/jemalloc/. Source compiled into static archive and linked.",
-      "versionInfo": "5.3.0"
-    },
-    {
-      "SPDXID": "SPDXRef-linenoise-71",
-      "name": "linenoise",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/linenoise/. Source compiled into static archive and linked.",
-      "versionInfo": "1.0"
-    },
-    {
-      "SPDXID": "SPDXRef-lua-72",
-      "name": "lua",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 10 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/lua/. Source compiled into static archive and linked.",
-      "versionInfo": "5.1.5"
     }
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-File-timeout.c-73",
-      "fileName": "repos/redis/src/timeout.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "01848ceecefb17f32bdbacff3495ec6153dfda9b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-eval.c-74",
-      "fileName": "repos/redis/src/eval.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0189561351452d82fba7798e23e5e4cc82f4c576"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-filtering-menu-action.go-75",
+      "SPDXID": "SPDXRef-File-filtering-menu-action.go-66",
       "fileName": "repos/lazygit/pkg/gui/controllers/filtering_menu_action.go",
       "checksums": [
         {
@@ -1207,7 +1112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sync-controller.go-76",
+      "SPDXID": "SPDXRef-File-sync-controller.go-67",
       "fileName": "repos/lazygit/pkg/gui/controllers/sync_controller.go",
       "checksums": [
         {
@@ -1217,7 +1122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amend-helper.go-77",
+      "SPDXID": "SPDXRef-File-amend-helper.go-68",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/amend_helper.go",
       "checksums": [
         {
@@ -1227,7 +1132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-menu-controller.go-78",
+      "SPDXID": "SPDXRef-File-menu-controller.go-69",
       "fileName": "repos/lazygit/pkg/gui/controllers/menu_controller.go",
       "checksums": [
         {
@@ -1237,7 +1142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-state.go-79",
+      "SPDXID": "SPDXRef-File-state.go-70",
       "fileName": "repos/lazygit/pkg/gui/mergeconflicts/state.go",
       "checksums": [
         {
@@ -1247,7 +1152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-message-panel-driver.go-80",
+      "SPDXID": "SPDXRef-File-commit-message-panel-driver.go-71",
       "fileName": "repos/lazygit/pkg/integration/components/commit_message_panel_driver.go",
       "checksums": [
         {
@@ -1257,7 +1162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-window-arrangement-helper.go-81",
+      "SPDXID": "SPDXRef-File-window-arrangement-helper.go-72",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/window_arrangement_helper.go",
       "checksums": [
         {
@@ -1267,7 +1172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-assertion-helper.go-82",
+      "SPDXID": "SPDXRef-File-assertion-helper.go-73",
       "fileName": "repos/lazygit/pkg/integration/components/assertion_helper.go",
       "checksums": [
         {
@@ -1277,7 +1182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree.go-83",
+      "SPDXID": "SPDXRef-File-worktree.go-74",
       "fileName": "repos/lazygit/pkg/commands/models/worktree.go",
       "checksums": [
         {
@@ -1287,7 +1192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflog-commit-loader.go-84",
+      "SPDXID": "SPDXRef-File-reflog-commit-loader.go-75",
       "fileName": "repos/lazygit/pkg/commands/git_commands/reflog_commit_loader.go",
       "checksums": [
         {
@@ -1297,7 +1202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hyperlink.go-85",
+      "SPDXID": "SPDXRef-File-hyperlink.go-76",
       "fileName": "repos/lazygit/pkg/gui/style/hyperlink.go",
       "checksums": [
         {
@@ -1307,7 +1212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-default-platform.go-86",
+      "SPDXID": "SPDXRef-File-os-default-platform.go-77",
       "fileName": "repos/lazygit/pkg/commands/oscommands/os_default_platform.go",
       "checksums": [
         {
@@ -1317,7 +1222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dummies.go-87",
+      "SPDXID": "SPDXRef-File-dummies.go-78",
       "fileName": "repos/lazygit/pkg/config/dummies.go",
       "checksums": [
         {
@@ -1327,17 +1232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rax-malloc.h-88",
-      "fileName": "repos/redis/src/rax_malloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0794b05ecf639818530235d6d7e635441fe9d3a5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sub-commits-helper.go-89",
+      "SPDXID": "SPDXRef-File-sub-commits-helper.go-79",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/sub_commits_helper.go",
       "checksums": [
         {
@@ -1347,7 +1242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch-explorer-context.go-90",
+      "SPDXID": "SPDXRef-File-patch-explorer-context.go-80",
       "fileName": "repos/lazygit/pkg/gui/context/patch_explorer_context.go",
       "checksums": [
         {
@@ -1357,7 +1252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file-node.go-91",
+      "SPDXID": "SPDXRef-File-file-node.go-81",
       "fileName": "repos/lazygit/pkg/gui/filetree/file_node.go",
       "checksums": [
         {
@@ -1367,7 +1262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-upstream-helper.go-92",
+      "SPDXID": "SPDXRef-File-upstream-helper.go-82",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/upstream_helper.go",
       "checksums": [
         {
@@ -1377,17 +1272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-latency.c-93",
-      "fileName": "repos/redis/src/latency.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "09639bd50544337098770f7e04e57cc79b685389"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-menu-context.go-94",
+      "SPDXID": "SPDXRef-File-menu-context.go-83",
       "fileName": "repos/lazygit/pkg/gui/context/menu_context.go",
       "checksums": [
         {
@@ -1397,7 +1282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-app.go-95",
+      "SPDXID": "SPDXRef-File-app.go-84",
       "fileName": "repos/lazygit/pkg/app/app.go",
       "checksums": [
         {
@@ -1407,27 +1292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eventnotifier.c-96",
-      "fileName": "repos/redis/src/eventnotifier.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0a6c145c13e0f11bb1dc44b50dc1a729997b0c52"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-redismodule.h-97",
-      "fileName": "repos/redis/src/redismodule.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0b395feaf8fa59fc560517d07b566f45fb0c2210"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tags-context.go-98",
+      "SPDXID": "SPDXRef-File-tags-context.go-85",
       "fileName": "repos/lazygit/pkg/gui/context/tags_context.go",
       "checksums": [
         {
@@ -1437,17 +1302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cli-common.c-99",
-      "fileName": "repos/redis/src/cli_common.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0c269de9aa676d615d6e418b5ddf4ee7d2d27253"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-worktree-options-controller.go-100",
+      "SPDXID": "SPDXRef-File-worktree-options-controller.go-86",
       "fileName": "repos/lazygit/pkg/gui/controllers/worktree_options_controller.go",
       "checksums": [
         {
@@ -1457,7 +1312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base-controller.go-101",
+      "SPDXID": "SPDXRef-File-base-controller.go-87",
       "fileName": "repos/lazygit/pkg/gui/controllers/base_controller.go",
       "checksums": [
         {
@@ -1467,7 +1322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-loader.go-102",
+      "SPDXID": "SPDXRef-File-worktree-loader.go-88",
       "fileName": "repos/lazygit/pkg/commands/git_commands/worktree_loader.go",
       "checksums": [
         {
@@ -1477,7 +1332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stash.go-103",
+      "SPDXID": "SPDXRef-File-stash.go-89",
       "fileName": "repos/lazygit/pkg/commands/git_commands/stash.go",
       "checksums": [
         {
@@ -1487,7 +1342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slice.go-104",
+      "SPDXID": "SPDXRef-File-slice.go-90",
       "fileName": "repos/lazygit/pkg/utils/slice.go",
       "checksums": [
         {
@@ -1497,7 +1352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main-branches.go-105",
+      "SPDXID": "SPDXRef-File-main-branches.go-91",
       "fileName": "repos/lazygit/pkg/commands/git_commands/main_branches.go",
       "checksums": [
         {
@@ -1507,7 +1362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shell-command-action.go-106",
+      "SPDXID": "SPDXRef-File-shell-command-action.go-92",
       "fileName": "repos/lazygit/pkg/gui/controllers/shell_command_action.go",
       "checksums": [
         {
@@ -1517,27 +1372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-release.c-107",
-      "fileName": "repos/redis/src/release.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "11f7f5188aeda4d3ef073ce2b8f47d2246f1bf3d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-syscheck.c-108",
-      "fileName": "repos/redis/src/syscheck.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1251c1d72f471217293dd637d896d42840346e49"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-client.go-109",
+      "SPDXID": "SPDXRef-File-client.go-93",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/client.go",
       "checksums": [
         {
@@ -1547,17 +1382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-endianconv.c-110",
-      "fileName": "repos/redis/src/endianconv.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "12ee03cbd7c57c153c86857545d79e540b18d389"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-switch-to-focused-main-view-controller.go-111",
+      "SPDXID": "SPDXRef-File-switch-to-focused-main-view-controller.go-94",
       "fileName": "repos/lazygit/pkg/gui/controllers/switch_to_focused_main_view_controller.go",
       "checksums": [
         {
@@ -1567,17 +1392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sparkline.c-112",
-      "fileName": "repos/redis/src/sparkline.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "13370163716dee3f66e841ad0b8bad925bbc5074"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-commit.go-113",
+      "SPDXID": "SPDXRef-File-commit.go-95",
       "fileName": "repos/lazygit/pkg/commands/models/commit.go",
       "checksums": [
         {
@@ -1587,17 +1402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stream.h-114",
-      "fileName": "repos/redis/src/stream.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "146be3b12e4bf08dfe8e3776b992e2cbb2161657"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tasks-adapter.go-115",
+      "SPDXID": "SPDXRef-File-tasks-adapter.go-96",
       "fileName": "repos/lazygit/pkg/gui/tasks_adapter.go",
       "checksums": [
         {
@@ -1607,7 +1412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-editors.go-116",
+      "SPDXID": "SPDXRef-File-editors.go-97",
       "fileName": "repos/lazygit/pkg/gui/editors.go",
       "checksums": [
         {
@@ -1617,7 +1422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-repos-helper.go-117",
+      "SPDXID": "SPDXRef-File-repos-helper.go-98",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/repos_helper.go",
       "checksums": [
         {
@@ -1627,7 +1432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-graph.go-118",
+      "SPDXID": "SPDXRef-File-graph.go-99",
       "fileName": "repos/lazygit/pkg/gui/presentation/graph/graph.go",
       "checksums": [
         {
@@ -1637,7 +1442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-user-config-validation.go-119",
+      "SPDXID": "SPDXRef-File-user-config-validation.go-100",
       "fileName": "repos/lazygit/pkg/config/user_config_validation.go",
       "checksums": [
         {
@@ -1647,17 +1452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redisassert.h-120",
-      "fileName": "repos/redis/src/redisassert.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "17983318783a6272b66aab34f1784f23dcbc3e0a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-color.go-121",
+      "SPDXID": "SPDXRef-File-color.go-101",
       "fileName": "repos/lazygit/pkg/utils/color.go",
       "checksums": [
         {
@@ -1667,7 +1462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-user-config.go-122",
+      "SPDXID": "SPDXRef-File-user-config.go-102",
       "fileName": "repos/lazygit/pkg/config/user_config.go",
       "checksums": [
         {
@@ -1677,7 +1472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file-system.go-123",
+      "SPDXID": "SPDXRef-File-file-system.go-103",
       "fileName": "repos/lazygit/pkg/integration/components/file_system.go",
       "checksums": [
         {
@@ -1687,27 +1482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-evict.c-124",
-      "fileName": "repos/redis/src/evict.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "19e4d59f48ed42be4de8ba31efec3fbdaf314c6f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-geohash.h-125",
-      "fileName": "repos/redis/src/geohash.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "19fa5a1d0fdf74a911e9e179286b6a4d8d5b3c6d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-env.go-126",
+      "SPDXID": "SPDXRef-File-env.go-104",
       "fileName": "repos/lazygit/pkg/env/env.go",
       "checksums": [
         {
@@ -1717,7 +1492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context.go-127",
+      "SPDXID": "SPDXRef-File-context.go-105",
       "fileName": "repos/lazygit/pkg/gui/context.go",
       "checksums": [
         {
@@ -1727,7 +1502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-global-controller.go-128",
+      "SPDXID": "SPDXRef-File-global-controller.go-106",
       "fileName": "repos/lazygit/pkg/gui/controllers/global_controller.go",
       "checksums": [
         {
@@ -1737,17 +1512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sort.c-129",
-      "fileName": "repos/redis/src/sort.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1aed5977747dce1e5de4d45a933ef4778f8c2a1e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-git.go-130",
+      "SPDXID": "SPDXRef-File-git.go-107",
       "fileName": "repos/lazygit/pkg/integration/components/git.go",
       "checksums": [
         {
@@ -1757,7 +1522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.go-131",
+      "SPDXID": "SPDXRef-File-file.go-108",
       "fileName": "repos/lazygit/pkg/commands/git_commands/file.go",
       "checksums": [
         {
@@ -1767,17 +1532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut8.c-132",
-      "fileName": "repos/redis/src/lolwut8.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1be150e6e0c4892679e6caff9aa5475d1c7ebae5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hosting-service.go-133",
+      "SPDXID": "SPDXRef-File-hosting-service.go-109",
       "fileName": "repos/lazygit/pkg/commands/hosting_service/hosting_service.go",
       "checksums": [
         {
@@ -1787,7 +1542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-view-model.go-134",
+      "SPDXID": "SPDXRef-File-list-view-model.go-110",
       "fileName": "repos/lazygit/pkg/gui/context/list_view_model.go",
       "checksums": [
         {
@@ -1797,7 +1552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-io.go-135",
+      "SPDXID": "SPDXRef-File-io.go-111",
       "fileName": "repos/lazygit/pkg/utils/io.go",
       "checksums": [
         {
@@ -1807,7 +1562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-views.go-136",
+      "SPDXID": "SPDXRef-File-views.go-112",
       "fileName": "repos/lazygit/pkg/integration/components/views.go",
       "checksums": [
         {
@@ -1817,17 +1572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-anet.h-137",
-      "fileName": "repos/redis/src/anet.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1d3aec9cdf51edee5c47607a4223d1bae9654ad5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-suggestion.go-138",
+      "SPDXID": "SPDXRef-File-suggestion.go-113",
       "fileName": "repos/lazygit/pkg/gui/types/suggestion.go",
       "checksums": [
         {
@@ -1837,17 +1582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-solarisfixes.h-139",
-      "fileName": "repos/redis/src/solarisfixes.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e757490fe9f3abfc8f9f7087c4be4db6fdfa254"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-remote-branch.go-140",
+      "SPDXID": "SPDXRef-File-remote-branch.go-114",
       "fileName": "repos/lazygit/pkg/commands/models/remote_branch.go",
       "checksums": [
         {
@@ -1857,7 +1592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tag.go-141",
+      "SPDXID": "SPDXRef-File-tag.go-115",
       "fileName": "repos/lazygit/pkg/commands/git_commands/tag.go",
       "checksums": [
         {
@@ -1867,17 +1602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commands.h-142",
-      "fileName": "repos/redis/src/commands.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1eefab4812b8ba3f065c2955ad68d9f7984f2caa"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-prompt-controller.go-143",
+      "SPDXID": "SPDXRef-File-prompt-controller.go-116",
       "fileName": "repos/lazygit/pkg/gui/controllers/prompt_controller.go",
       "checksums": [
         {
@@ -1887,7 +1612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stash-context.go-144",
+      "SPDXID": "SPDXRef-File-stash-context.go-117",
       "fileName": "repos/lazygit/pkg/gui/context/stash_context.go",
       "checksums": [
         {
@@ -1897,7 +1622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-confirmation-controller.go-145",
+      "SPDXID": "SPDXRef-File-confirmation-controller.go-118",
       "fileName": "repos/lazygit/pkg/gui/controllers/confirmation_controller.go",
       "checksums": [
         {
@@ -1907,27 +1632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crccombine.c-146",
-      "fileName": "repos/redis/src/crccombine.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "20add37eeb6ce81ef508b6ffe0802699f7f7a84a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socket.c-147",
-      "fileName": "repos/redis/src/socket.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "226b414f85ed1ffee72b20a0b056729e1dab1fee"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-loader.go-148",
+      "SPDXID": "SPDXRef-File-loader.go-119",
       "fileName": "repos/lazygit/pkg/gui/presentation/loader.go",
       "checksums": [
         {
@@ -1937,7 +1642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git-icons.go-149",
+      "SPDXID": "SPDXRef-File-git-icons.go-120",
       "fileName": "repos/lazygit/pkg/gui/presentation/icons/git_icons.go",
       "checksums": [
         {
@@ -1947,7 +1652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-description-controller.go-150",
+      "SPDXID": "SPDXRef-File-commit-description-controller.go-121",
       "fileName": "repos/lazygit/pkg/gui/controllers/commit_description_controller.go",
       "checksums": [
         {
@@ -1957,7 +1662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmd-obj.go-151",
+      "SPDXID": "SPDXRef-File-cmd-obj.go-122",
       "fileName": "repos/lazygit/pkg/commands/oscommands/cmd_obj.go",
       "checksums": [
         {
@@ -1967,7 +1672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cached-git-config.go-152",
+      "SPDXID": "SPDXRef-File-cached-git-config.go-123",
       "fileName": "repos/lazygit/pkg/commands/git_config/cached_git_config.go",
       "checksums": [
         {
@@ -1977,7 +1682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybinding-creator.go-153",
+      "SPDXID": "SPDXRef-File-keybinding-creator.go-124",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/keybinding_creator.go",
       "checksums": [
         {
@@ -1987,7 +1692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-definitions.go-154",
+      "SPDXID": "SPDXRef-File-definitions.go-125",
       "fileName": "repos/lazygit/pkg/commands/hosting_service/definitions.go",
       "checksums": [
         {
@@ -1997,27 +1702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-geohash-helper.h-155",
-      "fileName": "repos/redis/src/geohash_helper.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "262bd8e8da3f9985dcc320a1608606beeffc26a7"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-foo.c-156",
-      "fileName": "repos/redis/src/foo.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2643cf37b3f62703653fb0ffd4c9641058979129"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-common.go-157",
+      "SPDXID": "SPDXRef-File-common.go-126",
       "fileName": "repos/lazygit/pkg/commands/git_commands/common.go",
       "checksums": [
         {
@@ -2027,47 +1712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut5.c-158",
-      "fileName": "repos/redis/src/lolwut5.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "29f0a2f8d144e3de631804ca67dfb20137e9f715"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-functions.h-159",
-      "fileName": "repos/redis/src/functions.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a487da74accbc22e7f3bcc243d3e02196b4fba1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-call-reply.c-160",
-      "fileName": "repos/redis/src/call_reply.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a4f7100d8fc77ce8e95d63bfca5a935cd6ce964"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-server.h-161",
-      "fileName": "repos/redis/src/server.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a70b28379be19f46b1c8982f7a91e43b46d3f62"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch.go-162",
+      "SPDXID": "SPDXRef-File-patch.go-127",
       "fileName": "repos/lazygit/pkg/commands/git_commands/patch.go",
       "checksums": [
         {
@@ -2077,7 +1722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-conflicts-context.go-163",
+      "SPDXID": "SPDXRef-File-merge-conflicts-context.go-128",
       "fileName": "repos/lazygit/pkg/gui/context/merge_conflicts_context.go",
       "checksums": [
         {
@@ -2087,7 +1732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cherry-picking.go-164",
+      "SPDXID": "SPDXRef-File-cherry-picking.go-129",
       "fileName": "repos/lazygit/pkg/gui/modes/cherrypicking/cherry_picking.go",
       "checksums": [
         {
@@ -2097,7 +1742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-165",
+      "SPDXID": "SPDXRef-File-color.go-130",
       "fileName": "repos/lazygit/pkg/gui/style/color.go",
       "checksums": [
         {
@@ -2107,7 +1752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-prompt-driver.go-166",
+      "SPDXID": "SPDXRef-File-prompt-driver.go-131",
       "fileName": "repos/lazygit/pkg/integration/components/prompt_driver.go",
       "checksums": [
         {
@@ -2117,17 +1762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-listpack.h-167",
-      "fileName": "repos/redis/src/listpack.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2c3b789337dd566192d4ec0be6b48a7195ec5cb6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-side-window-controller.go-168",
+      "SPDXID": "SPDXRef-File-side-window-controller.go-132",
       "fileName": "repos/lazygit/pkg/gui/controllers/side_window_controller.go",
       "checksums": [
         {
@@ -2137,7 +1772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-regexp.go-169",
+      "SPDXID": "SPDXRef-File-regexp.go-133",
       "fileName": "repos/lazygit/pkg/utils/regexp.go",
       "checksums": [
         {
@@ -2147,7 +1782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflog-commits-controller.go-170",
+      "SPDXID": "SPDXRef-File-reflog-commits-controller.go-134",
       "fileName": "repos/lazygit/pkg/gui/controllers/reflog_commits_controller.go",
       "checksums": [
         {
@@ -2157,7 +1792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rename-similarity-threshold-controller.go-171",
+      "SPDXID": "SPDXRef-File-rename-similarity-threshold-controller.go-135",
       "fileName": "repos/lazygit/pkg/gui/controllers/rename_similarity_threshold_controller.go",
       "checksums": [
         {
@@ -2167,7 +1802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-172",
+      "SPDXID": "SPDXRef-File-common.go-136",
       "fileName": "repos/lazygit/pkg/integration/components/common.go",
       "checksums": [
         {
@@ -2177,7 +1812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dummies.go-173",
+      "SPDXID": "SPDXRef-File-dummies.go-137",
       "fileName": "repos/lazygit/pkg/utils/dummies.go",
       "checksums": [
         {
@@ -2187,17 +1822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redis-benchmark.c-174",
-      "fileName": "repos/redis/src/redis-benchmark.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2dbdbd6a1cb7f348323e5ec4c84a62682ecde250"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-copy.go-175",
+      "SPDXID": "SPDXRef-File-copy.go-138",
       "fileName": "repos/lazygit/pkg/commands/oscommands/copy.go",
       "checksums": [
         {
@@ -2207,17 +1832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slowlog.h-176",
-      "fileName": "repos/redis/src/slowlog.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2e284201c0922be34e47ce3f58cf007200b2d1dc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-shell.go-177",
+      "SPDXID": "SPDXRef-File-shell.go-139",
       "fileName": "repos/lazygit/pkg/integration/components/shell.go",
       "checksums": [
         {
@@ -2227,7 +1842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote-loader.go-178",
+      "SPDXID": "SPDXRef-File-remote-loader.go-140",
       "fileName": "repos/lazygit/pkg/commands/git_commands/remote_loader.go",
       "checksums": [
         {
@@ -2237,7 +1852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main-panels.go-179",
+      "SPDXID": "SPDXRef-File-main-panels.go-141",
       "fileName": "repos/lazygit/pkg/gui/main_panels.go",
       "checksums": [
         {
@@ -2247,7 +1862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-command-log-controller.go-180",
+      "SPDXID": "SPDXRef-File-command-log-controller.go-142",
       "fileName": "repos/lazygit/pkg/gui/controllers/command_log_controller.go",
       "checksums": [
         {
@@ -2257,7 +1872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff.go-181",
+      "SPDXID": "SPDXRef-File-diff.go-143",
       "fileName": "repos/lazygit/pkg/commands/git_commands/diff.go",
       "checksums": [
         {
@@ -2267,7 +1882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-refresh-helper.go-182",
+      "SPDXID": "SPDXRef-File-refresh-helper.go-144",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/refresh_helper.go",
       "checksums": [
         {
@@ -2277,7 +1892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file-loader.go-183",
+      "SPDXID": "SPDXRef-File-commit-file-loader.go-145",
       "fileName": "repos/lazygit/pkg/commands/git_commands/commit_file_loader.go",
       "checksums": [
         {
@@ -2287,7 +1902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-random.go-184",
+      "SPDXID": "SPDXRef-File-random.go-146",
       "fileName": "repos/lazygit/pkg/integration/components/random.go",
       "checksums": [
         {
@@ -2297,7 +1912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-185",
+      "SPDXID": "SPDXRef-File-common.go-147",
       "fileName": "repos/lazygit/pkg/gui/controllers/common.go",
       "checksums": [
         {
@@ -2307,7 +1922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui.go-186",
+      "SPDXID": "SPDXRef-File-gui.go-148",
       "fileName": "repos/lazygit/pkg/gui/gui.go",
       "checksums": [
         {
@@ -2317,17 +1932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bio.c-187",
-      "fileName": "repos/redis/src/bio.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "34e3ac1e9727e31d1ba17ce3abe239459fba243b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cherry-pick-helper.go-188",
+      "SPDXID": "SPDXRef-File-cherry-pick-helper.go-149",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/cherry_pick_helper.go",
       "checksums": [
         {
@@ -2337,7 +1942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui-driver.go-189",
+      "SPDXID": "SPDXRef-File-gui-driver.go-150",
       "fileName": "repos/lazygit/pkg/gui/gui_driver.go",
       "checksums": [
         {
@@ -2347,17 +1952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mstr.c-190",
-      "fileName": "repos/redis/src/mstr.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3648806eb7ac1d953aa98f82ff57c7d8b7ce9b34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-confirmation-helper.go-191",
+      "SPDXID": "SPDXRef-File-confirmation-helper.go-151",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/confirmation_helper.go",
       "checksums": [
         {
@@ -2367,7 +1962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file-loader.go-192",
+      "SPDXID": "SPDXRef-File-file-loader.go-152",
       "fileName": "repos/lazygit/pkg/commands/git_commands/file_loader.go",
       "checksums": [
         {
@@ -2377,7 +1972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-record-directory-helper.go-193",
+      "SPDXID": "SPDXRef-File-record-directory-helper.go-153",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/record_directory_helper.go",
       "checksums": [
         {
@@ -2387,7 +1982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-status-controller.go-194",
+      "SPDXID": "SPDXRef-File-status-controller.go-154",
       "fileName": "repos/lazygit/pkg/gui/controllers/status_controller.go",
       "checksums": [
         {
@@ -2397,17 +1992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.h-195",
-      "fileName": "repos/redis/src/rand.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "37b03f41f18b91ac4dd141d645096a3437717d68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-state.go-196",
+      "SPDXID": "SPDXRef-File-state.go-155",
       "fileName": "repos/lazygit/pkg/gui/patch_exploring/state.go",
       "checksums": [
         {
@@ -2417,7 +2002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inline-status-helper.go-197",
+      "SPDXID": "SPDXRef-File-inline-status-helper.go-156",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/inline_status_helper.go",
       "checksums": [
         {
@@ -2427,7 +2012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch.go-198",
+      "SPDXID": "SPDXRef-File-patch.go-157",
       "fileName": "repos/lazygit/pkg/commands/patch/patch.go",
       "checksums": [
         {
@@ -2437,7 +2022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-controller.go-199",
+      "SPDXID": "SPDXRef-File-search-controller.go-158",
       "fileName": "repos/lazygit/pkg/gui/controllers/search_controller.go",
       "checksums": [
         {
@@ -2447,7 +2032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-text-matcher.go-200",
+      "SPDXID": "SPDXRef-File-text-matcher.go-159",
       "fileName": "repos/lazygit/pkg/integration/components/text_matcher.go",
       "checksums": [
         {
@@ -2457,7 +2042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote-branches-controller.go-201",
+      "SPDXID": "SPDXRef-File-remote-branches-controller.go-160",
       "fileName": "repos/lazygit/pkg/gui/controllers/remote_branches_controller.go",
       "checksums": [
         {
@@ -2467,7 +2052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-entry-point.go-202",
+      "SPDXID": "SPDXRef-File-entry-point.go-161",
       "fileName": "repos/lazygit/pkg/app/entry_point.go",
       "checksums": [
         {
@@ -2477,7 +2062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diffing-menu-action.go-203",
+      "SPDXID": "SPDXRef-File-diffing-menu-action.go-162",
       "fileName": "repos/lazygit/pkg/gui/controllers/diffing_menu_action.go",
       "checksums": [
         {
@@ -2487,7 +2072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-cursor.go-204",
+      "SPDXID": "SPDXRef-File-list-cursor.go-163",
       "fileName": "repos/lazygit/pkg/gui/context/traits/list_cursor.go",
       "checksums": [
         {
@@ -2497,17 +2082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha256.c-205",
-      "fileName": "repos/redis/src/sha256.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3b53c45c41458245e5ef18e72d68c02656b7ef0a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-popup.go-206",
+      "SPDXID": "SPDXRef-File-popup.go-164",
       "fileName": "repos/lazygit/pkg/integration/components/popup.go",
       "checksums": [
         {
@@ -2517,17 +2092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cluster.c-207",
-      "fileName": "repos/redis/src/cluster.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3d0e7840468cc91804a9061372175e2d81ab747c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-logs-default.go-208",
+      "SPDXID": "SPDXRef-File-logs-default.go-165",
       "fileName": "repos/lazygit/pkg/logs/tail/logs_default.go",
       "checksums": [
         {
@@ -2537,7 +2102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktrees-context.go-209",
+      "SPDXID": "SPDXRef-File-worktrees-context.go-166",
       "fileName": "repos/lazygit/pkg/gui/context/worktrees_context.go",
       "checksums": [
         {
@@ -2547,7 +2112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-working-tree-state.go-210",
+      "SPDXID": "SPDXRef-File-working-tree-state.go-167",
       "fileName": "repos/lazygit/pkg/commands/models/working_tree_state.go",
       "checksums": [
         {
@@ -2557,17 +2122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dict.c-211",
-      "fileName": "repos/redis/src/dict.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3f60bd165e2a7f979bd60e9838eceb3e3d5056dd"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-status-manager.go-212",
+      "SPDXID": "SPDXRef-File-status-manager.go-168",
       "fileName": "repos/lazygit/pkg/gui/status/status_manager.go",
       "checksums": [
         {
@@ -2577,7 +2132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signal-handling.go-213",
+      "SPDXID": "SPDXRef-File-signal-handling.go-169",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/signal_handling.go",
       "checksums": [
         {
@@ -2587,7 +2142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit.go-214",
+      "SPDXID": "SPDXRef-File-commit.go-170",
       "fileName": "repos/lazygit/pkg/commands/git_commands/commit.go",
       "checksums": [
         {
@@ -2597,7 +2152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote.go-215",
+      "SPDXID": "SPDXRef-File-remote.go-171",
       "fileName": "repos/lazygit/pkg/commands/models/remote.go",
       "checksums": [
         {
@@ -2607,7 +2162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-host-helper.go-216",
+      "SPDXID": "SPDXRef-File-host-helper.go-172",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/host_helper.go",
       "checksums": [
         {
@@ -2617,17 +2172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-intset.h-217",
-      "fileName": "repos/redis/src/intset.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4259aaa7930400c70849761e13cad09d3b84841e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-suggestions.go-218",
+      "SPDXID": "SPDXRef-File-suggestions.go-173",
       "fileName": "repos/lazygit/pkg/gui/presentation/suggestions.go",
       "checksums": [
         {
@@ -2637,7 +2182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ref-range.go-219",
+      "SPDXID": "SPDXRef-File-ref-range.go-174",
       "fileName": "repos/lazygit/pkg/gui/types/ref_range.go",
       "checksums": [
         {
@@ -2647,7 +2192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-style.go-220",
+      "SPDXID": "SPDXRef-File-style.go-175",
       "fileName": "repos/lazygit/pkg/theme/style.go",
       "checksums": [
         {
@@ -2657,17 +2202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-release.h-221",
-      "fileName": "repos/redis/src/release.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "43fd0f1875e93b787f3eea9a6e8ba3347d8c91f6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-update-helper.go-222",
+      "SPDXID": "SPDXRef-File-update-helper.go-176",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/update_helper.go",
       "checksums": [
         {
@@ -2677,7 +2212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-text-style.go-223",
+      "SPDXID": "SPDXRef-File-text-style.go-177",
       "fileName": "repos/lazygit/pkg/gui/style/text_style.go",
       "checksums": [
         {
@@ -2687,7 +2222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options-map.go-224",
+      "SPDXID": "SPDXRef-File-options-map.go-178",
       "fileName": "repos/lazygit/pkg/gui/options_map.go",
       "checksums": [
         {
@@ -2697,17 +2232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lzf.h-225",
-      "fileName": "repos/redis/src/lzf.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "45ddfa8da05be7a7565e2bbe53f2a099f7a262e3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-views.go-226",
+      "SPDXID": "SPDXRef-File-views.go-179",
       "fileName": "repos/lazygit/pkg/gui/types/views.go",
       "checksums": [
         {
@@ -2717,7 +2242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-quit-actions.go-227",
+      "SPDXID": "SPDXRef-File-quit-actions.go-180",
       "fileName": "repos/lazygit/pkg/gui/controllers/quit_actions.go",
       "checksums": [
         {
@@ -2727,7 +2252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commits-helper.go-228",
+      "SPDXID": "SPDXRef-File-commits-helper.go-181",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/commits_helper.go",
       "checksums": [
         {
@@ -2737,17 +2262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.h-229",
-      "fileName": "repos/redis/src/config.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "47338554aaf3ca45c4b4b001ea43d1c35d599879"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-search-driver.go-230",
+      "SPDXID": "SPDXRef-File-search-driver.go-182",
       "fileName": "repos/lazygit/pkg/integration/components/search_driver.go",
       "checksums": [
         {
@@ -2757,7 +2272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-trait.go-231",
+      "SPDXID": "SPDXRef-File-search-trait.go-183",
       "fileName": "repos/lazygit/pkg/gui/context/search_trait.go",
       "checksums": [
         {
@@ -2767,7 +2282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remotes-context.go-232",
+      "SPDXID": "SPDXRef-File-remotes-context.go-184",
       "fileName": "repos/lazygit/pkg/gui/context/remotes_context.go",
       "checksums": [
         {
@@ -2777,27 +2292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-call-reply.h-233",
-      "fileName": "repos/redis/src/call_reply.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4ae7f3cf1fc9e2c424f747f8cd88aae948ef4766"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-script-lua.h-234",
-      "fileName": "repos/redis/src/script_lua.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4c2c3e9c281018d51ecdcfcb4efd075f012aac9a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-english.go-235",
+      "SPDXID": "SPDXRef-File-english.go-185",
       "fileName": "repos/lazygit/pkg/i18n/english.go",
       "checksums": [
         {
@@ -2807,7 +2302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-236",
+      "SPDXID": "SPDXRef-File-common.go-186",
       "fileName": "repos/lazygit/pkg/gui/types/common.go",
       "checksums": [
         {
@@ -2817,7 +2312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-helpers.go-237",
+      "SPDXID": "SPDXRef-File-helpers.go-187",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/helpers.go",
       "checksums": [
         {
@@ -2827,7 +2322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remotes.go-238",
+      "SPDXID": "SPDXRef-File-remotes.go-188",
       "fileName": "repos/lazygit/pkg/gui/presentation/remotes.go",
       "checksums": [
         {
@@ -2837,7 +2332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transform.go-239",
+      "SPDXID": "SPDXRef-File-transform.go-189",
       "fileName": "repos/lazygit/pkg/commands/patch/transform.go",
       "checksums": [
         {
@@ -2847,7 +2342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-int-matcher.go-240",
+      "SPDXID": "SPDXRef-File-int-matcher.go-190",
       "fileName": "repos/lazygit/pkg/integration/components/int_matcher.go",
       "checksums": [
         {
@@ -2857,17 +2352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bitops.c-241",
-      "fileName": "repos/redis/src/bitops.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4d33ff953ae75156b636c080e1ae369278a5e670"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch-building-controller.go-242",
+      "SPDXID": "SPDXRef-File-patch-building-controller.go-191",
       "fileName": "repos/lazygit/pkg/gui/controllers/patch_building_controller.go",
       "checksums": [
         {
@@ -2877,17 +2362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha1.c-243",
-      "fileName": "repos/redis/src/sha1.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4d8c14094d0ab217b14794029b81c27481c86b8b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branch.go-244",
+      "SPDXID": "SPDXRef-File-branch.go-192",
       "fileName": "repos/lazygit/pkg/commands/models/branch.go",
       "checksums": [
         {
@@ -2897,7 +2372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-cmd-obj-runner.go-245",
+      "SPDXID": "SPDXRef-File-fake-cmd-obj-runner.go-193",
       "fileName": "repos/lazygit/pkg/commands/oscommands/fake_cmd_obj_runner.go",
       "checksums": [
         {
@@ -2907,7 +2382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-controller-trait.go-246",
+      "SPDXID": "SPDXRef-File-list-controller-trait.go-194",
       "fileName": "repos/lazygit/pkg/gui/controllers/list_controller_trait.go",
       "checksums": [
         {
@@ -2917,17 +2392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-script.h-247",
-      "fileName": "repos/redis/src/script.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4f43c09d52217886d00ff96c3c7f4ca4c08de573"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-parent-context-mgr.go-248",
+      "SPDXID": "SPDXRef-File-parent-context-mgr.go-195",
       "fileName": "repos/lazygit/pkg/gui/context/parent_context_mgr.go",
       "checksums": [
         {
@@ -2937,7 +2402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-249",
+      "SPDXID": "SPDXRef-File-errors.go-196",
       "fileName": "repos/lazygit/pkg/app/errors.go",
       "checksums": [
         {
@@ -2947,17 +2412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-db.c-250",
-      "fileName": "repos/redis/src/db.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "508c342fb33a599a8a65db805792ccb78f20f8fc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-local-commits-controller.go-251",
+      "SPDXID": "SPDXRef-File-local-commits-controller.go-197",
       "fileName": "repos/lazygit/pkg/gui/controllers/local_commits_controller.go",
       "checksums": [
         {
@@ -2967,27 +2422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zipmap.c-252",
-      "fileName": "repos/redis/src/zipmap.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "51c64ca81274424d81c921651912ee69ea6018a3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-intset.c-253",
-      "fileName": "repos/redis/src/intset.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5216251eb52a5e5e0d9ff006710ffe1e7f323631"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-submodules-context.go-254",
+      "SPDXID": "SPDXRef-File-submodules-context.go-198",
       "fileName": "repos/lazygit/pkg/gui/context/submodules_context.go",
       "checksums": [
         {
@@ -2997,7 +2432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-branches-helper.go-255",
+      "SPDXID": "SPDXRef-File-branches-helper.go-199",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/branches_helper.go",
       "checksums": [
         {
@@ -3007,7 +2442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-staging-helper.go-256",
+      "SPDXID": "SPDXRef-File-staging-helper.go-200",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/staging_helper.go",
       "checksums": [
         {
@@ -3017,7 +2452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-i18n.go-257",
+      "SPDXID": "SPDXRef-File-i18n.go-201",
       "fileName": "repos/lazygit/pkg/i18n/i18n.go",
       "checksums": [
         {
@@ -3027,7 +2462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote-branches.go-258",
+      "SPDXID": "SPDXRef-File-remote-branches.go-202",
       "fileName": "repos/lazygit/pkg/gui/presentation/remote_branches.go",
       "checksums": [
         {
@@ -3037,27 +2472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lzfP.h-259",
-      "fileName": "repos/redis/src/lzfP.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "567f5a201918ab32ddc085b2f8e3f7c4fb7adf64"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-server.c-260",
-      "fileName": "repos/redis/src/server.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "56f2c9e93883af1c49a0ae5c72eb0c7911e199a9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-app-status-helper.go-261",
+      "SPDXID": "SPDXRef-File-app-status-helper.go-203",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/app_status_helper.go",
       "checksums": [
         {
@@ -3067,7 +2482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basic-styles.go-262",
+      "SPDXID": "SPDXRef-File-basic-styles.go-204",
       "fileName": "repos/lazygit/pkg/gui/style/basic_styles.go",
       "checksums": [
         {
@@ -3077,27 +2492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sdsalloc.h-263",
-      "fileName": "repos/redis/src/sdsalloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5a53d4de836ddc212b086333b8a76a3c1e1c3e10"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-pqsort.h-264",
-      "fileName": "repos/redis/src/pqsort.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5a87e55b085be30f51deefe48a6849322095e0da"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tasks.go-265",
+      "SPDXID": "SPDXRef-File-tasks.go-205",
       "fileName": "repos/lazygit/pkg/tasks/tasks.go",
       "checksums": [
         {
@@ -3107,27 +2502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-t-hash.c-266",
-      "fileName": "repos/redis/src/t_hash.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5dc6ea418444a79eee82a954be6d6e1b50683340"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-commands.c-267",
-      "fileName": "repos/redis/src/commands.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5dcfe1973899eb88d5bdd8c51e154151eb81f464"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-git-command-builder.go-268",
+      "SPDXID": "SPDXRef-File-git-command-builder.go-206",
       "fileName": "repos/lazygit/pkg/commands/git_commands/git_command_builder.go",
       "checksums": [
         {
@@ -3137,7 +2512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-extras-panel.go-269",
+      "SPDXID": "SPDXRef-File-extras-panel.go-207",
       "fileName": "repos/lazygit/pkg/gui/extras_panel.go",
       "checksums": [
         {
@@ -3147,17 +2522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rax.c-270",
-      "fileName": "repos/redis/src/rax.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5f3a8c17617b851ccc7023d66d3caf5a039819b2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-gocui.go-271",
+      "SPDXID": "SPDXRef-File-gocui.go-208",
       "fileName": "repos/lazygit/pkg/theme/gocui.go",
       "checksums": [
         {
@@ -3167,17 +2532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-replication.c-272",
-      "fileName": "repos/redis/src/replication.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5fab23b1c7cde1630082bb948648f133496dcd81"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-editor-presets.go-273",
+      "SPDXID": "SPDXRef-File-editor-presets.go-209",
       "fileName": "repos/lazygit/pkg/config/editor_presets.go",
       "checksums": [
         {
@@ -3187,27 +2542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rdb.h-274",
-      "fileName": "repos/redis/src/rdb.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "602b075c1dd3590cc239a3eff51704ed1acf78ea"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-threads-mngr.c-275",
-      "fileName": "repos/redis/src/threads_mngr.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "606f39c2fdf92949f97476c1caa9edcd7dd45ff7"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-updates.go-276",
+      "SPDXID": "SPDXRef-File-updates.go-210",
       "fileName": "repos/lazygit/pkg/updates/updates.go",
       "checksums": [
         {
@@ -3217,17 +2552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bio.h-277",
-      "fileName": "repos/redis/src/bio.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "615cf45b8ca2d79e496a5dd890fe7b7fdcbd2952"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-icons.go-278",
+      "SPDXID": "SPDXRef-File-icons.go-211",
       "fileName": "repos/lazygit/pkg/gui/presentation/icons/icons.go",
       "checksums": [
         {
@@ -3237,27 +2562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pqsort.c-279",
-      "fileName": "repos/redis/src/pqsort.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "62527170573de87c2cc1c60ca8b3fd3c75199696"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rand.c-280",
-      "fileName": "repos/redis/src/rand.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6256c3bc3c26c75cb995ee2172c5369229277abf"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-snake.go-281",
+      "SPDXID": "SPDXRef-File-snake.go-212",
       "fileName": "repos/lazygit/pkg/snake/snake.go",
       "checksums": [
         {
@@ -3267,7 +2572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflog-commits-context.go-282",
+      "SPDXID": "SPDXRef-File-reflog-commits-context.go-213",
       "fileName": "repos/lazygit/pkg/gui/context/reflog_commits_context.go",
       "checksums": [
         {
@@ -3277,7 +2582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-selection-controller.go-283",
+      "SPDXID": "SPDXRef-File-view-selection-controller.go-214",
       "fileName": "repos/lazygit/pkg/gui/controllers/view_selection_controller.go",
       "checksums": [
         {
@@ -3287,7 +2592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-async-handler.go-284",
+      "SPDXID": "SPDXRef-File-async-handler.go-215",
       "fileName": "repos/lazygit/pkg/tasks/async_handler.go",
       "checksums": [
         {
@@ -3297,17 +2602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-module.c-285",
-      "fileName": "repos/redis/src/module.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "65d77f2e0e8007383a82942f4bf60bef9e16b31c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-remote-branches-context.go-286",
+      "SPDXID": "SPDXRef-File-remote-branches-context.go-216",
       "fileName": "repos/lazygit/pkg/gui/context/remote_branches_context.go",
       "checksums": [
         {
@@ -3317,7 +2612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-types.go-287",
+      "SPDXID": "SPDXRef-File-types.go-217",
       "fileName": "repos/lazygit/pkg/app/types/types.go",
       "checksums": [
         {
@@ -3327,7 +2622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff-helper.go-288",
+      "SPDXID": "SPDXRef-File-diff-helper.go-218",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/diff_helper.go",
       "checksums": [
         {
@@ -3337,17 +2632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rax.h-289",
-      "fileName": "repos/redis/src/rax.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "66afe4085ef6f253b64cd42d6baac2ff8e89922e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-pty.go-290",
+      "SPDXID": "SPDXRef-File-pty.go-219",
       "fileName": "repos/lazygit/pkg/gui/pty.go",
       "checksums": [
         {
@@ -3357,7 +2642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-history-buffer.go-291",
+      "SPDXID": "SPDXRef-File-history-buffer.go-220",
       "fileName": "repos/lazygit/pkg/utils/history_buffer.go",
       "checksums": [
         {
@@ -3367,7 +2652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-helper.go-292",
+      "SPDXID": "SPDXRef-File-worktree-helper.go-221",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/worktree_helper.go",
       "checksums": [
         {
@@ -3377,7 +2662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commits.go-293",
+      "SPDXID": "SPDXRef-File-commits.go-222",
       "fileName": "repos/lazygit/pkg/gui/presentation/commits.go",
       "checksums": [
         {
@@ -3387,17 +2672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adlist.c-294",
-      "fileName": "repos/redis/src/adlist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "68a5d70f7c420c062bbd1eb8948ad241cb8d1299"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-confirmation-context.go-295",
+      "SPDXID": "SPDXRef-File-confirmation-context.go-223",
       "fileName": "repos/lazygit/pkg/gui/context/confirmation_context.go",
       "checksums": [
         {
@@ -3407,7 +2682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui-io.go-296",
+      "SPDXID": "SPDXRef-File-gui-io.go-224",
       "fileName": "repos/lazygit/pkg/commands/oscommands/gui_io.go",
       "checksums": [
         {
@@ -3417,7 +2692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tags-helper.go-297",
+      "SPDXID": "SPDXRef-File-tags-helper.go-225",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/tags_helper.go",
       "checksums": [
         {
@@ -3427,27 +2702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connection.c-298",
-      "fileName": "repos/redis/src/connection.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6ac1b99d9aec356e51cb18a2bcd9c292a3383d4e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ae-epoll.c-299",
-      "fileName": "repos/redis/src/ae_epoll.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6b916618bb7eec1be1eb7f39abcfda0988d57e6e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-bisect-helper.go-300",
+      "SPDXID": "SPDXRef-File-bisect-helper.go-226",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/bisect_helper.go",
       "checksums": [
         {
@@ -3457,7 +2712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hunk.go-301",
+      "SPDXID": "SPDXRef-File-hunk.go-227",
       "fileName": "repos/lazygit/pkg/commands/patch/hunk.go",
       "checksums": [
         {
@@ -3467,17 +2722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-monotonic.c-302",
-      "fileName": "repos/redis/src/monotonic.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6da03677bdac00f64666e770336d4e82a967debc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-list-controller.go-303",
+      "SPDXID": "SPDXRef-File-list-controller.go-228",
       "fileName": "repos/lazygit/pkg/gui/controllers/list_controller.go",
       "checksums": [
         {
@@ -3487,7 +2732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-conflicts-helper.go-304",
+      "SPDXID": "SPDXRef-File-merge-conflicts-helper.go-229",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/merge_conflicts_helper.go",
       "checksums": [
         {
@@ -3497,7 +2742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-test.go-305",
+      "SPDXID": "SPDXRef-File-test.go-230",
       "fileName": "repos/lazygit/pkg/integration/components/test.go",
       "checksums": [
         {
@@ -3507,7 +2752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ref.go-306",
+      "SPDXID": "SPDXRef-File-ref.go-231",
       "fileName": "repos/lazygit/pkg/commands/models/ref.go",
       "checksums": [
         {
@@ -3517,27 +2762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cluster-legacy.c-307",
-      "fileName": "repos/redis/src/cluster_legacy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6f1635e9e5da171c1780a23f56d6bde0a2b21204"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-syscheck.h-308",
-      "fileName": "repos/redis/src/syscheck.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6f324d151e8f8720cb624132e289b45dc970c2e9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-stash-controller.go-309",
+      "SPDXID": "SPDXRef-File-stash-controller.go-232",
       "fileName": "repos/lazygit/pkg/gui/controllers/stash_controller.go",
       "checksums": [
         {
@@ -3547,7 +2772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-controllers.go-310",
+      "SPDXID": "SPDXRef-File-controllers.go-233",
       "fileName": "repos/lazygit/pkg/gui/controllers.go",
       "checksums": [
         {
@@ -3557,7 +2782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rendering.go-311",
+      "SPDXID": "SPDXRef-File-rendering.go-234",
       "fileName": "repos/lazygit/pkg/gui/types/rendering.go",
       "checksums": [
         {
@@ -3567,27 +2792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adlist.h-312",
-      "fileName": "repos/redis/src/adlist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "712c03fd71ec074fe5c0976df6eaa4031ae1b761"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ziplist.c-313",
-      "fileName": "repos/redis/src/ziplist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "712d259a942945260ea06cdd8867d88945c6a897"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-suggestions-controller.go-314",
+      "SPDXID": "SPDXRef-File-suggestions-controller.go-235",
       "fileName": "repos/lazygit/pkg/gui/controllers/suggestions_controller.go",
       "checksums": [
         {
@@ -3597,7 +2802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main-context.go-315",
+      "SPDXID": "SPDXRef-File-main-context.go-236",
       "fileName": "repos/lazygit/pkg/gui/context/main_context.go",
       "checksums": [
         {
@@ -3607,7 +2812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmd-obj-runner-default.go-316",
+      "SPDXID": "SPDXRef-File-cmd-obj-runner-default.go-237",
       "fileName": "repos/lazygit/pkg/commands/oscommands/cmd_obj_runner_default.go",
       "checksums": [
         {
@@ -3617,17 +2822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ae.c-317",
-      "fileName": "repos/redis/src/ae.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "733c88d52d3105e31c0460490b19d3e22f0df70b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-get-key.go-318",
+      "SPDXID": "SPDXRef-File-get-key.go-238",
       "fileName": "repos/lazygit/pkg/commands/git_config/get_key.go",
       "checksums": [
         {
@@ -3637,17 +2832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asciilogo.h-319",
-      "fileName": "repos/redis/src/asciilogo.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "73a99777835544022b224021c609597418de7c32"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file-tree-view-model.go-320",
+      "SPDXID": "SPDXRef-File-file-tree-view-model.go-239",
       "fileName": "repos/lazygit/pkg/gui/filetree/file_tree_view_model.go",
       "checksums": [
         {
@@ -3657,7 +2842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common-commands.go-321",
+      "SPDXID": "SPDXRef-File-common-commands.go-240",
       "fileName": "repos/lazygit/pkg/gui/types/common_commands.go",
       "checksums": [
         {
@@ -3667,7 +2852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git-cmd-obj-builder.go-322",
+      "SPDXID": "SPDXRef-File-git-cmd-obj-builder.go-241",
       "fileName": "repos/lazygit/pkg/commands/git_cmd_obj_builder.go",
       "checksums": [
         {
@@ -3677,17 +2862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vset.c-323",
-      "fileName": "repos/redis/src/../modules/vector-sets/vset.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "75de692562ff060978a028a3a8c220d6029eb514"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-information-panel.go-324",
+      "SPDXID": "SPDXRef-File-information-panel.go-242",
       "fileName": "repos/lazygit/pkg/gui/information_panel.go",
       "checksums": [
         {
@@ -3697,7 +2872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybindings.go-325",
+      "SPDXID": "SPDXRef-File-keybindings.go-243",
       "fileName": "repos/lazygit/pkg/gui/keybindings/keybindings.go",
       "checksums": [
         {
@@ -3707,7 +2882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lines.go-326",
+      "SPDXID": "SPDXRef-File-lines.go-244",
       "fileName": "repos/lazygit/pkg/utils/lines.go",
       "checksums": [
         {
@@ -3717,67 +2892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sparkline.h-327",
-      "fileName": "repos/redis/src/sparkline.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7769fdb852f362b2246ca3d3df907f8c265c2c12"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-object.c-328",
-      "fileName": "repos/redis/src/object.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "779a2b0142e174fb6167bae71fa43c276d0acbc2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-debug.c-329",
-      "fileName": "repos/redis/src/debug.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "77a4cf78cc397df8ece6771b220109181a518caf"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-setcpuaffinity.c-330",
-      "fileName": "repos/redis/src/setcpuaffinity.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "77b162103ec2714f5a937a030872e3b820969159"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-function-lua.c-331",
-      "fileName": "repos/redis/src/function_lua.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "785f825f354a869022731f58ce317117ba366b68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fastjson.c-332",
-      "fileName": "repos/redis/src/../modules/vector-sets/fastjson.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "78926e256f8b2cca384d367fc6f819211b879633"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch-line.go-333",
+      "SPDXID": "SPDXRef-File-patch-line.go-245",
       "fileName": "repos/lazygit/pkg/commands/patch/patch_line.go",
       "checksums": [
         {
@@ -3787,7 +2902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context.go-334",
+      "SPDXID": "SPDXRef-File-context.go-246",
       "fileName": "repos/lazygit/pkg/gui/types/context.go",
       "checksums": [
         {
@@ -3797,7 +2912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-confirmation-driver.go-335",
+      "SPDXID": "SPDXRef-File-confirmation-driver.go-247",
       "fileName": "repos/lazygit/pkg/integration/components/confirmation_driver.go",
       "checksums": [
         {
@@ -3807,17 +2922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-geo.h-336",
-      "fileName": "repos/redis/src/geo.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "79d0a6a4aa27040754aa42821113c803951b5086"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branches.go-337",
+      "SPDXID": "SPDXRef-File-branches.go-248",
       "fileName": "repos/lazygit/pkg/gui/presentation/branches.go",
       "checksums": [
         {
@@ -3827,17 +2932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-expire.c-338",
-      "fileName": "repos/redis/src/expire.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7a5cdce81b783f9121f62a85ccd9945d566cec54"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-working-tree.go-339",
+      "SPDXID": "SPDXRef-File-working-tree.go-249",
       "fileName": "repos/lazygit/pkg/commands/git_commands/working_tree.go",
       "checksums": [
         {
@@ -3847,7 +2942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-layout.go-340",
+      "SPDXID": "SPDXRef-File-layout.go-250",
       "fileName": "repos/lazygit/pkg/gui/layout.go",
       "checksums": [
         {
@@ -3857,7 +2952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base-context.go-341",
+      "SPDXID": "SPDXRef-File-base-context.go-251",
       "fileName": "repos/lazygit/pkg/gui/context/base_context.go",
       "checksums": [
         {
@@ -3867,17 +2962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lzf-c.c-342",
-      "fileName": "repos/redis/src/lzf_c.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7cbbc82fa4674ff2d09f8ef012af9f6d20de70ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-authors.go-343",
+      "SPDXID": "SPDXRef-File-authors.go-252",
       "fileName": "repos/lazygit/pkg/gui/presentation/authors/authors.go",
       "checksums": [
         {
@@ -3887,7 +2972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-and-rebase-helper.go-344",
+      "SPDXID": "SPDXRef-File-merge-and-rebase-helper.go-253",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/merge_and_rebase_helper.go",
       "checksums": [
         {
@@ -3897,7 +2982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commits-files-controller.go-345",
+      "SPDXID": "SPDXRef-File-commits-files-controller.go-254",
       "fileName": "repos/lazygit/pkg/gui/controllers/commits_files_controller.go",
       "checksums": [
         {
@@ -3907,7 +2992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodule-config.go-346",
+      "SPDXID": "SPDXRef-File-submodule-config.go-255",
       "fileName": "repos/lazygit/pkg/commands/models/submodule_config.go",
       "checksums": [
         {
@@ -3917,7 +3002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sub-commits-context.go-347",
+      "SPDXID": "SPDXRef-File-sub-commits-context.go-256",
       "fileName": "repos/lazygit/pkg/gui/context/sub_commits_context.go",
       "checksums": [
         {
@@ -3927,7 +3012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-348",
+      "SPDXID": "SPDXRef-File-utils.go-257",
       "fileName": "repos/lazygit/pkg/utils/utils.go",
       "checksums": [
         {
@@ -3937,7 +3022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logs.go-349",
+      "SPDXID": "SPDXRef-File-logs.go-258",
       "fileName": "repos/lazygit/pkg/logs/logs.go",
       "checksums": [
         {
@@ -3947,27 +3032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sds.c-350",
-      "fileName": "repos/redis/src/sds.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7f1429c46b869f38a67712b7b10269680c5d2754"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-quicklist.c-351",
-      "fileName": "repos/redis/src/quicklist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "81bc706468eb17d9493687c126e35b37f91fa3c9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-files-helper.go-352",
+      "SPDXID": "SPDXRef-File-files-helper.go-259",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/files_helper.go",
       "checksums": [
         {
@@ -3977,7 +3042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-app-config.go-353",
+      "SPDXID": "SPDXRef-File-app-config.go-260",
       "fileName": "repos/lazygit/pkg/config/app_config.go",
       "checksums": [
         {
@@ -3987,7 +3052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-workspace-reset-controller.go-354",
+      "SPDXID": "SPDXRef-File-workspace-reset-controller.go-261",
       "fileName": "repos/lazygit/pkg/gui/controllers/workspace_reset_controller.go",
       "checksums": [
         {
@@ -3997,17 +3062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-functions.c-355",
-      "fileName": "repos/redis/src/functions.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "82ab2e09ce0162b94f9a2460b9a5e9ed2c4a5ca4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-common.go-356",
+      "SPDXID": "SPDXRef-File-common.go-262",
       "fileName": "repos/lazygit/pkg/common/common.go",
       "checksums": [
         {
@@ -4017,7 +3072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-runner.go-357",
+      "SPDXID": "SPDXRef-File-runner.go-263",
       "fileName": "repos/lazygit/pkg/integration/components/runner.go",
       "checksums": [
         {
@@ -4027,7 +3082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context-config.go-358",
+      "SPDXID": "SPDXRef-File-context-config.go-264",
       "fileName": "repos/lazygit/pkg/gui/context_config.go",
       "checksums": [
         {
@@ -4037,17 +3092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut.c-359",
-      "fileName": "repos/redis/src/lolwut.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8467c7803bb1dc3a79192a09179a0c0d59744b0b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-snake-helper.go-360",
+      "SPDXID": "SPDXRef-File-snake-helper.go-265",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/snake_helper.go",
       "checksums": [
         {
@@ -4057,17 +3102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blocked.c-361",
-      "fileName": "repos/redis/src/blocked.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "86cff0b7facdd3ee3dc7be4692a0e3518e1040a3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tag.go-362",
+      "SPDXID": "SPDXRef-File-tag.go-266",
       "fileName": "repos/lazygit/pkg/commands/models/tag.go",
       "checksums": [
         {
@@ -4077,7 +3112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sub-commits-controller.go-363",
+      "SPDXID": "SPDXRef-File-sub-commits-controller.go-267",
       "fileName": "repos/lazygit/pkg/gui/controllers/sub_commits_controller.go",
       "checksums": [
         {
@@ -4087,17 +3122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hnsw.h-364",
-      "fileName": "repos/redis/src/../modules/vector-sets/hnsw.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8935521a63ff31441bda8e4ca704306212946ca1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-context.go-365",
+      "SPDXID": "SPDXRef-File-context.go-268",
       "fileName": "repos/lazygit/pkg/gui/context/context.go",
       "checksums": [
         {
@@ -4107,7 +3132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filter-controller.go-366",
+      "SPDXID": "SPDXRef-File-filter-controller.go-269",
       "fileName": "repos/lazygit/pkg/gui/controllers/filter_controller.go",
       "checksums": [
         {
@@ -4117,7 +3142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-loader.go-367",
+      "SPDXID": "SPDXRef-File-commit-loader.go-270",
       "fileName": "repos/lazygit/pkg/commands/git_commands/commit_loader.go",
       "checksums": [
         {
@@ -4127,17 +3152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-resp-parser.c-368",
-      "fileName": "repos/redis/src/resp_parser.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8c0f17d394b1cd624a6755231af78cb3912bcb34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-attach.go-369",
+      "SPDXID": "SPDXRef-File-attach.go-271",
       "fileName": "repos/lazygit/pkg/gui/controllers/attach.go",
       "checksums": [
         {
@@ -4147,7 +3162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-files-controller.go-370",
+      "SPDXID": "SPDXRef-File-files-controller.go-272",
       "fileName": "repos/lazygit/pkg/gui/controllers/files_controller.go",
       "checksums": [
         {
@@ -4157,27 +3172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connhelpers.h-371",
-      "fileName": "repos/redis/src/connhelpers.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8d6f4b90c0715a7d6a49a6f71797beb32a745ed0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-crccombine.h-372",
-      "fileName": "repos/redis/src/crccombine.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8da7c5fe6ace5ee22f35c611af37788f99da567f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file-icons.go-373",
+      "SPDXID": "SPDXRef-File-file-icons.go-273",
       "fileName": "repos/lazygit/pkg/gui/presentation/icons/file_icons.go",
       "checksums": [
         {
@@ -4187,7 +3182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-setup.go-374",
+      "SPDXID": "SPDXRef-File-setup.go-274",
       "fileName": "repos/lazygit/pkg/gui/context/setup.go",
       "checksums": [
         {
@@ -4197,7 +3192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-description-panel-driver.go-375",
+      "SPDXID": "SPDXRef-File-commit-description-panel-driver.go-275",
       "fileName": "repos/lazygit/pkg/integration/components/commit_description_panel_driver.go",
       "checksums": [
         {
@@ -4207,7 +3202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git.go-376",
+      "SPDXID": "SPDXRef-File-git.go-276",
       "fileName": "repos/lazygit/pkg/commands/git.go",
       "checksums": [
         {
@@ -4217,7 +3212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file.go-377",
+      "SPDXID": "SPDXRef-File-commit-file.go-277",
       "fileName": "repos/lazygit/pkg/commands/models/commit_file.go",
       "checksums": [
         {
@@ -4227,27 +3222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut.h-378",
-      "fileName": "repos/redis/src/lolwut.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "914db0d7e50bb907a878e0fbd01b88066d2609db"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-aof.c-379",
-      "fileName": "repos/redis/src/aof.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "91a21617b263d942f6b418d8308067cd6238d362"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-build-tree.go-380",
+      "SPDXID": "SPDXRef-File-build-tree.go-278",
       "fileName": "repos/lazygit/pkg/gui/filetree/build_tree.go",
       "checksums": [
         {
@@ -4257,7 +3232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-switch-to-sub-commits-controller.go-381",
+      "SPDXID": "SPDXRef-File-switch-to-sub-commits-controller.go-279",
       "fileName": "repos/lazygit/pkg/gui/controllers/switch_to_sub_commits_controller.go",
       "checksums": [
         {
@@ -4267,7 +3242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybindings.go-382",
+      "SPDXID": "SPDXRef-File-keybindings.go-280",
       "fileName": "repos/lazygit/pkg/gui/types/keybindings.go",
       "checksums": [
         {
@@ -4277,7 +3252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context-common.go-383",
+      "SPDXID": "SPDXRef-File-context-common.go-281",
       "fileName": "repos/lazygit/pkg/gui/context/context_common.go",
       "checksums": [
         {
@@ -4287,17 +3262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-latency.h-384",
-      "fileName": "repos/redis/src/latency.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "945004a484c853b2e9f92314e712c6d518593506"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dummies.go-385",
+      "SPDXID": "SPDXRef-File-dummies.go-282",
       "fileName": "repos/lazygit/pkg/commands/oscommands/dummies.go",
       "checksums": [
         {
@@ -4307,7 +3272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-working-tree-helper.go-386",
+      "SPDXID": "SPDXRef-File-working-tree-helper.go-283",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/working_tree_helper.go",
       "checksums": [
         {
@@ -4317,7 +3282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-menu-generator.go-387",
+      "SPDXID": "SPDXRef-File-menu-generator.go-284",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/menu_generator.go",
       "checksums": [
         {
@@ -4327,17 +3292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-childinfo.c-388",
-      "fileName": "repos/redis/src/childinfo.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "95cbbbb1c0606646cfaf46bf9c1378d3b1092799"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-menu-driver.go-389",
+      "SPDXID": "SPDXRef-File-menu-driver.go-285",
       "fileName": "repos/lazygit/pkg/integration/components/menu_driver.go",
       "checksums": [
         {
@@ -4347,17 +3302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cluster.h-390",
-      "fileName": "repos/redis/src/cluster.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9710e5d92e41e85b9cae632b6af867140cfd4ff1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dummies.go-391",
+      "SPDXID": "SPDXRef-File-dummies.go-286",
       "fileName": "repos/lazygit/pkg/gui/dummies.go",
       "checksums": [
         {
@@ -4367,7 +3312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-suggestions-context.go-392",
+      "SPDXID": "SPDXRef-File-suggestions-context.go-287",
       "fileName": "repos/lazygit/pkg/gui/context/suggestions_context.go",
       "checksums": [
         {
@@ -4377,7 +3322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rebase.go-393",
+      "SPDXID": "SPDXRef-File-rebase.go-288",
       "fileName": "repos/lazygit/pkg/commands/git_commands/rebase.go",
       "checksums": [
         {
@@ -4387,7 +3332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-node.go-394",
+      "SPDXID": "SPDXRef-File-node.go-289",
       "fileName": "repos/lazygit/pkg/gui/filetree/node.go",
       "checksums": [
         {
@@ -4397,17 +3342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logreqres.c-395",
-      "fileName": "repos/redis/src/logreqres.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "97d594823f2f538691d212cb21fddf2b0a9e03b5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file-tree.go-396",
+      "SPDXID": "SPDXRef-File-file-tree.go-290",
       "fileName": "repos/lazygit/pkg/gui/filetree/file_tree.go",
       "checksums": [
         {
@@ -4417,7 +3352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree.go-397",
+      "SPDXID": "SPDXRef-File-worktree.go-291",
       "fileName": "repos/lazygit/pkg/commands/git_commands/worktree.go",
       "checksums": [
         {
@@ -4427,7 +3362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-context-trait.go-398",
+      "SPDXID": "SPDXRef-File-list-context-trait.go-292",
       "fileName": "repos/lazygit/pkg/gui/context/list_context_trait.go",
       "checksums": [
         {
@@ -4437,7 +3372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-string-pool.go-399",
+      "SPDXID": "SPDXRef-File-string-pool.go-293",
       "fileName": "repos/lazygit/pkg/utils/string_pool.go",
       "checksums": [
         {
@@ -4447,17 +3382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ae.h-400",
-      "fileName": "repos/redis/src/ae.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "996d48b0f838e771a3751bde522c7bbea773006e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-bisect-controller.go-401",
+      "SPDXID": "SPDXRef-File-bisect-controller.go-294",
       "fileName": "repos/lazygit/pkg/gui/controllers/bisect_controller.go",
       "checksums": [
         {
@@ -4467,7 +3392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-credentials-helper.go-402",
+      "SPDXID": "SPDXRef-File-credentials-helper.go-295",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/credentials_helper.go",
       "checksums": [
         {
@@ -4477,7 +3402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-helper.go-403",
+      "SPDXID": "SPDXRef-File-search-helper.go-296",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/search_helper.go",
       "checksums": [
         {
@@ -4487,7 +3412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-global-handlers.go-404",
+      "SPDXID": "SPDXRef-File-global-handlers.go-297",
       "fileName": "repos/lazygit/pkg/gui/global_handlers.go",
       "checksums": [
         {
@@ -4497,7 +3422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-conflict.go-405",
+      "SPDXID": "SPDXRef-File-merge-conflict.go-298",
       "fileName": "repos/lazygit/pkg/gui/mergeconflicts/merge_conflict.go",
       "checksums": [
         {
@@ -4507,27 +3432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-expr.c-406",
-      "fileName": "repos/redis/src/../modules/vector-sets/expr.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9be54eb261c1d21f1de57bbe46830239a3111a35"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-siphash.c-407",
-      "fileName": "repos/redis/src/siphash.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9c3e6ce9e197c9234621dfff4ce64c93c67b57bd"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-types.go-408",
+      "SPDXID": "SPDXRef-File-types.go-299",
       "fileName": "repos/lazygit/pkg/integration/types/types.go",
       "checksums": [
         {
@@ -4537,27 +3442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-threads-mngr.h-409",
-      "fileName": "repos/redis/src/threads_mngr.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9c585c0bd1a0e3079e7db0898d4a66ac4a208c86"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rio.h-410",
-      "fileName": "repos/redis/src/rio.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9cd24cdab62f6c3f9306eb85da28d8593c17c9b8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-date.go-411",
+      "SPDXID": "SPDXRef-File-date.go-300",
       "fileName": "repos/lazygit/pkg/utils/date.go",
       "checksums": [
         {
@@ -4567,7 +3452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-prompt-controller.go-412",
+      "SPDXID": "SPDXRef-File-search-prompt-controller.go-301",
       "fileName": "repos/lazygit/pkg/gui/controllers/search_prompt_controller.go",
       "checksums": [
         {
@@ -4577,7 +3462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybindings.go-413",
+      "SPDXID": "SPDXRef-File-keybindings.go-302",
       "fileName": "repos/lazygit/pkg/gui/keybindings.go",
       "checksums": [
         {
@@ -4587,17 +3472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tls.c-414",
-      "fileName": "repos/redis/src/tls.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a0733a4b636a2be7ad3beb0f905dcb9b6d05b088"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-screen-mode-actions.go-415",
+      "SPDXID": "SPDXRef-File-screen-mode-actions.go-303",
       "fileName": "repos/lazygit/pkg/gui/controllers/screen_mode_actions.go",
       "checksums": [
         {
@@ -4607,27 +3482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mt19937-64.c-416",
-      "fileName": "repos/redis/src/mt19937-64.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a0c897ff6ddb0770df1949a46fd89d468f00c9b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sha256.h-417",
-      "fileName": "repos/redis/src/sha256.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a0d90a714f0df241c39358f326900c297ea0ad5f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-handler-creator.go-418",
+      "SPDXID": "SPDXRef-File-handler-creator.go-304",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/handler_creator.go",
       "checksums": [
         {
@@ -4637,7 +3492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-modes.go-419",
+      "SPDXID": "SPDXRef-File-modes.go-305",
       "fileName": "repos/lazygit/pkg/gui/types/modes.go",
       "checksums": [
         {
@@ -4647,7 +3502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-test-driver.go-420",
+      "SPDXID": "SPDXRef-File-test-driver.go-306",
       "fileName": "repos/lazygit/pkg/integration/components/test_driver.go",
       "checksums": [
         {
@@ -4657,17 +3512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-networking.c-421",
-      "fileName": "repos/redis/src/networking.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a18c6815333de1682676d837f7b0456522a549d0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-toggle-whitespace-action.go-422",
+      "SPDXID": "SPDXRef-File-toggle-whitespace-action.go-307",
       "fileName": "repos/lazygit/pkg/gui/controllers/toggle_whitespace_action.go",
       "checksums": [
         {
@@ -4677,7 +3522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context-lines-controller.go-423",
+      "SPDXID": "SPDXRef-File-context-lines-controller.go-308",
       "fileName": "repos/lazygit/pkg/gui/controllers/context_lines_controller.go",
       "checksums": [
         {
@@ -4687,7 +3532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stash-loader.go-424",
+      "SPDXID": "SPDXRef-File-stash-loader.go-309",
       "fileName": "repos/lazygit/pkg/commands/git_commands/stash_loader.go",
       "checksums": [
         {
@@ -4697,7 +3542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-snake-controller.go-425",
+      "SPDXID": "SPDXRef-File-snake-controller.go-310",
       "fileName": "repos/lazygit/pkg/gui/controllers/snake_controller.go",
       "checksums": [
         {
@@ -4707,17 +3552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zipmap.h-426",
-      "fileName": "repos/redis/src/zipmap.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a3e7aea34fc27632c6b588234d180850094bd117"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branch-loader.go-427",
+      "SPDXID": "SPDXRef-File-branch-loader.go-311",
       "fileName": "repos/lazygit/pkg/commands/git_commands/branch_loader.go",
       "checksums": [
         {
@@ -4727,17 +3562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tracking.c-428",
-      "fileName": "repos/redis/src/tracking.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a50b512326e0d7f739998b8a37f2cb8d45eab414"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branch.go-429",
+      "SPDXID": "SPDXRef-File-branch.go-312",
       "fileName": "repos/lazygit/pkg/commands/git_commands/branch.go",
       "checksums": [
         {
@@ -4747,27 +3572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cli-common.h-430",
-      "fileName": "repos/redis/src/cli_common.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a5b8e44a28cc1528dd27290e73355144f9459454"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sha1.h-431",
-      "fileName": "repos/redis/src/sha1.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a6cb6e885787bae370b4e03cc4fa6b20dee27274"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-thread-safe-map.go-432",
+      "SPDXID": "SPDXRef-File-thread-safe-map.go-313",
       "fileName": "repos/lazygit/pkg/utils/thread_safe_map.go",
       "checksums": [
         {
@@ -4777,7 +3582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-local-commits-context.go-433",
+      "SPDXID": "SPDXRef-File-local-commits-context.go-314",
       "fileName": "repos/lazygit/pkg/gui/context/local_commits_context.go",
       "checksums": [
         {
@@ -4787,7 +3592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-434",
+      "SPDXID": "SPDXRef-File-config.go-315",
       "fileName": "repos/lazygit/pkg/commands/git_commands/config.go",
       "checksums": [
         {
@@ -4797,7 +3602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diffing.go-435",
+      "SPDXID": "SPDXRef-File-diffing.go-316",
       "fileName": "repos/lazygit/pkg/gui/modes/diffing/diffing.go",
       "checksums": [
         {
@@ -4807,7 +3612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config-linux.go-436",
+      "SPDXID": "SPDXRef-File-config-linux.go-317",
       "fileName": "repos/lazygit/pkg/config/config_linux.go",
       "checksums": [
         {
@@ -4817,7 +3622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version.go-437",
+      "SPDXID": "SPDXRef-File-version.go-318",
       "fileName": "repos/lazygit/pkg/commands/git_commands/version.go",
       "checksums": [
         {
@@ -4827,7 +3632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blame.go-438",
+      "SPDXID": "SPDXRef-File-blame.go-319",
       "fileName": "repos/lazygit/pkg/commands/git_commands/blame.go",
       "checksums": [
         {
@@ -4837,7 +3642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-theme.go-439",
+      "SPDXID": "SPDXRef-File-theme.go-320",
       "fileName": "repos/lazygit/pkg/theme/theme.go",
       "checksums": [
         {
@@ -4847,7 +3652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filtering.go-440",
+      "SPDXID": "SPDXRef-File-filtering.go-321",
       "fileName": "repos/lazygit/pkg/gui/modes/filtering/filtering.go",
       "checksums": [
         {
@@ -4857,7 +3662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-marked-base-commit.go-441",
+      "SPDXID": "SPDXRef-File-marked-base-commit.go-322",
       "fileName": "repos/lazygit/pkg/gui/modes/marked_base_commit/marked_base_commit.go",
       "checksums": [
         {
@@ -4867,7 +3672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-number.go-442",
+      "SPDXID": "SPDXRef-File-version-number.go-323",
       "fileName": "repos/lazygit/pkg/gui/types/version_number.go",
       "checksums": [
         {
@@ -4877,17 +3682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-testhelp.h-443",
-      "fileName": "repos/redis/src/testhelp.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aeae372dd6c16e66813bc4779535231c411e67a8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-once-writer.go-444",
+      "SPDXID": "SPDXRef-File-once-writer.go-324",
       "fileName": "repos/lazygit/pkg/utils/once_writer.go",
       "checksums": [
         {
@@ -4897,7 +3692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-state.go-445",
+      "SPDXID": "SPDXRef-File-search-state.go-325",
       "fileName": "repos/lazygit/pkg/gui/types/search_state.go",
       "checksums": [
         {
@@ -4907,7 +3702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gpg-helper.go-446",
+      "SPDXID": "SPDXRef-File-gpg-helper.go-326",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/gpg_helper.go",
       "checksums": [
         {
@@ -4917,7 +3712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-format.go-447",
+      "SPDXID": "SPDXRef-File-format.go-327",
       "fileName": "repos/lazygit/pkg/commands/patch/format.go",
       "checksums": [
         {
@@ -4927,7 +3722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-menu-panel.go-448",
+      "SPDXID": "SPDXRef-File-menu-panel.go-328",
       "fileName": "repos/lazygit/pkg/gui/menu_panel.go",
       "checksums": [
         {
@@ -4937,7 +3732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tail.go-449",
+      "SPDXID": "SPDXRef-File-tail.go-329",
       "fileName": "repos/lazygit/pkg/logs/tail/tail.go",
       "checksums": [
         {
@@ -4947,7 +3742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-session-state-loader.go-450",
+      "SPDXID": "SPDXRef-File-session-state-loader.go-330",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/session_state_loader.go",
       "checksums": [
         {
@@ -4957,17 +3752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ebuckets.c-451",
-      "fileName": "repos/redis/src/ebuckets.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b2c955b3f4964f53923472e4bdc392e074ee7a0a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-worktrees.go-452",
+      "SPDXID": "SPDXRef-File-worktrees.go-331",
       "fileName": "repos/lazygit/pkg/gui/presentation/worktrees.go",
       "checksums": [
         {
@@ -4977,17 +3762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zmalloc.c-453",
-      "fileName": "repos/redis/src/zmalloc.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b2f57184fbf9d5a25671621cd872bdbe24f10908"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-item-operations.go-454",
+      "SPDXID": "SPDXRef-File-item-operations.go-332",
       "fileName": "repos/lazygit/pkg/gui/presentation/item_operations.go",
       "checksums": [
         {
@@ -4997,27 +3772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-monotonic.h-455",
-      "fileName": "repos/redis/src/monotonic.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b465f90b10937f11a1e625c5e65de35519017af8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.h-456",
-      "fileName": "repos/redis/src/dict.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b4bf581b90fa1c4f87014434271b32058fe66cba"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-decoration.go-457",
+      "SPDXID": "SPDXRef-File-decoration.go-333",
       "fileName": "repos/lazygit/pkg/gui/style/decoration.go",
       "checksums": [
         {
@@ -5027,7 +3782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-status.go-458",
+      "SPDXID": "SPDXRef-File-status.go-334",
       "fileName": "repos/lazygit/pkg/gui/presentation/status.go",
       "checksums": [
         {
@@ -5037,7 +3792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflog-commits.go-459",
+      "SPDXID": "SPDXRef-File-reflog-commits.go-335",
       "fileName": "repos/lazygit/pkg/gui/presentation/reflog_commits.go",
       "checksums": [
         {
@@ -5047,7 +3802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktrees-controller.go-460",
+      "SPDXID": "SPDXRef-File-worktrees-controller.go-336",
       "fileName": "repos/lazygit/pkg/gui/controllers/worktrees_controller.go",
       "checksums": [
         {
@@ -5057,7 +3812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vertical-scroll-controller.go-461",
+      "SPDXID": "SPDXRef-File-vertical-scroll-controller.go-337",
       "fileName": "repos/lazygit/pkg/gui/controllers/vertical_scroll_controller.go",
       "checksums": [
         {
@@ -5067,7 +3822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-paths.go-462",
+      "SPDXID": "SPDXRef-File-paths.go-338",
       "fileName": "repos/lazygit/pkg/integration/components/paths.go",
       "checksums": [
         {
@@ -5077,7 +3832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-helpers.go-463",
+      "SPDXID": "SPDXRef-File-view-helpers.go-339",
       "fileName": "repos/lazygit/pkg/gui/view_helpers.go",
       "checksums": [
         {
@@ -5087,7 +3842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmd-obj-runner.go-464",
+      "SPDXID": "SPDXRef-File-cmd-obj-runner.go-340",
       "fileName": "repos/lazygit/pkg/commands/oscommands/cmd_obj_runner.go",
       "checksums": [
         {
@@ -5097,37 +3852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mt19937-64.h-465",
-      "fileName": "repos/redis/src/mt19937-64.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b98348fd4ffa24859c144b5973961592cde6f699"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-geohash-helper.c-466",
-      "fileName": "repos/redis/src/geohash_helper.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ba3732689214507ef25cec84690848d8e3eca70b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-util.c-467",
-      "fileName": "repos/redis/src/util.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ba3d9d072d6e43fe1a87fd2afceb7fd333cf8bd6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-views.go-468",
+      "SPDXID": "SPDXRef-File-views.go-341",
       "fileName": "repos/lazygit/pkg/gui/views.go",
       "checksums": [
         {
@@ -5137,7 +3862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-recent-repos-panel.go-469",
+      "SPDXID": "SPDXRef-File-recent-repos-panel.go-342",
       "fileName": "repos/lazygit/pkg/gui/recent_repos_panel.go",
       "checksums": [
         {
@@ -5147,17 +3872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mstr.h-470",
-      "fileName": "repos/redis/src/mstr.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bb8f9c1cfdbb316b7b5835941d655772b8124e94"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-keynames.go-471",
+      "SPDXID": "SPDXRef-File-keynames.go-343",
       "fileName": "repos/lazygit/pkg/config/keynames.go",
       "checksums": [
         {
@@ -5167,27 +3882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redis-cli.c-472",
-      "fileName": "repos/redis/src/redis-cli.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bbaabca52bac60ac00d7aca838a8c4da7b6e745e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-zmalloc.h-473",
-      "fileName": "repos/redis/src/zmalloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bbb74a0deb1f49bf3aeb95360c6ab5a71ccbd558"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tag-loader.go-474",
+      "SPDXID": "SPDXRef-File-tag-loader.go-344",
       "fileName": "repos/lazygit/pkg/commands/git_commands/tag_loader.go",
       "checksums": [
         {
@@ -5197,17 +3892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rio.c-475",
-      "fileName": "repos/redis/src/rio.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bdab6d8c9c6b0a24f8de38a9b03b77d2c6423972"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cell.go-476",
+      "SPDXID": "SPDXRef-File-cell.go-345",
       "fileName": "repos/lazygit/pkg/gui/presentation/graph/cell.go",
       "checksums": [
         {
@@ -5217,17 +3902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pubsub.c-477",
-      "fileName": "repos/redis/src/pubsub.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "be82ced35660dacd980c4a34074b7ccd46683da3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-basic-commits-controller.go-478",
+      "SPDXID": "SPDXRef-File-basic-commits-controller.go-346",
       "fileName": "repos/lazygit/pkg/gui/controllers/basic_commits_controller.go",
       "checksums": [
         {
@@ -5237,7 +3912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file-node.go-479",
+      "SPDXID": "SPDXRef-File-commit-file-node.go-347",
       "fileName": "repos/lazygit/pkg/gui/filetree/commit_file_node.go",
       "checksums": [
         {
@@ -5247,7 +3922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file-tree.go-480",
+      "SPDXID": "SPDXRef-File-commit-file-tree.go-348",
       "fileName": "repos/lazygit/pkg/gui/filetree/commit_file_tree.go",
       "checksums": [
         {
@@ -5257,37 +3932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sentinel.c-481",
-      "fileName": "repos/redis/src/sentinel.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bf749e9b4c19595e4ed65a4ea976f20bf684a361"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-crc64.c-482",
-      "fileName": "repos/redis/src/crc64.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c00ead4830b84b73570a21f64a8c2e1fdaf0c75a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rdb.c-483",
-      "fileName": "repos/redis/src/rdb.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c09cd14bc3e1c6b274fb0372aea3bf72901c9a21"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-jump-to-side-window-controller.go-484",
+      "SPDXID": "SPDXRef-File-jump-to-side-window-controller.go-349",
       "fileName": "repos/lazygit/pkg/gui/controllers/jump_to_side_window_controller.go",
       "checksums": [
         {
@@ -5297,7 +3942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodules-controller.go-485",
+      "SPDXID": "SPDXRef-File-submodules-controller.go-350",
       "fileName": "repos/lazygit/pkg/gui/controllers/submodules_controller.go",
       "checksums": [
         {
@@ -5307,7 +3952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-prompt-context.go-486",
+      "SPDXID": "SPDXRef-File-prompt-context.go-351",
       "fileName": "repos/lazygit/pkg/gui/context/prompt_context.go",
       "checksums": [
         {
@@ -5317,7 +3962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-refresh.go-487",
+      "SPDXID": "SPDXRef-File-refresh.go-352",
       "fileName": "repos/lazygit/pkg/gui/types/refresh.go",
       "checksums": [
         {
@@ -5327,17 +3972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crcspeed.h-488",
-      "fileName": "repos/redis/src/crcspeed.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c29f236bc0fc01425c02fd3534f4a47b669c47f7"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-string-stack.go-489",
+      "SPDXID": "SPDXRef-File-string-stack.go-353",
       "fileName": "repos/lazygit/pkg/utils/string_stack.go",
       "checksums": [
         {
@@ -5347,7 +3982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file-tree-view-model.go-490",
+      "SPDXID": "SPDXRef-File-commit-file-tree-view-model.go-354",
       "fileName": "repos/lazygit/pkg/gui/filetree/commit_file_tree_view_model.go",
       "checksums": [
         {
@@ -5357,27 +3992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lazyfree.c-491",
-      "fileName": "repos/redis/src/lazyfree.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c33bc923e75e3ade525edbce5f80bc48e9c87b0c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-t-zset.c-492",
-      "fileName": "repos/redis/src/t_zset.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c415fdb3c7628cefe4ee1ec8fc54fb86cfb94f2d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-bisect-info.go-493",
+      "SPDXID": "SPDXRef-File-bisect-info.go-355",
       "fileName": "repos/lazygit/pkg/commands/git_commands/bisect_info.go",
       "checksums": [
         {
@@ -5387,7 +4002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stash-entries.go-494",
+      "SPDXID": "SPDXRef-File-stash-entries.go-356",
       "fileName": "repos/lazygit/pkg/gui/presentation/stash_entries.go",
       "checksums": [
         {
@@ -5397,27 +4012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-quicklist.h-495",
-      "fileName": "repos/redis/src/quicklist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c4b07e0c009c88a3820dc4b7c45d8160fd58c6e3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sds.h-496",
-      "fileName": "repos/redis/src/sds.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c4cbf6bf5babd3b0a9beb1f0525e1b454f6a35f1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-find-conflicts.go-497",
+      "SPDXID": "SPDXRef-File-find-conflicts.go-357",
       "fileName": "repos/lazygit/pkg/gui/mergeconflicts/find_conflicts.go",
       "checksums": [
         {
@@ -5427,7 +4022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-custom.go-498",
+      "SPDXID": "SPDXRef-File-custom.go-358",
       "fileName": "repos/lazygit/pkg/commands/git_commands/custom.go",
       "checksums": [
         {
@@ -5437,7 +4032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-repo-paths.go-499",
+      "SPDXID": "SPDXRef-File-repo-paths.go-359",
       "fileName": "repos/lazygit/pkg/commands/git_commands/repo_paths.go",
       "checksums": [
         {
@@ -5447,7 +4042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dummies.go-500",
+      "SPDXID": "SPDXRef-File-dummies.go-360",
       "fileName": "repos/lazygit/pkg/common/dummies.go",
       "checksums": [
         {
@@ -5457,37 +4052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connection.h-501",
-      "fileName": "repos/redis/src/connection.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c6de005c8b31947b7b059e0dc1a6f5a003ea0ed4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-t-list.c-502",
-      "fileName": "repos/redis/src/t_list.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c6fb1e76b5597df904d5167125550286603a7e9d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-crcspeed.c-503",
-      "fileName": "repos/redis/src/crcspeed.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c7073cba2f82b9b184703d533a55f6690541cfe0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branches-controller.go-504",
+      "SPDXID": "SPDXRef-File-branches-controller.go-361",
       "fileName": "repos/lazygit/pkg/gui/controllers/branches_controller.go",
       "checksums": [
         {
@@ -5497,7 +4062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodules.go-505",
+      "SPDXID": "SPDXRef-File-submodules.go-362",
       "fileName": "repos/lazygit/pkg/gui/presentation/submodules.go",
       "checksums": [
         {
@@ -5507,17 +4072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.c-506",
-      "fileName": "repos/redis/src/multi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c8082c2974b1372d97fdd33efdd8136405732c4c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tags-controller.go-507",
+      "SPDXID": "SPDXRef-File-tags-controller.go-363",
       "fileName": "repos/lazygit/pkg/gui/controllers/tags_controller.go",
       "checksums": [
         {
@@ -5527,7 +4082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-helper.go-508",
+      "SPDXID": "SPDXRef-File-view-helper.go-364",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/view_helper.go",
       "checksums": [
         {
@@ -5537,17 +4092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-atomicvar.h-509",
-      "fileName": "repos/redis/src/atomicvar.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c9093470a8156541e9056e4480810555c42cbdb2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-search.go-510",
+      "SPDXID": "SPDXRef-File-search.go-365",
       "fileName": "repos/lazygit/pkg/utils/search.go",
       "checksums": [
         {
@@ -5557,37 +4102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-debugmacro.h-511",
-      "fileName": "repos/redis/src/debugmacro.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c977381fc4affa790561a1207ae7e6400f11c003"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hnsw.c-512",
-      "fileName": "repos/redis/src/../modules/vector-sets/hnsw.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "cae43e305b5a0a0b7c6f474e29740a5b8fa6eeb2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-acl.c-513",
-      "fileName": "repos/redis/src/acl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "caf099c8d2d5169c80b07ddb1aa2fd43b810cedd"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-stash-entry.go-514",
+      "SPDXID": "SPDXRef-File-stash-entry.go-366",
       "fileName": "repos/lazygit/pkg/commands/models/stash_entry.go",
       "checksums": [
         {
@@ -5597,7 +4112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file-filter.go-515",
+      "SPDXID": "SPDXRef-File-file-filter.go-367",
       "fileName": "repos/lazygit/pkg/gui/filetree/file_filter.go",
       "checksums": [
         {
@@ -5607,27 +4122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-geo.c-516",
-      "fileName": "repos/redis/src/geo.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "cbb96cc25957d661901be88fe80260da65b83fd6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-util.h-517",
-      "fileName": "repos/redis/src/util.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "cbc63ea6c5e3704e1684a6c4806dadd7a83a72bb"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-files.go-518",
+      "SPDXID": "SPDXRef-File-files.go-368",
       "fileName": "repos/lazygit/pkg/gui/presentation/files.go",
       "checksums": [
         {
@@ -5637,17 +4132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-setproctitle.c-519",
-      "fileName": "repos/redis/src/setproctitle.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "cc31845ef0656a01ac50e9a0dd30e94431e58266"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-suspend-resume-helper.go-520",
+      "SPDXID": "SPDXRef-File-suspend-resume-helper.go-369",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/suspend_resume_helper.go",
       "checksums": [
         {
@@ -5657,7 +4142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-521",
+      "SPDXID": "SPDXRef-File-errors.go-370",
       "fileName": "repos/lazygit/pkg/utils/errors.go",
       "checksums": [
         {
@@ -5667,7 +4152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-undo-controller.go-522",
+      "SPDXID": "SPDXRef-File-undo-controller.go-371",
       "fileName": "repos/lazygit/pkg/gui/controllers/undo_controller.go",
       "checksums": [
         {
@@ -5677,7 +4162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-switch-to-diff-files-controller.go-523",
+      "SPDXID": "SPDXRef-File-switch-to-diff-files-controller.go-372",
       "fileName": "repos/lazygit/pkg/gui/controllers/switch_to_diff_files_controller.go",
       "checksums": [
         {
@@ -5687,7 +4172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filtered-list-view-model.go-524",
+      "SPDXID": "SPDXRef-File-filtered-list-view-model.go-373",
       "fileName": "repos/lazygit/pkg/gui/context/filtered_list_view_model.go",
       "checksums": [
         {
@@ -5697,17 +4182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ebuckets.h-525",
-      "fileName": "repos/redis/src/ebuckets.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ce5bbb2bdd1b7a9473c804c7e9a110c14cf83ff4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-focus.go-526",
+      "SPDXID": "SPDXRef-File-focus.go-374",
       "fileName": "repos/lazygit/pkg/gui/patch_exploring/focus.go",
       "checksums": [
         {
@@ -5717,7 +4192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git-flow-controller.go-527",
+      "SPDXID": "SPDXRef-File-git-flow-controller.go-375",
       "fileName": "repos/lazygit/pkg/gui/controllers/git_flow_controller.go",
       "checksums": [
         {
@@ -5727,7 +4202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote.go-528",
+      "SPDXID": "SPDXRef-File-remote.go-376",
       "fileName": "repos/lazygit/pkg/commands/git_commands/remote.go",
       "checksums": [
         {
@@ -5737,7 +4212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-matcher.go-529",
+      "SPDXID": "SPDXRef-File-matcher.go-377",
       "fileName": "repos/lazygit/pkg/integration/components/matcher.go",
       "checksums": [
         {
@@ -5747,27 +4222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fmacros.h-530",
-      "fileName": "repos/redis/src/fmacros.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d05230dcae1ab88d4db8e85449920babec708424"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cluster-legacy.h-531",
-      "fileName": "repos/redis/src/cluster_legacy.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0cb89d5c96f0e42cfa9dba723502a77b26728a8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-resolver.go-532",
+      "SPDXID": "SPDXRef-File-resolver.go-378",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/resolver.go",
       "checksums": [
         {
@@ -5777,7 +4232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-trait.go-533",
+      "SPDXID": "SPDXRef-File-view-trait.go-379",
       "fileName": "repos/lazygit/pkg/gui/context/view_trait.go",
       "checksums": [
         {
@@ -5787,7 +4242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bisect.go-534",
+      "SPDXID": "SPDXRef-File-bisect.go-380",
       "fileName": "repos/lazygit/pkg/commands/git_commands/bisect.go",
       "checksums": [
         {
@@ -5797,7 +4252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-command-log-panel.go-535",
+      "SPDXID": "SPDXRef-File-command-log-panel.go-381",
       "fileName": "repos/lazygit/pkg/gui/command_log_panel.go",
       "checksums": [
         {
@@ -5807,7 +4262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-refs-helper.go-536",
+      "SPDXID": "SPDXRef-File-refs-helper.go-382",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/refs_helper.go",
       "checksums": [
         {
@@ -5817,7 +4272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-message-context.go-537",
+      "SPDXID": "SPDXRef-File-commit-message-context.go-383",
       "fileName": "repos/lazygit/pkg/gui/context/commit_message_context.go",
       "checksums": [
         {
@@ -5827,17 +4282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iothread.c-538",
-      "fileName": "repos/redis/src/iothread.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d643905d6b507658cd37330fc70907acb654d5da"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sync.go-539",
+      "SPDXID": "SPDXRef-File-sync.go-384",
       "fileName": "repos/lazygit/pkg/commands/git_commands/sync.go",
       "checksums": [
         {
@@ -5847,7 +4292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-branches-context.go-540",
+      "SPDXID": "SPDXRef-File-branches-context.go-385",
       "fileName": "repos/lazygit/pkg/gui/context/branches_context.go",
       "checksums": [
         {
@@ -5857,27 +4302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mixer.h-541",
-      "fileName": "repos/redis/src/../modules/vector-sets/mixer.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d75e193f3dcc7d5cc02d0550b6f5ddad04f30d3a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-anet.c-542",
-      "fileName": "repos/redis/src/anet.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d79434cef03463649d167eacccc32d82abf7e5b8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-main.go-543",
+      "SPDXID": "SPDXRef-File-main.go-386",
       "fileName": "repos/lazygit/main.go",
       "checksums": [
         {
@@ -5887,7 +4312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-working-tree-context.go-544",
+      "SPDXID": "SPDXRef-File-working-tree-context.go-387",
       "fileName": "repos/lazygit/pkg/gui/context/working_tree_context.go",
       "checksums": [
         {
@@ -5897,7 +4322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-popup-handler.go-545",
+      "SPDXID": "SPDXRef-File-popup-handler.go-388",
       "fileName": "repos/lazygit/pkg/gui/popup/popup_handler.go",
       "checksums": [
         {
@@ -5907,17 +4332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-t-set.c-546",
-      "fileName": "repos/redis/src/t_set.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d91edcd1e8c758b567472fa5c7d0e703c41a53b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-gui-common.go-547",
+      "SPDXID": "SPDXRef-File-gui-common.go-389",
       "fileName": "repos/lazygit/pkg/gui/gui_common.go",
       "checksums": [
         {
@@ -5927,27 +4342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc16.c-548",
-      "fileName": "repos/redis/src/crc16.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d9e4f3f499706c4d12096b035504f19aa7674cff"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-t-stream.c-549",
-      "fileName": "repos/redis/src/t_stream.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "dae1ce372c8373f90d2d882c96d1f5ccc3e8c1d4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch-builder.go-550",
+      "SPDXID": "SPDXRef-File-patch-builder.go-390",
       "fileName": "repos/lazygit/pkg/commands/patch/patch_builder.go",
       "checksums": [
         {
@@ -5957,7 +4352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-conflicts-controller.go-551",
+      "SPDXID": "SPDXRef-File-merge-conflicts-controller.go-391",
       "fileName": "repos/lazygit/pkg/gui/controllers/merge_conflicts_controller.go",
       "checksums": [
         {
@@ -5967,7 +4362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-suggestions-helper.go-552",
+      "SPDXID": "SPDXRef-File-suggestions-helper.go-392",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/suggestions_helper.go",
       "checksums": [
         {
@@ -5977,7 +4372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-daemon.go-553",
+      "SPDXID": "SPDXRef-File-daemon.go-393",
       "fileName": "repos/lazygit/pkg/app/daemon/daemon.go",
       "checksums": [
         {
@@ -5987,17 +4382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-notify.c-554",
-      "fileName": "repos/redis/src/notify.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "df5435a087b303a3770c56b8a09eb54f18057a25"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fixup-helper.go-555",
+      "SPDXID": "SPDXRef-File-fixup-helper.go-394",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/fixup_helper.go",
       "checksums": [
         {
@@ -6007,27 +4392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redis-check-rdb.c-556",
-      "fileName": "repos/redis/src/redis-check-rdb.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e070fad9a052b59d25dbf31e581a4fae5e34edc3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-crc64.h-557",
-      "fileName": "repos/redis/src/crc64.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e0fccd98bbd657ec23af68489b8ed9510dc59a71"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-background.go-558",
+      "SPDXID": "SPDXRef-File-background.go-395",
       "fileName": "repos/lazygit/pkg/gui/background.go",
       "checksums": [
         {
@@ -6037,7 +4402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remotes-controller.go-559",
+      "SPDXID": "SPDXRef-File-remotes-controller.go-396",
       "fileName": "repos/lazygit/pkg/gui/controllers/remotes_controller.go",
       "checksums": [
         {
@@ -6047,7 +4412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-collapsed-paths.go-560",
+      "SPDXID": "SPDXRef-File-collapsed-paths.go-397",
       "fileName": "repos/lazygit/pkg/gui/filetree/collapsed_paths.go",
       "checksums": [
         {
@@ -6057,37 +4422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-kvstore.h-561",
-      "fileName": "repos/redis/src/kvstore.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e2431a94e5356e6063ae9ebed0eb38e35cc7eab2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-unix.c-562",
-      "fileName": "repos/redis/src/unix.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e26f0d27ad129112f909f87ede6cc60439905e0b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-eventnotifier.h-563",
-      "fileName": "repos/redis/src/eventnotifier.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e2ae907380042a788836e6c650405ba8ce0907e9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-window-helper.go-564",
+      "SPDXID": "SPDXRef-File-window-helper.go-398",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/window_helper.go",
       "checksums": [
         {
@@ -6097,7 +4432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mode-helper.go-565",
+      "SPDXID": "SPDXRef-File-mode-helper.go-399",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/mode_helper.go",
       "checksums": [
         {
@@ -6107,7 +4442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.go-566",
+      "SPDXID": "SPDXRef-File-file.go-400",
       "fileName": "repos/lazygit/pkg/commands/models/file.go",
       "checksums": [
         {
@@ -6117,37 +4452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redisassert.c-567",
-      "fileName": "repos/redis/src/redisassert.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e4918f2894aabe8711720df257b7513b59e5b4f4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fmtargs.h-568",
-      "fileName": "repos/redis/src/fmtargs.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e52d3b99c5034cb102f397c841092041ec5ee308"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cli-commands.c-569",
-      "fileName": "repos/redis/src/cli_commands.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e56d48cfaebe55f846bb210afe96fb8ef7c017a7"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rendering.go-570",
+      "SPDXID": "SPDXRef-File-rendering.go-401",
       "fileName": "repos/lazygit/pkg/gui/mergeconflicts/rendering.go",
       "checksums": [
         {
@@ -6157,7 +4462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tags.go-571",
+      "SPDXID": "SPDXRef-File-tags.go-402",
       "fileName": "repos/lazygit/pkg/gui/presentation/tags.go",
       "checksums": [
         {
@@ -6167,7 +4472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options-menu-action.go-572",
+      "SPDXID": "SPDXRef-File-options-menu-action.go-403",
       "fileName": "repos/lazygit/pkg/gui/controllers/options_menu_action.go",
       "checksums": [
         {
@@ -6177,17 +4482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-script-lua.c-573",
-      "fileName": "repos/redis/src/script_lua.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e71312a4eb353e94f7a59672f79ae02a877c61f5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-pager-config.go-574",
+      "SPDXID": "SPDXRef-File-pager-config.go-404",
       "fileName": "repos/lazygit/pkg/config/pager_config.go",
       "checksums": [
         {
@@ -6197,7 +4492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-models.go-575",
+      "SPDXID": "SPDXRef-File-models.go-405",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/models.go",
       "checksums": [
         {
@@ -6207,7 +4502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-env.go-576",
+      "SPDXID": "SPDXRef-File-env.go-406",
       "fileName": "repos/lazygit/pkg/integration/components/env.go",
       "checksums": [
         {
@@ -6217,7 +4512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filtered-list.go-577",
+      "SPDXID": "SPDXRef-File-filtered-list.go-407",
       "fileName": "repos/lazygit/pkg/gui/context/filtered_list.go",
       "checksums": [
         {
@@ -6227,7 +4522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-git-config.go-578",
+      "SPDXID": "SPDXRef-File-fake-git-config.go-408",
       "fileName": "repos/lazygit/pkg/commands/git_config/fake_git_config.go",
       "checksums": [
         {
@@ -6237,7 +4532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-renderer.go-579",
+      "SPDXID": "SPDXRef-File-list-renderer.go-409",
       "fileName": "repos/lazygit/pkg/gui/context/list_renderer.go",
       "checksums": [
         {
@@ -6247,37 +4542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut6.c-580",
-      "fileName": "repos/redis/src/lolwut6.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e88be3b10b81ccf3bcadede81fe1d0abdca8e621"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-listpack-malloc.h-581",
-      "fileName": "repos/redis/src/listpack_malloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e9040544e22785ccc067cd1b7317f0203f864041"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-localtime.c-582",
-      "fileName": "repos/redis/src/localtime.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e95eb69116c837dd1226b573a1fdf9977837f0e0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-links.go-583",
+      "SPDXID": "SPDXRef-File-links.go-410",
       "fileName": "repos/lazygit/pkg/constants/links.go",
       "checksums": [
         {
@@ -6287,17 +4552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-geohash.c-584",
-      "fileName": "repos/redis/src/geohash.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e9f0c654dd6528043edc5d15297829bcd7795109"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-commit-message-controller.go-585",
+      "SPDXID": "SPDXRef-File-commit-message-controller.go-411",
       "fileName": "repos/lazygit/pkg/gui/controllers/commit_message_controller.go",
       "checksums": [
         {
@@ -6307,7 +4562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-driver.go-586",
+      "SPDXID": "SPDXRef-File-view-driver.go-412",
       "fileName": "repos/lazygit/pkg/integration/components/view_driver.go",
       "checksums": [
         {
@@ -6317,47 +4572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-resp-parser.h-587",
-      "fileName": "repos/redis/src/resp_parser.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eaf1e323ecf508749f3ab3b5184428fb78db1ab1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slowlog.c-588",
-      "fileName": "repos/redis/src/slowlog.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eaf88cc33fcf5e7ab27ce276822008079b4928e2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-script.c-589",
-      "fileName": "repos/redis/src/script.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eb45978f8fafde7af51440f13bae05b79e24d112"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cli-commands.h-590",
-      "fileName": "repos/redis/src/cli_commands.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eb5a476e38e8d9607e92953ccd22c88c1d6c0042"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-scroll-off-margin.go-591",
+      "SPDXID": "SPDXRef-File-scroll-off-margin.go-413",
       "fileName": "repos/lazygit/pkg/gui/controllers/scroll_off_margin.go",
       "checksums": [
         {
@@ -6367,7 +4582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-author.go-592",
+      "SPDXID": "SPDXRef-File-author.go-414",
       "fileName": "repos/lazygit/pkg/commands/models/author.go",
       "checksums": [
         {
@@ -6377,7 +4592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynamic-title-builder.go-593",
+      "SPDXID": "SPDXRef-File-dynamic-title-builder.go-415",
       "fileName": "repos/lazygit/pkg/gui/context/dynamic_title_builder.go",
       "checksums": [
         {
@@ -6387,37 +4602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-listpack.c-594",
-      "fileName": "repos/redis/src/listpack.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eef83092da44e372dc933cb774eaf876e328e590"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-kvstore.c-595",
-      "fileName": "repos/redis/src/kvstore.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ef29bd4d0996805e491d4908793ac3cb8cdf2fbb"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ziplist.h-596",
-      "fileName": "repos/redis/src/ziplist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ef38e73aa95db4d2c182843fc339c965f5da3b92"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-test-mode.go-597",
+      "SPDXID": "SPDXRef-File-test-mode.go-416",
       "fileName": "repos/lazygit/pkg/gui/test_mode.go",
       "checksums": [
         {
@@ -6427,7 +4612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-formatting.go-598",
+      "SPDXID": "SPDXRef-File-formatting.go-417",
       "fileName": "repos/lazygit/pkg/utils/formatting.go",
       "checksums": [
         {
@@ -6437,7 +4622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodule.go-599",
+      "SPDXID": "SPDXRef-File-submodule.go-418",
       "fileName": "repos/lazygit/pkg/commands/git_commands/submodule.go",
       "checksums": [
         {
@@ -6447,7 +4632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os.go-600",
+      "SPDXID": "SPDXRef-File-os.go-419",
       "fileName": "repos/lazygit/pkg/commands/oscommands/os.go",
       "checksums": [
         {
@@ -6457,7 +4642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-alert-driver.go-601",
+      "SPDXID": "SPDXRef-File-alert-driver.go-420",
       "fileName": "repos/lazygit/pkg/integration/components/alert_driver.go",
       "checksums": [
         {
@@ -6467,7 +4652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-loading-shared.go-602",
+      "SPDXID": "SPDXRef-File-commit-loading-shared.go-421",
       "fileName": "repos/lazygit/pkg/commands/git_commands/commit_loading_shared.go",
       "checksums": [
         {
@@ -6477,17 +4662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc16-slottable.h-603",
-      "fileName": "repos/redis/src/crc16_slottable.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f25e2412e891a073c8f447b28d1f16822f65d2a2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-simple-context.go-604",
+      "SPDXID": "SPDXRef-File-simple-context.go-422",
       "fileName": "repos/lazygit/pkg/gui/context/simple_context.go",
       "checksums": [
         {
@@ -6497,27 +4672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hyperloglog.c-605",
-      "fileName": "repos/redis/src/hyperloglog.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f52df29e25e6fc512d2b59d8f2fd9ba3aaf7dc79"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-config.c-606",
-      "fileName": "repos/redis/src/config.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f5c885ed257beae34aebb61fb093b7ab3b441b61"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-template.go-607",
+      "SPDXID": "SPDXRef-File-template.go-423",
       "fileName": "repos/lazygit/pkg/utils/template.go",
       "checksums": [
         {
@@ -6527,7 +4682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-staging-controller.go-608",
+      "SPDXID": "SPDXRef-File-staging-controller.go-424",
       "fileName": "repos/lazygit/pkg/gui/controllers/staging_controller.go",
       "checksums": [
         {
@@ -6537,47 +4692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strl.c-609",
-      "fileName": "repos/redis/src/strl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f73cf796c22f547f46c422237f045832d3c6e306"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-memtest.c-610",
-      "fileName": "repos/redis/src/memtest.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f75d6b21ced2157784e4197d95e5414b0becfac4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-endianconv.h-611",
-      "fileName": "repos/redis/src/endianconv.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f7cc91eca12863deda28bff7d875168ab621dda9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-redis-check-aof.c-612",
-      "fileName": "repos/redis/src/redis-check-aof.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f7cdbbc69aec9b3c402d5d7fa8d4e7a40a2b9a3d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-commit-files-context.go-613",
+      "SPDXID": "SPDXRef-File-commit-files-context.go-425",
       "fileName": "repos/lazygit/pkg/gui/context/commit_files_context.go",
       "checksums": [
         {
@@ -6587,7 +4702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-history-trait.go-614",
+      "SPDXID": "SPDXRef-File-history-trait.go-426",
       "fileName": "repos/lazygit/pkg/gui/context/history_trait.go",
       "checksums": [
         {
@@ -6597,7 +4712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yaml-utils.go-615",
+      "SPDXID": "SPDXRef-File-yaml-utils.go-427",
       "fileName": "repos/lazygit/pkg/utils/yaml_utils/yaml_utils.go",
       "checksums": [
         {
@@ -6607,17 +4722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version.h-616",
-      "fileName": "repos/redis/src/version.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f9e61ca71ab0118af1b0029270d701575eb60e6a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-custom-patch-options-menu-action.go-617",
+      "SPDXID": "SPDXRef-File-custom-patch-options-menu-action.go-428",
       "fileName": "repos/lazygit/pkg/gui/controllers/custom_patch_options_menu_action.go",
       "checksums": [
         {
@@ -6627,7 +4732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main-view-controller.go-618",
+      "SPDXID": "SPDXRef-File-main-view-controller.go-429",
       "fileName": "repos/lazygit/pkg/gui/controllers/main_view_controller.go",
       "checksums": [
         {
@@ -6637,7 +4742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-flow.go-619",
+      "SPDXID": "SPDXRef-File-flow.go-430",
       "fileName": "repos/lazygit/pkg/commands/git_commands/flow.go",
       "checksums": [
         {
@@ -6647,27 +4752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syncio.c-620",
-      "fileName": "repos/redis/src/syncio.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fc1f553b861e17655a469d3aeec1fb2e702437a4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-defrag.c-621",
-      "fileName": "repos/redis/src/defrag.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fc451e0b9656c2a48e44539a69032268cccdd8cc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch-building-helper.go-622",
+      "SPDXID": "SPDXRef-File-patch-building-helper.go-431",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/patch_building_helper.go",
       "checksums": [
         {
@@ -6677,7 +4762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git-cmd-obj-runner.go-623",
+      "SPDXID": "SPDXRef-File-git-cmd-obj-runner.go-432",
       "fileName": "repos/lazygit/pkg/commands/git_cmd_obj_runner.go",
       "checksums": [
         {
@@ -6687,7 +4772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch-explorer-controller.go-624",
+      "SPDXID": "SPDXRef-File-patch-explorer-controller.go-433",
       "fileName": "repos/lazygit/pkg/gui/controllers/patch_explorer_controller.go",
       "checksums": [
         {
@@ -6697,7 +4782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rebase.go-625",
+      "SPDXID": "SPDXRef-File-rebase.go-434",
       "fileName": "repos/lazygit/pkg/app/daemon/rebase.go",
       "checksums": [
         {
@@ -6707,7 +4792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmd-obj-builder.go-626",
+      "SPDXID": "SPDXRef-File-cmd-obj-builder.go-435",
       "fileName": "repos/lazygit/pkg/commands/oscommands/cmd_obj_builder.go",
       "checksums": [
         {
@@ -6717,7 +4802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rebase-todo.go-627",
+      "SPDXID": "SPDXRef-File-rebase-todo.go-436",
       "fileName": "repos/lazygit/pkg/utils/rebase_todo.go",
       "checksums": [
         {
@@ -6727,17 +4812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-t-string.c-628",
-      "fileName": "repos/redis/src/t_string.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fe10589827d0b0d3f682ed6e8c6529cc9d441fb9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-parse.go-629",
+      "SPDXID": "SPDXRef-File-parse.go-437",
       "fileName": "repos/lazygit/pkg/commands/patch/parse.go",
       "checksums": [
         {
@@ -6747,7 +4822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-status.go-630",
+      "SPDXID": "SPDXRef-File-status.go-438",
       "fileName": "repos/lazygit/pkg/commands/git_commands/status.go",
       "checksums": [
         {
@@ -6757,17 +4832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lzf-d.c-631",
-      "fileName": "repos/redis/src/lzf_d.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ff32be892a3842ec624b2fa60971d03a92af7cd0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-const-win-unix.go-632",
+      "SPDXID": "SPDXRef-File-const-win-unix.go-439",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/const_win_unix.go",
       "checksums": [
         {
@@ -6777,7 +4842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cacheOnReadFs.go-633",
+      "SPDXID": "SPDXRef-File-cacheOnReadFs.go-440",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/cacheOnReadFs.go",
       "checksums": [
         {
@@ -6787,7 +4852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dirmap.go-634",
+      "SPDXID": "SPDXRef-File-dirmap.go-441",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/mem/dirmap.go",
       "checksums": [
         {
@@ -6797,7 +4862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-copyOnWriteFs.go-635",
+      "SPDXID": "SPDXRef-File-copyOnWriteFs.go-442",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/copyOnWriteFs.go",
       "checksums": [
         {
@@ -6807,7 +4872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-path.go-636",
+      "SPDXID": "SPDXRef-File-path.go-443",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/path.go",
       "checksums": [
         {
@@ -6817,7 +4882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-regexpfs.go-637",
+      "SPDXID": "SPDXRef-File-regexpfs.go-444",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/regexpfs.go",
       "checksums": [
         {
@@ -6827,7 +4892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basepath.go-638",
+      "SPDXID": "SPDXRef-File-basepath.go-445",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/basepath.go",
       "checksums": [
         {
@@ -6837,7 +4902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-afero.go-639",
+      "SPDXID": "SPDXRef-File-afero.go-446",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/afero.go",
       "checksums": [
         {
@@ -6847,7 +4912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adapters.go-640",
+      "SPDXID": "SPDXRef-File-adapters.go-447",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/internal/common/adapters.go",
       "checksums": [
         {
@@ -6857,7 +4922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-unionFile.go-641",
+      "SPDXID": "SPDXRef-File-unionFile.go-448",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/unionFile.go",
       "checksums": [
         {
@@ -6867,7 +4932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.go-642",
+      "SPDXID": "SPDXRef-File-file.go-449",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/mem/file.go",
       "checksums": [
         {
@@ -6877,7 +4942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-match.go-643",
+      "SPDXID": "SPDXRef-File-match.go-450",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/match.go",
       "checksums": [
         {
@@ -6887,7 +4952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lstater.go-644",
+      "SPDXID": "SPDXRef-File-lstater.go-451",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/lstater.go",
       "checksums": [
         {
@@ -6897,7 +4962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iofs.go-645",
+      "SPDXID": "SPDXRef-File-iofs.go-452",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/iofs.go",
       "checksums": [
         {
@@ -6907,7 +4972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-util.go-646",
+      "SPDXID": "SPDXRef-File-util.go-453",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/util.go",
       "checksums": [
         {
@@ -6917,7 +4982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symlink.go-647",
+      "SPDXID": "SPDXRef-File-symlink.go-454",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/symlink.go",
       "checksums": [
         {
@@ -6927,7 +4992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-httpFs.go-648",
+      "SPDXID": "SPDXRef-File-httpFs.go-455",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/httpFs.go",
       "checksums": [
         {
@@ -6937,7 +5002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-readonlyfs.go-649",
+      "SPDXID": "SPDXRef-File-readonlyfs.go-456",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/readonlyfs.go",
       "checksums": [
         {
@@ -6947,7 +5012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dir.go-650",
+      "SPDXID": "SPDXRef-File-dir.go-457",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/mem/dir.go",
       "checksums": [
         {
@@ -6957,7 +5022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-memmap.go-651",
+      "SPDXID": "SPDXRef-File-memmap.go-458",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/memmap.go",
       "checksums": [
         {
@@ -6967,7 +5032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os.go-652",
+      "SPDXID": "SPDXRef-File-os.go-459",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/os.go",
       "checksums": [
         {
@@ -6977,7 +5042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ioutil.go-653",
+      "SPDXID": "SPDXRef-File-ioutil.go-460",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/ioutil.go",
       "checksums": [
         {
@@ -6987,7 +5052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-osext-go18.go-654",
+      "SPDXID": "SPDXRef-File-osext-go18.go-461",
       "fileName": "repos/lazygit/vendor/github.com/kardianos/osext/osext_go18.go",
       "checksums": [
         {
@@ -6997,7 +5062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-osext.go-655",
+      "SPDXID": "SPDXRef-File-osext.go-462",
       "fileName": "repos/lazygit/vendor/github.com/kardianos/osext/osext.go",
       "checksums": [
         {
@@ -7007,7 +5072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-656",
+      "SPDXID": "SPDXRef-File-config.go-463",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/config.go",
       "checksums": [
         {
@@ -7017,7 +5082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lexer.go-657",
+      "SPDXID": "SPDXRef-File-lexer.go-464",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/lexer.go",
       "checksums": [
         {
@@ -7027,7 +5092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-658",
+      "SPDXID": "SPDXRef-File-parser.go-465",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/parser.go",
       "checksums": [
         {
@@ -7037,7 +5102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-validators.go-659",
+      "SPDXID": "SPDXRef-File-validators.go-466",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/validators.go",
       "checksums": [
         {
@@ -7047,7 +5112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-token.go-660",
+      "SPDXID": "SPDXRef-File-token.go-467",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/token.go",
       "checksums": [
         {
@@ -7057,7 +5122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-position.go-661",
+      "SPDXID": "SPDXRef-File-position.go-468",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/position.go",
       "checksums": [
         {
@@ -7067,7 +5132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cast5.go-662",
+      "SPDXID": "SPDXRef-File-cast5.go-469",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/cast5/cast5.go",
       "checksums": [
         {
@@ -7077,7 +5142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve25519.go-663",
+      "SPDXID": "SPDXRef-File-curve25519.go-470",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/curve25519/curve25519.go",
       "checksums": [
         {
@@ -7087,7 +5152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blamka-amd64.go-664",
+      "SPDXID": "SPDXRef-File-blamka-amd64.go-471",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/argon2/blamka_amd64.go",
       "checksums": [
         {
@@ -7097,7 +5162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-665",
+      "SPDXID": "SPDXRef-File-server.go-472",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/server.go",
       "checksums": [
         {
@@ -7107,7 +5172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cipher.go-666",
+      "SPDXID": "SPDXRef-File-cipher.go-473",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blowfish/cipher.go",
       "checksums": [
         {
@@ -7117,7 +5182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-legacy-keccakf.go-667",
+      "SPDXID": "SPDXRef-File-legacy-keccakf.go-474",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/sha3/legacy_keccakf.go",
       "checksums": [
         {
@@ -7127,7 +5192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2b.go-668",
+      "SPDXID": "SPDXRef-File-blake2b.go-475",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/argon2/blake2b.go",
       "checksums": [
         {
@@ -7137,7 +5202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-certs.go-669",
+      "SPDXID": "SPDXRef-File-certs.go-476",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/certs.go",
       "checksums": [
         {
@@ -7147,7 +5212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-streamlocal.go-670",
+      "SPDXID": "SPDXRef-File-streamlocal.go-477",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/streamlocal.go",
       "checksums": [
         {
@@ -7157,7 +5222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2bAVX2-amd64.go-671",
+      "SPDXID": "SPDXRef-File-blake2bAVX2-amd64.go-478",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/blake2bAVX2_amd64.go",
       "checksums": [
         {
@@ -7167,7 +5232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-buffer.go-672",
+      "SPDXID": "SPDXRef-File-buffer.go-479",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/buffer.go",
       "checksums": [
         {
@@ -7177,7 +5242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-knownhosts.go-673",
+      "SPDXID": "SPDXRef-File-knownhosts.go-480",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/knownhosts/knownhosts.go",
       "checksums": [
         {
@@ -7187,7 +5252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-argon2.go-674",
+      "SPDXID": "SPDXRef-File-argon2.go-481",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/argon2/argon2.go",
       "checksums": [
         {
@@ -7197,7 +5262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-675",
+      "SPDXID": "SPDXRef-File-common.go-482",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/common.go",
       "checksums": [
         {
@@ -7207,7 +5272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client-auth.go-676",
+      "SPDXID": "SPDXRef-File-client-auth.go-483",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/client_auth.go",
       "checksums": [
         {
@@ -7217,7 +5282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2b-generic.go-677",
+      "SPDXID": "SPDXRef-File-blake2b-generic.go-484",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/blake2b_generic.go",
       "checksums": [
         {
@@ -7227,7 +5292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-678",
+      "SPDXID": "SPDXRef-File-client.go-485",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/client.go",
       "checksums": [
         {
@@ -7237,7 +5302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hkdf.go-679",
+      "SPDXID": "SPDXRef-File-hkdf.go-486",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/hkdf/hkdf.go",
       "checksums": [
         {
@@ -7247,7 +5312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keys.go-680",
+      "SPDXID": "SPDXRef-File-keys.go-487",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/keys.go",
       "checksums": [
         {
@@ -7257,7 +5322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-handshake.go-681",
+      "SPDXID": "SPDXRef-File-handshake.go-488",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/handshake.go",
       "checksums": [
         {
@@ -7267,7 +5332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-682",
+      "SPDXID": "SPDXRef-File-server.go-489",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/agent/server.go",
       "checksums": [
         {
@@ -7277,7 +5342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-register.go-683",
+      "SPDXID": "SPDXRef-File-register.go-490",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/register.go",
       "checksums": [
         {
@@ -7287,7 +5352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-684",
+      "SPDXID": "SPDXRef-File-doc.go-491",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/doc.go",
       "checksums": [
         {
@@ -7297,7 +5362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-kex.go-685",
+      "SPDXID": "SPDXRef-File-kex.go-492",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/kex.go",
       "checksums": [
         {
@@ -7307,7 +5372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connection.go-686",
+      "SPDXID": "SPDXRef-File-connection.go-493",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/connection.go",
       "checksums": [
         {
@@ -7317,7 +5382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-go125.go-687",
+      "SPDXID": "SPDXRef-File-go125.go-494",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/go125.go",
       "checksums": [
         {
@@ -7327,7 +5392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shake.go-688",
+      "SPDXID": "SPDXRef-File-shake.go-495",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/sha3/shake.go",
       "checksums": [
         {
@@ -7337,7 +5402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cipher.go-689",
+      "SPDXID": "SPDXRef-File-cipher.go-496",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/cipher.go",
       "checksums": [
         {
@@ -7347,7 +5412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2x.go-690",
+      "SPDXID": "SPDXRef-File-blake2x.go-497",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/blake2x.go",
       "checksums": [
         {
@@ -7357,7 +5422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tcpip.go-691",
+      "SPDXID": "SPDXRef-File-tcpip.go-498",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/tcpip.go",
       "checksums": [
         {
@@ -7367,7 +5432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mac.go-692",
+      "SPDXID": "SPDXRef-File-mac.go-499",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/mac.go",
       "checksums": [
         {
@@ -7377,7 +5442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-block.go-693",
+      "SPDXID": "SPDXRef-File-block.go-500",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blowfish/block.go",
       "checksums": [
         {
@@ -7387,7 +5452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blamka-generic.go-694",
+      "SPDXID": "SPDXRef-File-blamka-generic.go-501",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/argon2/blamka_generic.go",
       "checksums": [
         {
@@ -7397,7 +5462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hashes.go-695",
+      "SPDXID": "SPDXRef-File-hashes.go-502",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/sha3/hashes.go",
       "checksums": [
         {
@@ -7407,7 +5472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ssh-gss.go-696",
+      "SPDXID": "SPDXRef-File-ssh-gss.go-503",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/ssh_gss.go",
       "checksums": [
         {
@@ -7417,7 +5482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-messages.go-697",
+      "SPDXID": "SPDXRef-File-messages.go-504",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/messages.go",
       "checksums": [
         {
@@ -7427,7 +5492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-session.go-698",
+      "SPDXID": "SPDXRef-File-session.go-505",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/session.go",
       "checksums": [
         {
@@ -7437,7 +5502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bcrypt-pbkdf.go-699",
+      "SPDXID": "SPDXRef-File-bcrypt-pbkdf.go-506",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/internal/bcrypt_pbkdf/bcrypt_pbkdf.go",
       "checksums": [
         {
@@ -7447,7 +5512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-700",
+      "SPDXID": "SPDXRef-File-client.go-507",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/agent/client.go",
       "checksums": [
         {
@@ -7457,7 +5522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-legacy-hash.go-701",
+      "SPDXID": "SPDXRef-File-legacy-hash.go-508",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/sha3/legacy_hash.go",
       "checksums": [
         {
@@ -7467,7 +5532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-channel.go-702",
+      "SPDXID": "SPDXRef-File-channel.go-509",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/channel.go",
       "checksums": [
         {
@@ -7477,7 +5542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-const.go-703",
+      "SPDXID": "SPDXRef-File-const.go-510",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blowfish/const.go",
       "checksums": [
         {
@@ -7487,7 +5552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keyring.go-704",
+      "SPDXID": "SPDXRef-File-keyring.go-511",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/agent/keyring.go",
       "checksums": [
         {
@@ -7497,7 +5562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mux.go-705",
+      "SPDXID": "SPDXRef-File-mux.go-512",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/mux.go",
       "checksums": [
         {
@@ -7507,7 +5572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2b.go-706",
+      "SPDXID": "SPDXRef-File-blake2b.go-513",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/blake2b.go",
       "checksums": [
         {
@@ -7517,7 +5582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mlkem.go-707",
+      "SPDXID": "SPDXRef-File-mlkem.go-514",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/mlkem.go",
       "checksums": [
         {
@@ -7527,7 +5592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transport.go-708",
+      "SPDXID": "SPDXRef-File-transport.go-515",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/transport.go",
       "checksums": [
         {
@@ -7537,7 +5602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-forward.go-709",
+      "SPDXID": "SPDXRef-File-forward.go-516",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/agent/forward.go",
       "checksums": [
         {
@@ -7547,7 +5612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decode.go-710",
+      "SPDXID": "SPDXRef-File-decode.go-517",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/decode.go",
       "checksums": [
         {
@@ -7557,7 +5622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-emitterc.go-711",
+      "SPDXID": "SPDXRef-File-emitterc.go-518",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/emitterc.go",
       "checksums": [
         {
@@ -7567,7 +5632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parserc.go-712",
+      "SPDXID": "SPDXRef-File-parserc.go-519",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/parserc.go",
       "checksums": [
         {
@@ -7577,7 +5642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-resolve.go-713",
+      "SPDXID": "SPDXRef-File-resolve.go-520",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/resolve.go",
       "checksums": [
         {
@@ -7587,7 +5652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yamlh.go-714",
+      "SPDXID": "SPDXRef-File-yamlh.go-521",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/yamlh.go",
       "checksums": [
         {
@@ -7597,7 +5662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yaml.go-715",
+      "SPDXID": "SPDXRef-File-yaml.go-522",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/yaml.go",
       "checksums": [
         {
@@ -7607,7 +5672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sorter.go-716",
+      "SPDXID": "SPDXRef-File-sorter.go-523",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/sorter.go",
       "checksums": [
         {
@@ -7617,7 +5682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apic.go-717",
+      "SPDXID": "SPDXRef-File-apic.go-524",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/apic.go",
       "checksums": [
         {
@@ -7627,7 +5692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-readerc.go-718",
+      "SPDXID": "SPDXRef-File-readerc.go-525",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/readerc.go",
       "checksums": [
         {
@@ -7637,7 +5702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writerc.go-719",
+      "SPDXID": "SPDXRef-File-writerc.go-526",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/writerc.go",
       "checksums": [
         {
@@ -7647,7 +5712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scannerc.go-720",
+      "SPDXID": "SPDXRef-File-scannerc.go-527",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/scannerc.go",
       "checksums": [
         {
@@ -7657,7 +5722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encode.go-721",
+      "SPDXID": "SPDXRef-File-encode.go-528",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/encode.go",
       "checksums": [
         {
@@ -7667,7 +5732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yamlprivateh.go-722",
+      "SPDXID": "SPDXRef-File-yamlprivateh.go-529",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/yamlprivateh.go",
       "checksums": [
         {
@@ -7677,7 +5742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-exported.go-723",
+      "SPDXID": "SPDXRef-File-exported.go-530",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/exported.go",
       "checksums": [
         {
@@ -7687,7 +5752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal-check-unix.go-724",
+      "SPDXID": "SPDXRef-File-terminal-check-unix.go-531",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/terminal_check_unix.go",
       "checksums": [
         {
@@ -7697,7 +5762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writer.go-725",
+      "SPDXID": "SPDXRef-File-writer.go-532",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/writer.go",
       "checksums": [
         {
@@ -7707,7 +5772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logrus.go-726",
+      "SPDXID": "SPDXRef-File-logrus.go-533",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/logrus.go",
       "checksums": [
         {
@@ -7717,7 +5782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal-check-notappengine.go-727",
+      "SPDXID": "SPDXRef-File-terminal-check-notappengine.go-534",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/terminal_check_notappengine.go",
       "checksums": [
         {
@@ -7727,7 +5792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hooks.go-728",
+      "SPDXID": "SPDXRef-File-hooks.go-535",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/hooks.go",
       "checksums": [
         {
@@ -7737,7 +5802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-formatter.go-729",
+      "SPDXID": "SPDXRef-File-formatter.go-536",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/formatter.go",
       "checksums": [
         {
@@ -7747,7 +5812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logger.go-730",
+      "SPDXID": "SPDXRef-File-logger.go-537",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/logger.go",
       "checksums": [
         {
@@ -7757,7 +5822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-entry.go-731",
+      "SPDXID": "SPDXRef-File-entry.go-538",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/entry.go",
       "checksums": [
         {
@@ -7767,7 +5832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-alt-exit.go-732",
+      "SPDXID": "SPDXRef-File-alt-exit.go-539",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/alt_exit.go",
       "checksums": [
         {
@@ -7777,7 +5842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-text-formatter.go-733",
+      "SPDXID": "SPDXRef-File-text-formatter.go-540",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/text_formatter.go",
       "checksums": [
         {
@@ -7787,7 +5852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-buffer-pool.go-734",
+      "SPDXID": "SPDXRef-File-buffer-pool.go-541",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/buffer_pool.go",
       "checksums": [
         {
@@ -7797,7 +5862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-json-formatter.go-735",
+      "SPDXID": "SPDXRef-File-json-formatter.go-542",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/json_formatter.go",
       "checksums": [
         {
@@ -7807,7 +5872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-736",
+      "SPDXID": "SPDXRef-File-doc.go-543",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/doc.go",
       "checksums": [
         {
@@ -7817,17 +5882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hdr-histogram.h-737",
-      "fileName": "repos/redis/src/../deps/hdr_histogram/hdr_histogram.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "01b1e086cae8365d5ebee885ac3b47a70d43bfb0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-private-key-test-data.go-738",
+      "SPDXID": "SPDXRef-File-private-key-test-data.go-544",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/private_key_test_data.go",
       "checksums": [
         {
@@ -7837,7 +5892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mpi.go-739",
+      "SPDXID": "SPDXRef-File-mpi.go-545",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/encoding/mpi.go",
       "checksums": [
         {
@@ -7847,7 +5902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-compressed.go-740",
+      "SPDXID": "SPDXRef-File-compressed.go-546",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/compressed.go",
       "checksums": [
         {
@@ -7857,7 +5912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-info.go-741",
+      "SPDXID": "SPDXRef-File-curve-info.go-547",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/curve_info.go",
       "checksums": [
         {
@@ -7867,7 +5922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symmetrically-encrypted.go-742",
+      "SPDXID": "SPDXRef-File-symmetrically-encrypted.go-548",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/symmetrically_encrypted.go",
       "checksums": [
         {
@@ -7877,7 +5932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-random-vectors.go-743",
+      "SPDXID": "SPDXRef-File-random-vectors.go-549",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/ocb/random_vectors.go",
       "checksums": [
         {
@@ -7887,7 +5942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keys-test-data.go-744",
+      "SPDXID": "SPDXRef-File-keys-test-data.go-550",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/keys_test_data.go",
       "checksums": [
         {
@@ -7897,7 +5952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rfc7253-test-vectors-suite-b.go-745",
+      "SPDXID": "SPDXRef-File-rfc7253-test-vectors-suite-b.go-551",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/ocb/rfc7253_test_vectors_suite_b.go",
       "checksums": [
         {
@@ -7907,7 +5962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-packet.go-746",
+      "SPDXID": "SPDXRef-File-packet.go-552",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/packet.go",
       "checksums": [
         {
@@ -7917,7 +5972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-marker.go-747",
+      "SPDXID": "SPDXRef-File-marker.go-553",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/marker.go",
       "checksums": [
         {
@@ -7927,7 +5982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ocb.go-748",
+      "SPDXID": "SPDXRef-File-ocb.go-554",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/ocb/ocb.go",
       "checksums": [
         {
@@ -7937,7 +5992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-749",
+      "SPDXID": "SPDXRef-File-config.go-555",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/config.go",
       "checksums": [
         {
@@ -7947,7 +6002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symmetric-key-encrypted.go-750",
+      "SPDXID": "SPDXRef-File-symmetric-key-encrypted.go-556",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/symmetric_key_encrypted.go",
       "checksums": [
         {
@@ -7957,7 +6012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-notation.go-751",
+      "SPDXID": "SPDXRef-File-notation.go-557",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/notation.go",
       "checksums": [
         {
@@ -7967,7 +6022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-packet-unsupported.go-752",
+      "SPDXID": "SPDXRef-File-packet-unsupported.go-558",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/packet_unsupported.go",
       "checksums": [
         {
@@ -7977,7 +6032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rfc7253-test-vectors-suite-a.go-753",
+      "SPDXID": "SPDXRef-File-rfc7253-test-vectors-suite-a.go-559",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/ocb/rfc7253_test_vectors_suite_a.go",
       "checksums": [
         {
@@ -7987,7 +6042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x25519.go-754",
+      "SPDXID": "SPDXRef-File-x25519.go-560",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/x25519/x25519.go",
       "checksums": [
         {
@@ -7997,7 +6052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eax.go-755",
+      "SPDXID": "SPDXRef-File-eax.go-561",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/eax/eax.go",
       "checksums": [
         {
@@ -8007,7 +6062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-padding.go-756",
+      "SPDXID": "SPDXRef-File-padding.go-562",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/padding.go",
       "checksums": [
         {
@@ -8017,7 +6072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keywrap.go-757",
+      "SPDXID": "SPDXRef-File-keywrap.go-563",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/aes/keywrap/keywrap.go",
       "checksums": [
         {
@@ -8027,7 +6082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-userid.go-758",
+      "SPDXID": "SPDXRef-File-userid.go-564",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/userid.go",
       "checksums": [
         {
@@ -8037,7 +6092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symmetrically-encrypted-aead.go-759",
+      "SPDXID": "SPDXRef-File-symmetrically-encrypted-aead.go-565",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/symmetrically_encrypted_aead.go",
       "checksums": [
         {
@@ -8047,7 +6102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-random-vectors.go-760",
+      "SPDXID": "SPDXRef-File-random-vectors.go-566",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/eax/random_vectors.go",
       "checksums": [
         {
@@ -8057,7 +6112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ocfb.go-761",
+      "SPDXID": "SPDXRef-File-ocfb.go-567",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/ocfb.go",
       "checksums": [
         {
@@ -8067,7 +6122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.go-762",
+      "SPDXID": "SPDXRef-File-hash.go-568",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/hash.go",
       "checksums": [
         {
@@ -8077,7 +6132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encode.go-763",
+      "SPDXID": "SPDXRef-File-encode.go-569",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/armor/encode.go",
       "checksums": [
         {
@@ -8087,7 +6142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-packet-sequence.go-764",
+      "SPDXID": "SPDXRef-File-packet-sequence.go-570",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/packet_sequence.go",
       "checksums": [
         {
@@ -8097,7 +6152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aead-encrypted.go-765",
+      "SPDXID": "SPDXRef-File-aead-encrypted.go-571",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/aead_encrypted.go",
       "checksums": [
         {
@@ -8107,7 +6162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed25519.go-766",
+      "SPDXID": "SPDXRef-File-ed25519.go-572",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/ed25519.go",
       "checksums": [
         {
@@ -8117,7 +6172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-canonical-text.go-767",
+      "SPDXID": "SPDXRef-File-canonical-text.go-573",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/canonical_text.go",
       "checksums": [
         {
@@ -8127,7 +6182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aead-crypter.go-768",
+      "SPDXID": "SPDXRef-File-aead-crypter.go-574",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/aead_crypter.go",
       "checksums": [
         {
@@ -8137,7 +6192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curves.go-769",
+      "SPDXID": "SPDXRef-File-curves.go-575",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/curves.go",
       "checksums": [
         {
@@ -8147,7 +6202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-s2k-cache.go-770",
+      "SPDXID": "SPDXRef-File-s2k-cache.go-576",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/s2k/s2k_cache.go",
       "checksums": [
         {
@@ -8157,7 +6212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-userattribute.go-771",
+      "SPDXID": "SPDXRef-File-userattribute.go-577",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/userattribute.go",
       "checksums": [
         {
@@ -8167,7 +6222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x448.go-772",
+      "SPDXID": "SPDXRef-File-x448.go-578",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/x448/x448.go",
       "checksums": [
         {
@@ -8177,7 +6232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read-write-test-data.go-773",
+      "SPDXID": "SPDXRef-File-read-write-test-data.go-579",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/read_write_test_data.go",
       "checksums": [
         {
@@ -8187,7 +6242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-s2k.go-774",
+      "SPDXID": "SPDXRef-File-s2k.go-580",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/s2k/s2k.go",
       "checksums": [
         {
@@ -8197,7 +6252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed25519.go-775",
+      "SPDXID": "SPDXRef-File-ed25519.go-581",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/ed25519/ed25519.go",
       "checksums": [
         {
@@ -8207,7 +6262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoding.go-776",
+      "SPDXID": "SPDXRef-File-encoding.go-582",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/encoding/encoding.go",
       "checksums": [
         {
@@ -8217,7 +6272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-key-generation.go-777",
+      "SPDXID": "SPDXRef-File-key-generation.go-583",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/key_generation.go",
       "checksums": [
         {
@@ -8227,7 +6282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rcurve.go-778",
+      "SPDXID": "SPDXRef-File-rcurve.go-584",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/brainpool/rcurve.go",
       "checksums": [
         {
@@ -8237,7 +6292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signature.go-779",
+      "SPDXID": "SPDXRef-File-signature.go-585",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/signature.go",
       "checksums": [
         {
@@ -8247,7 +6302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve25519.go-780",
+      "SPDXID": "SPDXRef-File-curve25519.go-586",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/curve25519.go",
       "checksums": [
         {
@@ -8257,7 +6312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-literal.go-781",
+      "SPDXID": "SPDXRef-File-literal.go-587",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/literal.go",
       "checksums": [
         {
@@ -8267,7 +6322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symmetrically-encrypted-mdc.go-782",
+      "SPDXID": "SPDXRef-File-symmetrically-encrypted-mdc.go-588",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/symmetrically_encrypted_mdc.go",
       "checksums": [
         {
@@ -8277,7 +6332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eddsa.go-783",
+      "SPDXID": "SPDXRef-File-eddsa.go-589",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/eddsa/eddsa.go",
       "checksums": [
         {
@@ -8287,7 +6342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keys.go-784",
+      "SPDXID": "SPDXRef-File-keys.go-590",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/keys.go",
       "checksums": [
         {
@@ -8297,7 +6352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-write.go-785",
+      "SPDXID": "SPDXRef-File-write.go-591",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/write.go",
       "checksums": [
         {
@@ -8307,7 +6362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed448.go-786",
+      "SPDXID": "SPDXRef-File-ed448.go-592",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/ed448/ed448.go",
       "checksums": [
         {
@@ -8317,7 +6372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-public-key-test-data.go-787",
+      "SPDXID": "SPDXRef-File-public-key-test-data.go-593",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/public_key_test_data.go",
       "checksums": [
         {
@@ -8327,7 +6382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed448.go-788",
+      "SPDXID": "SPDXRef-File-ed448.go-594",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/ed448.go",
       "checksums": [
         {
@@ -8337,7 +6392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encrypted-key.go-789",
+      "SPDXID": "SPDXRef-File-encrypted-key.go-595",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/encrypted_key.go",
       "checksums": [
         {
@@ -8347,7 +6402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-s2k-config.go-790",
+      "SPDXID": "SPDXRef-File-s2k-config.go-596",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/s2k/s2k_config.go",
       "checksums": [
         {
@@ -8357,7 +6412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-elgamal.go-791",
+      "SPDXID": "SPDXRef-File-elgamal.go-597",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/elgamal/elgamal.go",
       "checksums": [
         {
@@ -8367,7 +6422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cipher.go-792",
+      "SPDXID": "SPDXRef-File-cipher.go-598",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/algorithm/cipher.go",
       "checksums": [
         {
@@ -8377,7 +6432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bitcurve.go-793",
+      "SPDXID": "SPDXRef-File-bitcurve.go-599",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/bitcurves/bitcurve.go",
       "checksums": [
         {
@@ -8387,7 +6442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-oid.go-794",
+      "SPDXID": "SPDXRef-File-oid.go-600",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/encoding/oid.go",
       "checksums": [
         {
@@ -8397,7 +6452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-brainpool.go-795",
+      "SPDXID": "SPDXRef-File-brainpool.go-601",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/brainpool/brainpool.go",
       "checksums": [
         {
@@ -8407,7 +6462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-opaque.go-796",
+      "SPDXID": "SPDXRef-File-opaque.go-602",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/opaque.go",
       "checksums": [
         {
@@ -8417,7 +6472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aead.go-797",
+      "SPDXID": "SPDXRef-File-aead.go-603",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/algorithm/aead.go",
       "checksums": [
         {
@@ -8427,7 +6482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.go-798",
+      "SPDXID": "SPDXRef-File-hash.go-604",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/algorithm/hash.go",
       "checksums": [
         {
@@ -8437,7 +6492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-byteutil.go-799",
+      "SPDXID": "SPDXRef-File-byteutil.go-605",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/internal/byteutil/byteutil.go",
       "checksums": [
         {
@@ -8447,7 +6502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ecdh.go-800",
+      "SPDXID": "SPDXRef-File-ecdh.go-606",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/ecdh/ecdh.go",
       "checksums": [
         {
@@ -8457,7 +6512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reader.go-801",
+      "SPDXID": "SPDXRef-File-reader.go-607",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/reader.go",
       "checksums": [
         {
@@ -8467,7 +6522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eax-test-vectors.go-802",
+      "SPDXID": "SPDXRef-File-eax-test-vectors.go-608",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/eax/eax_test_vectors.go",
       "checksums": [
         {
@@ -8477,7 +6532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x448.go-803",
+      "SPDXID": "SPDXRef-File-x448.go-609",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/x448.go",
       "checksums": [
         {
@@ -8487,7 +6542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-armor.go-804",
+      "SPDXID": "SPDXRef-File-armor.go-610",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/armor/armor.go",
       "checksums": [
         {
@@ -8497,7 +6552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-public-key.go-805",
+      "SPDXID": "SPDXRef-File-public-key.go-611",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/public_key.go",
       "checksums": [
         {
@@ -8507,7 +6562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-generic.go-806",
+      "SPDXID": "SPDXRef-File-generic.go-612",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/generic.go",
       "checksums": [
         {
@@ -8517,7 +6572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-807",
+      "SPDXID": "SPDXRef-File-errors.go-613",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/errors/errors.go",
       "checksums": [
         {
@@ -8527,7 +6582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read.go-808",
+      "SPDXID": "SPDXRef-File-read.go-614",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/read.go",
       "checksums": [
         {
@@ -8537,7 +6592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-private-key.go-809",
+      "SPDXID": "SPDXRef-File-private-key.go-615",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/private_key.go",
       "checksums": [
         {
@@ -8547,7 +6602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config-v5.go-810",
+      "SPDXID": "SPDXRef-File-config-v5.go-616",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/config_v5.go",
       "checksums": [
         {
@@ -8557,7 +6612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-one-pass-signature.go-811",
+      "SPDXID": "SPDXRef-File-one-pass-signature.go-617",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/one_pass_signature.go",
       "checksums": [
         {
@@ -8567,7 +6622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ecdsa.go-812",
+      "SPDXID": "SPDXRef-File-ecdsa.go-618",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/ecdsa/ecdsa.go",
       "checksums": [
         {
@@ -8577,7 +6632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-recipient.go-813",
+      "SPDXID": "SPDXRef-File-recipient.go-619",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/recipient.go",
       "checksums": [
         {
@@ -8587,7 +6642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aead-config.go-814",
+      "SPDXID": "SPDXRef-File-aead-config.go-620",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/aead_config.go",
       "checksums": [
         {
@@ -8597,7 +6652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-jsonstring.go-815",
+      "SPDXID": "SPDXRef-File-jsonstring.go-621",
       "fileName": "repos/lazygit/vendor/github.com/go-logfmt/logfmt/jsonstring.go",
       "checksums": [
         {
@@ -8607,7 +6662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decode.go-816",
+      "SPDXID": "SPDXRef-File-decode.go-622",
       "fileName": "repos/lazygit/vendor/github.com/go-logfmt/logfmt/decode.go",
       "checksums": [
         {
@@ -8617,7 +6672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-817",
+      "SPDXID": "SPDXRef-File-doc.go-623",
       "fileName": "repos/lazygit/vendor/github.com/go-logfmt/logfmt/doc.go",
       "checksums": [
         {
@@ -8627,7 +6682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encode.go-818",
+      "SPDXID": "SPDXRef-File-encode.go-624",
       "fileName": "repos/lazygit/vendor/github.com/go-logfmt/logfmt/encode.go",
       "checksums": [
         {
@@ -8637,7 +6692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pagesize-unix.go-819",
+      "SPDXID": "SPDXRef-File-pagesize-unix.go-625",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/pagesize_unix.go",
       "checksums": [
         {
@@ -8647,7 +6702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-unix-gc.go-820",
+      "SPDXID": "SPDXRef-File-syscall-unix-gc.go-626",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_unix_gc.go",
       "checksums": [
         {
@@ -8657,7 +6712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux.go-821",
+      "SPDXID": "SPDXRef-File-syscall-linux.go-627",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux.go",
       "checksums": [
         {
@@ -8667,7 +6722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vgetrandom-linux.go-822",
+      "SPDXID": "SPDXRef-File-vgetrandom-linux.go-628",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/vgetrandom_linux.go",
       "checksums": [
         {
@@ -8677,7 +6732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zerrors-linux.go-823",
+      "SPDXID": "SPDXRef-File-zerrors-linux.go-629",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zerrors_linux.go",
       "checksums": [
         {
@@ -8687,7 +6742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dirent.go-824",
+      "SPDXID": "SPDXRef-File-dirent.go-630",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/dirent.go",
       "checksums": [
         {
@@ -8697,7 +6752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsysnum-linux-amd64.go-825",
+      "SPDXID": "SPDXRef-File-zsysnum-linux-amd64.go-631",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go",
       "checksums": [
         {
@@ -8707,7 +6762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ifreq-linux.go-826",
+      "SPDXID": "SPDXRef-File-ifreq-linux.go-632",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ifreq_linux.go",
       "checksums": [
         {
@@ -8717,7 +6772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-auxv.go-827",
+      "SPDXID": "SPDXRef-File-auxv.go-633",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/auxv.go",
       "checksums": [
         {
@@ -8727,7 +6782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux-alarm.go-828",
+      "SPDXID": "SPDXRef-File-syscall-linux-alarm.go-634",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux_alarm.go",
       "checksums": [
         {
@@ -8737,7 +6792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mremap.go-829",
+      "SPDXID": "SPDXRef-File-mremap.go-635",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/mremap.go",
       "checksums": [
         {
@@ -8747,7 +6802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-execabs.go-830",
+      "SPDXID": "SPDXRef-File-execabs.go-636",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/execabs/execabs.go",
       "checksums": [
         {
@@ -8757,7 +6812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-affinity-linux.go-831",
+      "SPDXID": "SPDXRef-File-affinity-linux.go-637",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/affinity_linux.go",
       "checksums": [
         {
@@ -8767,7 +6822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ztypes-linux.go-832",
+      "SPDXID": "SPDXRef-File-ztypes-linux.go-638",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ztypes_linux.go",
       "checksums": [
         {
@@ -8777,7 +6832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockcmsg-unix-other.go-833",
+      "SPDXID": "SPDXRef-File-sockcmsg-unix-other.go-639",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sockcmsg_unix_other.go",
       "checksums": [
         {
@@ -8787,7 +6842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-race0.go-834",
+      "SPDXID": "SPDXRef-File-race0.go-640",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/race0.go",
       "checksums": [
         {
@@ -8797,7 +6852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sysvshm-linux.go-835",
+      "SPDXID": "SPDXRef-File-sysvshm-linux.go-641",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sysvshm_linux.go",
       "checksums": [
         {
@@ -8807,7 +6862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zptrace-x86-linux.go-836",
+      "SPDXID": "SPDXRef-File-zptrace-x86-linux.go-642",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zptrace_x86_linux.go",
       "checksums": [
         {
@@ -8817,7 +6872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall.go-837",
+      "SPDXID": "SPDXRef-File-syscall.go-643",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall.go",
       "checksums": [
         {
@@ -8827,7 +6882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockcmsg-linux.go-838",
+      "SPDXID": "SPDXRef-File-sockcmsg-linux.go-644",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sockcmsg_linux.go",
       "checksums": [
         {
@@ -8837,7 +6892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fcntl.go-839",
+      "SPDXID": "SPDXRef-File-fcntl.go-645",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/fcntl.go",
       "checksums": [
         {
@@ -8847,7 +6902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fdset.go-840",
+      "SPDXID": "SPDXRef-File-fdset.go-646",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/fdset.go",
       "checksums": [
         {
@@ -8857,7 +6912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sysvshm-unix.go-841",
+      "SPDXID": "SPDXRef-File-sysvshm-unix.go-647",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sysvshm_unix.go",
       "checksums": [
         {
@@ -8867,7 +6922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-constants.go-842",
+      "SPDXID": "SPDXRef-File-constants.go-648",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/constants.go",
       "checksums": [
         {
@@ -8877,7 +6932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timestruct.go-843",
+      "SPDXID": "SPDXRef-File-timestruct.go-649",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/timestruct.go",
       "checksums": [
         {
@@ -8887,7 +6942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ioctl-linux.go-844",
+      "SPDXID": "SPDXRef-File-ioctl-linux.go-650",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ioctl_linux.go",
       "checksums": [
         {
@@ -8897,7 +6952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsyscall-linux.go-845",
+      "SPDXID": "SPDXRef-File-zsyscall-linux.go-651",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zsyscall_linux.go",
       "checksums": [
         {
@@ -8907,7 +6962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zerrors-linux-amd64.go-846",
+      "SPDXID": "SPDXRef-File-zerrors-linux-amd64.go-652",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go",
       "checksums": [
         {
@@ -8917,7 +6972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bluetooth-linux.go-847",
+      "SPDXID": "SPDXRef-File-bluetooth-linux.go-653",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/bluetooth_linux.go",
       "checksums": [
         {
@@ -8927,7 +6982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-env-unix.go-848",
+      "SPDXID": "SPDXRef-File-env-unix.go-654",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/env_unix.go",
       "checksums": [
         {
@@ -8937,7 +6992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aliases.go-849",
+      "SPDXID": "SPDXRef-File-aliases.go-655",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/aliases.go",
       "checksums": [
         {
@@ -8947,7 +7002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-endian-little.go-850",
+      "SPDXID": "SPDXRef-File-endian-little.go-656",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/endian_little.go",
       "checksums": [
         {
@@ -8957,7 +7012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockcmsg-unix.go-851",
+      "SPDXID": "SPDXRef-File-sockcmsg-unix.go-657",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sockcmsg_unix.go",
       "checksums": [
         {
@@ -8967,7 +7022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dev-linux.go-852",
+      "SPDXID": "SPDXRef-File-dev-linux.go-658",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/dev_linux.go",
       "checksums": [
         {
@@ -8977,7 +7032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux-amd64.go-853",
+      "SPDXID": "SPDXRef-File-syscall-linux-amd64.go-659",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux_amd64.go",
       "checksums": [
         {
@@ -8987,7 +7042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-execabs-go119.go-854",
+      "SPDXID": "SPDXRef-File-execabs-go119.go-660",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/execabs/execabs_go119.go",
       "checksums": [
         {
@@ -8997,7 +7052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-readdirent-getdents.go-855",
+      "SPDXID": "SPDXRef-File-readdirent-getdents.go-661",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/readdirent_getdents.go",
       "checksums": [
         {
@@ -9007,7 +7062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-unix.go-856",
+      "SPDXID": "SPDXRef-File-syscall-unix.go-662",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_unix.go",
       "checksums": [
         {
@@ -9017,7 +7072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ztypes-linux-amd64.go-857",
+      "SPDXID": "SPDXRef-File-ztypes-linux-amd64.go-663",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go",
       "checksums": [
         {
@@ -9027,7 +7082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ioctl-unsigned.go-858",
+      "SPDXID": "SPDXRef-File-ioctl-unsigned.go-664",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ioctl_unsigned.go",
       "checksums": [
         {
@@ -9037,7 +7092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-x86.go-859",
+      "SPDXID": "SPDXRef-File-cpu-x86.go-665",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/cpu/cpu_x86.go",
       "checksums": [
         {
@@ -9047,7 +7102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux-amd64-gc.go-860",
+      "SPDXID": "SPDXRef-File-syscall-linux-amd64-gc.go-666",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux_amd64_gc.go",
       "checksums": [
         {
@@ -9057,7 +7112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsyscall-linux-amd64.go-861",
+      "SPDXID": "SPDXRef-File-zsyscall-linux-amd64.go-667",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zsyscall_linux_amd64.go",
       "checksums": [
         {
@@ -9067,7 +7122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux-gc.go-862",
+      "SPDXID": "SPDXRef-File-syscall-linux-gc.go-668",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux_gc.go",
       "checksums": [
         {
@@ -9077,7 +7132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedValue.go-863",
+      "SPDXID": "SPDXRef-File-parsedValue.go-669",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/parsedValue.go",
       "checksums": [
         {
@@ -9087,7 +7142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-argumentParser.go-864",
+      "SPDXID": "SPDXRef-File-argumentParser.go-670",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/argumentParser.go",
       "checksums": [
         {
@@ -9097,7 +7152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-help.go-865",
+      "SPDXID": "SPDXRef-File-help.go-671",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/help.go",
       "checksums": [
         {
@@ -9107,7 +7162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-flag.go-866",
+      "SPDXID": "SPDXRef-File-flag.go-672",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/flag.go",
       "checksums": [
         {
@@ -9117,7 +7172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-867",
+      "SPDXID": "SPDXRef-File-parser.go-673",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/parser.go",
       "checksums": [
         {
@@ -9127,7 +7182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-subCommand.go-868",
+      "SPDXID": "SPDXRef-File-subCommand.go-674",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/subCommand.go",
       "checksums": [
         {
@@ -9137,7 +7192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main.go-869",
+      "SPDXID": "SPDXRef-File-main.go-675",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/main.go",
       "checksums": [
         {
@@ -9147,7 +7202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-positionalValue.go-870",
+      "SPDXID": "SPDXRef-File-positionalValue.go-676",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/positionalValue.go",
       "checksums": [
         {
@@ -9157,7 +7212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-helpValues.go-871",
+      "SPDXID": "SPDXRef-File-helpValues.go-677",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/helpValues.go",
       "checksums": [
         {
@@ -9167,7 +7222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color-tag.go-872",
+      "SPDXID": "SPDXRef-File-color-tag.go-678",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color_tag.go",
       "checksums": [
         {
@@ -9177,7 +7232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color-16.go-873",
+      "SPDXID": "SPDXRef-File-color-16.go-679",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color_16.go",
       "checksums": [
         {
@@ -9187,7 +7242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-printer.go-874",
+      "SPDXID": "SPDXRef-File-printer.go-680",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/printer.go",
       "checksums": [
         {
@@ -9197,7 +7252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-quickstart.go-875",
+      "SPDXID": "SPDXRef-File-quickstart.go-681",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/quickstart.go",
       "checksums": [
         {
@@ -9207,7 +7262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-detect-nonwin.go-876",
+      "SPDXID": "SPDXRef-File-detect-nonwin.go-682",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/detect_nonwin.go",
       "checksums": [
         {
@@ -9217,7 +7272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color-rgb.go-877",
+      "SPDXID": "SPDXRef-File-color-rgb.go-683",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color_rgb.go",
       "checksums": [
         {
@@ -9227,7 +7282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-convert.go-878",
+      "SPDXID": "SPDXRef-File-convert.go-684",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/convert.go",
       "checksums": [
         {
@@ -9237,7 +7292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-879",
+      "SPDXID": "SPDXRef-File-utils.go-685",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/utils.go",
       "checksums": [
         {
@@ -9247,7 +7302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-880",
+      "SPDXID": "SPDXRef-File-color.go-686",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color.go",
       "checksums": [
         {
@@ -9257,7 +7312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color-256.go-881",
+      "SPDXID": "SPDXRef-File-color-256.go-687",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color_256.go",
       "checksums": [
         {
@@ -9267,7 +7322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-detect-env.go-882",
+      "SPDXID": "SPDXRef-File-detect-env.go-688",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/detect_env.go",
       "checksums": [
         {
@@ -9277,7 +7332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-style.go-883",
+      "SPDXID": "SPDXRef-File-style.go-689",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/style.go",
       "checksums": [
         {
@@ -9287,7 +7342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.go-884",
+      "SPDXID": "SPDXRef-File-hash.go-690",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/hash.go",
       "checksums": [
         {
@@ -9297,7 +7352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-885",
+      "SPDXID": "SPDXRef-File-config.go-691",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/config.go",
       "checksums": [
         {
@@ -9307,7 +7362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filter.go-886",
+      "SPDXID": "SPDXRef-File-filter.go-692",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/filter.go",
       "checksums": [
         {
@@ -9317,7 +7372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-commit.go-887",
+      "SPDXID": "SPDXRef-File-worktree-commit.go-693",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/worktree_commit.go",
       "checksums": [
         {
@@ -9327,7 +7382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-index.go-888",
+      "SPDXID": "SPDXRef-File-index.go-694",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/index.go",
       "checksums": [
         {
@@ -9337,7 +7392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writer.go-889",
+      "SPDXID": "SPDXRef-File-writer.go-695",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/objfile/writer.go",
       "checksums": [
         {
@@ -9347,7 +7402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options.go-890",
+      "SPDXID": "SPDXRef-File-options.go-696",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/options.go",
       "checksums": [
         {
@@ -9357,7 +7412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-891",
+      "SPDXID": "SPDXRef-File-client.go-697",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/client/client.go",
       "checksums": [
         {
@@ -9367,7 +7422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-892",
+      "SPDXID": "SPDXRef-File-client.go-698",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/file/client.go",
       "checksums": [
         {
@@ -9377,7 +7432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-delta-selector.go-893",
+      "SPDXID": "SPDXRef-File-delta-selector.go-699",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/delta_selector.go",
       "checksums": [
         {
@@ -9387,7 +7442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-894",
+      "SPDXID": "SPDXRef-File-encoder.go-700",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/encoder.go",
       "checksums": [
         {
@@ -9397,7 +7452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-895",
+      "SPDXID": "SPDXRef-File-doc.go-701",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/doc.go",
       "checksums": [
         {
@@ -9407,7 +7462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-896",
+      "SPDXID": "SPDXRef-File-server.go-702",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/internal/common/server.go",
       "checksums": [
         {
@@ -9417,7 +7472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-auth-method.go-897",
+      "SPDXID": "SPDXRef-File-auth-method.go-703",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/ssh/auth_method.go",
       "checksums": [
         {
@@ -9427,7 +7482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colorconfig.go-898",
+      "SPDXID": "SPDXRef-File-colorconfig.go-704",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/diff/colorconfig.go",
       "checksums": [
         {
@@ -9437,7 +7492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-status.go-899",
+      "SPDXID": "SPDXRef-File-worktree-status.go-705",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/worktree_status.go",
       "checksums": [
         {
@@ -9447,7 +7502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-900",
+      "SPDXID": "SPDXRef-File-common.go-706",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/ioutil/common.go",
       "checksums": [
         {
@@ -9457,7 +7512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dotgit.go-901",
+      "SPDXID": "SPDXRef-File-dotgit.go-707",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/dotgit.go",
       "checksums": [
         {
@@ -9467,7 +7522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-902",
+      "SPDXID": "SPDXRef-File-scanner.go-708",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/revision/scanner.go",
       "checksums": [
         {
@@ -9477,7 +7532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-limit.go-903",
+      "SPDXID": "SPDXRef-File-commit-walker-limit.go-709",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_limit.go",
       "checksums": [
         {
@@ -9487,7 +7542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-url.go-904",
+      "SPDXID": "SPDXRef-File-url.go-710",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/url/url.go",
       "checksums": [
         {
@@ -9497,7 +7552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-905",
+      "SPDXID": "SPDXRef-File-doc.go-711",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/doc.go",
       "checksums": [
         {
@@ -9507,7 +7562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-match.go-906",
+      "SPDXID": "SPDXRef-File-match.go-712",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/match.go",
       "checksums": [
         {
@@ -9517,7 +7572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reader.go-907",
+      "SPDXID": "SPDXRef-File-reader.go-713",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/reader.go",
       "checksums": [
         {
@@ -9527,7 +7582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doubleiter.go-908",
+      "SPDXID": "SPDXRef-File-doubleiter.go-714",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/doubleiter.go",
       "checksums": [
         {
@@ -9537,7 +7592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-error.go-909",
+      "SPDXID": "SPDXRef-File-error.go-715",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/pktline/error.go",
       "checksums": [
         {
@@ -9547,7 +7602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-910",
+      "SPDXID": "SPDXRef-File-color.go-716",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/color/color.go",
       "checksums": [
         {
@@ -9557,7 +7612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-911",
+      "SPDXID": "SPDXRef-File-server.go-717",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/server/server.go",
       "checksums": [
         {
@@ -9567,7 +7622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blame.go-912",
+      "SPDXID": "SPDXRef-File-blame.go-718",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/blame.go",
       "checksums": [
         {
@@ -9577,7 +7632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object-walker.go-913",
+      "SPDXID": "SPDXRef-File-object-walker.go-719",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/object_walker.go",
       "checksums": [
         {
@@ -9587,7 +7642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-index.go-914",
+      "SPDXID": "SPDXRef-File-index.go-720",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/index.go",
       "checksums": [
         {
@@ -9597,7 +7652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree.go-915",
+      "SPDXID": "SPDXRef-File-worktree.go-721",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/worktree.go",
       "checksums": [
         {
@@ -9607,7 +7662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dotgit-setref.go-916",
+      "SPDXID": "SPDXRef-File-dotgit-setref.go-722",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/dotgit_setref.go",
       "checksums": [
         {
@@ -9617,7 +7672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mocks.go-917",
+      "SPDXID": "SPDXRef-File-mocks.go-723",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/internal/common/mocks.go",
       "checksums": [
         {
@@ -9627,7 +7682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch.go-918",
+      "SPDXID": "SPDXRef-File-patch.go-724",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/diff/patch.go",
       "checksums": [
         {
@@ -9637,7 +7692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-base.go-919",
+      "SPDXID": "SPDXRef-File-merge-base.go-725",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/merge_base.go",
       "checksums": [
         {
@@ -9647,7 +7702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ulreq-encode.go-920",
+      "SPDXID": "SPDXRef-File-ulreq-encode.go-726",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/ulreq_encode.go",
       "checksums": [
         {
@@ -9657,7 +7712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tree.go-921",
+      "SPDXID": "SPDXRef-File-tree.go-727",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/tree.go",
       "checksums": [
         {
@@ -9667,7 +7722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-storage.go-922",
+      "SPDXID": "SPDXRef-File-storage.go-728",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/storage.go",
       "checksums": [
         {
@@ -9677,7 +7732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-923",
+      "SPDXID": "SPDXRef-File-doc.go-729",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/doc.go",
       "checksums": [
         {
@@ -9687,7 +7742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-924",
+      "SPDXID": "SPDXRef-File-doc.go-730",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/doc.go",
       "checksums": [
         {
@@ -9697,7 +7752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-925",
+      "SPDXID": "SPDXRef-File-parser.go-731",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/parser.go",
       "checksums": [
         {
@@ -9707,7 +7762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-url.go-926",
+      "SPDXID": "SPDXRef-File-url.go-732",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/url.go",
       "checksums": [
         {
@@ -9717,7 +7772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reference.go-927",
+      "SPDXID": "SPDXRef-File-reference.go-733",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/reference.go",
       "checksums": [
         {
@@ -9727,7 +7782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-928",
+      "SPDXID": "SPDXRef-File-doc.go-734",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/doc.go",
       "checksums": [
         {
@@ -9737,7 +7792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-trace.go-929",
+      "SPDXID": "SPDXRef-File-trace.go-735",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/trace/trace.go",
       "checksums": [
         {
@@ -9747,7 +7802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object.go-930",
+      "SPDXID": "SPDXRef-File-object.go-736",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object.go",
       "checksums": [
         {
@@ -9757,7 +7812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shallow.go-931",
+      "SPDXID": "SPDXRef-File-shallow.go-737",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/shallow.go",
       "checksums": [
         {
@@ -9767,7 +7822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufio.go-932",
+      "SPDXID": "SPDXRef-File-bufio.go-738",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/sync/bufio.go",
       "checksums": [
         {
@@ -9777,7 +7832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reader.go-933",
+      "SPDXID": "SPDXRef-File-reader.go-739",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/objfile/reader.go",
       "checksums": [
         {
@@ -9787,7 +7842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pattern.go-934",
+      "SPDXID": "SPDXRef-File-pattern.go-740",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/gitignore/pattern.go",
       "checksums": [
         {
@@ -9797,7 +7852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-section.go-935",
+      "SPDXID": "SPDXRef-File-section.go-741",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/section.go",
       "checksums": [
         {
@@ -9807,7 +7862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uppackresp.go-936",
+      "SPDXID": "SPDXRef-File-uppackresp.go-742",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/uppackresp.go",
       "checksums": [
         {
@@ -9817,7 +7872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-937",
+      "SPDXID": "SPDXRef-File-scanner.go-743",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/scanner.go",
       "checksums": [
         {
@@ -9827,7 +7882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object-pack.go-938",
+      "SPDXID": "SPDXRef-File-object-pack.go-744",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/object_pack.go",
       "checksums": [
         {
@@ -9837,7 +7892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-format.go-939",
+      "SPDXID": "SPDXRef-File-format.go-745",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/format.go",
       "checksums": [
         {
@@ -9847,7 +7902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-path-util.go-940",
+      "SPDXID": "SPDXRef-File-path-util.go-746",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/path_util/path_util.go",
       "checksums": [
         {
@@ -9857,7 +7912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-941",
+      "SPDXID": "SPDXRef-File-doc.go-747",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/doc.go",
       "checksums": [
         {
@@ -9867,7 +7922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-942",
+      "SPDXID": "SPDXRef-File-doc.go-748",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/doc.go",
       "checksums": [
         {
@@ -9877,7 +7932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reference.go-943",
+      "SPDXID": "SPDXRef-File-reference.go-749",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/reference.go",
       "checksums": [
         {
@@ -9887,7 +7942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-944",
+      "SPDXID": "SPDXRef-File-doc.go-750",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/doc.go",
       "checksums": [
         {
@@ -9897,7 +7952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-status.go-945",
+      "SPDXID": "SPDXRef-File-status.go-751",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/status.go",
       "checksums": [
         {
@@ -9907,7 +7962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch-delta.go-946",
+      "SPDXID": "SPDXRef-File-patch-delta.go-752",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/patch_delta.go",
       "checksums": [
         {
@@ -9917,7 +7972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list.go-947",
+      "SPDXID": "SPDXRef-File-list.go-753",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/capability/list.go",
       "checksums": [
         {
@@ -9927,7 +7982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote.go-948",
+      "SPDXID": "SPDXRef-File-remote.go-754",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/remote.go",
       "checksums": [
         {
@@ -9937,7 +7992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-949",
+      "SPDXID": "SPDXRef-File-encoder.go-755",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/pktline/encoder.go",
       "checksums": [
         {
@@ -9947,7 +8002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-node.go-950",
+      "SPDXID": "SPDXRef-File-node.go-756",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/index/node.go",
       "checksums": [
         {
@@ -9957,7 +8012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-receive-pack.go-951",
+      "SPDXID": "SPDXRef-File-receive-pack.go-757",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/http/receive_pack.go",
       "checksums": [
         {
@@ -9967,7 +8022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-muxer.go-952",
+      "SPDXID": "SPDXRef-File-muxer.go-758",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/sideband/muxer.go",
       "checksums": [
         {
@@ -9977,7 +8032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-change.go-953",
+      "SPDXID": "SPDXRef-File-change.go-759",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/change.go",
       "checksums": [
         {
@@ -9987,7 +8042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-revision.go-954",
+      "SPDXID": "SPDXRef-File-revision.go-760",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/revision.go",
       "checksums": [
         {
@@ -9997,7 +8052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shallow.go-955",
+      "SPDXID": "SPDXRef-File-shallow.go-761",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/shallow.go",
       "checksums": [
         {
@@ -10007,7 +8062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker.go-956",
+      "SPDXID": "SPDXRef-File-commit-walker.go-762",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker.go",
       "checksums": [
         {
@@ -10017,7 +8072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-957",
+      "SPDXID": "SPDXRef-File-common.go-763",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/common.go",
       "checksums": [
         {
@@ -10027,7 +8082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-storer.go-958",
+      "SPDXID": "SPDXRef-File-storer.go-764",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/storer.go",
       "checksums": [
         {
@@ -10037,7 +8092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fsobject.go-959",
+      "SPDXID": "SPDXRef-File-fsobject.go-765",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/fsobject.go",
       "checksums": [
         {
@@ -10047,7 +8102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object.go-960",
+      "SPDXID": "SPDXRef-File-object.go-766",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/object.go",
       "checksums": [
         {
@@ -10057,7 +8112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deltaobject.go-961",
+      "SPDXID": "SPDXRef-File-deltaobject.go-767",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/deltaobject.go",
       "checksums": [
         {
@@ -10067,7 +8122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read.go-962",
+      "SPDXID": "SPDXRef-File-read.go-768",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/binary/read.go",
       "checksums": [
         {
@@ -10077,7 +8132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-ctime.go-963",
+      "SPDXID": "SPDXRef-File-commit-walker-ctime.go-769",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_ctime.go",
       "checksums": [
         {
@@ -10087,7 +8142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decoder.go-964",
+      "SPDXID": "SPDXRef-File-decoder.go-770",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/decoder.go",
       "checksums": [
         {
@@ -10097,7 +8152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-path.go-965",
+      "SPDXID": "SPDXRef-File-path.go-771",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/noder/path.go",
       "checksums": [
         {
@@ -10107,7 +8162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-966",
+      "SPDXID": "SPDXRef-File-common.go-772",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/internal/common/common.go",
       "checksums": [
         {
@@ -10117,7 +8172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-memory.go-967",
+      "SPDXID": "SPDXRef-File-memory.go-773",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/memory.go",
       "checksums": [
         {
@@ -10127,7 +8182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noder.go-968",
+      "SPDXID": "SPDXRef-File-noder.go-774",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/noder/noder.go",
       "checksums": [
         {
@@ -10137,7 +8192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-969",
+      "SPDXID": "SPDXRef-File-common.go-775",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/common.go",
       "checksums": [
         {
@@ -10147,7 +8202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tag.go-970",
+      "SPDXID": "SPDXRef-File-tag.go-776",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/tag.go",
       "checksums": [
         {
@@ -10157,7 +8212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writers.go-971",
+      "SPDXID": "SPDXRef-File-writers.go-777",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/writers.go",
       "checksums": [
         {
@@ -10167,7 +8222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff.go-972",
+      "SPDXID": "SPDXRef-File-diff.go-778",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/diff/diff.go",
       "checksums": [
         {
@@ -10177,7 +8232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-bfs-filtered.go-973",
+      "SPDXID": "SPDXRef-File-commit-walker-bfs-filtered.go-779",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_bfs_filtered.go",
       "checksums": [
         {
@@ -10187,7 +8242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ulreq.go-974",
+      "SPDXID": "SPDXRef-File-ulreq.go-780",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/ulreq.go",
       "checksums": [
         {
@@ -10197,7 +8252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.go-975",
+      "SPDXID": "SPDXRef-File-file.go-781",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/file.go",
       "checksums": [
         {
@@ -10207,7 +8262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object-lru.go-976",
+      "SPDXID": "SPDXRef-File-object-lru.go-782",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/cache/object_lru.go",
       "checksums": [
         {
@@ -10217,7 +8272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-module.go-977",
+      "SPDXID": "SPDXRef-File-module.go-783",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/module.go",
       "checksums": [
         {
@@ -10227,7 +8282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-978",
+      "SPDXID": "SPDXRef-File-common.go-784",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/cache/common.go",
       "checksums": [
         {
@@ -10237,7 +8292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-979",
+      "SPDXID": "SPDXRef-File-server.go-785",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/file/server.go",
       "checksums": [
         {
@@ -10247,7 +8302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch.go-980",
+      "SPDXID": "SPDXRef-File-patch.go-786",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/patch.go",
       "checksums": [
         {
@@ -10257,7 +8312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-advrefs.go-981",
+      "SPDXID": "SPDXRef-File-advrefs.go-787",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/advrefs.go",
       "checksums": [
         {
@@ -10267,7 +8322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blob.go-982",
+      "SPDXID": "SPDXRef-File-blob.go-788",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/blob.go",
       "checksums": [
         {
@@ -10277,7 +8332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-unified-encoder.go-983",
+      "SPDXID": "SPDXRef-File-unified-encoder.go-789",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/diff/unified_encoder.go",
       "checksums": [
         {
@@ -10287,7 +8342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-984",
+      "SPDXID": "SPDXRef-File-common.go-790",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/git/common.go",
       "checksums": [
         {
@@ -10297,7 +8352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.go-985",
+      "SPDXID": "SPDXRef-File-hash.go-791",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/hash/hash.go",
       "checksums": [
         {
@@ -10307,7 +8362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object.go-986",
+      "SPDXID": "SPDXRef-File-object.go-792",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/object.go",
       "checksums": [
         {
@@ -10317,7 +8372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-modules.go-987",
+      "SPDXID": "SPDXRef-File-modules.go-793",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/modules.go",
       "checksums": [
         {
@@ -10327,7 +8382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-988",
+      "SPDXID": "SPDXRef-File-parser.go-794",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/revision/parser.go",
       "checksums": [
         {
@@ -10337,7 +8392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-index.go-989",
+      "SPDXID": "SPDXRef-File-index.go-795",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/index.go",
       "checksums": [
         {
@@ -10347,7 +8402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-repository-filesystem.go-990",
+      "SPDXID": "SPDXRef-File-repository-filesystem.go-796",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/repository_filesystem.go",
       "checksums": [
         {
@@ -10357,7 +8412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decoder.go-991",
+      "SPDXID": "SPDXRef-File-decoder.go-797",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/decoder.go",
       "checksums": [
         {
@@ -10367,7 +8422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodule.go-992",
+      "SPDXID": "SPDXRef-File-submodule.go-798",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/submodule.go",
       "checksums": [
         {
@@ -10377,7 +8432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-993",
+      "SPDXID": "SPDXRef-File-common.go-799",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/common.go",
       "checksums": [
         {
@@ -10387,7 +8442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-repository.go-994",
+      "SPDXID": "SPDXRef-File-repository.go-800",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/repository.go",
       "checksums": [
         {
@@ -10397,7 +8452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-995",
+      "SPDXID": "SPDXRef-File-common.go-801",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/common.go",
       "checksums": [
         {
@@ -10407,7 +8462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-996",
+      "SPDXID": "SPDXRef-File-common.go-802",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/http/common.go",
       "checksums": [
         {
@@ -10417,7 +8472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-997",
+      "SPDXID": "SPDXRef-File-encoder.go-803",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/encoder.go",
       "checksums": [
         {
@@ -10427,7 +8482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-upload-pack.go-998",
+      "SPDXID": "SPDXRef-File-upload-pack.go-804",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/http/upload_pack.go",
       "checksums": [
         {
@@ -10437,7 +8492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-revlist.go-999",
+      "SPDXID": "SPDXRef-File-revlist.go-805",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/revlist/revlist.go",
       "checksums": [
         {
@@ -10447,7 +8502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-idxfile.go-1000",
+      "SPDXID": "SPDXRef-File-idxfile.go-806",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/idxfile.go",
       "checksums": [
         {
@@ -10457,7 +8512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rename.go-1001",
+      "SPDXID": "SPDXRef-File-rename.go-807",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/rename.go",
       "checksums": [
         {
@@ -10467,7 +8522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-advrefs-encode.go-1002",
+      "SPDXID": "SPDXRef-File-advrefs-encode.go-808",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/advrefs_encode.go",
       "checksums": [
         {
@@ -10477,7 +8532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-refspec.go-1003",
+      "SPDXID": "SPDXRef-File-refspec.go-809",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/refspec.go",
       "checksums": [
         {
@@ -10487,7 +8542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-1004",
+      "SPDXID": "SPDXRef-File-encoder.go-810",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/encoder.go",
       "checksums": [
         {
@@ -10497,7 +8552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-difftree.go-1005",
+      "SPDXID": "SPDXRef-File-difftree.go-811",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/difftree.go",
       "checksums": [
         {
@@ -10507,7 +8562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-error.go-1006",
+      "SPDXID": "SPDXRef-File-error.go-812",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/error.go",
       "checksums": [
         {
@@ -10517,7 +8572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-delta-index.go-1007",
+      "SPDXID": "SPDXRef-File-delta-index.go-813",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/delta_index.go",
       "checksums": [
         {
@@ -10527,7 +8582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-updreq-encode.go-1008",
+      "SPDXID": "SPDXRef-File-updreq-encode.go-814",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/updreq_encode.go",
       "checksums": [
         {
@@ -10537,7 +8592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1009",
+      "SPDXID": "SPDXRef-File-doc.go-815",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/objfile/doc.go",
       "checksums": [
         {
@@ -10547,7 +8602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-1010",
+      "SPDXID": "SPDXRef-File-common.go-816",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/common.go",
       "checksums": [
         {
@@ -10557,7 +8612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-1011",
+      "SPDXID": "SPDXRef-File-scanner.go-817",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/pktline/scanner.go",
       "checksums": [
         {
@@ -10567,7 +8622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-demux.go-1012",
+      "SPDXID": "SPDXRef-File-demux.go-818",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/sideband/demux.go",
       "checksums": [
         {
@@ -10577,7 +8632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-report-status.go-1013",
+      "SPDXID": "SPDXRef-File-report-status.go-819",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/report_status.go",
       "checksums": [
         {
@@ -10587,7 +8642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-node.go-1014",
+      "SPDXID": "SPDXRef-File-node.go-820",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/filesystem/node.go",
       "checksums": [
         {
@@ -10597,7 +8652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-token.go-1015",
+      "SPDXID": "SPDXRef-File-token.go-821",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/revision/token.go",
       "checksums": [
         {
@@ -10607,7 +8662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-buffer-lru.go-1016",
+      "SPDXID": "SPDXRef-File-buffer-lru.go-822",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/cache/buffer_lru.go",
       "checksums": [
         {
@@ -10617,7 +8672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-treenoder.go-1017",
+      "SPDXID": "SPDXRef-File-treenoder.go-823",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/treenoder.go",
       "checksums": [
         {
@@ -10627,7 +8682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dir.go-1018",
+      "SPDXID": "SPDXRef-File-dir.go-824",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/gitignore/dir.go",
       "checksums": [
         {
@@ -10637,7 +8692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shallowupd.go-1019",
+      "SPDXID": "SPDXRef-File-shallowupd.go-825",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/shallowupd.go",
       "checksums": [
         {
@@ -10647,7 +8702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-frame.go-1020",
+      "SPDXID": "SPDXRef-File-frame.go-826",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/internal/frame/frame.go",
       "checksums": [
         {
@@ -10657,7 +8712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-capability.go-1021",
+      "SPDXID": "SPDXRef-File-capability.go-827",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/capability/capability.go",
       "checksums": [
         {
@@ -10667,7 +8722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-path.go-1022",
+      "SPDXID": "SPDXRef-File-commit-walker-path.go-828",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_path.go",
       "checksums": [
         {
@@ -10677,7 +8732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writer.go-1023",
+      "SPDXID": "SPDXRef-File-writer.go-829",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/writer.go",
       "checksums": [
         {
@@ -10687,7 +8742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff-delta.go-1024",
+      "SPDXID": "SPDXRef-File-diff-delta.go-830",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/diff_delta.go",
       "checksums": [
         {
@@ -10697,7 +8752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-matcher.go-1025",
+      "SPDXID": "SPDXRef-File-matcher.go-831",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/gitignore/matcher.go",
       "checksums": [
         {
@@ -10707,7 +8762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-difftree.go-1026",
+      "SPDXID": "SPDXRef-File-difftree.go-832",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/difftree.go",
       "checksums": [
         {
@@ -10717,7 +8772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-write.go-1027",
+      "SPDXID": "SPDXRef-File-write.go-833",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/binary/write.go",
       "checksums": [
         {
@@ -10727,7 +8782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-error.go-1028",
+      "SPDXID": "SPDXRef-File-error.go-834",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/error.go",
       "checksums": [
         {
@@ -10737,7 +8792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-change-adaptor.go-1029",
+      "SPDXID": "SPDXRef-File-change-adaptor.go-835",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/change_adaptor.go",
       "checksums": [
         {
@@ -10747,7 +8802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1030",
+      "SPDXID": "SPDXRef-File-doc.go-836",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/sideband/doc.go",
       "checksums": [
         {
@@ -10757,7 +8812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bytes.go-1031",
+      "SPDXID": "SPDXRef-File-bytes.go-837",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/sync/bytes.go",
       "checksums": [
         {
@@ -10767,7 +8822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-storer.go-1032",
+      "SPDXID": "SPDXRef-File-storer.go-838",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/storer.go",
       "checksums": [
         {
@@ -10777,7 +8832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transport.go-1033",
+      "SPDXID": "SPDXRef-File-transport.go-839",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/http/transport.go",
       "checksums": [
         {
@@ -10787,7 +8842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-bfs.go-1034",
+      "SPDXID": "SPDXRef-File-commit-walker-bfs.go-840",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_bfs.go",
       "checksums": [
         {
@@ -10797,7 +8852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-option.go-1035",
+      "SPDXID": "SPDXRef-File-option.go-841",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/option.go",
       "checksums": [
         {
@@ -10807,7 +8862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gitproto.go-1036",
+      "SPDXID": "SPDXRef-File-gitproto.go-842",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/gitproto.go",
       "checksums": [
         {
@@ -10817,7 +8872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-updreq.go-1037",
+      "SPDXID": "SPDXRef-File-updreq.go-843",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/updreq.go",
       "checksums": [
         {
@@ -10827,7 +8882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signer.go-1038",
+      "SPDXID": "SPDXRef-File-signer.go-844",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/signer.go",
       "checksums": [
         {
@@ -10837,7 +8892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-updreq-decode.go-1039",
+      "SPDXID": "SPDXRef-File-updreq-decode.go-845",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/updreq_decode.go",
       "checksums": [
         {
@@ -10847,7 +8902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dotgit-rewrite-packed-refs.go-1040",
+      "SPDXID": "SPDXRef-File-dotgit-rewrite-packed-refs.go-846",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go",
       "checksums": [
         {
@@ -10857,7 +8912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decoder.go-1041",
+      "SPDXID": "SPDXRef-File-decoder.go-847",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/decoder.go",
       "checksums": [
         {
@@ -10867,7 +8922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-advrefs-decode.go-1042",
+      "SPDXID": "SPDXRef-File-advrefs-decode.go-848",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/advrefs_decode.go",
       "checksums": [
         {
@@ -10877,7 +8932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-1043",
+      "SPDXID": "SPDXRef-File-common.go-849",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/ssh/common.go",
       "checksums": [
         {
@@ -10887,7 +8942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reference.go-1044",
+      "SPDXID": "SPDXRef-File-reference.go-850",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/reference.go",
       "checksums": [
         {
@@ -10897,7 +8952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object.go-1045",
+      "SPDXID": "SPDXRef-File-object.go-851",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/object.go",
       "checksums": [
         {
@@ -10907,7 +8962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-packfile.go-1046",
+      "SPDXID": "SPDXRef-File-packfile.go-852",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/packfile.go",
       "checksums": [
         {
@@ -10917,7 +8972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-prune.go-1047",
+      "SPDXID": "SPDXRef-File-prune.go-853",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/prune.go",
       "checksums": [
         {
@@ -10927,7 +8982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iter.go-1048",
+      "SPDXID": "SPDXRef-File-iter.go-854",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/iter.go",
       "checksums": [
         {
@@ -10937,7 +8992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-storage.go-1049",
+      "SPDXID": "SPDXRef-File-storage.go-855",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/memory/storage.go",
       "checksums": [
         {
@@ -10947,7 +9002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-1050",
+      "SPDXID": "SPDXRef-File-encoder.go-856",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/encoder.go",
       "checksums": [
         {
@@ -10957,7 +9012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-1051",
+      "SPDXID": "SPDXRef-File-common.go-857",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/sideband/common.go",
       "checksums": [
         {
@@ -10967,7 +9022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-loader.go-1052",
+      "SPDXID": "SPDXRef-File-loader.go-858",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/server/loader.go",
       "checksums": [
         {
@@ -10977,7 +9032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-srvresp.go-1053",
+      "SPDXID": "SPDXRef-File-srvresp.go-859",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/srvresp.go",
       "checksums": [
         {
@@ -10987,7 +9042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash-sha1.go-1054",
+      "SPDXID": "SPDXRef-File-hash-sha1.go-860",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/hash/hash_sha1.go",
       "checksums": [
         {
@@ -10997,7 +9052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filemode.go-1055",
+      "SPDXID": "SPDXRef-File-filemode.go-861",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/filemode/filemode.go",
       "checksums": [
         {
@@ -11007,7 +9062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ulreq-decode.go-1056",
+      "SPDXID": "SPDXRef-File-ulreq-decode.go-862",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/ulreq_decode.go",
       "checksums": [
         {
@@ -11017,7 +9072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zlib.go-1057",
+      "SPDXID": "SPDXRef-File-zlib.go-863",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/sync/zlib.go",
       "checksums": [
         {
@@ -11027,7 +9082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-linux.go-1058",
+      "SPDXID": "SPDXRef-File-worktree-linux.go-864",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/worktree_linux.go",
       "checksums": [
         {
@@ -11037,7 +9092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1059",
+      "SPDXID": "SPDXRef-File-doc.go-865",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/gitignore/doc.go",
       "checksums": [
         {
@@ -11047,7 +9102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-change.go-1060",
+      "SPDXID": "SPDXRef-File-change.go-866",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/change.go",
       "checksums": [
         {
@@ -11057,7 +9112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit.go-1061",
+      "SPDXID": "SPDXRef-File-commit.go-867",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit.go",
       "checksums": [
         {
@@ -11067,7 +9122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-branch.go-1062",
+      "SPDXID": "SPDXRef-File-branch.go-868",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/branch.go",
       "checksums": [
         {
@@ -11077,7 +9132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signature.go-1063",
+      "SPDXID": "SPDXRef-File-signature.go-869",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/signature.go",
       "checksums": [
         {
@@ -11087,7 +9142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-1064",
+      "SPDXID": "SPDXRef-File-config.go-870",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/config.go",
       "checksums": [
         {
@@ -11097,7 +9152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uppackreq.go-1065",
+      "SPDXID": "SPDXRef-File-uppackreq.go-871",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/uppackreq.go",
       "checksums": [
         {
@@ -11107,7 +9162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp-amd64.go-1066",
+      "SPDXID": "SPDXRef-File-fp-amd64.go-872",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp25519/fp_amd64.go",
       "checksums": [
         {
@@ -11117,7 +9172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-xor-unaligned.go-1067",
+      "SPDXID": "SPDXRef-File-xor-unaligned.go-873",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/xor_unaligned.go",
       "checksums": [
         {
@@ -11127,7 +9182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-modular.go-1068",
+      "SPDXID": "SPDXRef-File-modular.go-874",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/modular.go",
       "checksums": [
         {
@@ -11137,7 +9192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-point.go-1069",
+      "SPDXID": "SPDXRef-File-point.go-875",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/point.go",
       "checksums": [
         {
@@ -11147,7 +9202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sign.go-1070",
+      "SPDXID": "SPDXRef-File-sign.go-876",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/sign.go",
       "checksums": [
         {
@@ -11157,7 +9212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-primes.go-1071",
+      "SPDXID": "SPDXRef-File-primes.go-877",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/primes.go",
       "checksums": [
         {
@@ -11167,7 +9222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keccakf.go-1072",
+      "SPDXID": "SPDXRef-File-keccakf.go-878",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/keccakf.go",
       "checksums": [
         {
@@ -11177,7 +9232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve.go-1073",
+      "SPDXID": "SPDXRef-File-curve.go-879",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/curve.go",
       "checksums": [
         {
@@ -11187,7 +9242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signapi.go-1074",
+      "SPDXID": "SPDXRef-File-signapi.go-880",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed448/signapi.go",
       "checksums": [
         {
@@ -11197,7 +9252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-table.go-1075",
+      "SPDXID": "SPDXRef-File-table.go-881",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/table.go",
       "checksums": [
         {
@@ -11207,7 +9262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed25519.go-1076",
+      "SPDXID": "SPDXRef-File-ed25519.go-882",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/ed25519.go",
       "checksums": [
         {
@@ -11217,7 +9272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-key.go-1077",
+      "SPDXID": "SPDXRef-File-key.go-883",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/key.go",
       "checksums": [
         {
@@ -11227,7 +9282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mult.go-1078",
+      "SPDXID": "SPDXRef-File-mult.go-884",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/mult.go",
       "checksums": [
         {
@@ -11237,7 +9292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp-generic.go-1079",
+      "SPDXID": "SPDXRef-File-fp-generic.go-885",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp25519/fp_generic.go",
       "checksums": [
         {
@@ -11247,7 +9302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1080",
+      "SPDXID": "SPDXRef-File-doc.go-886",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/doc.go",
       "checksums": [
         {
@@ -11257,7 +9312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-power.go-1081",
+      "SPDXID": "SPDXRef-File-power.go-887",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/mlsbset/power.go",
       "checksums": [
         {
@@ -11267,7 +9322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conv.go-1082",
+      "SPDXID": "SPDXRef-File-conv.go-888",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/conv/conv.go",
       "checksums": [
         {
@@ -11277,7 +9332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp-generic.go-1083",
+      "SPDXID": "SPDXRef-File-fp-generic.go-889",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp448/fp_generic.go",
       "checksums": [
         {
@@ -11287,7 +9342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp.go-1084",
+      "SPDXID": "SPDXRef-File-fp.go-890",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp25519/fp.go",
       "checksums": [
         {
@@ -11297,7 +9352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp-amd64.go-1085",
+      "SPDXID": "SPDXRef-File-fp-amd64.go-891",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp448/fp_amd64.go",
       "checksums": [
         {
@@ -11307,7 +9362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rc.go-1086",
+      "SPDXID": "SPDXRef-File-rc.go-892",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/rc.go",
       "checksums": [
         {
@@ -11317,7 +9372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shake.go-1087",
+      "SPDXID": "SPDXRef-File-shake.go-893",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/shake.go",
       "checksums": [
         {
@@ -11327,7 +9382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hashes.go-1088",
+      "SPDXID": "SPDXRef-File-hashes.go-894",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/hashes.go",
       "checksums": [
         {
@@ -11337,7 +9392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1089",
+      "SPDXID": "SPDXRef-File-doc.go-895",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/doc.go",
       "checksums": [
         {
@@ -11347,7 +9402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-twist.go-1090",
+      "SPDXID": "SPDXRef-File-twist.go-896",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/twist.go",
       "checksums": [
         {
@@ -11357,7 +9412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tables.go-1091",
+      "SPDXID": "SPDXRef-File-tables.go-897",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/tables.go",
       "checksums": [
         {
@@ -11367,7 +9422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-amd64.go-1092",
+      "SPDXID": "SPDXRef-File-curve-amd64.go-898",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/curve_amd64.go",
       "checksums": [
         {
@@ -11377,7 +9432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wnaf.go-1093",
+      "SPDXID": "SPDXRef-File-wnaf.go-899",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/wnaf.go",
       "checksums": [
         {
@@ -11387,7 +9442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-integer.go-1094",
+      "SPDXID": "SPDXRef-File-integer.go-900",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/integer.go",
       "checksums": [
         {
@@ -11397,7 +9452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-amd64.go-1095",
+      "SPDXID": "SPDXRef-File-curve-amd64.go-901",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/curve_amd64.go",
       "checksums": [
         {
@@ -11407,7 +9462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha3.go-1096",
+      "SPDXID": "SPDXRef-File-sha3.go-902",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/sha3.go",
       "checksums": [
         {
@@ -11417,7 +9472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mlsbset.go-1097",
+      "SPDXID": "SPDXRef-File-mlsbset.go-903",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/mlsbset/mlsbset.go",
       "checksums": [
         {
@@ -11427,7 +9482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp.go-1098",
+      "SPDXID": "SPDXRef-File-fp.go-904",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp448/fp.go",
       "checksums": [
         {
@@ -11437,7 +9492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-generic.go-1099",
+      "SPDXID": "SPDXRef-File-curve-generic.go-905",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/curve_generic.go",
       "checksums": [
         {
@@ -11447,7 +9502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-isogeny.go-1100",
+      "SPDXID": "SPDXRef-File-isogeny.go-906",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/isogeny.go",
       "checksums": [
         {
@@ -11457,7 +9512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-constants.go-1101",
+      "SPDXID": "SPDXRef-File-constants.go-907",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/constants.go",
       "checksums": [
         {
@@ -11467,7 +9522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1102",
+      "SPDXID": "SPDXRef-File-doc.go-908",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/doc.go",
       "checksums": [
         {
@@ -11477,7 +9532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pubkey.go-1103",
+      "SPDXID": "SPDXRef-File-pubkey.go-909",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/pubkey.go",
       "checksums": [
         {
@@ -11487,7 +9542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed448.go-1104",
+      "SPDXID": "SPDXRef-File-ed448.go-910",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed448/ed448.go",
       "checksums": [
         {
@@ -11497,7 +9552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-twistPoint.go-1105",
+      "SPDXID": "SPDXRef-File-twistPoint.go-911",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/twistPoint.go",
       "checksums": [
         {
@@ -11507,7 +9562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-key.go-1106",
+      "SPDXID": "SPDXRef-File-key.go-912",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/key.go",
       "checksums": [
         {
@@ -11517,7 +9572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-point.go-1107",
+      "SPDXID": "SPDXRef-File-point.go-913",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/point.go",
       "checksums": [
         {
@@ -11527,7 +9582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve.go-1108",
+      "SPDXID": "SPDXRef-File-curve.go-914",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/curve.go",
       "checksums": [
         {
@@ -11537,7 +9592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-generic.go-1109",
+      "SPDXID": "SPDXRef-File-curve-generic.go-915",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/curve_generic.go",
       "checksums": [
         {
@@ -11547,7 +9602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signapi.go-1110",
+      "SPDXID": "SPDXRef-File-signapi.go-916",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/signapi.go",
       "checksums": [
         {
@@ -11557,7 +9612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-twistTables.go-1111",
+      "SPDXID": "SPDXRef-File-twistTables.go-917",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/twistTables.go",
       "checksums": [
         {
@@ -11567,7 +9622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-table.go-1112",
+      "SPDXID": "SPDXRef-File-table.go-918",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/table.go",
       "checksums": [
         {
@@ -11577,7 +9632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-twist-basemult.go-1113",
+      "SPDXID": "SPDXRef-File-twist-basemult.go-919",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/twist_basemult.go",
       "checksums": [
         {
@@ -11587,7 +9642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve.go-1114",
+      "SPDXID": "SPDXRef-File-curve.go-920",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/curve.go",
       "checksums": [
         {
@@ -11597,7 +9652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scalar.go-1115",
+      "SPDXID": "SPDXRef-File-scalar.go-921",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/scalar.go",
       "checksums": [
         {
@@ -11607,7 +9662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-attr.go-1116",
+      "SPDXID": "SPDXRef-File-attr.go-922",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/attr.go",
       "checksums": [
         {
@@ -11617,7 +9672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1117",
+      "SPDXID": "SPDXRef-File-term.go-923",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/a/alacritty/term.go",
       "checksums": [
         {
@@ -11627,7 +9682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock-unix.go-1118",
+      "SPDXID": "SPDXRef-File-nonblock-unix.go-924",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/nonblock_unix.go",
       "checksums": [
         {
@@ -11637,7 +9692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-direct.go-1119",
+      "SPDXID": "SPDXRef-File-direct.go-925",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xterm/direct.go",
       "checksums": [
         {
@@ -11647,7 +9702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1120",
+      "SPDXID": "SPDXRef-File-term.go-926",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xfce/term.go",
       "checksums": [
         {
@@ -11657,7 +9712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1121",
+      "SPDXID": "SPDXRef-File-term.go-927",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/r/rxvt/term.go",
       "checksums": [
         {
@@ -11667,7 +9722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1122",
+      "SPDXID": "SPDXRef-File-term.go-928",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/c/cygwin/term.go",
       "checksums": [
         {
@@ -11677,7 +9732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-1123",
+      "SPDXID": "SPDXRef-File-errors.go-929",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/errors.go",
       "checksums": [
         {
@@ -11687,7 +9742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1124",
+      "SPDXID": "SPDXRef-File-term.go-930",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/a/ansi/term.go",
       "checksums": [
         {
@@ -11697,7 +9752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1125",
+      "SPDXID": "SPDXRef-File-term.go-931",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/l/linux/term.go",
       "checksums": [
         {
@@ -11707,7 +9762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1126",
+      "SPDXID": "SPDXRef-File-term.go-932",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt420/term.go",
       "checksums": [
         {
@@ -11717,7 +9772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tscreen-unix.go-1127",
+      "SPDXID": "SPDXRef-File-tscreen-unix.go-933",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/tscreen_unix.go",
       "checksums": [
         {
@@ -11727,7 +9782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1128",
+      "SPDXID": "SPDXRef-File-term.go-934",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/g/gnome/term.go",
       "checksums": [
         {
@@ -11737,7 +9792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mouse.go-1129",
+      "SPDXID": "SPDXRef-File-mouse.go-935",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/mouse.go",
       "checksums": [
         {
@@ -11747,7 +9802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminfo.go-1130",
+      "SPDXID": "SPDXRef-File-terminfo.go-936",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/terminfo.go",
       "checksums": [
         {
@@ -11757,7 +9812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-extended.go-1131",
+      "SPDXID": "SPDXRef-File-extended.go-937",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/extended/extended.go",
       "checksums": [
         {
@@ -11767,7 +9822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1132",
+      "SPDXID": "SPDXRef-File-term.go-938",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/s/screen/term.go",
       "checksums": [
         {
@@ -11777,7 +9832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1133",
+      "SPDXID": "SPDXRef-File-term.go-939",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/a/aixterm/term.go",
       "checksums": [
         {
@@ -11787,7 +9842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1134",
+      "SPDXID": "SPDXRef-File-term.go-940",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/s/sun/term.go",
       "checksums": [
         {
@@ -11797,7 +9852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eastasian.go-1135",
+      "SPDXID": "SPDXRef-File-eastasian.go-941",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/eastasian.go",
       "checksums": [
         {
@@ -11807,7 +9862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1136",
+      "SPDXID": "SPDXRef-File-term.go-942",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt400/term.go",
       "checksums": [
         {
@@ -11817,7 +9872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-key.go-1137",
+      "SPDXID": "SPDXRef-File-key.go-943",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/key.go",
       "checksums": [
         {
@@ -11827,7 +9882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1138",
+      "SPDXID": "SPDXRef-File-term.go-944",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/t/tmux/term.go",
       "checksums": [
         {
@@ -11837,7 +9892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1139",
+      "SPDXID": "SPDXRef-File-doc.go-945",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/doc.go",
       "checksums": [
         {
@@ -11847,7 +9902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-console-stub.go-1140",
+      "SPDXID": "SPDXRef-File-console-stub.go-946",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/console_stub.go",
       "checksums": [
         {
@@ -11857,7 +9912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-interrupt.go-1141",
+      "SPDXID": "SPDXRef-File-interrupt.go-947",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/interrupt.go",
       "checksums": [
         {
@@ -11867,7 +9922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-style.go-1142",
+      "SPDXID": "SPDXRef-File-style.go-948",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/style.go",
       "checksums": [
         {
@@ -11877,7 +9932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1143",
+      "SPDXID": "SPDXRef-File-term.go-949",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xterm/term.go",
       "checksums": [
         {
@@ -11887,7 +9942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base.go-1144",
+      "SPDXID": "SPDXRef-File-base.go-950",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/base/base.go",
       "checksums": [
         {
@@ -11897,7 +9952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tscreen.go-1145",
+      "SPDXID": "SPDXRef-File-tscreen.go-951",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/tscreen.go",
       "checksums": [
         {
@@ -11907,7 +9962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-direct.go-1146",
+      "SPDXID": "SPDXRef-File-direct.go-952",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/a/alacritty/direct.go",
       "checksums": [
         {
@@ -11917,7 +9972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1147",
+      "SPDXID": "SPDXRef-File-term.go-953",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/e/emacs/term.go",
       "checksums": [
         {
@@ -11927,7 +9982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1148",
+      "SPDXID": "SPDXRef-File-term.go-954",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/k/konsole/term.go",
       "checksums": [
         {
@@ -11937,7 +9992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tty.go-1149",
+      "SPDXID": "SPDXRef-File-tty.go-955",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/tty.go",
       "checksums": [
         {
@@ -11947,7 +10002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-charset-unix.go-1150",
+      "SPDXID": "SPDXRef-File-charset-unix.go-956",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/charset_unix.go",
       "checksums": [
         {
@@ -11957,7 +10012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynamic.go-1151",
+      "SPDXID": "SPDXRef-File-dynamic.go-957",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/dynamic/dynamic.go",
       "checksums": [
         {
@@ -11967,7 +10022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-1152",
+      "SPDXID": "SPDXRef-File-color.go-958",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/color.go",
       "checksums": [
         {
@@ -11977,7 +10032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-simulation.go-1153",
+      "SPDXID": "SPDXRef-File-simulation.go-959",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/simulation.go",
       "checksums": [
         {
@@ -11987,7 +10042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terms-dynamic.go-1154",
+      "SPDXID": "SPDXRef-File-terms-dynamic.go-960",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terms_dynamic.go",
       "checksums": [
         {
@@ -11997,7 +10052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1155",
+      "SPDXID": "SPDXRef-File-term.go-961",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/s/simpleterm/term.go",
       "checksums": [
         {
@@ -12007,7 +10062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-foot.go-1156",
+      "SPDXID": "SPDXRef-File-foot.go-962",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/f/foot/foot.go",
       "checksums": [
         {
@@ -12017,7 +10072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-event.go-1157",
+      "SPDXID": "SPDXRef-File-event.go-963",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/event.go",
       "checksums": [
         {
@@ -12027,7 +10082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1158",
+      "SPDXID": "SPDXRef-File-term.go-964",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/k/kterm/term.go",
       "checksums": [
         {
@@ -12037,7 +10092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1159",
+      "SPDXID": "SPDXRef-File-term.go-965",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/p/pcansi/term.go",
       "checksums": [
         {
@@ -12047,7 +10102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stdin-unix.go-1160",
+      "SPDXID": "SPDXRef-File-stdin-unix.go-966",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/stdin_unix.go",
       "checksums": [
         {
@@ -12057,7 +10112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1161",
+      "SPDXID": "SPDXRef-File-term.go-967",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/d/dtterm/term.go",
       "checksums": [
         {
@@ -12067,7 +10122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoding.go-1162",
+      "SPDXID": "SPDXRef-File-encoding.go-968",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/encoding.go",
       "checksums": [
         {
@@ -12077,7 +10132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1163",
+      "SPDXID": "SPDXRef-File-term.go-969",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt220/term.go",
       "checksums": [
         {
@@ -12087,7 +10142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cell.go-1164",
+      "SPDXID": "SPDXRef-File-cell.go-970",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/cell.go",
       "checksums": [
         {
@@ -12097,7 +10152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1165",
+      "SPDXID": "SPDXRef-File-term.go-971",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xterm_ghostty/term.go",
       "checksums": [
         {
@@ -12107,7 +10162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tty-unix.go-1166",
+      "SPDXID": "SPDXRef-File-tty-unix.go-972",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/tty_unix.go",
       "checksums": [
         {
@@ -12117,7 +10172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1167",
+      "SPDXID": "SPDXRef-File-term.go-973",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt320/term.go",
       "checksums": [
         {
@@ -12127,7 +10182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-input.go-1168",
+      "SPDXID": "SPDXRef-File-input.go-974",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/input.go",
       "checksums": [
         {
@@ -12137,7 +10192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-screen.go-1169",
+      "SPDXID": "SPDXRef-File-screen.go-975",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/screen.go",
       "checksums": [
         {
@@ -12147,7 +10202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1170",
+      "SPDXID": "SPDXRef-File-term.go-976",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt100/term.go",
       "checksums": [
         {
@@ -12157,7 +10212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1171",
+      "SPDXID": "SPDXRef-File-term.go-977",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt102/term.go",
       "checksums": [
         {
@@ -12167,7 +10222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-focus.go-1172",
+      "SPDXID": "SPDXRef-File-focus.go-978",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/focus.go",
       "checksums": [
         {
@@ -12177,7 +10232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-runes.go-1173",
+      "SPDXID": "SPDXRef-File-runes.go-979",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/runes.go",
       "checksums": [
         {
@@ -12187,7 +10242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-resize.go-1174",
+      "SPDXID": "SPDXRef-File-resize.go-980",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/resize.go",
       "checksums": [
         {
@@ -12197,7 +10252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-paste.go-1175",
+      "SPDXID": "SPDXRef-File-paste.go-981",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/paste.go",
       "checksums": [
         {
@@ -12207,7 +10262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colorfit.go-1176",
+      "SPDXID": "SPDXRef-File-colorfit.go-982",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/colorfit.go",
       "checksums": [
         {
@@ -12217,7 +10272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1177",
+      "SPDXID": "SPDXRef-File-term.go-983",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xterm_kitty/term.go",
       "checksums": [
         {
@@ -12227,7 +10282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terms-default.go-1178",
+      "SPDXID": "SPDXRef-File-terms-default.go-984",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terms_default.go",
       "checksums": [
         {
@@ -12237,7 +10292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-orderedmap.go-1179",
+      "SPDXID": "SPDXRef-File-orderedmap.go-985",
       "fileName": "repos/lazygit/vendor/github.com/wk8/go-ordered-map/v2/orderedmap.go",
       "checksums": [
         {
@@ -12247,7 +10302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yaml.go-1180",
+      "SPDXID": "SPDXRef-File-yaml.go-986",
       "fileName": "repos/lazygit/vendor/github.com/wk8/go-ordered-map/v2/yaml.go",
       "checksums": [
         {
@@ -12257,7 +10312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-json.go-1181",
+      "SPDXID": "SPDXRef-File-json.go-987",
       "fileName": "repos/lazygit/vendor/github.com/wk8/go-ordered-map/v2/json.go",
       "checksums": [
         {
@@ -12267,7 +10322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-1182",
+      "SPDXID": "SPDXRef-File-utils.go-988",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/lazycore/pkg/utils/utils.go",
       "checksums": [
         {
@@ -12277,7 +10332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-boxlayout.go-1183",
+      "SPDXID": "SPDXRef-File-boxlayout.go-989",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/lazycore/pkg/boxlayout/boxlayout.go",
       "checksums": [
         {
@@ -12287,7 +10342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsortanyfunc.go-1184",
+      "SPDXID": "SPDXRef-File-zsortanyfunc.go-990",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/zsortanyfunc.go",
       "checksums": [
         {
@@ -12297,7 +10352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-constraints.go-1185",
+      "SPDXID": "SPDXRef-File-constraints.go-991",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/constraints/constraints.go",
       "checksums": [
         {
@@ -12307,7 +10362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slices.go-1186",
+      "SPDXID": "SPDXRef-File-slices.go-992",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/slices.go",
       "checksums": [
         {
@@ -12317,7 +10372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsortordered.go-1187",
+      "SPDXID": "SPDXRef-File-zsortordered.go-993",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/zsortordered.go",
       "checksums": [
         {
@@ -12327,7 +10382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sort.go-1188",
+      "SPDXID": "SPDXRef-File-sort.go-994",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/sort.go",
       "checksums": [
         {
@@ -12337,7 +10392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmp.go-1189",
+      "SPDXID": "SPDXRef-File-cmp.go-995",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/cmp.go",
       "checksums": [
         {
@@ -12347,7 +10402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ubc-amd64.go-1190",
+      "SPDXID": "SPDXRef-File-ubc-amd64.go-996",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/ubc/ubc_amd64.go",
       "checksums": [
         {
@@ -12357,7 +10412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha1cd.go-1191",
+      "SPDXID": "SPDXRef-File-sha1cd.go-997",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/sha1cd.go",
       "checksums": [
         {
@@ -12367,7 +10422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-const.go-1192",
+      "SPDXID": "SPDXRef-File-const.go-998",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/internal/const.go",
       "checksums": [
         {
@@ -12377,7 +10432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha1cdblock-amd64.go-1193",
+      "SPDXID": "SPDXRef-File-sha1cdblock-amd64.go-999",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/sha1cdblock_amd64.go",
       "checksums": [
         {
@@ -12387,7 +10442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-detection.go-1194",
+      "SPDXID": "SPDXRef-File-detection.go-1000",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/detection.go",
       "checksums": [
         {
@@ -12397,7 +10452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ubc.go-1195",
+      "SPDXID": "SPDXRef-File-ubc.go-1001",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/ubc/ubc.go",
       "checksums": [
         {
@@ -12407,7 +10462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha1cdblock-generic.go-1196",
+      "SPDXID": "SPDXRef-File-sha1cdblock-generic.go-1002",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/sha1cdblock_generic.go",
       "checksums": [
         {
@@ -12417,7 +10472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-const.go-1197",
+      "SPDXID": "SPDXRef-File-const.go-1003",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/ubc/const.go",
       "checksums": [
         {
@@ -12427,7 +10482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ubc-generic.go-1198",
+      "SPDXID": "SPDXRef-File-ubc-generic.go-1004",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/ubc/ubc_generic.go",
       "checksums": [
         {
@@ -12437,7 +10492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-1199",
+      "SPDXID": "SPDXRef-File-scanner.go-1005",
       "fileName": "repos/lazygit/vendor/github.com/kr/logfmt/scanner.go",
       "checksums": [
         {
@@ -12447,7 +10502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decode.go-1200",
+      "SPDXID": "SPDXRef-File-decode.go-1006",
       "fileName": "repos/lazygit/vendor/github.com/kr/logfmt/decode.go",
       "checksums": [
         {
@@ -12457,7 +10512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-unquote.go-1201",
+      "SPDXID": "SPDXRef-File-unquote.go-1007",
       "fileName": "repos/lazygit/vendor/github.com/kr/logfmt/unquote.go",
       "checksums": [
         {
@@ -12467,7 +10522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-1202",
+      "SPDXID": "SPDXRef-File-errors.go-1008",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/errors.go",
       "checksums": [
         {
@@ -12477,7 +10532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-intersect.go-1203",
+      "SPDXID": "SPDXRef-File-intersect.go-1009",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/intersect.go",
       "checksums": [
         {
@@ -12487,7 +10542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-condition.go-1204",
+      "SPDXID": "SPDXRef-File-condition.go-1010",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/condition.go",
       "checksums": [
         {
@@ -12497,7 +10552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-test.go-1205",
+      "SPDXID": "SPDXRef-File-test.go-1011",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/test.go",
       "checksums": [
         {
@@ -12507,7 +10562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-concurrency.go-1206",
+      "SPDXID": "SPDXRef-File-concurrency.go-1012",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/concurrency.go",
       "checksums": [
         {
@@ -12517,7 +10572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-math.go-1207",
+      "SPDXID": "SPDXRef-File-math.go-1013",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/math.go",
       "checksums": [
         {
@@ -12527,7 +10582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slice.go-1208",
+      "SPDXID": "SPDXRef-File-slice.go-1014",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/slice.go",
       "checksums": [
         {
@@ -12537,7 +10592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-types.go-1209",
+      "SPDXID": "SPDXRef-File-types.go-1015",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/types.go",
       "checksums": [
         {
@@ -12547,7 +10602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-map.go-1210",
+      "SPDXID": "SPDXRef-File-map.go-1016",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/map.go",
       "checksums": [
         {
@@ -12557,7 +10612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-func.go-1211",
+      "SPDXID": "SPDXRef-File-func.go-1017",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/func.go",
       "checksums": [
         {
@@ -12567,7 +10622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-string.go-1212",
+      "SPDXID": "SPDXRef-File-string.go-1018",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/string.go",
       "checksums": [
         {
@@ -12577,7 +10632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-retry.go-1213",
+      "SPDXID": "SPDXRef-File-retry.go-1019",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/retry.go",
       "checksums": [
         {
@@ -12587,7 +10642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-constraints.go-1214",
+      "SPDXID": "SPDXRef-File-constraints.go-1020",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/constraints.go",
       "checksums": [
         {
@@ -12597,7 +10652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-channel.go-1215",
+      "SPDXID": "SPDXRef-File-channel.go-1021",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/channel.go",
       "checksums": [
         {
@@ -12607,7 +10662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-find.go-1216",
+      "SPDXID": "SPDXRef-File-find.go-1022",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/find.go",
       "checksums": [
         {
@@ -12617,7 +10672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tuples.go-1217",
+      "SPDXID": "SPDXRef-File-tuples.go-1023",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/tuples.go",
       "checksums": [
         {
@@ -12627,7 +10682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-type-manipulation.go-1218",
+      "SPDXID": "SPDXRef-File-type-manipulation.go-1024",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/type_manipulation.go",
       "checksums": [
         {
@@ -12637,7 +10692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mergo.go-1219",
+      "SPDXID": "SPDXRef-File-mergo.go-1025",
       "fileName": "repos/lazygit/vendor/dario.cat/mergo/mergo.go",
       "checksums": [
         {
@@ -12647,7 +10702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-map.go-1220",
+      "SPDXID": "SPDXRef-File-map.go-1026",
       "fileName": "repos/lazygit/vendor/dario.cat/mergo/map.go",
       "checksums": [
         {
@@ -12657,7 +10712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1221",
+      "SPDXID": "SPDXRef-File-doc.go-1027",
       "fileName": "repos/lazygit/vendor/dario.cat/mergo/doc.go",
       "checksums": [
         {
@@ -12667,7 +10722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge.go-1222",
+      "SPDXID": "SPDXRef-File-merge.go-1028",
       "fileName": "repos/lazygit/vendor/dario.cat/mergo/merge.go",
       "checksums": [
         {
@@ -12677,7 +10732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybinding.go-1223",
+      "SPDXID": "SPDXRef-File-keybinding.go-1029",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/keybinding.go",
       "checksums": [
         {
@@ -12687,7 +10742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui-others.go-1224",
+      "SPDXID": "SPDXRef-File-gui-others.go-1030",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/gui_others.go",
       "checksums": [
         {
@@ -12697,7 +10752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-loader.go-1225",
+      "SPDXID": "SPDXRef-File-loader.go-1031",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/loader.go",
       "checksums": [
         {
@@ -12707,7 +10762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scrollbar.go-1226",
+      "SPDXID": "SPDXRef-File-scrollbar.go-1032",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/scrollbar.go",
       "checksums": [
         {
@@ -12717,7 +10772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tcell-driver.go-1227",
+      "SPDXID": "SPDXRef-File-tcell-driver.go-1033",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/tcell_driver.go",
       "checksums": [
         {
@@ -12727,7 +10782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui.go-1228",
+      "SPDXID": "SPDXRef-File-gui.go-1034",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/gui.go",
       "checksums": [
         {
@@ -12737,7 +10792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view.go-1229",
+      "SPDXID": "SPDXRef-File-view.go-1035",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/view.go",
       "checksums": [
         {
@@ -12747,7 +10802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-text-area.go-1230",
+      "SPDXID": "SPDXRef-File-text-area.go-1036",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/text_area.go",
       "checksums": [
         {
@@ -12757,7 +10812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-edit.go-1231",
+      "SPDXID": "SPDXRef-File-edit.go-1037",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/edit.go",
       "checksums": [
         {
@@ -12767,7 +10822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-task.go-1232",
+      "SPDXID": "SPDXRef-File-task.go-1038",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/task.go",
       "checksums": [
         {
@@ -12777,7 +10832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1233",
+      "SPDXID": "SPDXRef-File-doc.go-1039",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/doc.go",
       "checksums": [
         {
@@ -12787,7 +10842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-attribute.go-1234",
+      "SPDXID": "SPDXRef-File-attribute.go-1040",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/attribute.go",
       "checksums": [
         {
@@ -12797,7 +10852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-escape.go-1235",
+      "SPDXID": "SPDXRef-File-escape.go-1041",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/escape.go",
       "checksums": [
         {
@@ -12807,7 +10862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-task-manager.go-1236",
+      "SPDXID": "SPDXRef-File-task-manager.go-1042",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/task_manager.go",
       "checksums": [
         {
@@ -12817,7 +10872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-graphemeproperties.go-1237",
+      "SPDXID": "SPDXRef-File-graphemeproperties.go-1043",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/graphemeproperties.go",
       "checksums": [
         {
@@ -12827,7 +10882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sentencerules.go-1238",
+      "SPDXID": "SPDXRef-File-sentencerules.go-1044",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/sentencerules.go",
       "checksums": [
         {
@@ -12837,7 +10892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1239",
+      "SPDXID": "SPDXRef-File-doc.go-1045",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/doc.go",
       "checksums": [
         {
@@ -12847,7 +10902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wordproperties.go-1240",
+      "SPDXID": "SPDXRef-File-wordproperties.go-1046",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/wordproperties.go",
       "checksums": [
         {
@@ -12857,7 +10912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-word.go-1241",
+      "SPDXID": "SPDXRef-File-word.go-1047",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/word.go",
       "checksums": [
         {
@@ -12867,7 +10922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wordrules.go-1242",
+      "SPDXID": "SPDXRef-File-wordrules.go-1048",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/wordrules.go",
       "checksums": [
         {
@@ -12877,7 +10932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-graphemerules.go-1243",
+      "SPDXID": "SPDXRef-File-graphemerules.go-1049",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/graphemerules.go",
       "checksums": [
         {
@@ -12887,7 +10942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eastasianwidth.go-1244",
+      "SPDXID": "SPDXRef-File-eastasianwidth.go-1050",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/eastasianwidth.go",
       "checksums": [
         {
@@ -12897,7 +10952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-properties.go-1245",
+      "SPDXID": "SPDXRef-File-properties.go-1051",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/properties.go",
       "checksums": [
         {
@@ -12907,7 +10962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sentenceproperties.go-1246",
+      "SPDXID": "SPDXRef-File-sentenceproperties.go-1052",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/sentenceproperties.go",
       "checksums": [
         {
@@ -12917,7 +10972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-linerules.go-1247",
+      "SPDXID": "SPDXRef-File-linerules.go-1053",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/linerules.go",
       "checksums": [
         {
@@ -12927,7 +10982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-line.go-1248",
+      "SPDXID": "SPDXRef-File-line.go-1054",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/line.go",
       "checksums": [
         {
@@ -12937,7 +10992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-width.go-1249",
+      "SPDXID": "SPDXRef-File-width.go-1055",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/width.go",
       "checksums": [
         {
@@ -12947,7 +11002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-emojipresentation.go-1250",
+      "SPDXID": "SPDXRef-File-emojipresentation.go-1056",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/emojipresentation.go",
       "checksums": [
         {
@@ -12957,7 +11012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-step.go-1251",
+      "SPDXID": "SPDXRef-File-step.go-1057",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/step.go",
       "checksums": [
         {
@@ -12967,7 +11022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lineproperties.go-1252",
+      "SPDXID": "SPDXRef-File-lineproperties.go-1058",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/lineproperties.go",
       "checksums": [
         {
@@ -12977,7 +11032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sentence.go-1253",
+      "SPDXID": "SPDXRef-File-sentence.go-1059",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/sentence.go",
       "checksums": [
         {
@@ -12987,7 +11042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-grapheme.go-1254",
+      "SPDXID": "SPDXRef-File-grapheme.go-1060",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/grapheme.go",
       "checksums": [
         {
@@ -12997,7 +11052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bytes.go-1255",
+      "SPDXID": "SPDXRef-File-bytes.go-1061",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/bytes.go",
       "checksums": [
         {
@@ -13007,7 +11062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-1256",
+      "SPDXID": "SPDXRef-File-parser.go-1062",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/parser.go",
       "checksums": [
         {
@@ -13017,7 +11072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-escape.go-1257",
+      "SPDXID": "SPDXRef-File-escape.go-1063",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/escape.go",
       "checksums": [
         {
@@ -13027,7 +11082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bytes-unsafe.go-1258",
+      "SPDXID": "SPDXRef-File-bytes-unsafe.go-1064",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/bytes_unsafe.go",
       "checksums": [
         {
@@ -13037,7 +11092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fuzz.go-1259",
+      "SPDXID": "SPDXRef-File-fuzz.go-1065",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/fuzz.go",
       "checksums": [
         {
@@ -13047,7 +11102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-happy-palettegen.go-1260",
+      "SPDXID": "SPDXRef-File-happy-palettegen.go-1066",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/happy_palettegen.go",
       "checksums": [
         {
@@ -13057,7 +11112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colors.go-1261",
+      "SPDXID": "SPDXRef-File-colors.go-1067",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/colors.go",
       "checksums": [
         {
@@ -13067,7 +11122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-soft-palettegen.go-1262",
+      "SPDXID": "SPDXRef-File-soft-palettegen.go-1068",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/soft_palettegen.go",
       "checksums": [
         {
@@ -13077,7 +11132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colorgens.go-1263",
+      "SPDXID": "SPDXRef-File-colorgens.go-1069",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/colorgens.go",
       "checksums": [
         {
@@ -13087,7 +11142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hexcolor.go-1264",
+      "SPDXID": "SPDXRef-File-hexcolor.go-1070",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/hexcolor.go",
       "checksums": [
         {
@@ -13097,7 +11152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sort.go-1265",
+      "SPDXID": "SPDXRef-File-sort.go-1071",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/sort.go",
       "checksums": [
         {
@@ -13107,7 +11162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hsluv.go-1266",
+      "SPDXID": "SPDXRef-File-hsluv.go-1072",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/hsluv.go",
       "checksums": [
         {
@@ -13117,7 +11172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warm-palettegen.go-1267",
+      "SPDXID": "SPDXRef-File-warm-palettegen.go-1073",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/warm_palettegen.go",
       "checksums": [
         {
@@ -13127,7 +11182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.go-1268",
+      "SPDXID": "SPDXRef-File-rand.go-1074",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/rand.go",
       "checksums": [
         {
@@ -13137,7 +11192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch.go-1269",
+      "SPDXID": "SPDXRef-File-patch.go-1075",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/patch.go",
       "checksums": [
         {
@@ -13147,7 +11202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-match.go-1270",
+      "SPDXID": "SPDXRef-File-match.go-1076",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/match.go",
       "checksums": [
         {
@@ -13157,7 +11212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-operation-string.go-1271",
+      "SPDXID": "SPDXRef-File-operation-string.go-1077",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/operation_string.go",
       "checksums": [
         {
@@ -13167,7 +11222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff.go-1272",
+      "SPDXID": "SPDXRef-File-diff.go-1078",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/diff.go",
       "checksums": [
         {
@@ -13177,7 +11232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mathutil.go-1273",
+      "SPDXID": "SPDXRef-File-mathutil.go-1079",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/mathutil.go",
       "checksums": [
         {
@@ -13187,7 +11242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diffmatchpatch.go-1274",
+      "SPDXID": "SPDXRef-File-diffmatchpatch.go-1080",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/diffmatchpatch.go",
       "checksums": [
         {
@@ -13197,7 +11252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stringutil.go-1275",
+      "SPDXID": "SPDXRef-File-stringutil.go-1081",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/stringutil.go",
       "checksums": [
         {
@@ -13207,7 +11262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logfmt-handler.go-1276",
+      "SPDXID": "SPDXRef-File-logfmt-handler.go-1082",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/logfmt_handler.go",
       "checksums": [
         {
@@ -13217,7 +11272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-docker-compose-handler.go-1277",
+      "SPDXID": "SPDXRef-File-docker-compose-handler.go-1083",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/docker_compose_handler.go",
       "checksums": [
         {
@@ -13227,7 +11282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-handler.go-1278",
+      "SPDXID": "SPDXRef-File-handler.go-1084",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/handler.go",
       "checksums": [
         {
@@ -13237,7 +11292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-1279",
+      "SPDXID": "SPDXRef-File-scanner.go-1085",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/scanner.go",
       "checksums": [
         {
@@ -13247,7 +11302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-json-handler.go-1280",
+      "SPDXID": "SPDXRef-File-json-handler.go-1086",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/json_handler.go",
       "checksums": [
         {
@@ -13257,7 +11312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-time-parse.go-1281",
+      "SPDXID": "SPDXRef-File-time-parse.go-1087",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/time_parse.go",
       "checksums": [
         {
@@ -13267,107 +11322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lobject.h-1282",
-      "fileName": "repos/redis/src/../deps/lua/src/lobject.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "10e46b178022f6a4046a8b973ba10c3d9df5e3fa"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lua.h-1283",
-      "fileName": "repos/redis/src/../deps/lua/src/lua.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "280ef23821ab3480e95a2d918d35c290061fd174"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lauxlib.h-1284",
-      "fileName": "repos/redis/src/../deps/lua/src/lauxlib.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "34258235dbebff581b08a09d3acff87204cd5406"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lstate.h-1285",
-      "fileName": "repos/redis/src/../deps/lua/src/lstate.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3bc575b6bc8cdef8286ea4d8d539a4ee4fe5a180"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lualib.h-1286",
-      "fileName": "repos/redis/src/../deps/lua/src/lualib.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "469417f6703eb65a4559188f4febabac1a2ce01c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lzio.h-1287",
-      "fileName": "repos/redis/src/../deps/lua/src/lzio.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "51d695d8c1d5a26ba2146d5b1866c00c52771499"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ltm.h-1288",
-      "fileName": "repos/redis/src/../deps/lua/src/ltm.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "64343b781b6498930c30abc8f56ce2f7c5ede1ac"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lmem.h-1289",
-      "fileName": "repos/redis/src/../deps/lua/src/lmem.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7c2dcb32207a0438684eb0566ce769f47d895cf4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-llimits.h-1290",
-      "fileName": "repos/redis/src/../deps/lua/src/llimits.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ca8dcb72244bae473d27e605395b17a7d95c9c1c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-luaconf.h-1291",
-      "fileName": "repos/redis/src/../deps/lua/src/luaconf.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e2cb26163a2320cd5e27c89ba1e32cedbad41049"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-walk.go-1292",
+      "SPDXID": "SPDXRef-File-walk.go-1088",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/util/walk.go",
       "checksums": [
         {
@@ -13377,7 +11332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-polyfill.go-1293",
+      "SPDXID": "SPDXRef-File-polyfill.go-1089",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/helper/polyfill/polyfill.go",
       "checksums": [
         {
@@ -13387,7 +11342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-util.go-1294",
+      "SPDXID": "SPDXRef-File-util.go-1090",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/util/util.go",
       "checksums": [
         {
@@ -13397,7 +11352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-options.go-1295",
+      "SPDXID": "SPDXRef-File-os-options.go-1091",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os_options.go",
       "checksums": [
         {
@@ -13407,7 +11362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-posix.go-1296",
+      "SPDXID": "SPDXRef-File-os-posix.go-1092",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os_posix.go",
       "checksums": [
         {
@@ -13417,7 +11372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-chroot.go-1297",
+      "SPDXID": "SPDXRef-File-chroot.go-1093",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/helper/chroot/chroot.go",
       "checksums": [
         {
@@ -13427,7 +11382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os.go-1298",
+      "SPDXID": "SPDXRef-File-os.go-1094",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os.go",
       "checksums": [
         {
@@ -13437,7 +11392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-bound.go-1299",
+      "SPDXID": "SPDXRef-File-os-bound.go-1095",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os_bound.go",
       "checksums": [
         {
@@ -13447,7 +11402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fs.go-1300",
+      "SPDXID": "SPDXRef-File-fs.go-1096",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/fs.go",
       "checksums": [
         {
@@ -13457,7 +11412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-glob.go-1301",
+      "SPDXID": "SPDXRef-File-glob.go-1097",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/util/glob.go",
       "checksums": [
         {
@@ -13467,7 +11422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-chroot.go-1302",
+      "SPDXID": "SPDXRef-File-os-chroot.go-1098",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os_chroot.go",
       "checksums": [
         {
@@ -13477,17 +11432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fast-float-strtod.h-1303",
-      "fileName": "repos/redis/src/../deps/fast_float/fast_float_strtod.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1755076a1d8525cb895df2824bbe44aabca26d0a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-doc.go-1304",
+      "SPDXID": "SPDXRef-File-doc.go-1099",
       "fileName": "repos/lazygit/vendor/github.com/mattn/go-isatty/doc.go",
       "checksums": [
         {
@@ -13497,7 +11442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-isatty-tcgets.go-1305",
+      "SPDXID": "SPDXRef-File-isatty-tcgets.go-1100",
       "fileName": "repos/lazygit/vendor/github.com/mattn/go-isatty/isatty_tcgets.go",
       "checksums": [
         {
@@ -13507,7 +11452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1306",
+      "SPDXID": "SPDXRef-File-doc.go-1101",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/doc.go",
       "checksums": [
         {
@@ -13517,7 +11462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pty-linux.go-1307",
+      "SPDXID": "SPDXRef-File-pty-linux.go-1102",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/pty_linux.go",
       "checksums": [
         {
@@ -13527,7 +11472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-util.go-1308",
+      "SPDXID": "SPDXRef-File-util.go-1103",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/util.go",
       "checksums": [
         {
@@ -13537,7 +11482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-run.go-1309",
+      "SPDXID": "SPDXRef-File-run.go-1104",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/run.go",
       "checksums": [
         {
@@ -13547,7 +11492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ioctl.go-1310",
+      "SPDXID": "SPDXRef-File-ioctl.go-1105",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/ioctl.go",
       "checksums": [
         {
@@ -13557,7 +11502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ztypes-amd64.go-1311",
+      "SPDXID": "SPDXRef-File-ztypes-amd64.go-1106",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/ztypes_amd64.go",
       "checksums": [
         {
@@ -13567,7 +11512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-enum.go-1312",
+      "SPDXID": "SPDXRef-File-enum.go-1107",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/enum.go",
       "checksums": [
         {
@@ -13577,7 +11522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-serialize.go-1313",
+      "SPDXID": "SPDXRef-File-serialize.go-1108",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/token/serialize.go",
       "checksums": [
         {
@@ -13587,7 +11532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1314",
+      "SPDXID": "SPDXRef-File-doc.go-1109",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/doc.go",
       "checksums": [
         {
@@ -13597,7 +11542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-1315",
+      "SPDXID": "SPDXRef-File-errors.go-1110",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/errors.go",
       "checksums": [
         {
@@ -13607,7 +11552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bool.go-1316",
+      "SPDXID": "SPDXRef-File-bool.go-1111",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/bool.go",
       "checksums": [
         {
@@ -13617,7 +11562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1317",
+      "SPDXID": "SPDXRef-File-doc.go-1112",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/doc.go",
       "checksums": [
         {
@@ -13627,7 +11572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-1318",
+      "SPDXID": "SPDXRef-File-errors.go-1113",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/scanner/errors.go",
       "checksums": [
         {
@@ -13637,7 +11582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-int.go-1319",
+      "SPDXID": "SPDXRef-File-int.go-1114",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/int.go",
       "checksums": [
         {
@@ -13647,7 +11592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-token.go-1320",
+      "SPDXID": "SPDXRef-File-token.go-1115",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/token/token.go",
       "checksums": [
         {
@@ -13657,7 +11602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-1321",
+      "SPDXID": "SPDXRef-File-scanner.go-1116",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/scanner/scanner.go",
       "checksums": [
         {
@@ -13667,7 +11612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scan.go-1322",
+      "SPDXID": "SPDXRef-File-scan.go-1117",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/scan.go",
       "checksums": [
         {
@@ -13677,7 +11622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-set.go-1323",
+      "SPDXID": "SPDXRef-File-set.go-1118",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/set.go",
       "checksums": [
         {
@@ -13687,7 +11632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read.go-1324",
+      "SPDXID": "SPDXRef-File-read.go-1119",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/read.go",
       "checksums": [
         {
@@ -13697,7 +11642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-position.go-1325",
+      "SPDXID": "SPDXRef-File-position.go-1120",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/token/position.go",
       "checksums": [
         {
@@ -13707,7 +11652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1326",
+      "SPDXID": "SPDXRef-File-term.go-1121",
       "fileName": "repos/lazygit/vendor/golang.org/x/term/term.go",
       "checksums": [
         {
@@ -13717,7 +11662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term-unix.go-1327",
+      "SPDXID": "SPDXRef-File-term-unix.go-1122",
       "fileName": "repos/lazygit/vendor/golang.org/x/term/term_unix.go",
       "checksums": [
         {
@@ -13727,7 +11672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term-unix-other.go-1328",
+      "SPDXID": "SPDXRef-File-term-unix-other.go-1123",
       "fileName": "repos/lazygit/vendor/golang.org/x/term/term_unix_other.go",
       "checksums": [
         {
@@ -13737,7 +11682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal.go-1329",
+      "SPDXID": "SPDXRef-File-terminal.go-1124",
       "fileName": "repos/lazygit/vendor/golang.org/x/term/terminal.go",
       "checksums": [
         {
@@ -13747,7 +11692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1330",
+      "SPDXID": "SPDXRef-File-doc.go-1125",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/doc.go",
       "checksums": [
         {
@@ -13757,7 +11702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-open-linux.go-1331",
+      "SPDXID": "SPDXRef-File-open-linux.go-1126",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/open_linux.go",
       "checksums": [
         {
@@ -13767,7 +11712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vfs.go-1332",
+      "SPDXID": "SPDXRef-File-vfs.go-1127",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/vfs.go",
       "checksums": [
         {
@@ -13777,7 +11722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gocompat-errors-go120.go-1333",
+      "SPDXID": "SPDXRef-File-gocompat-errors-go120.go-1128",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/gocompat_errors_go120.go",
       "checksums": [
         {
@@ -13787,7 +11732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-procfs-linux.go-1334",
+      "SPDXID": "SPDXRef-File-procfs-linux.go-1129",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/procfs_linux.go",
       "checksums": [
         {
@@ -13797,7 +11742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-openat-linux.go-1335",
+      "SPDXID": "SPDXRef-File-openat-linux.go-1130",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/openat_linux.go",
       "checksums": [
         {
@@ -13807,7 +11752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mkdir-linux.go-1336",
+      "SPDXID": "SPDXRef-File-mkdir-linux.go-1131",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/mkdir_linux.go",
       "checksums": [
         {
@@ -13817,7 +11762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lookup-linux.go-1337",
+      "SPDXID": "SPDXRef-File-lookup-linux.go-1132",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/lookup_linux.go",
       "checksums": [
         {
@@ -13827,7 +11772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gocompat-generics-go121.go-1338",
+      "SPDXID": "SPDXRef-File-gocompat-generics-go121.go-1133",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/gocompat_generics_go121.go",
       "checksums": [
         {
@@ -13837,7 +11782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-join.go-1339",
+      "SPDXID": "SPDXRef-File-join.go-1134",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/join.go",
       "checksums": [
         {
@@ -13847,7 +11792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-openat2-linux.go-1340",
+      "SPDXID": "SPDXRef-File-openat2-linux.go-1135",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/openat2_linux.go",
       "checksums": [
         {
@@ -13857,7 +11802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-todo.go-1341",
+      "SPDXID": "SPDXRef-File-todo.go-1136",
       "fileName": "repos/lazygit/vendor/github.com/stefanhaller/git-todo-parser/todo/todo.go",
       "checksums": [
         {
@@ -13867,7 +11812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-write.go-1342",
+      "SPDXID": "SPDXRef-File-write.go-1137",
       "fileName": "repos/lazygit/vendor/github.com/stefanhaller/git-todo-parser/todo/write.go",
       "checksums": [
         {
@@ -13877,7 +11822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parse.go-1343",
+      "SPDXID": "SPDXRef-File-parse.go-1138",
       "fileName": "repos/lazygit/vendor/github.com/stefanhaller/git-todo-parser/todo/parse.go",
       "checksums": [
         {
@@ -13887,7 +11832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-latin1.go-1344",
+      "SPDXID": "SPDXRef-File-latin1.go-1139",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/latin1.go",
       "checksums": [
         {
@@ -13897,7 +11842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utf8.go-1345",
+      "SPDXID": "SPDXRef-File-utf8.go-1140",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/utf8.go",
       "checksums": [
         {
@@ -13907,7 +11852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1346",
+      "SPDXID": "SPDXRef-File-doc.go-1141",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/doc.go",
       "checksums": [
         {
@@ -13917,7 +11862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ebcdic.go-1347",
+      "SPDXID": "SPDXRef-File-ebcdic.go-1142",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/ebcdic.go",
       "checksums": [
         {
@@ -13927,7 +11872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ascii.go-1348",
+      "SPDXID": "SPDXRef-File-ascii.go-1143",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/ascii.go",
       "checksums": [
         {
@@ -13937,7 +11882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-latin5.go-1349",
+      "SPDXID": "SPDXRef-File-latin5.go-1144",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/latin5.go",
       "checksums": [
         {
@@ -13947,7 +11892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-charmap.go-1350",
+      "SPDXID": "SPDXRef-File-charmap.go-1145",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/charmap.go",
       "checksums": [
         {
@@ -13957,7 +11902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context.go-1351",
+      "SPDXID": "SPDXRef-File-context.go-1146",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/context/context.go",
       "checksums": [
         {
@@ -13967,7 +11912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-per-host.go-1352",
+      "SPDXID": "SPDXRef-File-per-host.go-1147",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/per_host.go",
       "checksums": [
         {
@@ -13977,7 +11922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-direct.go-1353",
+      "SPDXID": "SPDXRef-File-direct.go-1148",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/direct.go",
       "checksums": [
         {
@@ -13987,7 +11932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-1354",
+      "SPDXID": "SPDXRef-File-client.go-1149",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/internal/socks/client.go",
       "checksums": [
         {
@@ -13997,7 +11942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dial.go-1355",
+      "SPDXID": "SPDXRef-File-dial.go-1150",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/dial.go",
       "checksums": [
         {
@@ -14007,7 +11952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks.go-1356",
+      "SPDXID": "SPDXRef-File-socks.go-1151",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/internal/socks/socks.go",
       "checksums": [
         {
@@ -14017,7 +11962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-proxy.go-1357",
+      "SPDXID": "SPDXRef-File-proxy.go-1152",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/proxy.go",
       "checksums": [
         {
@@ -14027,7 +11972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks5.go-1358",
+      "SPDXID": "SPDXRef-File-socks5.go-1153",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/socks5.go",
       "checksums": [
         {
@@ -14037,7 +11982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-1359",
+      "SPDXID": "SPDXRef-File-utils.go-1154",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/utils/utils.go",
       "checksums": [
         {
@@ -14047,7 +11992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lists.go-1360",
+      "SPDXID": "SPDXRef-File-lists.go-1155",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/lists.go",
       "checksums": [
         {
@@ -14057,7 +12002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-serialization.go-1361",
+      "SPDXID": "SPDXRef-File-serialization.go-1156",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/arraylist/serialization.go",
       "checksums": [
         {
@@ -14067,7 +12012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-arraylist.go-1362",
+      "SPDXID": "SPDXRef-File-arraylist.go-1157",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/arraylist/arraylist.go",
       "checksums": [
         {
@@ -14077,7 +12022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-comparator.go-1363",
+      "SPDXID": "SPDXRef-File-comparator.go-1158",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/utils/comparator.go",
       "checksums": [
         {
@@ -14087,7 +12032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-enumerable.go-1364",
+      "SPDXID": "SPDXRef-File-enumerable.go-1159",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/containers/enumerable.go",
       "checksums": [
         {
@@ -14097,7 +12042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iterator.go-1365",
+      "SPDXID": "SPDXRef-File-iterator.go-1160",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/containers/iterator.go",
       "checksums": [
         {
@@ -14107,7 +12052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sort.go-1366",
+      "SPDXID": "SPDXRef-File-sort.go-1161",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/utils/sort.go",
       "checksums": [
         {
@@ -14117,7 +12062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-enumerable.go-1367",
+      "SPDXID": "SPDXRef-File-enumerable.go-1162",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/arraylist/enumerable.go",
       "checksums": [
         {
@@ -14127,7 +12072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-trees.go-1368",
+      "SPDXID": "SPDXRef-File-trees.go-1163",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/trees/trees.go",
       "checksums": [
         {
@@ -14137,7 +12082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-containers.go-1369",
+      "SPDXID": "SPDXRef-File-containers.go-1164",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/containers/containers.go",
       "checksums": [
         {
@@ -14147,7 +12092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-serialization.go-1370",
+      "SPDXID": "SPDXRef-File-serialization.go-1165",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/trees/binaryheap/serialization.go",
       "checksums": [
         {
@@ -14157,7 +12102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-binaryheap.go-1371",
+      "SPDXID": "SPDXRef-File-binaryheap.go-1166",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/trees/binaryheap/binaryheap.go",
       "checksums": [
         {
@@ -14167,7 +12112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iterator.go-1372",
+      "SPDXID": "SPDXRef-File-iterator.go-1167",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/trees/binaryheap/iterator.go",
       "checksums": [
         {
@@ -14177,7 +12122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iterator.go-1373",
+      "SPDXID": "SPDXRef-File-iterator.go-1168",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/arraylist/iterator.go",
       "checksums": [
         {
@@ -14187,7 +12132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-serialization.go-1374",
+      "SPDXID": "SPDXRef-File-serialization.go-1169",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/containers/serialization.go",
       "checksums": [
         {
@@ -14197,7 +12142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-maps.go-1375",
+      "SPDXID": "SPDXRef-File-maps.go-1170",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/generics/maps/maps.go",
       "checksums": [
         {
@@ -14207,7 +12152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-set.go-1376",
+      "SPDXID": "SPDXRef-File-set.go-1171",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/generics/set/set.go",
       "checksums": [
         {
@@ -14217,7 +12162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-orderedset.go-1377",
+      "SPDXID": "SPDXRef-File-orderedset.go-1172",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/generics/orderedset/orderedset.go",
       "checksums": [
         {
@@ -14227,7 +12172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-knownhosts.go-1378",
+      "SPDXID": "SPDXRef-File-knownhosts.go-1173",
       "fileName": "repos/lazygit/vendor/github.com/skeema/knownhosts/knownhosts.go",
       "checksums": [
         {
@@ -14237,7 +12182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writer.go-1379",
+      "SPDXID": "SPDXRef-File-writer.go-1174",
       "fileName": "repos/lazygit/vendor/github.com/mailru/easyjson/jwriter/writer.go",
       "checksums": [
         {
@@ -14247,7 +12192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pool.go-1380",
+      "SPDXID": "SPDXRef-File-pool.go-1175",
       "fileName": "repos/lazygit/vendor/github.com/mailru/easyjson/buffer/pool.go",
       "checksums": [
         {
@@ -14257,7 +12202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-discard-go15.go-1381",
+      "SPDXID": "SPDXRef-File-discard-go15.go-1176",
       "fileName": "repos/lazygit/vendor/github.com/spkg/bom/discard_go15.go",
       "checksums": [
         {
@@ -14267,7 +12212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bom.go-1382",
+      "SPDXID": "SPDXRef-File-bom.go-1177",
       "fileName": "repos/lazygit/vendor/github.com/spkg/bom/bom.go",
       "checksums": [
         {
@@ -14277,77 +12222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read.h-1383",
-      "fileName": "repos/redis/src/../deps/hiredis/read.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2d74d77a5b41d067537587f3a34565fed4bb1da3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-async.h-1384",
-      "fileName": "repos/redis/src/../deps/hiredis/async.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4f94660b123ed530169027b1dbe82b99deedd30d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hiredis.h-1385",
-      "fileName": "repos/redis/src/../deps/hiredis/hiredis.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "635988b7e1c41f7d5c07b5010b6f334672eac570"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-alloc.h-1386",
-      "fileName": "repos/redis/src/../deps/hiredis/alloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "771f9fee53fe1fe2230a28fa36349cfc14940868"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sds.h-1387",
-      "fileName": "repos/redis/src/../deps/hiredis/sds.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "80784bc838aed591073fe489dc3c5a4e68df5eb3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sdscompat.h-1388",
-      "fileName": "repos/redis/src/../deps/hiredis/sdscompat.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e5a2574f31e51d74ed43ad935b12f4ccf12096a8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fpconv-dtoa.h-1389",
-      "fileName": "repos/redis/src/../deps/fpconv/fpconv_dtoa.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "328ed83f0383ca446798496cd8ff79a76c97308d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-error-1-13.go-1390",
+      "SPDXID": "SPDXRef-File-error-1-13.go-1178",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/error_1_13.go",
       "checksums": [
         {
@@ -14357,7 +12232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-join-unwrap-1-20.go-1391",
+      "SPDXID": "SPDXRef-File-join-unwrap-1-20.go-1179",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/join_unwrap_1_20.go",
       "checksums": [
         {
@@ -14367,7 +12242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parse-panic.go-1392",
+      "SPDXID": "SPDXRef-File-parse-panic.go-1180",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/parse_panic.go",
       "checksums": [
         {
@@ -14377,7 +12252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-error.go-1393",
+      "SPDXID": "SPDXRef-File-error.go-1181",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/error.go",
       "checksums": [
         {
@@ -14387,7 +12262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stackframe.go-1394",
+      "SPDXID": "SPDXRef-File-stackframe.go-1182",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/stackframe.go",
       "checksums": [
         {
@@ -14397,7 +12272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mib.go-1395",
+      "SPDXID": "SPDXRef-File-mib.go-1183",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/encoding/internal/identifier/mib.go",
       "checksums": [
         {
@@ -14407,7 +12282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iter.go-1396",
+      "SPDXID": "SPDXRef-File-iter.go-1184",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/iter.go",
       "checksums": [
         {
@@ -14417,7 +12292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-normalize.go-1397",
+      "SPDXID": "SPDXRef-File-normalize.go-1185",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/normalize.go",
       "checksums": [
         {
@@ -14427,7 +12302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-input.go-1398",
+      "SPDXID": "SPDXRef-File-input.go-1186",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/input.go",
       "checksums": [
         {
@@ -14437,7 +12312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transform.go-1399",
+      "SPDXID": "SPDXRef-File-transform.go-1187",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/transform/transform.go",
       "checksums": [
         {
@@ -14447,7 +12322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-identifier.go-1400",
+      "SPDXID": "SPDXRef-File-identifier.go-1188",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/encoding/internal/identifier/identifier.go",
       "checksums": [
         {
@@ -14457,7 +12332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-runes.go-1401",
+      "SPDXID": "SPDXRef-File-runes.go-1189",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/runes/runes.go",
       "checksums": [
         {
@@ -14467,7 +12342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoding.go-1402",
+      "SPDXID": "SPDXRef-File-encoding.go-1190",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/encoding/encoding.go",
       "checksums": [
         {
@@ -14477,7 +12352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transform.go-1403",
+      "SPDXID": "SPDXRef-File-transform.go-1191",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/transform.go",
       "checksums": [
         {
@@ -14487,7 +12362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-readwriter.go-1404",
+      "SPDXID": "SPDXRef-File-readwriter.go-1192",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/readwriter.go",
       "checksums": [
         {
@@ -14497,7 +12372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tables15.0.0.go-1405",
+      "SPDXID": "SPDXRef-File-tables15.0.0.go-1193",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/tables15.0.0.go",
       "checksums": [
         {
@@ -14507,7 +12382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cond.go-1406",
+      "SPDXID": "SPDXRef-File-cond.go-1194",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/runes/cond.go",
       "checksums": [
         {
@@ -14517,7 +12392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-composition.go-1407",
+      "SPDXID": "SPDXRef-File-composition.go-1195",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/composition.go",
       "checksums": [
         {
@@ -14527,7 +12402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-trie.go-1408",
+      "SPDXID": "SPDXRef-File-trie.go-1196",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/trie.go",
       "checksums": [
         {
@@ -14537,7 +12412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-forminfo.go-1409",
+      "SPDXID": "SPDXRef-File-forminfo.go-1197",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/forminfo.go",
       "checksums": [
         {
@@ -14547,7 +12422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-jibber-jabber-unix.go-1410",
+      "SPDXID": "SPDXRef-File-jibber-jabber-unix.go-1198",
       "fileName": "repos/lazygit/vendor/github.com/cloudfoundry/jibber_jabber/jibber_jabber_unix.go",
       "checksums": [
         {
@@ -14557,7 +12432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-jibber-jabber.go-1411",
+      "SPDXID": "SPDXRef-File-jibber-jabber.go-1199",
       "fileName": "repos/lazygit/vendor/github.com/cloudfoundry/jibber_jabber/jibber_jabber.go",
       "checksums": [
         {
@@ -14567,7 +12442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-xdg.go-1412",
+      "SPDXID": "SPDXRef-File-xdg.go-1200",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/xdg.go",
       "checksums": [
         {
@@ -14577,7 +12452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-user-dirs.go-1413",
+      "SPDXID": "SPDXRef-File-user-dirs.go-1201",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/user_dirs.go",
       "checksums": [
         {
@@ -14587,7 +12462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pathutil.go-1414",
+      "SPDXID": "SPDXRef-File-pathutil.go-1202",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/internal/pathutil/pathutil.go",
       "checksums": [
         {
@@ -14597,7 +12472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1415",
+      "SPDXID": "SPDXRef-File-doc.go-1203",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/doc.go",
       "checksums": [
         {
@@ -14607,7 +12482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pathutil-unix.go-1416",
+      "SPDXID": "SPDXRef-File-pathutil-unix.go-1204",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/internal/pathutil/pathutil_unix.go",
       "checksums": [
         {
@@ -14617,7 +12492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base-dirs.go-1417",
+      "SPDXID": "SPDXRef-File-base-dirs.go-1205",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/base_dirs.go",
       "checksums": [
         {
@@ -14627,7 +12502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-paths-unix.go-1418",
+      "SPDXID": "SPDXRef-File-paths-unix.go-1206",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/paths_unix.go",
       "checksums": [
         {
@@ -14637,7 +12512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noncolorable.go-1419",
+      "SPDXID": "SPDXRef-File-noncolorable.go-1207",
       "fileName": "repos/lazygit/vendor/github.com/mattn/go-colorable/noncolorable.go",
       "checksums": [
         {
@@ -14647,7 +12522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colorable-others.go-1420",
+      "SPDXID": "SPDXRef-File-colorable-others.go-1208",
       "fileName": "repos/lazygit/vendor/github.com/mattn/go-colorable/colorable_others.go",
       "checksums": [
         {
@@ -14657,7 +12532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-goid.go-1421",
+      "SPDXID": "SPDXRef-File-goid.go-1209",
       "fileName": "repos/lazygit/vendor/github.com/petermattis/goid/goid.go",
       "checksums": [
         {
@@ -14667,7 +12542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-goid-go1.5.go-1422",
+      "SPDXID": "SPDXRef-File-goid-go1.5.go-1210",
       "fileName": "repos/lazygit/vendor/github.com/petermattis/goid/goid_go1.5.go",
       "checksums": [
         {
@@ -14677,7 +12552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-runtime-go1.25.go-1423",
+      "SPDXID": "SPDXRef-File-runtime-go1.25.go-1211",
       "fileName": "repos/lazygit/vendor/github.com/petermattis/goid/runtime_go1.25.go",
       "checksums": [
         {
@@ -14687,7 +12562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-1424",
+      "SPDXID": "SPDXRef-File-color.go-1212",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/color.go",
       "checksums": [
         {
@@ -14697,7 +12572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-util.go-1425",
+      "SPDXID": "SPDXRef-File-util.go-1213",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/util.go",
       "checksums": [
         {
@@ -14707,7 +12582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-capvals.go-1426",
+      "SPDXID": "SPDXRef-File-capvals.go-1214",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/capvals.go",
       "checksums": [
         {
@@ -14717,7 +12592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminfo.go-1427",
+      "SPDXID": "SPDXRef-File-terminfo.go-1215",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/terminfo.go",
       "checksums": [
         {
@@ -14727,7 +12602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-caps.go-1428",
+      "SPDXID": "SPDXRef-File-caps.go-1216",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/caps.go",
       "checksums": [
         {
@@ -14737,7 +12612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-load.go-1429",
+      "SPDXID": "SPDXRef-File-load.go-1217",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/load.go",
       "checksums": [
         {
@@ -14747,7 +12622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stack.go-1430",
+      "SPDXID": "SPDXRef-File-stack.go-1218",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/stack.go",
       "checksums": [
         {
@@ -14757,7 +12632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-param.go-1431",
+      "SPDXID": "SPDXRef-File-param.go-1219",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/param.go",
       "checksums": [
         {
@@ -14767,7 +12642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sshagent.go-1432",
+      "SPDXID": "SPDXRef-File-sshagent.go-1220",
       "fileName": "repos/lazygit/vendor/github.com/xanzy/ssh-agent/sshagent.go",
       "checksums": [
         {
@@ -14777,7 +12652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflect.go-1433",
+      "SPDXID": "SPDXRef-File-reflect.go-1221",
       "fileName": "repos/lazygit/vendor/github.com/karimkhaleel/jsonschema/reflect.go",
       "checksums": [
         {
@@ -14787,7 +12662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-id.go-1434",
+      "SPDXID": "SPDXRef-File-id.go-1222",
       "fileName": "repos/lazygit/vendor/github.com/karimkhaleel/jsonschema/id.go",
       "checksums": [
         {
@@ -14797,7 +12672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-comment-extractor.go-1435",
+      "SPDXID": "SPDXRef-File-comment-extractor.go-1223",
       "fileName": "repos/lazygit/vendor/github.com/karimkhaleel/jsonschema/comment_extractor.go",
       "checksums": [
         {
@@ -14807,7 +12682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-1436",
+      "SPDXID": "SPDXRef-File-utils.go-1224",
       "fileName": "repos/lazygit/vendor/github.com/karimkhaleel/jsonschema/utils.go",
       "checksums": [
         {
@@ -14817,7 +12692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-emoji.go-1437",
+      "SPDXID": "SPDXRef-File-emoji.go-1225",
       "fileName": "repos/lazygit/vendor/github.com/kyokomi/emoji/v2/emoji.go",
       "checksums": [
         {
@@ -14827,7 +12702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-emoji-codemap.go-1438",
+      "SPDXID": "SPDXRef-File-emoji-codemap.go-1226",
       "fileName": "repos/lazygit/vendor/github.com/kyokomi/emoji/v2/emoji_codemap.go",
       "checksums": [
         {
@@ -14837,7 +12712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patricia.go-1439",
+      "SPDXID": "SPDXRef-File-patricia.go-1227",
       "fileName": "repos/lazygit/vendor/gopkg.in/ozeidan/fuzzy-patricia.v3/patricia/patricia.go",
       "checksums": [
         {
@@ -14847,7 +12722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-children.go-1440",
+      "SPDXID": "SPDXRef-File-children.go-1228",
       "fileName": "repos/lazygit/vendor/gopkg.in/ozeidan/fuzzy-patricia.v3/patricia/children.go",
       "checksums": [
         {
@@ -14857,17 +12732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-jemalloc.h-1441",
-      "fileName": "repos/redis/src/../deps/jemalloc/include/jemalloc/jemalloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "86c5d64ab67e5678cb94f1dce310c4637130dff4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-color.go-1442",
+      "SPDXID": "SPDXRef-File-color.go-1229",
       "fileName": "repos/lazygit/vendor/github.com/fatih/color/color.go",
       "checksums": [
         {
@@ -14877,7 +12742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1443",
+      "SPDXID": "SPDXRef-File-doc.go-1230",
       "fileName": "repos/lazygit/vendor/github.com/fatih/color/doc.go",
       "checksums": [
         {
@@ -14887,7 +12752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list.go-1444",
+      "SPDXID": "SPDXRef-File-list.go-1231",
       "fileName": "repos/lazygit/vendor/github.com/bahlo/generic-list-go/list.go",
       "checksums": [
         {
@@ -14897,7 +12762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deadlock.go-1445",
+      "SPDXID": "SPDXRef-File-deadlock.go-1232",
       "fileName": "repos/lazygit/vendor/github.com/sasha-s/go-deadlock/deadlock.go",
       "checksums": [
         {
@@ -14907,7 +12772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stacktraces.go-1446",
+      "SPDXID": "SPDXRef-File-stacktraces.go-1233",
       "fileName": "repos/lazygit/vendor/github.com/sasha-s/go-deadlock/stacktraces.go",
       "checksums": [
         {
@@ -14917,7 +12782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-trylock.go-1447",
+      "SPDXID": "SPDXRef-File-trylock.go-1234",
       "fileName": "repos/lazygit/vendor/github.com/sasha-s/go-deadlock/trylock.go",
       "checksums": [
         {
@@ -14927,7 +12792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deadlock-map.go-1448",
+      "SPDXID": "SPDXRef-File-deadlock-map.go-1235",
       "fileName": "repos/lazygit/vendor/github.com/sasha-s/go-deadlock/deadlock_map.go",
       "checksums": [
         {
@@ -14937,7 +12802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ctxio.go-1449",
+      "SPDXID": "SPDXRef-File-ctxio.go-1236",
       "fileName": "repos/lazygit/vendor/github.com/jbenet/go-context/io/ctxio.go",
       "checksums": [
         {
@@ -14947,7 +12812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnings.go-1450",
+      "SPDXID": "SPDXRef-File-warnings.go-1237",
       "fileName": "repos/lazygit/vendor/gopkg.in/warnings.v0/warnings.go",
       "checksums": [
         {
@@ -14957,7 +12822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fuzzy.go-1451",
+      "SPDXID": "SPDXRef-File-fuzzy.go-1238",
       "fileName": "repos/lazygit/vendor/github.com/sahilm/fuzzy/fuzzy.go",
       "checksums": [
         {
@@ -14967,17 +12832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-linenoise.h-1452",
-      "fileName": "repos/redis/src/../deps/linenoise/linenoise.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "beac6df467a04748fc6625659856dda7b5ac2d82"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-clipboard.go-1453",
+      "SPDXID": "SPDXRef-File-clipboard.go-1239",
       "fileName": "repos/lazygit/vendor/github.com/atotto/clipboard/clipboard.go",
       "checksums": [
         {
@@ -14987,7 +12842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-clipboard-unix.go-1454",
+      "SPDXID": "SPDXRef-File-clipboard-unix.go-1240",
       "fileName": "repos/lazygit/vendor/github.com/atotto/clipboard/clipboard_unix.go",
       "checksums": [
         {
@@ -14997,7 +12852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-funcsPZ.go-1455",
+      "SPDXID": "SPDXRef-File-funcsPZ.go-1241",
       "fileName": "repos/lazygit/vendor/github.com/mgutz/str/funcsPZ.go",
       "checksums": [
         {
@@ -15007,7 +12862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1456",
+      "SPDXID": "SPDXRef-File-doc.go-1242",
       "fileName": "repos/lazygit/vendor/github.com/mgutz/str/doc.go",
       "checksums": [
         {
@@ -15017,7 +12872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-funcsAO.go-1457",
+      "SPDXID": "SPDXRef-File-funcsAO.go-1243",
       "fileName": "repos/lazygit/vendor/github.com/mgutz/str/funcsAO.go",
       "checksums": [
         {
@@ -15027,7 +12882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lru.go-1458",
+      "SPDXID": "SPDXRef-File-lru.go-1244",
       "fileName": "repos/lazygit/vendor/github.com/golang/groupcache/lru/lru.go",
       "checksums": [
         {
@@ -15037,7 +12892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errgroup.go-1459",
+      "SPDXID": "SPDXRef-File-errgroup.go-1245",
       "fileName": "repos/lazygit/vendor/golang.org/x/sync/errgroup/errgroup.go",
       "checksums": [
         {
@@ -15065,7313 +12920,6208 @@
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-fast-float-5"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-fast-float-5"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-fpconv-6"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-fpconv-6"
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-github.com-ProtonMail-go-crypto-5"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-ProtonMail-go-crypto-7"
+      "relatedSpdxElement": "SPDXRef-github.com-adrg-xdg-6"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-adrg-xdg-8"
+      "relatedSpdxElement": "SPDXRef-github.com-atotto-clipboard-7"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-atotto-clipboard-9"
+      "relatedSpdxElement": "SPDXRef-github.com-aybabtme-humanlog-8"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-aybabtme-humanlog-10"
+      "relatedSpdxElement": "SPDXRef-github.com-bahlo-generic-list-go-9"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-bahlo-generic-list-go-11"
+      "relatedSpdxElement": "SPDXRef-github.com-buger-jsonparser-10"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-buger-jsonparser-12"
+      "relatedSpdxElement": "SPDXRef-github.com-cloudflare-circl-11"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-cloudflare-circl-13"
+      "relatedSpdxElement": "SPDXRef-github.com-cloudfoundry-jibber-jabber-12"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-cloudfoundry-jibber-jabber-14"
+      "relatedSpdxElement": "SPDXRef-github.com-creack-pty-13"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-creack-pty-15"
+      "relatedSpdxElement": "SPDXRef-github.com-cyphar-filepath-securejoin-14"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-cyphar-filepath-securejoin-16"
+      "relatedSpdxElement": "SPDXRef-github.com-emirpasic-gods-15"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-emirpasic-gods-17"
+      "relatedSpdxElement": "SPDXRef-github.com-fatih-color-16"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-fatih-color-18"
+      "relatedSpdxElement": "SPDXRef-github.com-gdamore-encoding-17"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-gdamore-encoding-19"
+      "relatedSpdxElement": "SPDXRef-github.com-gdamore-tcell-v2-18"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-gdamore-tcell-v2-20"
+      "relatedSpdxElement": "SPDXRef-github.com-go-errors-errors-19"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-go-errors-errors-21"
+      "relatedSpdxElement": "SPDXRef-github.com-go-git-gcfg-20"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-go-git-gcfg-22"
+      "relatedSpdxElement": "SPDXRef-github.com-go-git-go-billy-v5-21"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-go-git-go-billy-v5-23"
+      "relatedSpdxElement": "SPDXRef-github.com-go-logfmt-logfmt-22"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-go-logfmt-logfmt-24"
+      "relatedSpdxElement": "SPDXRef-github.com-golang-groupcache-23"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-golang-groupcache-25"
+      "relatedSpdxElement": "SPDXRef-github.com-gookit-color-24"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-gookit-color-26"
+      "relatedSpdxElement": "SPDXRef-github.com-integrii-flaggy-25"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-integrii-flaggy-27"
+      "relatedSpdxElement": "SPDXRef-github.com-jbenet-go-context-26"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jbenet-go-context-28"
+      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-generics-27"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-generics-29"
+      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-go-git-v5-28"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-go-git-v5-30"
+      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-gocui-29"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-gocui-31"
+      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-lazycore-30"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-lazycore-32"
+      "relatedSpdxElement": "SPDXRef-github.com-kardianos-osext-31"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-kardianos-osext-33"
+      "relatedSpdxElement": "SPDXRef-github.com-karimkhaleel-jsonschema-32"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-karimkhaleel-jsonschema-34"
+      "relatedSpdxElement": "SPDXRef-github.com-kevinburke-ssh-config-33"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-kevinburke-ssh-config-35"
+      "relatedSpdxElement": "SPDXRef-github.com-kr-logfmt-34"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-kr-logfmt-36"
+      "relatedSpdxElement": "SPDXRef-github.com-kyokomi-emoji-v2-35"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-kyokomi-emoji-v2-37"
+      "relatedSpdxElement": "SPDXRef-github.com-lucasb-eyer-go-colorful-36"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-lucasb-eyer-go-colorful-38"
+      "relatedSpdxElement": "SPDXRef-github.com-mailru-easyjson-37"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-mailru-easyjson-39"
+      "relatedSpdxElement": "SPDXRef-github.com-mattn-go-colorable-38"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-mattn-go-colorable-40"
+      "relatedSpdxElement": "SPDXRef-github.com-mattn-go-isatty-39"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-mattn-go-isatty-41"
+      "relatedSpdxElement": "SPDXRef-github.com-mgutz-str-40"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-mgutz-str-42"
+      "relatedSpdxElement": "SPDXRef-github.com-petermattis-goid-41"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-petermattis-goid-43"
+      "relatedSpdxElement": "SPDXRef-github.com-pjbgf-sha1cd-42"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-pjbgf-sha1cd-44"
+      "relatedSpdxElement": "SPDXRef-github.com-rivo-uniseg-43"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-rivo-uniseg-45"
+      "relatedSpdxElement": "SPDXRef-github.com-sahilm-fuzzy-44"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-sahilm-fuzzy-46"
+      "relatedSpdxElement": "SPDXRef-github.com-samber-lo-45"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-samber-lo-47"
+      "relatedSpdxElement": "SPDXRef-github.com-sasha-s-go-deadlock-46"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-sasha-s-go-deadlock-48"
+      "relatedSpdxElement": "SPDXRef-github.com-sergi-go-diff-47"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-sergi-go-diff-49"
+      "relatedSpdxElement": "SPDXRef-github.com-sirupsen-logrus-48"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-sirupsen-logrus-50"
+      "relatedSpdxElement": "SPDXRef-github.com-skeema-knownhosts-49"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-skeema-knownhosts-51"
+      "relatedSpdxElement": "SPDXRef-github.com-spf13-afero-50"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-spf13-afero-52"
+      "relatedSpdxElement": "SPDXRef-github.com-spkg-bom-51"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-spkg-bom-53"
+      "relatedSpdxElement": "SPDXRef-github.com-stefanhaller-git-todo-parser-52"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-stefanhaller-git-todo-parser-54"
+      "relatedSpdxElement": "SPDXRef-github.com-wk8-go-ordered-map-v2-53"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-wk8-go-ordered-map-v2-55"
+      "relatedSpdxElement": "SPDXRef-github.com-xanzy-ssh-agent-54"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-xanzy-ssh-agent-56"
+      "relatedSpdxElement": "SPDXRef-github.com-xo-terminfo-55"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-xo-terminfo-57"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-crypto-56"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-crypto-58"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-exp-57"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-exp-59"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-net-58"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-net-60"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-sync-59"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-sync-61"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-sys-60"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-sys-62"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-term-61"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-term-63"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-text-62"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-text-64"
+      "relatedSpdxElement": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-63"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-65"
+      "relatedSpdxElement": "SPDXRef-gopkg.in-warnings.v0-64"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-gopkg.in-warnings.v0-66"
+      "relatedSpdxElement": "SPDXRef-gopkg.in-yaml.v3-65"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-gopkg.in-yaml.v3-67"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-hdr-histogram-68"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-hdr-histogram-68"
+      "relatedSpdxElement": "SPDXRef-File-filtering-menu-action.go-66"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-hiredis-69"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-hiredis-69"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-jemalloc-70"
+      "relatedSpdxElement": "SPDXRef-File-sync-controller.go-67"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-jemalloc-70"
+      "relatedSpdxElement": "SPDXRef-File-amend-helper.go-68"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-linenoise-71"
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-menu-controller.go-69"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-linenoise-71"
+      "relatedSpdxElement": "SPDXRef-File-state.go-70"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-lua-72"
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-commit-message-panel-driver.go-71"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-lua-72"
+      "relatedSpdxElement": "SPDXRef-File-window-arrangement-helper.go-72"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeout.c-73"
+      "relatedSpdxElement": "SPDXRef-File-assertion-helper.go-73"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eval.c-74"
+      "relatedSpdxElement": "SPDXRef-File-worktree.go-74"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filtering-menu-action.go-75"
+      "relatedSpdxElement": "SPDXRef-File-reflog-commit-loader.go-75"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sync-controller.go-76"
+      "relatedSpdxElement": "SPDXRef-File-hyperlink.go-76"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amend-helper.go-77"
+      "relatedSpdxElement": "SPDXRef-File-os-default-platform.go-77"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-controller.go-78"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-78"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-state.go-79"
+      "relatedSpdxElement": "SPDXRef-File-sub-commits-helper.go-79"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-message-panel-driver.go-80"
+      "relatedSpdxElement": "SPDXRef-File-patch-explorer-context.go-80"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-window-arrangement-helper.go-81"
+      "relatedSpdxElement": "SPDXRef-File-file-node.go-81"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-assertion-helper.go-82"
+      "relatedSpdxElement": "SPDXRef-File-upstream-helper.go-82"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree.go-83"
+      "relatedSpdxElement": "SPDXRef-File-menu-context.go-83"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflog-commit-loader.go-84"
+      "relatedSpdxElement": "SPDXRef-File-app.go-84"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hyperlink.go-85"
+      "relatedSpdxElement": "SPDXRef-File-tags-context.go-85"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-default-platform.go-86"
+      "relatedSpdxElement": "SPDXRef-File-worktree-options-controller.go-86"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-87"
+      "relatedSpdxElement": "SPDXRef-File-base-controller.go-87"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rax-malloc.h-88"
+      "relatedSpdxElement": "SPDXRef-File-worktree-loader.go-88"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sub-commits-helper.go-89"
+      "relatedSpdxElement": "SPDXRef-File-stash.go-89"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-explorer-context.go-90"
+      "relatedSpdxElement": "SPDXRef-File-slice.go-90"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-node.go-91"
+      "relatedSpdxElement": "SPDXRef-File-main-branches.go-91"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-upstream-helper.go-92"
+      "relatedSpdxElement": "SPDXRef-File-shell-command-action.go-92"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-latency.c-93"
+      "relatedSpdxElement": "SPDXRef-File-client.go-93"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-context.go-94"
+      "relatedSpdxElement": "SPDXRef-File-switch-to-focused-main-view-controller.go-94"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-app.go-95"
+      "relatedSpdxElement": "SPDXRef-File-commit.go-95"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eventnotifier.c-96"
+      "relatedSpdxElement": "SPDXRef-File-tasks-adapter.go-96"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redismodule.h-97"
+      "relatedSpdxElement": "SPDXRef-File-editors.go-97"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tags-context.go-98"
+      "relatedSpdxElement": "SPDXRef-File-repos-helper.go-98"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cli-common.c-99"
+      "relatedSpdxElement": "SPDXRef-File-graph.go-99"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-options-controller.go-100"
+      "relatedSpdxElement": "SPDXRef-File-user-config-validation.go-100"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base-controller.go-101"
+      "relatedSpdxElement": "SPDXRef-File-color.go-101"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-loader.go-102"
+      "relatedSpdxElement": "SPDXRef-File-user-config.go-102"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash.go-103"
+      "relatedSpdxElement": "SPDXRef-File-file-system.go-103"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slice.go-104"
+      "relatedSpdxElement": "SPDXRef-File-env.go-104"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main-branches.go-105"
+      "relatedSpdxElement": "SPDXRef-File-context.go-105"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shell-command-action.go-106"
+      "relatedSpdxElement": "SPDXRef-File-global-controller.go-106"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-release.c-107"
+      "relatedSpdxElement": "SPDXRef-File-git.go-107"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscheck.c-108"
+      "relatedSpdxElement": "SPDXRef-File-file.go-108"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-109"
+      "relatedSpdxElement": "SPDXRef-File-hosting-service.go-109"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-endianconv.c-110"
+      "relatedSpdxElement": "SPDXRef-File-list-view-model.go-110"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-switch-to-focused-main-view-controller.go-111"
+      "relatedSpdxElement": "SPDXRef-File-io.go-111"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sparkline.c-112"
+      "relatedSpdxElement": "SPDXRef-File-views.go-112"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit.go-113"
+      "relatedSpdxElement": "SPDXRef-File-suggestion.go-113"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stream.h-114"
+      "relatedSpdxElement": "SPDXRef-File-remote-branch.go-114"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tasks-adapter.go-115"
+      "relatedSpdxElement": "SPDXRef-File-tag.go-115"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-editors.go-116"
+      "relatedSpdxElement": "SPDXRef-File-prompt-controller.go-116"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-repos-helper.go-117"
+      "relatedSpdxElement": "SPDXRef-File-stash-context.go-117"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-graph.go-118"
+      "relatedSpdxElement": "SPDXRef-File-confirmation-controller.go-118"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-user-config-validation.go-119"
+      "relatedSpdxElement": "SPDXRef-File-loader.go-119"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redisassert.h-120"
+      "relatedSpdxElement": "SPDXRef-File-git-icons.go-120"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-121"
+      "relatedSpdxElement": "SPDXRef-File-commit-description-controller.go-121"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-user-config.go-122"
+      "relatedSpdxElement": "SPDXRef-File-cmd-obj.go-122"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-system.go-123"
+      "relatedSpdxElement": "SPDXRef-File-cached-git-config.go-123"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-evict.c-124"
+      "relatedSpdxElement": "SPDXRef-File-keybinding-creator.go-124"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geohash.h-125"
+      "relatedSpdxElement": "SPDXRef-File-definitions.go-125"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-env.go-126"
+      "relatedSpdxElement": "SPDXRef-File-common.go-126"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context.go-127"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-127"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-global-controller.go-128"
+      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-context.go-128"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sort.c-129"
+      "relatedSpdxElement": "SPDXRef-File-cherry-picking.go-129"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git.go-130"
+      "relatedSpdxElement": "SPDXRef-File-color.go-130"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.go-131"
+      "relatedSpdxElement": "SPDXRef-File-prompt-driver.go-131"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut8.c-132"
+      "relatedSpdxElement": "SPDXRef-File-side-window-controller.go-132"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hosting-service.go-133"
+      "relatedSpdxElement": "SPDXRef-File-regexp.go-133"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-view-model.go-134"
+      "relatedSpdxElement": "SPDXRef-File-reflog-commits-controller.go-134"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-io.go-135"
+      "relatedSpdxElement": "SPDXRef-File-rename-similarity-threshold-controller.go-135"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-views.go-136"
+      "relatedSpdxElement": "SPDXRef-File-common.go-136"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-anet.h-137"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-137"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestion.go-138"
+      "relatedSpdxElement": "SPDXRef-File-copy.go-138"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-solarisfixes.h-139"
+      "relatedSpdxElement": "SPDXRef-File-shell.go-139"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-branch.go-140"
+      "relatedSpdxElement": "SPDXRef-File-remote-loader.go-140"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tag.go-141"
+      "relatedSpdxElement": "SPDXRef-File-main-panels.go-141"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commands.h-142"
+      "relatedSpdxElement": "SPDXRef-File-command-log-controller.go-142"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-prompt-controller.go-143"
+      "relatedSpdxElement": "SPDXRef-File-diff.go-143"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-context.go-144"
+      "relatedSpdxElement": "SPDXRef-File-refresh-helper.go-144"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-confirmation-controller.go-145"
+      "relatedSpdxElement": "SPDXRef-File-commit-file-loader.go-145"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crccombine.c-146"
+      "relatedSpdxElement": "SPDXRef-File-random.go-146"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socket.c-147"
+      "relatedSpdxElement": "SPDXRef-File-common.go-147"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-loader.go-148"
+      "relatedSpdxElement": "SPDXRef-File-gui.go-148"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-icons.go-149"
+      "relatedSpdxElement": "SPDXRef-File-cherry-pick-helper.go-149"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-description-controller.go-150"
+      "relatedSpdxElement": "SPDXRef-File-gui-driver.go-150"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmd-obj.go-151"
+      "relatedSpdxElement": "SPDXRef-File-confirmation-helper.go-151"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cached-git-config.go-152"
+      "relatedSpdxElement": "SPDXRef-File-file-loader.go-152"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybinding-creator.go-153"
+      "relatedSpdxElement": "SPDXRef-File-record-directory-helper.go-153"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-definitions.go-154"
+      "relatedSpdxElement": "SPDXRef-File-status-controller.go-154"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geohash-helper.h-155"
+      "relatedSpdxElement": "SPDXRef-File-state.go-155"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-foo.c-156"
+      "relatedSpdxElement": "SPDXRef-File-inline-status-helper.go-156"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-157"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-157"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut5.c-158"
+      "relatedSpdxElement": "SPDXRef-File-search-controller.go-158"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-functions.h-159"
+      "relatedSpdxElement": "SPDXRef-File-text-matcher.go-159"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-call-reply.c-160"
+      "relatedSpdxElement": "SPDXRef-File-remote-branches-controller.go-160"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.h-161"
+      "relatedSpdxElement": "SPDXRef-File-entry-point.go-161"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-162"
+      "relatedSpdxElement": "SPDXRef-File-diffing-menu-action.go-162"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-context.go-163"
+      "relatedSpdxElement": "SPDXRef-File-list-cursor.go-163"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cherry-picking.go-164"
+      "relatedSpdxElement": "SPDXRef-File-popup.go-164"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-165"
+      "relatedSpdxElement": "SPDXRef-File-logs-default.go-165"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-prompt-driver.go-166"
+      "relatedSpdxElement": "SPDXRef-File-worktrees-context.go-166"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-listpack.h-167"
+      "relatedSpdxElement": "SPDXRef-File-working-tree-state.go-167"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-side-window-controller.go-168"
+      "relatedSpdxElement": "SPDXRef-File-status-manager.go-168"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-regexp.go-169"
+      "relatedSpdxElement": "SPDXRef-File-signal-handling.go-169"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflog-commits-controller.go-170"
+      "relatedSpdxElement": "SPDXRef-File-commit.go-170"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rename-similarity-threshold-controller.go-171"
+      "relatedSpdxElement": "SPDXRef-File-remote.go-171"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-172"
+      "relatedSpdxElement": "SPDXRef-File-host-helper.go-172"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-173"
+      "relatedSpdxElement": "SPDXRef-File-suggestions.go-173"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redis-benchmark.c-174"
+      "relatedSpdxElement": "SPDXRef-File-ref-range.go-174"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-copy.go-175"
+      "relatedSpdxElement": "SPDXRef-File-style.go-175"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slowlog.h-176"
+      "relatedSpdxElement": "SPDXRef-File-update-helper.go-176"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shell.go-177"
+      "relatedSpdxElement": "SPDXRef-File-text-style.go-177"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-loader.go-178"
+      "relatedSpdxElement": "SPDXRef-File-options-map.go-178"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main-panels.go-179"
+      "relatedSpdxElement": "SPDXRef-File-views.go-179"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-command-log-controller.go-180"
+      "relatedSpdxElement": "SPDXRef-File-quit-actions.go-180"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff.go-181"
+      "relatedSpdxElement": "SPDXRef-File-commits-helper.go-181"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-refresh-helper.go-182"
+      "relatedSpdxElement": "SPDXRef-File-search-driver.go-182"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file-loader.go-183"
+      "relatedSpdxElement": "SPDXRef-File-search-trait.go-183"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-random.go-184"
+      "relatedSpdxElement": "SPDXRef-File-remotes-context.go-184"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-185"
+      "relatedSpdxElement": "SPDXRef-File-english.go-185"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui.go-186"
+      "relatedSpdxElement": "SPDXRef-File-common.go-186"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bio.c-187"
+      "relatedSpdxElement": "SPDXRef-File-helpers.go-187"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cherry-pick-helper.go-188"
+      "relatedSpdxElement": "SPDXRef-File-remotes.go-188"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui-driver.go-189"
+      "relatedSpdxElement": "SPDXRef-File-transform.go-189"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mstr.c-190"
+      "relatedSpdxElement": "SPDXRef-File-int-matcher.go-190"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-confirmation-helper.go-191"
+      "relatedSpdxElement": "SPDXRef-File-patch-building-controller.go-191"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-loader.go-192"
+      "relatedSpdxElement": "SPDXRef-File-branch.go-192"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-record-directory-helper.go-193"
+      "relatedSpdxElement": "SPDXRef-File-fake-cmd-obj-runner.go-193"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status-controller.go-194"
+      "relatedSpdxElement": "SPDXRef-File-list-controller-trait.go-194"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.h-195"
+      "relatedSpdxElement": "SPDXRef-File-parent-context-mgr.go-195"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-state.go-196"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-196"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inline-status-helper.go-197"
+      "relatedSpdxElement": "SPDXRef-File-local-commits-controller.go-197"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-198"
+      "relatedSpdxElement": "SPDXRef-File-submodules-context.go-198"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-controller.go-199"
+      "relatedSpdxElement": "SPDXRef-File-branches-helper.go-199"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-text-matcher.go-200"
+      "relatedSpdxElement": "SPDXRef-File-staging-helper.go-200"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-branches-controller.go-201"
+      "relatedSpdxElement": "SPDXRef-File-i18n.go-201"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-entry-point.go-202"
+      "relatedSpdxElement": "SPDXRef-File-remote-branches.go-202"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diffing-menu-action.go-203"
+      "relatedSpdxElement": "SPDXRef-File-app-status-helper.go-203"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-cursor.go-204"
+      "relatedSpdxElement": "SPDXRef-File-basic-styles.go-204"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha256.c-205"
+      "relatedSpdxElement": "SPDXRef-File-tasks.go-205"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-popup.go-206"
+      "relatedSpdxElement": "SPDXRef-File-git-command-builder.go-206"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cluster.c-207"
+      "relatedSpdxElement": "SPDXRef-File-extras-panel.go-207"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logs-default.go-208"
+      "relatedSpdxElement": "SPDXRef-File-gocui.go-208"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktrees-context.go-209"
+      "relatedSpdxElement": "SPDXRef-File-editor-presets.go-209"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-working-tree-state.go-210"
+      "relatedSpdxElement": "SPDXRef-File-updates.go-210"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.c-211"
+      "relatedSpdxElement": "SPDXRef-File-icons.go-211"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status-manager.go-212"
+      "relatedSpdxElement": "SPDXRef-File-snake.go-212"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signal-handling.go-213"
+      "relatedSpdxElement": "SPDXRef-File-reflog-commits-context.go-213"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit.go-214"
+      "relatedSpdxElement": "SPDXRef-File-view-selection-controller.go-214"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote.go-215"
+      "relatedSpdxElement": "SPDXRef-File-async-handler.go-215"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-host-helper.go-216"
+      "relatedSpdxElement": "SPDXRef-File-remote-branches-context.go-216"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-intset.h-217"
+      "relatedSpdxElement": "SPDXRef-File-types.go-217"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestions.go-218"
+      "relatedSpdxElement": "SPDXRef-File-diff-helper.go-218"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ref-range.go-219"
+      "relatedSpdxElement": "SPDXRef-File-pty.go-219"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-style.go-220"
+      "relatedSpdxElement": "SPDXRef-File-history-buffer.go-220"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-release.h-221"
+      "relatedSpdxElement": "SPDXRef-File-worktree-helper.go-221"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-update-helper.go-222"
+      "relatedSpdxElement": "SPDXRef-File-commits.go-222"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-text-style.go-223"
+      "relatedSpdxElement": "SPDXRef-File-confirmation-context.go-223"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options-map.go-224"
+      "relatedSpdxElement": "SPDXRef-File-gui-io.go-224"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzf.h-225"
+      "relatedSpdxElement": "SPDXRef-File-tags-helper.go-225"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-views.go-226"
+      "relatedSpdxElement": "SPDXRef-File-bisect-helper.go-226"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-quit-actions.go-227"
+      "relatedSpdxElement": "SPDXRef-File-hunk.go-227"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commits-helper.go-228"
+      "relatedSpdxElement": "SPDXRef-File-list-controller.go-228"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.h-229"
+      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-helper.go-229"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-driver.go-230"
+      "relatedSpdxElement": "SPDXRef-File-test.go-230"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-trait.go-231"
+      "relatedSpdxElement": "SPDXRef-File-ref.go-231"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remotes-context.go-232"
+      "relatedSpdxElement": "SPDXRef-File-stash-controller.go-232"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-call-reply.h-233"
+      "relatedSpdxElement": "SPDXRef-File-controllers.go-233"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-script-lua.h-234"
+      "relatedSpdxElement": "SPDXRef-File-rendering.go-234"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-english.go-235"
+      "relatedSpdxElement": "SPDXRef-File-suggestions-controller.go-235"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-236"
+      "relatedSpdxElement": "SPDXRef-File-main-context.go-236"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-helpers.go-237"
+      "relatedSpdxElement": "SPDXRef-File-cmd-obj-runner-default.go-237"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remotes.go-238"
+      "relatedSpdxElement": "SPDXRef-File-get-key.go-238"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transform.go-239"
+      "relatedSpdxElement": "SPDXRef-File-file-tree-view-model.go-239"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-int-matcher.go-240"
+      "relatedSpdxElement": "SPDXRef-File-common-commands.go-240"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bitops.c-241"
+      "relatedSpdxElement": "SPDXRef-File-git-cmd-obj-builder.go-241"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-building-controller.go-242"
+      "relatedSpdxElement": "SPDXRef-File-information-panel.go-242"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1.c-243"
+      "relatedSpdxElement": "SPDXRef-File-keybindings.go-243"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branch.go-244"
+      "relatedSpdxElement": "SPDXRef-File-lines.go-244"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-cmd-obj-runner.go-245"
+      "relatedSpdxElement": "SPDXRef-File-patch-line.go-245"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-controller-trait.go-246"
+      "relatedSpdxElement": "SPDXRef-File-context.go-246"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-script.h-247"
+      "relatedSpdxElement": "SPDXRef-File-confirmation-driver.go-247"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parent-context-mgr.go-248"
+      "relatedSpdxElement": "SPDXRef-File-branches.go-248"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-249"
+      "relatedSpdxElement": "SPDXRef-File-working-tree.go-249"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-db.c-250"
+      "relatedSpdxElement": "SPDXRef-File-layout.go-250"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-local-commits-controller.go-251"
+      "relatedSpdxElement": "SPDXRef-File-base-context.go-251"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zipmap.c-252"
+      "relatedSpdxElement": "SPDXRef-File-authors.go-252"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-intset.c-253"
+      "relatedSpdxElement": "SPDXRef-File-merge-and-rebase-helper.go-253"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodules-context.go-254"
+      "relatedSpdxElement": "SPDXRef-File-commits-files-controller.go-254"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branches-helper.go-255"
+      "relatedSpdxElement": "SPDXRef-File-submodule-config.go-255"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-staging-helper.go-256"
+      "relatedSpdxElement": "SPDXRef-File-sub-commits-context.go-256"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-i18n.go-257"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-257"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-branches.go-258"
+      "relatedSpdxElement": "SPDXRef-File-logs.go-258"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzfP.h-259"
+      "relatedSpdxElement": "SPDXRef-File-files-helper.go-259"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.c-260"
+      "relatedSpdxElement": "SPDXRef-File-app-config.go-260"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-app-status-helper.go-261"
+      "relatedSpdxElement": "SPDXRef-File-workspace-reset-controller.go-261"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basic-styles.go-262"
+      "relatedSpdxElement": "SPDXRef-File-common.go-262"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sdsalloc.h-263"
+      "relatedSpdxElement": "SPDXRef-File-runner.go-263"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pqsort.h-264"
+      "relatedSpdxElement": "SPDXRef-File-context-config.go-264"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tasks.go-265"
+      "relatedSpdxElement": "SPDXRef-File-snake-helper.go-265"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-hash.c-266"
+      "relatedSpdxElement": "SPDXRef-File-tag.go-266"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commands.c-267"
+      "relatedSpdxElement": "SPDXRef-File-sub-commits-controller.go-267"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-command-builder.go-268"
+      "relatedSpdxElement": "SPDXRef-File-context.go-268"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-extras-panel.go-269"
+      "relatedSpdxElement": "SPDXRef-File-filter-controller.go-269"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rax.c-270"
+      "relatedSpdxElement": "SPDXRef-File-commit-loader.go-270"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gocui.go-271"
+      "relatedSpdxElement": "SPDXRef-File-attach.go-271"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-replication.c-272"
+      "relatedSpdxElement": "SPDXRef-File-files-controller.go-272"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-editor-presets.go-273"
+      "relatedSpdxElement": "SPDXRef-File-file-icons.go-273"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rdb.h-274"
+      "relatedSpdxElement": "SPDXRef-File-setup.go-274"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-threads-mngr.c-275"
+      "relatedSpdxElement": "SPDXRef-File-commit-description-panel-driver.go-275"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-updates.go-276"
+      "relatedSpdxElement": "SPDXRef-File-git.go-276"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bio.h-277"
+      "relatedSpdxElement": "SPDXRef-File-commit-file.go-277"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-icons.go-278"
+      "relatedSpdxElement": "SPDXRef-File-build-tree.go-278"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pqsort.c-279"
+      "relatedSpdxElement": "SPDXRef-File-switch-to-sub-commits-controller.go-279"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.c-280"
+      "relatedSpdxElement": "SPDXRef-File-keybindings.go-280"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snake.go-281"
+      "relatedSpdxElement": "SPDXRef-File-context-common.go-281"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflog-commits-context.go-282"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-282"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-selection-controller.go-283"
+      "relatedSpdxElement": "SPDXRef-File-working-tree-helper.go-283"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-async-handler.go-284"
+      "relatedSpdxElement": "SPDXRef-File-menu-generator.go-284"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-module.c-285"
+      "relatedSpdxElement": "SPDXRef-File-menu-driver.go-285"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-branches-context.go-286"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-286"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-types.go-287"
+      "relatedSpdxElement": "SPDXRef-File-suggestions-context.go-287"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff-helper.go-288"
+      "relatedSpdxElement": "SPDXRef-File-rebase.go-288"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rax.h-289"
+      "relatedSpdxElement": "SPDXRef-File-node.go-289"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pty.go-290"
+      "relatedSpdxElement": "SPDXRef-File-file-tree.go-290"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-history-buffer.go-291"
+      "relatedSpdxElement": "SPDXRef-File-worktree.go-291"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-helper.go-292"
+      "relatedSpdxElement": "SPDXRef-File-list-context-trait.go-292"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commits.go-293"
+      "relatedSpdxElement": "SPDXRef-File-string-pool.go-293"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adlist.c-294"
+      "relatedSpdxElement": "SPDXRef-File-bisect-controller.go-294"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-confirmation-context.go-295"
+      "relatedSpdxElement": "SPDXRef-File-credentials-helper.go-295"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui-io.go-296"
+      "relatedSpdxElement": "SPDXRef-File-search-helper.go-296"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tags-helper.go-297"
+      "relatedSpdxElement": "SPDXRef-File-global-handlers.go-297"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connection.c-298"
+      "relatedSpdxElement": "SPDXRef-File-merge-conflict.go-298"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ae-epoll.c-299"
+      "relatedSpdxElement": "SPDXRef-File-types.go-299"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bisect-helper.go-300"
+      "relatedSpdxElement": "SPDXRef-File-date.go-300"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hunk.go-301"
+      "relatedSpdxElement": "SPDXRef-File-search-prompt-controller.go-301"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-monotonic.c-302"
+      "relatedSpdxElement": "SPDXRef-File-keybindings.go-302"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-controller.go-303"
+      "relatedSpdxElement": "SPDXRef-File-screen-mode-actions.go-303"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-helper.go-304"
+      "relatedSpdxElement": "SPDXRef-File-handler-creator.go-304"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-test.go-305"
+      "relatedSpdxElement": "SPDXRef-File-modes.go-305"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ref.go-306"
+      "relatedSpdxElement": "SPDXRef-File-test-driver.go-306"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cluster-legacy.c-307"
+      "relatedSpdxElement": "SPDXRef-File-toggle-whitespace-action.go-307"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscheck.h-308"
+      "relatedSpdxElement": "SPDXRef-File-context-lines-controller.go-308"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-controller.go-309"
+      "relatedSpdxElement": "SPDXRef-File-stash-loader.go-309"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-controllers.go-310"
+      "relatedSpdxElement": "SPDXRef-File-snake-controller.go-310"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rendering.go-311"
+      "relatedSpdxElement": "SPDXRef-File-branch-loader.go-311"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adlist.h-312"
+      "relatedSpdxElement": "SPDXRef-File-branch.go-312"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ziplist.c-313"
+      "relatedSpdxElement": "SPDXRef-File-thread-safe-map.go-313"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestions-controller.go-314"
+      "relatedSpdxElement": "SPDXRef-File-local-commits-context.go-314"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main-context.go-315"
+      "relatedSpdxElement": "SPDXRef-File-config.go-315"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmd-obj-runner-default.go-316"
+      "relatedSpdxElement": "SPDXRef-File-diffing.go-316"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ae.c-317"
+      "relatedSpdxElement": "SPDXRef-File-config-linux.go-317"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-get-key.go-318"
+      "relatedSpdxElement": "SPDXRef-File-version.go-318"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asciilogo.h-319"
+      "relatedSpdxElement": "SPDXRef-File-blame.go-319"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-tree-view-model.go-320"
+      "relatedSpdxElement": "SPDXRef-File-theme.go-320"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common-commands.go-321"
+      "relatedSpdxElement": "SPDXRef-File-filtering.go-321"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-cmd-obj-builder.go-322"
+      "relatedSpdxElement": "SPDXRef-File-marked-base-commit.go-322"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vset.c-323"
+      "relatedSpdxElement": "SPDXRef-File-version-number.go-323"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-information-panel.go-324"
+      "relatedSpdxElement": "SPDXRef-File-once-writer.go-324"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybindings.go-325"
+      "relatedSpdxElement": "SPDXRef-File-search-state.go-325"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lines.go-326"
+      "relatedSpdxElement": "SPDXRef-File-gpg-helper.go-326"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sparkline.h-327"
+      "relatedSpdxElement": "SPDXRef-File-format.go-327"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.c-328"
+      "relatedSpdxElement": "SPDXRef-File-menu-panel.go-328"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-debug.c-329"
+      "relatedSpdxElement": "SPDXRef-File-tail.go-329"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setcpuaffinity.c-330"
+      "relatedSpdxElement": "SPDXRef-File-session-state-loader.go-330"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-function-lua.c-331"
+      "relatedSpdxElement": "SPDXRef-File-worktrees.go-331"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fastjson.c-332"
+      "relatedSpdxElement": "SPDXRef-File-item-operations.go-332"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-line.go-333"
+      "relatedSpdxElement": "SPDXRef-File-decoration.go-333"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context.go-334"
+      "relatedSpdxElement": "SPDXRef-File-status.go-334"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-confirmation-driver.go-335"
+      "relatedSpdxElement": "SPDXRef-File-reflog-commits.go-335"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geo.h-336"
+      "relatedSpdxElement": "SPDXRef-File-worktrees-controller.go-336"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branches.go-337"
+      "relatedSpdxElement": "SPDXRef-File-vertical-scroll-controller.go-337"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-expire.c-338"
+      "relatedSpdxElement": "SPDXRef-File-paths.go-338"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-working-tree.go-339"
+      "relatedSpdxElement": "SPDXRef-File-view-helpers.go-339"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-layout.go-340"
+      "relatedSpdxElement": "SPDXRef-File-cmd-obj-runner.go-340"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base-context.go-341"
+      "relatedSpdxElement": "SPDXRef-File-views.go-341"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzf-c.c-342"
+      "relatedSpdxElement": "SPDXRef-File-recent-repos-panel.go-342"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-authors.go-343"
+      "relatedSpdxElement": "SPDXRef-File-keynames.go-343"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-and-rebase-helper.go-344"
+      "relatedSpdxElement": "SPDXRef-File-tag-loader.go-344"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commits-files-controller.go-345"
+      "relatedSpdxElement": "SPDXRef-File-cell.go-345"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodule-config.go-346"
+      "relatedSpdxElement": "SPDXRef-File-basic-commits-controller.go-346"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sub-commits-context.go-347"
+      "relatedSpdxElement": "SPDXRef-File-commit-file-node.go-347"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-348"
+      "relatedSpdxElement": "SPDXRef-File-commit-file-tree.go-348"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logs.go-349"
+      "relatedSpdxElement": "SPDXRef-File-jump-to-side-window-controller.go-349"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sds.c-350"
+      "relatedSpdxElement": "SPDXRef-File-submodules-controller.go-350"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-quicklist.c-351"
+      "relatedSpdxElement": "SPDXRef-File-prompt-context.go-351"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-files-helper.go-352"
+      "relatedSpdxElement": "SPDXRef-File-refresh.go-352"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-app-config.go-353"
+      "relatedSpdxElement": "SPDXRef-File-string-stack.go-353"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-workspace-reset-controller.go-354"
+      "relatedSpdxElement": "SPDXRef-File-commit-file-tree-view-model.go-354"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-functions.c-355"
+      "relatedSpdxElement": "SPDXRef-File-bisect-info.go-355"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-356"
+      "relatedSpdxElement": "SPDXRef-File-stash-entries.go-356"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-runner.go-357"
+      "relatedSpdxElement": "SPDXRef-File-find-conflicts.go-357"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context-config.go-358"
+      "relatedSpdxElement": "SPDXRef-File-custom.go-358"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut.c-359"
+      "relatedSpdxElement": "SPDXRef-File-repo-paths.go-359"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snake-helper.go-360"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-360"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blocked.c-361"
+      "relatedSpdxElement": "SPDXRef-File-branches-controller.go-361"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tag.go-362"
+      "relatedSpdxElement": "SPDXRef-File-submodules.go-362"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sub-commits-controller.go-363"
+      "relatedSpdxElement": "SPDXRef-File-tags-controller.go-363"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hnsw.h-364"
+      "relatedSpdxElement": "SPDXRef-File-view-helper.go-364"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context.go-365"
+      "relatedSpdxElement": "SPDXRef-File-search.go-365"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filter-controller.go-366"
+      "relatedSpdxElement": "SPDXRef-File-stash-entry.go-366"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-loader.go-367"
+      "relatedSpdxElement": "SPDXRef-File-file-filter.go-367"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resp-parser.c-368"
+      "relatedSpdxElement": "SPDXRef-File-files.go-368"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-attach.go-369"
+      "relatedSpdxElement": "SPDXRef-File-suspend-resume-helper.go-369"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-files-controller.go-370"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-370"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connhelpers.h-371"
+      "relatedSpdxElement": "SPDXRef-File-undo-controller.go-371"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crccombine.h-372"
+      "relatedSpdxElement": "SPDXRef-File-switch-to-diff-files-controller.go-372"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-icons.go-373"
+      "relatedSpdxElement": "SPDXRef-File-filtered-list-view-model.go-373"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setup.go-374"
+      "relatedSpdxElement": "SPDXRef-File-focus.go-374"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-description-panel-driver.go-375"
+      "relatedSpdxElement": "SPDXRef-File-git-flow-controller.go-375"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git.go-376"
+      "relatedSpdxElement": "SPDXRef-File-remote.go-376"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file.go-377"
+      "relatedSpdxElement": "SPDXRef-File-matcher.go-377"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut.h-378"
+      "relatedSpdxElement": "SPDXRef-File-resolver.go-378"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aof.c-379"
+      "relatedSpdxElement": "SPDXRef-File-view-trait.go-379"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build-tree.go-380"
+      "relatedSpdxElement": "SPDXRef-File-bisect.go-380"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-switch-to-sub-commits-controller.go-381"
+      "relatedSpdxElement": "SPDXRef-File-command-log-panel.go-381"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybindings.go-382"
+      "relatedSpdxElement": "SPDXRef-File-refs-helper.go-382"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context-common.go-383"
+      "relatedSpdxElement": "SPDXRef-File-commit-message-context.go-383"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-latency.h-384"
+      "relatedSpdxElement": "SPDXRef-File-sync.go-384"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-385"
+      "relatedSpdxElement": "SPDXRef-File-branches-context.go-385"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-working-tree-helper.go-386"
+      "relatedSpdxElement": "SPDXRef-File-main.go-386"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-generator.go-387"
+      "relatedSpdxElement": "SPDXRef-File-working-tree-context.go-387"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-childinfo.c-388"
+      "relatedSpdxElement": "SPDXRef-File-popup-handler.go-388"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-driver.go-389"
+      "relatedSpdxElement": "SPDXRef-File-gui-common.go-389"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cluster.h-390"
+      "relatedSpdxElement": "SPDXRef-File-patch-builder.go-390"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-391"
+      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-controller.go-391"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestions-context.go-392"
+      "relatedSpdxElement": "SPDXRef-File-suggestions-helper.go-392"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rebase.go-393"
+      "relatedSpdxElement": "SPDXRef-File-daemon.go-393"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-node.go-394"
+      "relatedSpdxElement": "SPDXRef-File-fixup-helper.go-394"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logreqres.c-395"
+      "relatedSpdxElement": "SPDXRef-File-background.go-395"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-tree.go-396"
+      "relatedSpdxElement": "SPDXRef-File-remotes-controller.go-396"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree.go-397"
+      "relatedSpdxElement": "SPDXRef-File-collapsed-paths.go-397"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-context-trait.go-398"
+      "relatedSpdxElement": "SPDXRef-File-window-helper.go-398"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-string-pool.go-399"
+      "relatedSpdxElement": "SPDXRef-File-mode-helper.go-399"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ae.h-400"
+      "relatedSpdxElement": "SPDXRef-File-file.go-400"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bisect-controller.go-401"
+      "relatedSpdxElement": "SPDXRef-File-rendering.go-401"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-credentials-helper.go-402"
+      "relatedSpdxElement": "SPDXRef-File-tags.go-402"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-helper.go-403"
+      "relatedSpdxElement": "SPDXRef-File-options-menu-action.go-403"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-global-handlers.go-404"
+      "relatedSpdxElement": "SPDXRef-File-pager-config.go-404"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-conflict.go-405"
+      "relatedSpdxElement": "SPDXRef-File-models.go-405"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-expr.c-406"
+      "relatedSpdxElement": "SPDXRef-File-env.go-406"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-siphash.c-407"
+      "relatedSpdxElement": "SPDXRef-File-filtered-list.go-407"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-types.go-408"
+      "relatedSpdxElement": "SPDXRef-File-fake-git-config.go-408"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-threads-mngr.h-409"
+      "relatedSpdxElement": "SPDXRef-File-list-renderer.go-409"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rio.h-410"
+      "relatedSpdxElement": "SPDXRef-File-links.go-410"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-date.go-411"
+      "relatedSpdxElement": "SPDXRef-File-commit-message-controller.go-411"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-prompt-controller.go-412"
+      "relatedSpdxElement": "SPDXRef-File-view-driver.go-412"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybindings.go-413"
+      "relatedSpdxElement": "SPDXRef-File-scroll-off-margin.go-413"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tls.c-414"
+      "relatedSpdxElement": "SPDXRef-File-author.go-414"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-screen-mode-actions.go-415"
+      "relatedSpdxElement": "SPDXRef-File-dynamic-title-builder.go-415"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mt19937-64.c-416"
+      "relatedSpdxElement": "SPDXRef-File-test-mode.go-416"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha256.h-417"
+      "relatedSpdxElement": "SPDXRef-File-formatting.go-417"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-handler-creator.go-418"
+      "relatedSpdxElement": "SPDXRef-File-submodule.go-418"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-modes.go-419"
+      "relatedSpdxElement": "SPDXRef-File-os.go-419"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-test-driver.go-420"
+      "relatedSpdxElement": "SPDXRef-File-alert-driver.go-420"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-networking.c-421"
+      "relatedSpdxElement": "SPDXRef-File-commit-loading-shared.go-421"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-toggle-whitespace-action.go-422"
+      "relatedSpdxElement": "SPDXRef-File-simple-context.go-422"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context-lines-controller.go-423"
+      "relatedSpdxElement": "SPDXRef-File-template.go-423"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-loader.go-424"
+      "relatedSpdxElement": "SPDXRef-File-staging-controller.go-424"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snake-controller.go-425"
+      "relatedSpdxElement": "SPDXRef-File-commit-files-context.go-425"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zipmap.h-426"
+      "relatedSpdxElement": "SPDXRef-File-history-trait.go-426"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branch-loader.go-427"
+      "relatedSpdxElement": "SPDXRef-File-yaml-utils.go-427"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tracking.c-428"
+      "relatedSpdxElement": "SPDXRef-File-custom-patch-options-menu-action.go-428"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branch.go-429"
+      "relatedSpdxElement": "SPDXRef-File-main-view-controller.go-429"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cli-common.h-430"
+      "relatedSpdxElement": "SPDXRef-File-flow.go-430"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1.h-431"
+      "relatedSpdxElement": "SPDXRef-File-patch-building-helper.go-431"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-thread-safe-map.go-432"
+      "relatedSpdxElement": "SPDXRef-File-git-cmd-obj-runner.go-432"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-local-commits-context.go-433"
+      "relatedSpdxElement": "SPDXRef-File-patch-explorer-controller.go-433"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-434"
+      "relatedSpdxElement": "SPDXRef-File-rebase.go-434"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diffing.go-435"
+      "relatedSpdxElement": "SPDXRef-File-cmd-obj-builder.go-435"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config-linux.go-436"
+      "relatedSpdxElement": "SPDXRef-File-rebase-todo.go-436"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version.go-437"
+      "relatedSpdxElement": "SPDXRef-File-parse.go-437"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blame.go-438"
+      "relatedSpdxElement": "SPDXRef-File-status.go-438"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-theme.go-439"
+      "relatedSpdxElement": "SPDXRef-File-const-win-unix.go-439"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filtering.go-440"
+      "relatedSpdxElement": "SPDXRef-File-cacheOnReadFs.go-440"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-marked-base-commit.go-441"
+      "relatedSpdxElement": "SPDXRef-File-dirmap.go-441"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-number.go-442"
+      "relatedSpdxElement": "SPDXRef-File-copyOnWriteFs.go-442"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-testhelp.h-443"
+      "relatedSpdxElement": "SPDXRef-File-path.go-443"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-once-writer.go-444"
+      "relatedSpdxElement": "SPDXRef-File-regexpfs.go-444"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-state.go-445"
+      "relatedSpdxElement": "SPDXRef-File-basepath.go-445"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gpg-helper.go-446"
+      "relatedSpdxElement": "SPDXRef-File-afero.go-446"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-format.go-447"
+      "relatedSpdxElement": "SPDXRef-File-adapters.go-447"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-panel.go-448"
+      "relatedSpdxElement": "SPDXRef-File-unionFile.go-448"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tail.go-449"
+      "relatedSpdxElement": "SPDXRef-File-file.go-449"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-session-state-loader.go-450"
+      "relatedSpdxElement": "SPDXRef-File-match.go-450"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ebuckets.c-451"
+      "relatedSpdxElement": "SPDXRef-File-lstater.go-451"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktrees.go-452"
+      "relatedSpdxElement": "SPDXRef-File-iofs.go-452"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zmalloc.c-453"
+      "relatedSpdxElement": "SPDXRef-File-util.go-453"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-item-operations.go-454"
+      "relatedSpdxElement": "SPDXRef-File-symlink.go-454"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-monotonic.h-455"
+      "relatedSpdxElement": "SPDXRef-File-httpFs.go-455"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.h-456"
+      "relatedSpdxElement": "SPDXRef-File-readonlyfs.go-456"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decoration.go-457"
+      "relatedSpdxElement": "SPDXRef-File-dir.go-457"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status.go-458"
+      "relatedSpdxElement": "SPDXRef-File-memmap.go-458"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflog-commits.go-459"
+      "relatedSpdxElement": "SPDXRef-File-os.go-459"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktrees-controller.go-460"
+      "relatedSpdxElement": "SPDXRef-File-ioutil.go-460"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kardianos-osext-31",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vertical-scroll-controller.go-461"
+      "relatedSpdxElement": "SPDXRef-File-osext-go18.go-461"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kardianos-osext-31",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-paths.go-462"
+      "relatedSpdxElement": "SPDXRef-File-osext.go-462"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-helpers.go-463"
+      "relatedSpdxElement": "SPDXRef-File-config.go-463"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmd-obj-runner.go-464"
+      "relatedSpdxElement": "SPDXRef-File-lexer.go-464"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mt19937-64.h-465"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-465"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geohash-helper.c-466"
+      "relatedSpdxElement": "SPDXRef-File-validators.go-466"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.c-467"
+      "relatedSpdxElement": "SPDXRef-File-token.go-467"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-views.go-468"
+      "relatedSpdxElement": "SPDXRef-File-position.go-468"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-recent-repos-panel.go-469"
+      "relatedSpdxElement": "SPDXRef-File-cast5.go-469"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mstr.h-470"
+      "relatedSpdxElement": "SPDXRef-File-curve25519.go-470"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keynames.go-471"
+      "relatedSpdxElement": "SPDXRef-File-blamka-amd64.go-471"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redis-cli.c-472"
+      "relatedSpdxElement": "SPDXRef-File-server.go-472"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zmalloc.h-473"
+      "relatedSpdxElement": "SPDXRef-File-cipher.go-473"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tag-loader.go-474"
+      "relatedSpdxElement": "SPDXRef-File-legacy-keccakf.go-474"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rio.c-475"
+      "relatedSpdxElement": "SPDXRef-File-blake2b.go-475"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cell.go-476"
+      "relatedSpdxElement": "SPDXRef-File-certs.go-476"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pubsub.c-477"
+      "relatedSpdxElement": "SPDXRef-File-streamlocal.go-477"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basic-commits-controller.go-478"
+      "relatedSpdxElement": "SPDXRef-File-blake2bAVX2-amd64.go-478"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file-node.go-479"
+      "relatedSpdxElement": "SPDXRef-File-buffer.go-479"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file-tree.go-480"
+      "relatedSpdxElement": "SPDXRef-File-knownhosts.go-480"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sentinel.c-481"
+      "relatedSpdxElement": "SPDXRef-File-argon2.go-481"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc64.c-482"
+      "relatedSpdxElement": "SPDXRef-File-common.go-482"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rdb.c-483"
+      "relatedSpdxElement": "SPDXRef-File-client-auth.go-483"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jump-to-side-window-controller.go-484"
+      "relatedSpdxElement": "SPDXRef-File-blake2b-generic.go-484"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodules-controller.go-485"
+      "relatedSpdxElement": "SPDXRef-File-client.go-485"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-prompt-context.go-486"
+      "relatedSpdxElement": "SPDXRef-File-hkdf.go-486"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-refresh.go-487"
+      "relatedSpdxElement": "SPDXRef-File-keys.go-487"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crcspeed.h-488"
+      "relatedSpdxElement": "SPDXRef-File-handshake.go-488"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-string-stack.go-489"
+      "relatedSpdxElement": "SPDXRef-File-server.go-489"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file-tree-view-model.go-490"
+      "relatedSpdxElement": "SPDXRef-File-register.go-490"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lazyfree.c-491"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-491"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-zset.c-492"
+      "relatedSpdxElement": "SPDXRef-File-kex.go-492"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bisect-info.go-493"
+      "relatedSpdxElement": "SPDXRef-File-connection.go-493"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-entries.go-494"
+      "relatedSpdxElement": "SPDXRef-File-go125.go-494"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-quicklist.h-495"
+      "relatedSpdxElement": "SPDXRef-File-shake.go-495"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sds.h-496"
+      "relatedSpdxElement": "SPDXRef-File-cipher.go-496"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-find-conflicts.go-497"
+      "relatedSpdxElement": "SPDXRef-File-blake2x.go-497"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-custom.go-498"
+      "relatedSpdxElement": "SPDXRef-File-tcpip.go-498"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-repo-paths.go-499"
+      "relatedSpdxElement": "SPDXRef-File-mac.go-499"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-500"
+      "relatedSpdxElement": "SPDXRef-File-block.go-500"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connection.h-501"
+      "relatedSpdxElement": "SPDXRef-File-blamka-generic.go-501"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-list.c-502"
+      "relatedSpdxElement": "SPDXRef-File-hashes.go-502"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crcspeed.c-503"
+      "relatedSpdxElement": "SPDXRef-File-ssh-gss.go-503"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branches-controller.go-504"
+      "relatedSpdxElement": "SPDXRef-File-messages.go-504"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodules.go-505"
+      "relatedSpdxElement": "SPDXRef-File-session.go-505"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.c-506"
+      "relatedSpdxElement": "SPDXRef-File-bcrypt-pbkdf.go-506"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tags-controller.go-507"
+      "relatedSpdxElement": "SPDXRef-File-client.go-507"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-helper.go-508"
+      "relatedSpdxElement": "SPDXRef-File-legacy-hash.go-508"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-atomicvar.h-509"
+      "relatedSpdxElement": "SPDXRef-File-channel.go-509"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search.go-510"
+      "relatedSpdxElement": "SPDXRef-File-const.go-510"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-debugmacro.h-511"
+      "relatedSpdxElement": "SPDXRef-File-keyring.go-511"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hnsw.c-512"
+      "relatedSpdxElement": "SPDXRef-File-mux.go-512"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-acl.c-513"
+      "relatedSpdxElement": "SPDXRef-File-blake2b.go-513"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-entry.go-514"
+      "relatedSpdxElement": "SPDXRef-File-mlkem.go-514"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-filter.go-515"
+      "relatedSpdxElement": "SPDXRef-File-transport.go-515"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geo.c-516"
+      "relatedSpdxElement": "SPDXRef-File-forward.go-516"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.h-517"
+      "relatedSpdxElement": "SPDXRef-File-decode.go-517"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-files.go-518"
+      "relatedSpdxElement": "SPDXRef-File-emitterc.go-518"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setproctitle.c-519"
+      "relatedSpdxElement": "SPDXRef-File-parserc.go-519"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suspend-resume-helper.go-520"
+      "relatedSpdxElement": "SPDXRef-File-resolve.go-520"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-521"
+      "relatedSpdxElement": "SPDXRef-File-yamlh.go-521"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-undo-controller.go-522"
+      "relatedSpdxElement": "SPDXRef-File-yaml.go-522"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-switch-to-diff-files-controller.go-523"
+      "relatedSpdxElement": "SPDXRef-File-sorter.go-523"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filtered-list-view-model.go-524"
+      "relatedSpdxElement": "SPDXRef-File-apic.go-524"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ebuckets.h-525"
+      "relatedSpdxElement": "SPDXRef-File-readerc.go-525"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-focus.go-526"
+      "relatedSpdxElement": "SPDXRef-File-writerc.go-526"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-flow-controller.go-527"
+      "relatedSpdxElement": "SPDXRef-File-scannerc.go-527"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote.go-528"
+      "relatedSpdxElement": "SPDXRef-File-encode.go-528"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-matcher.go-529"
+      "relatedSpdxElement": "SPDXRef-File-yamlprivateh.go-529"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fmacros.h-530"
+      "relatedSpdxElement": "SPDXRef-File-exported.go-530"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cluster-legacy.h-531"
+      "relatedSpdxElement": "SPDXRef-File-terminal-check-unix.go-531"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resolver.go-532"
+      "relatedSpdxElement": "SPDXRef-File-writer.go-532"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-trait.go-533"
+      "relatedSpdxElement": "SPDXRef-File-logrus.go-533"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bisect.go-534"
+      "relatedSpdxElement": "SPDXRef-File-terminal-check-notappengine.go-534"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-command-log-panel.go-535"
+      "relatedSpdxElement": "SPDXRef-File-hooks.go-535"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-refs-helper.go-536"
+      "relatedSpdxElement": "SPDXRef-File-formatter.go-536"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-message-context.go-537"
+      "relatedSpdxElement": "SPDXRef-File-logger.go-537"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iothread.c-538"
+      "relatedSpdxElement": "SPDXRef-File-entry.go-538"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sync.go-539"
+      "relatedSpdxElement": "SPDXRef-File-alt-exit.go-539"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branches-context.go-540"
+      "relatedSpdxElement": "SPDXRef-File-text-formatter.go-540"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mixer.h-541"
+      "relatedSpdxElement": "SPDXRef-File-buffer-pool.go-541"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-anet.c-542"
+      "relatedSpdxElement": "SPDXRef-File-json-formatter.go-542"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main.go-543"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-543"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-working-tree-context.go-544"
+      "relatedSpdxElement": "SPDXRef-File-private-key-test-data.go-544"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-popup-handler.go-545"
+      "relatedSpdxElement": "SPDXRef-File-mpi.go-545"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-set.c-546"
+      "relatedSpdxElement": "SPDXRef-File-compressed.go-546"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui-common.go-547"
+      "relatedSpdxElement": "SPDXRef-File-curve-info.go-547"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc16.c-548"
+      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted.go-548"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-stream.c-549"
+      "relatedSpdxElement": "SPDXRef-File-random-vectors.go-549"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-builder.go-550"
+      "relatedSpdxElement": "SPDXRef-File-keys-test-data.go-550"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-controller.go-551"
+      "relatedSpdxElement": "SPDXRef-File-rfc7253-test-vectors-suite-b.go-551"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestions-helper.go-552"
+      "relatedSpdxElement": "SPDXRef-File-packet.go-552"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-daemon.go-553"
+      "relatedSpdxElement": "SPDXRef-File-marker.go-553"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-notify.c-554"
+      "relatedSpdxElement": "SPDXRef-File-ocb.go-554"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fixup-helper.go-555"
+      "relatedSpdxElement": "SPDXRef-File-config.go-555"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redis-check-rdb.c-556"
+      "relatedSpdxElement": "SPDXRef-File-symmetric-key-encrypted.go-556"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc64.h-557"
+      "relatedSpdxElement": "SPDXRef-File-notation.go-557"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-background.go-558"
+      "relatedSpdxElement": "SPDXRef-File-packet-unsupported.go-558"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remotes-controller.go-559"
+      "relatedSpdxElement": "SPDXRef-File-rfc7253-test-vectors-suite-a.go-559"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-collapsed-paths.go-560"
+      "relatedSpdxElement": "SPDXRef-File-x25519.go-560"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-kvstore.h-561"
+      "relatedSpdxElement": "SPDXRef-File-eax.go-561"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-unix.c-562"
+      "relatedSpdxElement": "SPDXRef-File-padding.go-562"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eventnotifier.h-563"
+      "relatedSpdxElement": "SPDXRef-File-keywrap.go-563"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-window-helper.go-564"
+      "relatedSpdxElement": "SPDXRef-File-userid.go-564"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mode-helper.go-565"
+      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted-aead.go-565"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.go-566"
+      "relatedSpdxElement": "SPDXRef-File-random-vectors.go-566"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redisassert.c-567"
+      "relatedSpdxElement": "SPDXRef-File-ocfb.go-567"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fmtargs.h-568"
+      "relatedSpdxElement": "SPDXRef-File-hash.go-568"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cli-commands.c-569"
+      "relatedSpdxElement": "SPDXRef-File-encode.go-569"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rendering.go-570"
+      "relatedSpdxElement": "SPDXRef-File-packet-sequence.go-570"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tags.go-571"
+      "relatedSpdxElement": "SPDXRef-File-aead-encrypted.go-571"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options-menu-action.go-572"
+      "relatedSpdxElement": "SPDXRef-File-ed25519.go-572"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-script-lua.c-573"
+      "relatedSpdxElement": "SPDXRef-File-canonical-text.go-573"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pager-config.go-574"
+      "relatedSpdxElement": "SPDXRef-File-aead-crypter.go-574"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-models.go-575"
+      "relatedSpdxElement": "SPDXRef-File-curves.go-575"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-env.go-576"
+      "relatedSpdxElement": "SPDXRef-File-s2k-cache.go-576"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filtered-list.go-577"
+      "relatedSpdxElement": "SPDXRef-File-userattribute.go-577"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-git-config.go-578"
+      "relatedSpdxElement": "SPDXRef-File-x448.go-578"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-renderer.go-579"
+      "relatedSpdxElement": "SPDXRef-File-read-write-test-data.go-579"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut6.c-580"
+      "relatedSpdxElement": "SPDXRef-File-s2k.go-580"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-listpack-malloc.h-581"
+      "relatedSpdxElement": "SPDXRef-File-ed25519.go-581"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-localtime.c-582"
+      "relatedSpdxElement": "SPDXRef-File-encoding.go-582"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-links.go-583"
+      "relatedSpdxElement": "SPDXRef-File-key-generation.go-583"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geohash.c-584"
+      "relatedSpdxElement": "SPDXRef-File-rcurve.go-584"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-message-controller.go-585"
+      "relatedSpdxElement": "SPDXRef-File-signature.go-585"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-driver.go-586"
+      "relatedSpdxElement": "SPDXRef-File-curve25519.go-586"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resp-parser.h-587"
+      "relatedSpdxElement": "SPDXRef-File-literal.go-587"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slowlog.c-588"
+      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted-mdc.go-588"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-script.c-589"
+      "relatedSpdxElement": "SPDXRef-File-eddsa.go-589"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cli-commands.h-590"
+      "relatedSpdxElement": "SPDXRef-File-keys.go-590"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scroll-off-margin.go-591"
+      "relatedSpdxElement": "SPDXRef-File-write.go-591"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-author.go-592"
+      "relatedSpdxElement": "SPDXRef-File-ed448.go-592"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynamic-title-builder.go-593"
+      "relatedSpdxElement": "SPDXRef-File-public-key-test-data.go-593"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-listpack.c-594"
+      "relatedSpdxElement": "SPDXRef-File-ed448.go-594"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-kvstore.c-595"
+      "relatedSpdxElement": "SPDXRef-File-encrypted-key.go-595"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ziplist.h-596"
+      "relatedSpdxElement": "SPDXRef-File-s2k-config.go-596"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-test-mode.go-597"
+      "relatedSpdxElement": "SPDXRef-File-elgamal.go-597"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formatting.go-598"
+      "relatedSpdxElement": "SPDXRef-File-cipher.go-598"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodule.go-599"
+      "relatedSpdxElement": "SPDXRef-File-bitcurve.go-599"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os.go-600"
+      "relatedSpdxElement": "SPDXRef-File-oid.go-600"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-alert-driver.go-601"
+      "relatedSpdxElement": "SPDXRef-File-brainpool.go-601"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-loading-shared.go-602"
+      "relatedSpdxElement": "SPDXRef-File-opaque.go-602"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc16-slottable.h-603"
+      "relatedSpdxElement": "SPDXRef-File-aead.go-603"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-simple-context.go-604"
+      "relatedSpdxElement": "SPDXRef-File-hash.go-604"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hyperloglog.c-605"
+      "relatedSpdxElement": "SPDXRef-File-byteutil.go-605"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.c-606"
+      "relatedSpdxElement": "SPDXRef-File-ecdh.go-606"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-template.go-607"
+      "relatedSpdxElement": "SPDXRef-File-reader.go-607"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-staging-controller.go-608"
+      "relatedSpdxElement": "SPDXRef-File-eax-test-vectors.go-608"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strl.c-609"
+      "relatedSpdxElement": "SPDXRef-File-x448.go-609"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memtest.c-610"
+      "relatedSpdxElement": "SPDXRef-File-armor.go-610"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-endianconv.h-611"
+      "relatedSpdxElement": "SPDXRef-File-public-key.go-611"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redis-check-aof.c-612"
+      "relatedSpdxElement": "SPDXRef-File-generic.go-612"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-files-context.go-613"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-613"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-history-trait.go-614"
+      "relatedSpdxElement": "SPDXRef-File-read.go-614"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yaml-utils.go-615"
+      "relatedSpdxElement": "SPDXRef-File-private-key.go-615"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version.h-616"
+      "relatedSpdxElement": "SPDXRef-File-config-v5.go-616"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-custom-patch-options-menu-action.go-617"
+      "relatedSpdxElement": "SPDXRef-File-one-pass-signature.go-617"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main-view-controller.go-618"
+      "relatedSpdxElement": "SPDXRef-File-ecdsa.go-618"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-flow.go-619"
+      "relatedSpdxElement": "SPDXRef-File-recipient.go-619"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syncio.c-620"
+      "relatedSpdxElement": "SPDXRef-File-aead-config.go-620"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-defrag.c-621"
+      "relatedSpdxElement": "SPDXRef-File-jsonstring.go-621"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-building-helper.go-622"
+      "relatedSpdxElement": "SPDXRef-File-decode.go-622"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-cmd-obj-runner.go-623"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-623"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-explorer-controller.go-624"
+      "relatedSpdxElement": "SPDXRef-File-encode.go-624"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rebase.go-625"
+      "relatedSpdxElement": "SPDXRef-File-pagesize-unix.go-625"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmd-obj-builder.go-626"
+      "relatedSpdxElement": "SPDXRef-File-syscall-unix-gc.go-626"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rebase-todo.go-627"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux.go-627"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-string.c-628"
+      "relatedSpdxElement": "SPDXRef-File-vgetrandom-linux.go-628"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parse.go-629"
+      "relatedSpdxElement": "SPDXRef-File-zerrors-linux.go-629"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status.go-630"
+      "relatedSpdxElement": "SPDXRef-File-dirent.go-630"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzf-d.c-631"
+      "relatedSpdxElement": "SPDXRef-File-zsysnum-linux-amd64.go-631"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-const-win-unix.go-632"
+      "relatedSpdxElement": "SPDXRef-File-ifreq-linux.go-632"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cacheOnReadFs.go-633"
+      "relatedSpdxElement": "SPDXRef-File-auxv.go-633"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dirmap.go-634"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux-alarm.go-634"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-copyOnWriteFs.go-635"
+      "relatedSpdxElement": "SPDXRef-File-mremap.go-635"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-path.go-636"
+      "relatedSpdxElement": "SPDXRef-File-execabs.go-636"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-regexpfs.go-637"
+      "relatedSpdxElement": "SPDXRef-File-affinity-linux.go-637"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basepath.go-638"
+      "relatedSpdxElement": "SPDXRef-File-ztypes-linux.go-638"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-afero.go-639"
+      "relatedSpdxElement": "SPDXRef-File-sockcmsg-unix-other.go-639"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adapters.go-640"
+      "relatedSpdxElement": "SPDXRef-File-race0.go-640"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-unionFile.go-641"
+      "relatedSpdxElement": "SPDXRef-File-sysvshm-linux.go-641"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.go-642"
+      "relatedSpdxElement": "SPDXRef-File-zptrace-x86-linux.go-642"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-match.go-643"
+      "relatedSpdxElement": "SPDXRef-File-syscall.go-643"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lstater.go-644"
+      "relatedSpdxElement": "SPDXRef-File-sockcmsg-linux.go-644"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iofs.go-645"
+      "relatedSpdxElement": "SPDXRef-File-fcntl.go-645"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.go-646"
+      "relatedSpdxElement": "SPDXRef-File-fdset.go-646"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symlink.go-647"
+      "relatedSpdxElement": "SPDXRef-File-sysvshm-unix.go-647"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpFs.go-648"
+      "relatedSpdxElement": "SPDXRef-File-constants.go-648"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-readonlyfs.go-649"
+      "relatedSpdxElement": "SPDXRef-File-timestruct.go-649"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dir.go-650"
+      "relatedSpdxElement": "SPDXRef-File-ioctl-linux.go-650"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memmap.go-651"
+      "relatedSpdxElement": "SPDXRef-File-zsyscall-linux.go-651"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os.go-652"
+      "relatedSpdxElement": "SPDXRef-File-zerrors-linux-amd64.go-652"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-52",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ioutil.go-653"
+      "relatedSpdxElement": "SPDXRef-File-bluetooth-linux.go-653"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kardianos-osext-33",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-osext-go18.go-654"
+      "relatedSpdxElement": "SPDXRef-File-env-unix.go-654"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kardianos-osext-33",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-osext.go-655"
+      "relatedSpdxElement": "SPDXRef-File-aliases.go-655"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-35",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-656"
+      "relatedSpdxElement": "SPDXRef-File-endian-little.go-656"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-35",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lexer.go-657"
+      "relatedSpdxElement": "SPDXRef-File-sockcmsg-unix.go-657"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-35",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-658"
+      "relatedSpdxElement": "SPDXRef-File-dev-linux.go-658"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-35",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-validators.go-659"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux-amd64.go-659"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-35",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-token.go-660"
+      "relatedSpdxElement": "SPDXRef-File-execabs-go119.go-660"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-35",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-position.go-661"
+      "relatedSpdxElement": "SPDXRef-File-readdirent-getdents.go-661"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cast5.go-662"
+      "relatedSpdxElement": "SPDXRef-File-syscall-unix.go-662"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve25519.go-663"
+      "relatedSpdxElement": "SPDXRef-File-ztypes-linux-amd64.go-663"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blamka-amd64.go-664"
+      "relatedSpdxElement": "SPDXRef-File-ioctl-unsigned.go-664"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-665"
+      "relatedSpdxElement": "SPDXRef-File-cpu-x86.go-665"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher.go-666"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux-amd64-gc.go-666"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-legacy-keccakf.go-667"
+      "relatedSpdxElement": "SPDXRef-File-zsyscall-linux-amd64.go-667"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2b.go-668"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux-gc.go-668"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-certs.go-669"
+      "relatedSpdxElement": "SPDXRef-File-parsedValue.go-669"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-streamlocal.go-670"
+      "relatedSpdxElement": "SPDXRef-File-argumentParser.go-670"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2bAVX2-amd64.go-671"
+      "relatedSpdxElement": "SPDXRef-File-help.go-671"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-buffer.go-672"
+      "relatedSpdxElement": "SPDXRef-File-flag.go-672"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-knownhosts.go-673"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-673"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-argon2.go-674"
+      "relatedSpdxElement": "SPDXRef-File-subCommand.go-674"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-675"
+      "relatedSpdxElement": "SPDXRef-File-main.go-675"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client-auth.go-676"
+      "relatedSpdxElement": "SPDXRef-File-positionalValue.go-676"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2b-generic.go-677"
+      "relatedSpdxElement": "SPDXRef-File-helpValues.go-677"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-678"
+      "relatedSpdxElement": "SPDXRef-File-color-tag.go-678"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hkdf.go-679"
+      "relatedSpdxElement": "SPDXRef-File-color-16.go-679"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keys.go-680"
+      "relatedSpdxElement": "SPDXRef-File-printer.go-680"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-handshake.go-681"
+      "relatedSpdxElement": "SPDXRef-File-quickstart.go-681"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-682"
+      "relatedSpdxElement": "SPDXRef-File-detect-nonwin.go-682"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-register.go-683"
+      "relatedSpdxElement": "SPDXRef-File-color-rgb.go-683"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-684"
+      "relatedSpdxElement": "SPDXRef-File-convert.go-684"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-kex.go-685"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-685"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connection.go-686"
+      "relatedSpdxElement": "SPDXRef-File-color.go-686"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-go125.go-687"
+      "relatedSpdxElement": "SPDXRef-File-color-256.go-687"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shake.go-688"
+      "relatedSpdxElement": "SPDXRef-File-detect-env.go-688"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher.go-689"
+      "relatedSpdxElement": "SPDXRef-File-style.go-689"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2x.go-690"
+      "relatedSpdxElement": "SPDXRef-File-hash.go-690"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tcpip.go-691"
+      "relatedSpdxElement": "SPDXRef-File-config.go-691"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mac.go-692"
+      "relatedSpdxElement": "SPDXRef-File-filter.go-692"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-block.go-693"
+      "relatedSpdxElement": "SPDXRef-File-worktree-commit.go-693"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blamka-generic.go-694"
+      "relatedSpdxElement": "SPDXRef-File-index.go-694"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hashes.go-695"
+      "relatedSpdxElement": "SPDXRef-File-writer.go-695"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ssh-gss.go-696"
+      "relatedSpdxElement": "SPDXRef-File-options.go-696"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-messages.go-697"
+      "relatedSpdxElement": "SPDXRef-File-client.go-697"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-session.go-698"
+      "relatedSpdxElement": "SPDXRef-File-client.go-698"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bcrypt-pbkdf.go-699"
+      "relatedSpdxElement": "SPDXRef-File-delta-selector.go-699"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-700"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-700"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-legacy-hash.go-701"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-701"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-channel.go-702"
+      "relatedSpdxElement": "SPDXRef-File-server.go-702"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-const.go-703"
+      "relatedSpdxElement": "SPDXRef-File-auth-method.go-703"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keyring.go-704"
+      "relatedSpdxElement": "SPDXRef-File-colorconfig.go-704"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mux.go-705"
+      "relatedSpdxElement": "SPDXRef-File-worktree-status.go-705"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2b.go-706"
+      "relatedSpdxElement": "SPDXRef-File-common.go-706"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mlkem.go-707"
+      "relatedSpdxElement": "SPDXRef-File-dotgit.go-707"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transport.go-708"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-708"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-58",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-forward.go-709"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-limit.go-709"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decode.go-710"
+      "relatedSpdxElement": "SPDXRef-File-url.go-710"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-emitterc.go-711"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-711"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parserc.go-712"
+      "relatedSpdxElement": "SPDXRef-File-match.go-712"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resolve.go-713"
+      "relatedSpdxElement": "SPDXRef-File-reader.go-713"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yamlh.go-714"
+      "relatedSpdxElement": "SPDXRef-File-doubleiter.go-714"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yaml.go-715"
+      "relatedSpdxElement": "SPDXRef-File-error.go-715"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sorter.go-716"
+      "relatedSpdxElement": "SPDXRef-File-color.go-716"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apic.go-717"
+      "relatedSpdxElement": "SPDXRef-File-server.go-717"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-readerc.go-718"
+      "relatedSpdxElement": "SPDXRef-File-blame.go-718"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writerc.go-719"
+      "relatedSpdxElement": "SPDXRef-File-object-walker.go-719"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scannerc.go-720"
+      "relatedSpdxElement": "SPDXRef-File-index.go-720"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encode.go-721"
+      "relatedSpdxElement": "SPDXRef-File-worktree.go-721"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-67",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yamlprivateh.go-722"
+      "relatedSpdxElement": "SPDXRef-File-dotgit-setref.go-722"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-exported.go-723"
+      "relatedSpdxElement": "SPDXRef-File-mocks.go-723"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal-check-unix.go-724"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-724"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writer.go-725"
+      "relatedSpdxElement": "SPDXRef-File-merge-base.go-725"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logrus.go-726"
+      "relatedSpdxElement": "SPDXRef-File-ulreq-encode.go-726"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal-check-notappengine.go-727"
+      "relatedSpdxElement": "SPDXRef-File-tree.go-727"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hooks.go-728"
+      "relatedSpdxElement": "SPDXRef-File-storage.go-728"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formatter.go-729"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-729"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logger.go-730"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-730"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-entry.go-731"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-731"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-alt-exit.go-732"
+      "relatedSpdxElement": "SPDXRef-File-url.go-732"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-text-formatter.go-733"
+      "relatedSpdxElement": "SPDXRef-File-reference.go-733"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-buffer-pool.go-734"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-734"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-json-formatter.go-735"
+      "relatedSpdxElement": "SPDXRef-File-trace.go-735"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-50",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-736"
+      "relatedSpdxElement": "SPDXRef-File-object.go-736"
     },
     {
-      "spdxElementId": "SPDXRef-hdr-histogram-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hdr-histogram.h-737"
+      "relatedSpdxElement": "SPDXRef-File-shallow.go-737"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-private-key-test-data.go-738"
+      "relatedSpdxElement": "SPDXRef-File-bufio.go-738"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mpi.go-739"
+      "relatedSpdxElement": "SPDXRef-File-reader.go-739"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-compressed.go-740"
+      "relatedSpdxElement": "SPDXRef-File-pattern.go-740"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-info.go-741"
+      "relatedSpdxElement": "SPDXRef-File-section.go-741"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted.go-742"
+      "relatedSpdxElement": "SPDXRef-File-uppackresp.go-742"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-random-vectors.go-743"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-743"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keys-test-data.go-744"
+      "relatedSpdxElement": "SPDXRef-File-object-pack.go-744"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rfc7253-test-vectors-suite-b.go-745"
+      "relatedSpdxElement": "SPDXRef-File-format.go-745"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-packet.go-746"
+      "relatedSpdxElement": "SPDXRef-File-path-util.go-746"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-marker.go-747"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-747"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ocb.go-748"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-748"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-749"
+      "relatedSpdxElement": "SPDXRef-File-reference.go-749"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symmetric-key-encrypted.go-750"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-750"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-notation.go-751"
+      "relatedSpdxElement": "SPDXRef-File-status.go-751"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-packet-unsupported.go-752"
+      "relatedSpdxElement": "SPDXRef-File-patch-delta.go-752"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rfc7253-test-vectors-suite-a.go-753"
+      "relatedSpdxElement": "SPDXRef-File-list.go-753"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x25519.go-754"
+      "relatedSpdxElement": "SPDXRef-File-remote.go-754"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eax.go-755"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-755"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-padding.go-756"
+      "relatedSpdxElement": "SPDXRef-File-node.go-756"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keywrap.go-757"
+      "relatedSpdxElement": "SPDXRef-File-receive-pack.go-757"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-userid.go-758"
+      "relatedSpdxElement": "SPDXRef-File-muxer.go-758"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted-aead.go-759"
+      "relatedSpdxElement": "SPDXRef-File-change.go-759"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-random-vectors.go-760"
+      "relatedSpdxElement": "SPDXRef-File-revision.go-760"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ocfb.go-761"
+      "relatedSpdxElement": "SPDXRef-File-shallow.go-761"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.go-762"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker.go-762"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encode.go-763"
+      "relatedSpdxElement": "SPDXRef-File-common.go-763"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-packet-sequence.go-764"
+      "relatedSpdxElement": "SPDXRef-File-storer.go-764"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aead-encrypted.go-765"
+      "relatedSpdxElement": "SPDXRef-File-fsobject.go-765"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed25519.go-766"
+      "relatedSpdxElement": "SPDXRef-File-object.go-766"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-canonical-text.go-767"
+      "relatedSpdxElement": "SPDXRef-File-deltaobject.go-767"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aead-crypter.go-768"
+      "relatedSpdxElement": "SPDXRef-File-read.go-768"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curves.go-769"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-ctime.go-769"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-s2k-cache.go-770"
+      "relatedSpdxElement": "SPDXRef-File-decoder.go-770"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-userattribute.go-771"
+      "relatedSpdxElement": "SPDXRef-File-path.go-771"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x448.go-772"
+      "relatedSpdxElement": "SPDXRef-File-common.go-772"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read-write-test-data.go-773"
+      "relatedSpdxElement": "SPDXRef-File-memory.go-773"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-s2k.go-774"
+      "relatedSpdxElement": "SPDXRef-File-noder.go-774"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed25519.go-775"
+      "relatedSpdxElement": "SPDXRef-File-common.go-775"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoding.go-776"
+      "relatedSpdxElement": "SPDXRef-File-tag.go-776"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-key-generation.go-777"
+      "relatedSpdxElement": "SPDXRef-File-writers.go-777"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rcurve.go-778"
+      "relatedSpdxElement": "SPDXRef-File-diff.go-778"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signature.go-779"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-bfs-filtered.go-779"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve25519.go-780"
+      "relatedSpdxElement": "SPDXRef-File-ulreq.go-780"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-literal.go-781"
+      "relatedSpdxElement": "SPDXRef-File-file.go-781"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted-mdc.go-782"
+      "relatedSpdxElement": "SPDXRef-File-object-lru.go-782"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eddsa.go-783"
+      "relatedSpdxElement": "SPDXRef-File-module.go-783"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keys.go-784"
+      "relatedSpdxElement": "SPDXRef-File-common.go-784"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-write.go-785"
+      "relatedSpdxElement": "SPDXRef-File-server.go-785"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed448.go-786"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-786"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-public-key-test-data.go-787"
+      "relatedSpdxElement": "SPDXRef-File-advrefs.go-787"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed448.go-788"
+      "relatedSpdxElement": "SPDXRef-File-blob.go-788"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encrypted-key.go-789"
+      "relatedSpdxElement": "SPDXRef-File-unified-encoder.go-789"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-s2k-config.go-790"
+      "relatedSpdxElement": "SPDXRef-File-common.go-790"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-elgamal.go-791"
+      "relatedSpdxElement": "SPDXRef-File-hash.go-791"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher.go-792"
+      "relatedSpdxElement": "SPDXRef-File-object.go-792"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bitcurve.go-793"
+      "relatedSpdxElement": "SPDXRef-File-modules.go-793"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-oid.go-794"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-794"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-brainpool.go-795"
+      "relatedSpdxElement": "SPDXRef-File-index.go-795"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-opaque.go-796"
+      "relatedSpdxElement": "SPDXRef-File-repository-filesystem.go-796"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aead.go-797"
+      "relatedSpdxElement": "SPDXRef-File-decoder.go-797"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.go-798"
+      "relatedSpdxElement": "SPDXRef-File-submodule.go-798"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-byteutil.go-799"
+      "relatedSpdxElement": "SPDXRef-File-common.go-799"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ecdh.go-800"
+      "relatedSpdxElement": "SPDXRef-File-repository.go-800"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reader.go-801"
+      "relatedSpdxElement": "SPDXRef-File-common.go-801"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eax-test-vectors.go-802"
+      "relatedSpdxElement": "SPDXRef-File-common.go-802"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x448.go-803"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-803"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-armor.go-804"
+      "relatedSpdxElement": "SPDXRef-File-upload-pack.go-804"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-public-key.go-805"
+      "relatedSpdxElement": "SPDXRef-File-revlist.go-805"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-generic.go-806"
+      "relatedSpdxElement": "SPDXRef-File-idxfile.go-806"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-807"
+      "relatedSpdxElement": "SPDXRef-File-rename.go-807"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read.go-808"
+      "relatedSpdxElement": "SPDXRef-File-advrefs-encode.go-808"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-private-key.go-809"
+      "relatedSpdxElement": "SPDXRef-File-refspec.go-809"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config-v5.go-810"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-810"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-one-pass-signature.go-811"
+      "relatedSpdxElement": "SPDXRef-File-difftree.go-811"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ecdsa.go-812"
+      "relatedSpdxElement": "SPDXRef-File-error.go-812"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-recipient.go-813"
+      "relatedSpdxElement": "SPDXRef-File-delta-index.go-813"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-7",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aead-config.go-814"
+      "relatedSpdxElement": "SPDXRef-File-updreq-encode.go-814"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-24",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jsonstring.go-815"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-815"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-24",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decode.go-816"
+      "relatedSpdxElement": "SPDXRef-File-common.go-816"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-24",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-817"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-817"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-24",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encode.go-818"
+      "relatedSpdxElement": "SPDXRef-File-demux.go-818"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pagesize-unix.go-819"
+      "relatedSpdxElement": "SPDXRef-File-report-status.go-819"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-unix-gc.go-820"
+      "relatedSpdxElement": "SPDXRef-File-node.go-820"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux.go-821"
+      "relatedSpdxElement": "SPDXRef-File-token.go-821"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vgetrandom-linux.go-822"
+      "relatedSpdxElement": "SPDXRef-File-buffer-lru.go-822"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zerrors-linux.go-823"
+      "relatedSpdxElement": "SPDXRef-File-treenoder.go-823"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dirent.go-824"
+      "relatedSpdxElement": "SPDXRef-File-dir.go-824"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsysnum-linux-amd64.go-825"
+      "relatedSpdxElement": "SPDXRef-File-shallowupd.go-825"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ifreq-linux.go-826"
+      "relatedSpdxElement": "SPDXRef-File-frame.go-826"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-auxv.go-827"
+      "relatedSpdxElement": "SPDXRef-File-capability.go-827"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux-alarm.go-828"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-path.go-828"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mremap.go-829"
+      "relatedSpdxElement": "SPDXRef-File-writer.go-829"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-execabs.go-830"
+      "relatedSpdxElement": "SPDXRef-File-diff-delta.go-830"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-affinity-linux.go-831"
+      "relatedSpdxElement": "SPDXRef-File-matcher.go-831"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ztypes-linux.go-832"
+      "relatedSpdxElement": "SPDXRef-File-difftree.go-832"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockcmsg-unix-other.go-833"
+      "relatedSpdxElement": "SPDXRef-File-write.go-833"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-race0.go-834"
+      "relatedSpdxElement": "SPDXRef-File-error.go-834"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sysvshm-linux.go-835"
+      "relatedSpdxElement": "SPDXRef-File-change-adaptor.go-835"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zptrace-x86-linux.go-836"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-836"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall.go-837"
+      "relatedSpdxElement": "SPDXRef-File-bytes.go-837"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockcmsg-linux.go-838"
+      "relatedSpdxElement": "SPDXRef-File-storer.go-838"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fcntl.go-839"
+      "relatedSpdxElement": "SPDXRef-File-transport.go-839"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fdset.go-840"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-bfs.go-840"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sysvshm-unix.go-841"
+      "relatedSpdxElement": "SPDXRef-File-option.go-841"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-constants.go-842"
+      "relatedSpdxElement": "SPDXRef-File-gitproto.go-842"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timestruct.go-843"
+      "relatedSpdxElement": "SPDXRef-File-updreq.go-843"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ioctl-linux.go-844"
+      "relatedSpdxElement": "SPDXRef-File-signer.go-844"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsyscall-linux.go-845"
+      "relatedSpdxElement": "SPDXRef-File-updreq-decode.go-845"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zerrors-linux-amd64.go-846"
+      "relatedSpdxElement": "SPDXRef-File-dotgit-rewrite-packed-refs.go-846"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bluetooth-linux.go-847"
+      "relatedSpdxElement": "SPDXRef-File-decoder.go-847"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-env-unix.go-848"
+      "relatedSpdxElement": "SPDXRef-File-advrefs-decode.go-848"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aliases.go-849"
+      "relatedSpdxElement": "SPDXRef-File-common.go-849"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-endian-little.go-850"
+      "relatedSpdxElement": "SPDXRef-File-reference.go-850"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockcmsg-unix.go-851"
+      "relatedSpdxElement": "SPDXRef-File-object.go-851"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dev-linux.go-852"
+      "relatedSpdxElement": "SPDXRef-File-packfile.go-852"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux-amd64.go-853"
+      "relatedSpdxElement": "SPDXRef-File-prune.go-853"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-execabs-go119.go-854"
+      "relatedSpdxElement": "SPDXRef-File-iter.go-854"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-readdirent-getdents.go-855"
+      "relatedSpdxElement": "SPDXRef-File-storage.go-855"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-unix.go-856"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-856"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ztypes-linux-amd64.go-857"
+      "relatedSpdxElement": "SPDXRef-File-common.go-857"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ioctl-unsigned.go-858"
+      "relatedSpdxElement": "SPDXRef-File-loader.go-858"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-x86.go-859"
+      "relatedSpdxElement": "SPDXRef-File-srvresp.go-859"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux-amd64-gc.go-860"
+      "relatedSpdxElement": "SPDXRef-File-hash-sha1.go-860"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsyscall-linux-amd64.go-861"
+      "relatedSpdxElement": "SPDXRef-File-filemode.go-861"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-62",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux-gc.go-862"
+      "relatedSpdxElement": "SPDXRef-File-ulreq-decode.go-862"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-27",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedValue.go-863"
+      "relatedSpdxElement": "SPDXRef-File-zlib.go-863"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-27",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-argumentParser.go-864"
+      "relatedSpdxElement": "SPDXRef-File-worktree-linux.go-864"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-27",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-help.go-865"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-865"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-27",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-flag.go-866"
+      "relatedSpdxElement": "SPDXRef-File-change.go-866"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-27",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-867"
+      "relatedSpdxElement": "SPDXRef-File-commit.go-867"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-27",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-subCommand.go-868"
+      "relatedSpdxElement": "SPDXRef-File-branch.go-868"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-27",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main.go-869"
+      "relatedSpdxElement": "SPDXRef-File-signature.go-869"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-27",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-positionalValue.go-870"
+      "relatedSpdxElement": "SPDXRef-File-config.go-870"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-27",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-helpValues.go-871"
+      "relatedSpdxElement": "SPDXRef-File-uppackreq.go-871"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color-tag.go-872"
+      "relatedSpdxElement": "SPDXRef-File-fp-amd64.go-872"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color-16.go-873"
+      "relatedSpdxElement": "SPDXRef-File-xor-unaligned.go-873"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-printer.go-874"
+      "relatedSpdxElement": "SPDXRef-File-modular.go-874"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-quickstart.go-875"
+      "relatedSpdxElement": "SPDXRef-File-point.go-875"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-detect-nonwin.go-876"
+      "relatedSpdxElement": "SPDXRef-File-sign.go-876"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color-rgb.go-877"
+      "relatedSpdxElement": "SPDXRef-File-primes.go-877"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-convert.go-878"
+      "relatedSpdxElement": "SPDXRef-File-keccakf.go-878"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-879"
+      "relatedSpdxElement": "SPDXRef-File-curve.go-879"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-880"
+      "relatedSpdxElement": "SPDXRef-File-signapi.go-880"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color-256.go-881"
+      "relatedSpdxElement": "SPDXRef-File-table.go-881"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-detect-env.go-882"
+      "relatedSpdxElement": "SPDXRef-File-ed25519.go-882"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-26",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-style.go-883"
+      "relatedSpdxElement": "SPDXRef-File-key.go-883"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.go-884"
+      "relatedSpdxElement": "SPDXRef-File-mult.go-884"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-885"
+      "relatedSpdxElement": "SPDXRef-File-fp-generic.go-885"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filter.go-886"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-886"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-commit.go-887"
+      "relatedSpdxElement": "SPDXRef-File-power.go-887"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-index.go-888"
+      "relatedSpdxElement": "SPDXRef-File-conv.go-888"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writer.go-889"
+      "relatedSpdxElement": "SPDXRef-File-fp-generic.go-889"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options.go-890"
+      "relatedSpdxElement": "SPDXRef-File-fp.go-890"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-891"
+      "relatedSpdxElement": "SPDXRef-File-fp-amd64.go-891"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-892"
+      "relatedSpdxElement": "SPDXRef-File-rc.go-892"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-delta-selector.go-893"
+      "relatedSpdxElement": "SPDXRef-File-shake.go-893"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-894"
+      "relatedSpdxElement": "SPDXRef-File-hashes.go-894"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
       "relatedSpdxElement": "SPDXRef-File-doc.go-895"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-896"
+      "relatedSpdxElement": "SPDXRef-File-twist.go-896"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-auth-method.go-897"
+      "relatedSpdxElement": "SPDXRef-File-tables.go-897"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colorconfig.go-898"
+      "relatedSpdxElement": "SPDXRef-File-curve-amd64.go-898"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-status.go-899"
+      "relatedSpdxElement": "SPDXRef-File-wnaf.go-899"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-900"
+      "relatedSpdxElement": "SPDXRef-File-integer.go-900"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dotgit.go-901"
+      "relatedSpdxElement": "SPDXRef-File-curve-amd64.go-901"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-902"
+      "relatedSpdxElement": "SPDXRef-File-sha3.go-902"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-limit.go-903"
+      "relatedSpdxElement": "SPDXRef-File-mlsbset.go-903"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.go-904"
+      "relatedSpdxElement": "SPDXRef-File-fp.go-904"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-905"
+      "relatedSpdxElement": "SPDXRef-File-curve-generic.go-905"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-match.go-906"
+      "relatedSpdxElement": "SPDXRef-File-isogeny.go-906"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reader.go-907"
+      "relatedSpdxElement": "SPDXRef-File-constants.go-907"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doubleiter.go-908"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-908"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error.go-909"
+      "relatedSpdxElement": "SPDXRef-File-pubkey.go-909"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-910"
+      "relatedSpdxElement": "SPDXRef-File-ed448.go-910"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-911"
+      "relatedSpdxElement": "SPDXRef-File-twistPoint.go-911"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blame.go-912"
+      "relatedSpdxElement": "SPDXRef-File-key.go-912"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object-walker.go-913"
+      "relatedSpdxElement": "SPDXRef-File-point.go-913"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-index.go-914"
+      "relatedSpdxElement": "SPDXRef-File-curve.go-914"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree.go-915"
+      "relatedSpdxElement": "SPDXRef-File-curve-generic.go-915"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dotgit-setref.go-916"
+      "relatedSpdxElement": "SPDXRef-File-signapi.go-916"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mocks.go-917"
+      "relatedSpdxElement": "SPDXRef-File-twistTables.go-917"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-918"
+      "relatedSpdxElement": "SPDXRef-File-table.go-918"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-base.go-919"
+      "relatedSpdxElement": "SPDXRef-File-twist-basemult.go-919"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ulreq-encode.go-920"
+      "relatedSpdxElement": "SPDXRef-File-curve.go-920"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tree.go-921"
+      "relatedSpdxElement": "SPDXRef-File-scalar.go-921"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-storage.go-922"
+      "relatedSpdxElement": "SPDXRef-File-attr.go-922"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-923"
+      "relatedSpdxElement": "SPDXRef-File-term.go-923"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-924"
+      "relatedSpdxElement": "SPDXRef-File-nonblock-unix.go-924"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-925"
+      "relatedSpdxElement": "SPDXRef-File-direct.go-925"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.go-926"
+      "relatedSpdxElement": "SPDXRef-File-term.go-926"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reference.go-927"
+      "relatedSpdxElement": "SPDXRef-File-term.go-927"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-928"
+      "relatedSpdxElement": "SPDXRef-File-term.go-928"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-trace.go-929"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-929"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.go-930"
+      "relatedSpdxElement": "SPDXRef-File-term.go-930"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shallow.go-931"
+      "relatedSpdxElement": "SPDXRef-File-term.go-931"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufio.go-932"
+      "relatedSpdxElement": "SPDXRef-File-term.go-932"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reader.go-933"
+      "relatedSpdxElement": "SPDXRef-File-tscreen-unix.go-933"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pattern.go-934"
+      "relatedSpdxElement": "SPDXRef-File-term.go-934"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-section.go-935"
+      "relatedSpdxElement": "SPDXRef-File-mouse.go-935"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uppackresp.go-936"
+      "relatedSpdxElement": "SPDXRef-File-terminfo.go-936"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-937"
+      "relatedSpdxElement": "SPDXRef-File-extended.go-937"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object-pack.go-938"
+      "relatedSpdxElement": "SPDXRef-File-term.go-938"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-format.go-939"
+      "relatedSpdxElement": "SPDXRef-File-term.go-939"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-path-util.go-940"
+      "relatedSpdxElement": "SPDXRef-File-term.go-940"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-941"
+      "relatedSpdxElement": "SPDXRef-File-eastasian.go-941"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-942"
+      "relatedSpdxElement": "SPDXRef-File-term.go-942"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reference.go-943"
+      "relatedSpdxElement": "SPDXRef-File-key.go-943"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-944"
+      "relatedSpdxElement": "SPDXRef-File-term.go-944"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status.go-945"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-945"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-delta.go-946"
+      "relatedSpdxElement": "SPDXRef-File-console-stub.go-946"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list.go-947"
+      "relatedSpdxElement": "SPDXRef-File-interrupt.go-947"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote.go-948"
+      "relatedSpdxElement": "SPDXRef-File-style.go-948"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-949"
+      "relatedSpdxElement": "SPDXRef-File-term.go-949"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-node.go-950"
+      "relatedSpdxElement": "SPDXRef-File-base.go-950"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-receive-pack.go-951"
+      "relatedSpdxElement": "SPDXRef-File-tscreen.go-951"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-muxer.go-952"
+      "relatedSpdxElement": "SPDXRef-File-direct.go-952"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-change.go-953"
+      "relatedSpdxElement": "SPDXRef-File-term.go-953"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-revision.go-954"
+      "relatedSpdxElement": "SPDXRef-File-term.go-954"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shallow.go-955"
+      "relatedSpdxElement": "SPDXRef-File-tty.go-955"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker.go-956"
+      "relatedSpdxElement": "SPDXRef-File-charset-unix.go-956"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-957"
+      "relatedSpdxElement": "SPDXRef-File-dynamic.go-957"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-storer.go-958"
+      "relatedSpdxElement": "SPDXRef-File-color.go-958"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fsobject.go-959"
+      "relatedSpdxElement": "SPDXRef-File-simulation.go-959"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.go-960"
+      "relatedSpdxElement": "SPDXRef-File-terms-dynamic.go-960"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deltaobject.go-961"
+      "relatedSpdxElement": "SPDXRef-File-term.go-961"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read.go-962"
+      "relatedSpdxElement": "SPDXRef-File-foot.go-962"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-ctime.go-963"
+      "relatedSpdxElement": "SPDXRef-File-event.go-963"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decoder.go-964"
+      "relatedSpdxElement": "SPDXRef-File-term.go-964"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-path.go-965"
+      "relatedSpdxElement": "SPDXRef-File-term.go-965"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-966"
+      "relatedSpdxElement": "SPDXRef-File-stdin-unix.go-966"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memory.go-967"
+      "relatedSpdxElement": "SPDXRef-File-term.go-967"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noder.go-968"
+      "relatedSpdxElement": "SPDXRef-File-encoding.go-968"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-969"
+      "relatedSpdxElement": "SPDXRef-File-term.go-969"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tag.go-970"
+      "relatedSpdxElement": "SPDXRef-File-cell.go-970"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writers.go-971"
+      "relatedSpdxElement": "SPDXRef-File-term.go-971"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff.go-972"
+      "relatedSpdxElement": "SPDXRef-File-tty-unix.go-972"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-bfs-filtered.go-973"
+      "relatedSpdxElement": "SPDXRef-File-term.go-973"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ulreq.go-974"
+      "relatedSpdxElement": "SPDXRef-File-input.go-974"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.go-975"
+      "relatedSpdxElement": "SPDXRef-File-screen.go-975"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object-lru.go-976"
+      "relatedSpdxElement": "SPDXRef-File-term.go-976"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-module.go-977"
+      "relatedSpdxElement": "SPDXRef-File-term.go-977"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-978"
+      "relatedSpdxElement": "SPDXRef-File-focus.go-978"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-979"
+      "relatedSpdxElement": "SPDXRef-File-runes.go-979"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-980"
+      "relatedSpdxElement": "SPDXRef-File-resize.go-980"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-advrefs.go-981"
+      "relatedSpdxElement": "SPDXRef-File-paste.go-981"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blob.go-982"
+      "relatedSpdxElement": "SPDXRef-File-colorfit.go-982"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-unified-encoder.go-983"
+      "relatedSpdxElement": "SPDXRef-File-term.go-983"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-984"
+      "relatedSpdxElement": "SPDXRef-File-terms-default.go-984"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-53",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.go-985"
+      "relatedSpdxElement": "SPDXRef-File-orderedmap.go-985"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-53",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.go-986"
+      "relatedSpdxElement": "SPDXRef-File-yaml.go-986"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-53",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-modules.go-987"
+      "relatedSpdxElement": "SPDXRef-File-json.go-987"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-lazycore-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-988"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-988"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-lazycore-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-index.go-989"
+      "relatedSpdxElement": "SPDXRef-File-boxlayout.go-989"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-repository-filesystem.go-990"
+      "relatedSpdxElement": "SPDXRef-File-zsortanyfunc.go-990"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decoder.go-991"
+      "relatedSpdxElement": "SPDXRef-File-constraints.go-991"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodule.go-992"
+      "relatedSpdxElement": "SPDXRef-File-slices.go-992"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-993"
+      "relatedSpdxElement": "SPDXRef-File-zsortordered.go-993"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-repository.go-994"
+      "relatedSpdxElement": "SPDXRef-File-sort.go-994"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-995"
+      "relatedSpdxElement": "SPDXRef-File-cmp.go-995"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-996"
+      "relatedSpdxElement": "SPDXRef-File-ubc-amd64.go-996"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-997"
+      "relatedSpdxElement": "SPDXRef-File-sha1cd.go-997"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-upload-pack.go-998"
+      "relatedSpdxElement": "SPDXRef-File-const.go-998"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-revlist.go-999"
+      "relatedSpdxElement": "SPDXRef-File-sha1cdblock-amd64.go-999"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idxfile.go-1000"
+      "relatedSpdxElement": "SPDXRef-File-detection.go-1000"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rename.go-1001"
+      "relatedSpdxElement": "SPDXRef-File-ubc.go-1001"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-advrefs-encode.go-1002"
+      "relatedSpdxElement": "SPDXRef-File-sha1cdblock-generic.go-1002"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-refspec.go-1003"
+      "relatedSpdxElement": "SPDXRef-File-const.go-1003"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-1004"
+      "relatedSpdxElement": "SPDXRef-File-ubc-generic.go-1004"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-kr-logfmt-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-difftree.go-1005"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-1005"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-kr-logfmt-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error.go-1006"
+      "relatedSpdxElement": "SPDXRef-File-decode.go-1006"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-kr-logfmt-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-delta-index.go-1007"
+      "relatedSpdxElement": "SPDXRef-File-unquote.go-1007"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-updreq-encode.go-1008"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-1008"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1009"
+      "relatedSpdxElement": "SPDXRef-File-intersect.go-1009"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-1010"
+      "relatedSpdxElement": "SPDXRef-File-condition.go-1010"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-1011"
+      "relatedSpdxElement": "SPDXRef-File-test.go-1011"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-demux.go-1012"
+      "relatedSpdxElement": "SPDXRef-File-concurrency.go-1012"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-report-status.go-1013"
+      "relatedSpdxElement": "SPDXRef-File-math.go-1013"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-node.go-1014"
+      "relatedSpdxElement": "SPDXRef-File-slice.go-1014"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-token.go-1015"
+      "relatedSpdxElement": "SPDXRef-File-types.go-1015"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-buffer-lru.go-1016"
+      "relatedSpdxElement": "SPDXRef-File-map.go-1016"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-treenoder.go-1017"
+      "relatedSpdxElement": "SPDXRef-File-func.go-1017"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dir.go-1018"
+      "relatedSpdxElement": "SPDXRef-File-string.go-1018"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shallowupd.go-1019"
+      "relatedSpdxElement": "SPDXRef-File-retry.go-1019"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-frame.go-1020"
+      "relatedSpdxElement": "SPDXRef-File-constraints.go-1020"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-capability.go-1021"
+      "relatedSpdxElement": "SPDXRef-File-channel.go-1021"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-path.go-1022"
+      "relatedSpdxElement": "SPDXRef-File-find.go-1022"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writer.go-1023"
+      "relatedSpdxElement": "SPDXRef-File-tuples.go-1023"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff-delta.go-1024"
+      "relatedSpdxElement": "SPDXRef-File-type-manipulation.go-1024"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-dario.cat-mergo-4",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-matcher.go-1025"
+      "relatedSpdxElement": "SPDXRef-File-mergo.go-1025"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-dario.cat-mergo-4",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-difftree.go-1026"
+      "relatedSpdxElement": "SPDXRef-File-map.go-1026"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-dario.cat-mergo-4",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-write.go-1027"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1027"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-dario.cat-mergo-4",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error.go-1028"
+      "relatedSpdxElement": "SPDXRef-File-merge.go-1028"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-change-adaptor.go-1029"
+      "relatedSpdxElement": "SPDXRef-File-keybinding.go-1029"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1030"
+      "relatedSpdxElement": "SPDXRef-File-gui-others.go-1030"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bytes.go-1031"
+      "relatedSpdxElement": "SPDXRef-File-loader.go-1031"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-storer.go-1032"
+      "relatedSpdxElement": "SPDXRef-File-scrollbar.go-1032"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transport.go-1033"
+      "relatedSpdxElement": "SPDXRef-File-tcell-driver.go-1033"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-bfs.go-1034"
+      "relatedSpdxElement": "SPDXRef-File-gui.go-1034"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-option.go-1035"
+      "relatedSpdxElement": "SPDXRef-File-view.go-1035"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gitproto.go-1036"
+      "relatedSpdxElement": "SPDXRef-File-text-area.go-1036"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-updreq.go-1037"
+      "relatedSpdxElement": "SPDXRef-File-edit.go-1037"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signer.go-1038"
+      "relatedSpdxElement": "SPDXRef-File-task.go-1038"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-updreq-decode.go-1039"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1039"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dotgit-rewrite-packed-refs.go-1040"
+      "relatedSpdxElement": "SPDXRef-File-attribute.go-1040"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decoder.go-1041"
+      "relatedSpdxElement": "SPDXRef-File-escape.go-1041"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-advrefs-decode.go-1042"
+      "relatedSpdxElement": "SPDXRef-File-task-manager.go-1042"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-1043"
+      "relatedSpdxElement": "SPDXRef-File-graphemeproperties.go-1043"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reference.go-1044"
+      "relatedSpdxElement": "SPDXRef-File-sentencerules.go-1044"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.go-1045"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1045"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-packfile.go-1046"
+      "relatedSpdxElement": "SPDXRef-File-wordproperties.go-1046"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-prune.go-1047"
+      "relatedSpdxElement": "SPDXRef-File-word.go-1047"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iter.go-1048"
+      "relatedSpdxElement": "SPDXRef-File-wordrules.go-1048"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-storage.go-1049"
+      "relatedSpdxElement": "SPDXRef-File-graphemerules.go-1049"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-1050"
+      "relatedSpdxElement": "SPDXRef-File-eastasianwidth.go-1050"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-1051"
+      "relatedSpdxElement": "SPDXRef-File-properties.go-1051"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-loader.go-1052"
+      "relatedSpdxElement": "SPDXRef-File-sentenceproperties.go-1052"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-srvresp.go-1053"
+      "relatedSpdxElement": "SPDXRef-File-linerules.go-1053"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash-sha1.go-1054"
+      "relatedSpdxElement": "SPDXRef-File-line.go-1054"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filemode.go-1055"
+      "relatedSpdxElement": "SPDXRef-File-width.go-1055"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ulreq-decode.go-1056"
+      "relatedSpdxElement": "SPDXRef-File-emojipresentation.go-1056"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zlib.go-1057"
+      "relatedSpdxElement": "SPDXRef-File-step.go-1057"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-linux.go-1058"
+      "relatedSpdxElement": "SPDXRef-File-lineproperties.go-1058"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1059"
+      "relatedSpdxElement": "SPDXRef-File-sentence.go-1059"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-change.go-1060"
+      "relatedSpdxElement": "SPDXRef-File-grapheme.go-1060"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-10",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit.go-1061"
+      "relatedSpdxElement": "SPDXRef-File-bytes.go-1061"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-10",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branch.go-1062"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-1062"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-10",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signature.go-1063"
+      "relatedSpdxElement": "SPDXRef-File-escape.go-1063"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-10",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-1064"
+      "relatedSpdxElement": "SPDXRef-File-bytes-unsafe.go-1064"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-30",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-10",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uppackreq.go-1065"
+      "relatedSpdxElement": "SPDXRef-File-fuzz.go-1065"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp-amd64.go-1066"
+      "relatedSpdxElement": "SPDXRef-File-happy-palettegen.go-1066"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-xor-unaligned.go-1067"
+      "relatedSpdxElement": "SPDXRef-File-colors.go-1067"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-modular.go-1068"
+      "relatedSpdxElement": "SPDXRef-File-soft-palettegen.go-1068"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-point.go-1069"
+      "relatedSpdxElement": "SPDXRef-File-colorgens.go-1069"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sign.go-1070"
+      "relatedSpdxElement": "SPDXRef-File-hexcolor.go-1070"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-primes.go-1071"
+      "relatedSpdxElement": "SPDXRef-File-sort.go-1071"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keccakf.go-1072"
+      "relatedSpdxElement": "SPDXRef-File-hsluv.go-1072"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve.go-1073"
+      "relatedSpdxElement": "SPDXRef-File-warm-palettegen.go-1073"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signapi.go-1074"
+      "relatedSpdxElement": "SPDXRef-File-rand.go-1074"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-table.go-1075"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-1075"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed25519.go-1076"
+      "relatedSpdxElement": "SPDXRef-File-match.go-1076"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-key.go-1077"
+      "relatedSpdxElement": "SPDXRef-File-operation-string.go-1077"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mult.go-1078"
+      "relatedSpdxElement": "SPDXRef-File-diff.go-1078"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp-generic.go-1079"
+      "relatedSpdxElement": "SPDXRef-File-mathutil.go-1079"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1080"
+      "relatedSpdxElement": "SPDXRef-File-diffmatchpatch.go-1080"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-power.go-1081"
+      "relatedSpdxElement": "SPDXRef-File-stringutil.go-1081"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-8",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conv.go-1082"
+      "relatedSpdxElement": "SPDXRef-File-logfmt-handler.go-1082"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-8",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp-generic.go-1083"
+      "relatedSpdxElement": "SPDXRef-File-docker-compose-handler.go-1083"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-8",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp.go-1084"
+      "relatedSpdxElement": "SPDXRef-File-handler.go-1084"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-8",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp-amd64.go-1085"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-1085"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-8",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rc.go-1086"
+      "relatedSpdxElement": "SPDXRef-File-json-handler.go-1086"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-8",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shake.go-1087"
+      "relatedSpdxElement": "SPDXRef-File-time-parse.go-1087"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hashes.go-1088"
+      "relatedSpdxElement": "SPDXRef-File-walk.go-1088"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1089"
+      "relatedSpdxElement": "SPDXRef-File-polyfill.go-1089"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-twist.go-1090"
+      "relatedSpdxElement": "SPDXRef-File-util.go-1090"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tables.go-1091"
+      "relatedSpdxElement": "SPDXRef-File-os-options.go-1091"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-amd64.go-1092"
+      "relatedSpdxElement": "SPDXRef-File-os-posix.go-1092"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wnaf.go-1093"
+      "relatedSpdxElement": "SPDXRef-File-chroot.go-1093"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-integer.go-1094"
+      "relatedSpdxElement": "SPDXRef-File-os.go-1094"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-amd64.go-1095"
+      "relatedSpdxElement": "SPDXRef-File-os-bound.go-1095"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha3.go-1096"
+      "relatedSpdxElement": "SPDXRef-File-fs.go-1096"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mlsbset.go-1097"
+      "relatedSpdxElement": "SPDXRef-File-glob.go-1097"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp.go-1098"
+      "relatedSpdxElement": "SPDXRef-File-os-chroot.go-1098"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-mattn-go-isatty-39",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-generic.go-1099"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1099"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-mattn-go-isatty-39",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-isogeny.go-1100"
+      "relatedSpdxElement": "SPDXRef-File-isatty-tcgets.go-1100"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-constants.go-1101"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1101"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1102"
+      "relatedSpdxElement": "SPDXRef-File-pty-linux.go-1102"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pubkey.go-1103"
+      "relatedSpdxElement": "SPDXRef-File-util.go-1103"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed448.go-1104"
+      "relatedSpdxElement": "SPDXRef-File-run.go-1104"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-twistPoint.go-1105"
+      "relatedSpdxElement": "SPDXRef-File-ioctl.go-1105"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-key.go-1106"
+      "relatedSpdxElement": "SPDXRef-File-ztypes-amd64.go-1106"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-point.go-1107"
+      "relatedSpdxElement": "SPDXRef-File-enum.go-1107"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve.go-1108"
+      "relatedSpdxElement": "SPDXRef-File-serialize.go-1108"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-generic.go-1109"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1109"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signapi.go-1110"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-1110"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-twistTables.go-1111"
+      "relatedSpdxElement": "SPDXRef-File-bool.go-1111"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-table.go-1112"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1112"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-twist-basemult.go-1113"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-1113"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve.go-1114"
+      "relatedSpdxElement": "SPDXRef-File-int.go-1114"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-13",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scalar.go-1115"
+      "relatedSpdxElement": "SPDXRef-File-token.go-1115"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-attr.go-1116"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-1116"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1117"
+      "relatedSpdxElement": "SPDXRef-File-scan.go-1117"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock-unix.go-1118"
+      "relatedSpdxElement": "SPDXRef-File-set.go-1118"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-direct.go-1119"
+      "relatedSpdxElement": "SPDXRef-File-read.go-1119"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1120"
+      "relatedSpdxElement": "SPDXRef-File-position.go-1120"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-term-61",
       "relationshipType": "CONTAINS",
       "relatedSpdxElement": "SPDXRef-File-term.go-1121"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-term-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1122"
+      "relatedSpdxElement": "SPDXRef-File-term-unix.go-1122"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-term-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-1123"
+      "relatedSpdxElement": "SPDXRef-File-term-unix-other.go-1123"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-term-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1124"
+      "relatedSpdxElement": "SPDXRef-File-terminal.go-1124"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1125"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1125"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1126"
+      "relatedSpdxElement": "SPDXRef-File-open-linux.go-1126"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tscreen-unix.go-1127"
+      "relatedSpdxElement": "SPDXRef-File-vfs.go-1127"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1128"
+      "relatedSpdxElement": "SPDXRef-File-gocompat-errors-go120.go-1128"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mouse.go-1129"
+      "relatedSpdxElement": "SPDXRef-File-procfs-linux.go-1129"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminfo.go-1130"
+      "relatedSpdxElement": "SPDXRef-File-openat-linux.go-1130"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-extended.go-1131"
+      "relatedSpdxElement": "SPDXRef-File-mkdir-linux.go-1131"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1132"
+      "relatedSpdxElement": "SPDXRef-File-lookup-linux.go-1132"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1133"
+      "relatedSpdxElement": "SPDXRef-File-gocompat-generics-go121.go-1133"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1134"
+      "relatedSpdxElement": "SPDXRef-File-join.go-1134"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eastasian.go-1135"
+      "relatedSpdxElement": "SPDXRef-File-openat2-linux.go-1135"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-52",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1136"
+      "relatedSpdxElement": "SPDXRef-File-todo.go-1136"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-52",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-key.go-1137"
+      "relatedSpdxElement": "SPDXRef-File-write.go-1137"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-52",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1138"
+      "relatedSpdxElement": "SPDXRef-File-parse.go-1138"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1139"
+      "relatedSpdxElement": "SPDXRef-File-latin1.go-1139"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-console-stub.go-1140"
+      "relatedSpdxElement": "SPDXRef-File-utf8.go-1140"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-interrupt.go-1141"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1141"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-style.go-1142"
+      "relatedSpdxElement": "SPDXRef-File-ebcdic.go-1142"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1143"
+      "relatedSpdxElement": "SPDXRef-File-ascii.go-1143"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base.go-1144"
+      "relatedSpdxElement": "SPDXRef-File-latin5.go-1144"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tscreen.go-1145"
+      "relatedSpdxElement": "SPDXRef-File-charmap.go-1145"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-net-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-direct.go-1146"
+      "relatedSpdxElement": "SPDXRef-File-context.go-1146"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-net-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1147"
+      "relatedSpdxElement": "SPDXRef-File-per-host.go-1147"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-net-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1148"
+      "relatedSpdxElement": "SPDXRef-File-direct.go-1148"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-net-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tty.go-1149"
+      "relatedSpdxElement": "SPDXRef-File-client.go-1149"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-net-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-charset-unix.go-1150"
+      "relatedSpdxElement": "SPDXRef-File-dial.go-1150"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-net-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynamic.go-1151"
+      "relatedSpdxElement": "SPDXRef-File-socks.go-1151"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-net-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-1152"
+      "relatedSpdxElement": "SPDXRef-File-proxy.go-1152"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-golang.org-x-net-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-simulation.go-1153"
+      "relatedSpdxElement": "SPDXRef-File-socks5.go-1153"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terms-dynamic.go-1154"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-1154"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1155"
+      "relatedSpdxElement": "SPDXRef-File-lists.go-1155"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-foot.go-1156"
+      "relatedSpdxElement": "SPDXRef-File-serialization.go-1156"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-event.go-1157"
+      "relatedSpdxElement": "SPDXRef-File-arraylist.go-1157"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1158"
+      "relatedSpdxElement": "SPDXRef-File-comparator.go-1158"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1159"
+      "relatedSpdxElement": "SPDXRef-File-enumerable.go-1159"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stdin-unix.go-1160"
+      "relatedSpdxElement": "SPDXRef-File-iterator.go-1160"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1161"
+      "relatedSpdxElement": "SPDXRef-File-sort.go-1161"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoding.go-1162"
+      "relatedSpdxElement": "SPDXRef-File-enumerable.go-1162"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1163"
+      "relatedSpdxElement": "SPDXRef-File-trees.go-1163"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cell.go-1164"
+      "relatedSpdxElement": "SPDXRef-File-containers.go-1164"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1165"
+      "relatedSpdxElement": "SPDXRef-File-serialization.go-1165"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tty-unix.go-1166"
+      "relatedSpdxElement": "SPDXRef-File-binaryheap.go-1166"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1167"
+      "relatedSpdxElement": "SPDXRef-File-iterator.go-1167"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-input.go-1168"
+      "relatedSpdxElement": "SPDXRef-File-iterator.go-1168"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-screen.go-1169"
+      "relatedSpdxElement": "SPDXRef-File-serialization.go-1169"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-27",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1170"
+      "relatedSpdxElement": "SPDXRef-File-maps.go-1170"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-27",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1171"
+      "relatedSpdxElement": "SPDXRef-File-set.go-1171"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-27",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-focus.go-1172"
+      "relatedSpdxElement": "SPDXRef-File-orderedset.go-1172"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-skeema-knownhosts-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-runes.go-1173"
+      "relatedSpdxElement": "SPDXRef-File-knownhosts.go-1173"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-mailru-easyjson-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resize.go-1174"
+      "relatedSpdxElement": "SPDXRef-File-writer.go-1174"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-mailru-easyjson-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-paste.go-1175"
+      "relatedSpdxElement": "SPDXRef-File-pool.go-1175"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-spkg-bom-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colorfit.go-1176"
+      "relatedSpdxElement": "SPDXRef-File-discard-go15.go-1176"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-spkg-bom-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1177"
+      "relatedSpdxElement": "SPDXRef-File-bom.go-1177"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-20",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terms-default.go-1178"
+      "relatedSpdxElement": "SPDXRef-File-error-1-13.go-1178"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-55",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-orderedmap.go-1179"
+      "relatedSpdxElement": "SPDXRef-File-join-unwrap-1-20.go-1179"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-55",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yaml.go-1180"
+      "relatedSpdxElement": "SPDXRef-File-parse-panic.go-1180"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-55",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-json.go-1181"
+      "relatedSpdxElement": "SPDXRef-File-error.go-1181"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-lazycore-32",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-1182"
+      "relatedSpdxElement": "SPDXRef-File-stackframe.go-1182"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-lazycore-32",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-boxlayout.go-1183"
+      "relatedSpdxElement": "SPDXRef-File-mib.go-1183"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-59",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsortanyfunc.go-1184"
+      "relatedSpdxElement": "SPDXRef-File-iter.go-1184"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-59",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-constraints.go-1185"
+      "relatedSpdxElement": "SPDXRef-File-normalize.go-1185"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-59",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slices.go-1186"
+      "relatedSpdxElement": "SPDXRef-File-input.go-1186"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-59",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsortordered.go-1187"
+      "relatedSpdxElement": "SPDXRef-File-transform.go-1187"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-59",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sort.go-1188"
+      "relatedSpdxElement": "SPDXRef-File-identifier.go-1188"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-59",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmp.go-1189"
+      "relatedSpdxElement": "SPDXRef-File-runes.go-1189"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ubc-amd64.go-1190"
+      "relatedSpdxElement": "SPDXRef-File-encoding.go-1190"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1cd.go-1191"
+      "relatedSpdxElement": "SPDXRef-File-transform.go-1191"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-const.go-1192"
+      "relatedSpdxElement": "SPDXRef-File-readwriter.go-1192"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1cdblock-amd64.go-1193"
+      "relatedSpdxElement": "SPDXRef-File-tables15.0.0.go-1193"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-detection.go-1194"
+      "relatedSpdxElement": "SPDXRef-File-cond.go-1194"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ubc.go-1195"
+      "relatedSpdxElement": "SPDXRef-File-composition.go-1195"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1cdblock-generic.go-1196"
+      "relatedSpdxElement": "SPDXRef-File-trie.go-1196"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "spdxElementId": "SPDXRef-golang.org-x-text-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-const.go-1197"
+      "relatedSpdxElement": "SPDXRef-File-forminfo.go-1197"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-44",
+      "spdxElementId": "SPDXRef-github.com-cloudfoundry-jibber-jabber-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ubc-generic.go-1198"
+      "relatedSpdxElement": "SPDXRef-File-jibber-jabber-unix.go-1198"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kr-logfmt-36",
+      "spdxElementId": "SPDXRef-github.com-cloudfoundry-jibber-jabber-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-1199"
+      "relatedSpdxElement": "SPDXRef-File-jibber-jabber.go-1199"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kr-logfmt-36",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decode.go-1200"
+      "relatedSpdxElement": "SPDXRef-File-xdg.go-1200"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kr-logfmt-36",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-unquote.go-1201"
+      "relatedSpdxElement": "SPDXRef-File-user-dirs.go-1201"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-1202"
+      "relatedSpdxElement": "SPDXRef-File-pathutil.go-1202"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-intersect.go-1203"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1203"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-condition.go-1204"
+      "relatedSpdxElement": "SPDXRef-File-pathutil-unix.go-1204"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-test.go-1205"
+      "relatedSpdxElement": "SPDXRef-File-base-dirs.go-1205"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-concurrency.go-1206"
+      "relatedSpdxElement": "SPDXRef-File-paths-unix.go-1206"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-mattn-go-colorable-38",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-math.go-1207"
+      "relatedSpdxElement": "SPDXRef-File-noncolorable.go-1207"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-mattn-go-colorable-38",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slice.go-1208"
+      "relatedSpdxElement": "SPDXRef-File-colorable-others.go-1208"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-petermattis-goid-41",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-types.go-1209"
+      "relatedSpdxElement": "SPDXRef-File-goid.go-1209"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-petermattis-goid-41",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-map.go-1210"
+      "relatedSpdxElement": "SPDXRef-File-goid-go1.5.go-1210"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-petermattis-goid-41",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-func.go-1211"
+      "relatedSpdxElement": "SPDXRef-File-runtime-go1.25.go-1211"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-55",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-string.go-1212"
+      "relatedSpdxElement": "SPDXRef-File-color.go-1212"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-55",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-retry.go-1213"
+      "relatedSpdxElement": "SPDXRef-File-util.go-1213"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-55",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-constraints.go-1214"
+      "relatedSpdxElement": "SPDXRef-File-capvals.go-1214"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-55",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-channel.go-1215"
+      "relatedSpdxElement": "SPDXRef-File-terminfo.go-1215"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-55",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-find.go-1216"
+      "relatedSpdxElement": "SPDXRef-File-caps.go-1216"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-55",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tuples.go-1217"
+      "relatedSpdxElement": "SPDXRef-File-load.go-1217"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-47",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-55",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-type-manipulation.go-1218"
+      "relatedSpdxElement": "SPDXRef-File-stack.go-1218"
     },
     {
-      "spdxElementId": "SPDXRef-dario.cat-mergo-4",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-55",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mergo.go-1219"
+      "relatedSpdxElement": "SPDXRef-File-param.go-1219"
     },
     {
-      "spdxElementId": "SPDXRef-dario.cat-mergo-4",
+      "spdxElementId": "SPDXRef-github.com-xanzy-ssh-agent-54",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-map.go-1220"
+      "relatedSpdxElement": "SPDXRef-File-sshagent.go-1220"
     },
     {
-      "spdxElementId": "SPDXRef-dario.cat-mergo-4",
+      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-32",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1221"
+      "relatedSpdxElement": "SPDXRef-File-reflect.go-1221"
     },
     {
-      "spdxElementId": "SPDXRef-dario.cat-mergo-4",
+      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-32",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge.go-1222"
+      "relatedSpdxElement": "SPDXRef-File-id.go-1222"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-32",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybinding.go-1223"
+      "relatedSpdxElement": "SPDXRef-File-comment-extractor.go-1223"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-32",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui-others.go-1224"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-1224"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-kyokomi-emoji-v2-35",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-loader.go-1225"
+      "relatedSpdxElement": "SPDXRef-File-emoji.go-1225"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-kyokomi-emoji-v2-35",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scrollbar.go-1226"
+      "relatedSpdxElement": "SPDXRef-File-emoji-codemap.go-1226"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tcell-driver.go-1227"
+      "relatedSpdxElement": "SPDXRef-File-patricia.go-1227"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui.go-1228"
+      "relatedSpdxElement": "SPDXRef-File-children.go-1228"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-fatih-color-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view.go-1229"
+      "relatedSpdxElement": "SPDXRef-File-color.go-1229"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-fatih-color-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-text-area.go-1230"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1230"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-bahlo-generic-list-go-9",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-edit.go-1231"
+      "relatedSpdxElement": "SPDXRef-File-list.go-1231"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-task.go-1232"
+      "relatedSpdxElement": "SPDXRef-File-deadlock.go-1232"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1233"
+      "relatedSpdxElement": "SPDXRef-File-stacktraces.go-1233"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-attribute.go-1234"
+      "relatedSpdxElement": "SPDXRef-File-trylock.go-1234"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.go-1235"
+      "relatedSpdxElement": "SPDXRef-File-deadlock-map.go-1235"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-31",
+      "spdxElementId": "SPDXRef-github.com-jbenet-go-context-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-task-manager.go-1236"
+      "relatedSpdxElement": "SPDXRef-File-ctxio.go-1236"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
+      "spdxElementId": "SPDXRef-gopkg.in-warnings.v0-64",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-graphemeproperties.go-1237"
+      "relatedSpdxElement": "SPDXRef-File-warnings.go-1237"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
+      "spdxElementId": "SPDXRef-github.com-sahilm-fuzzy-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sentencerules.go-1238"
+      "relatedSpdxElement": "SPDXRef-File-fuzzy.go-1238"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
+      "spdxElementId": "SPDXRef-github.com-atotto-clipboard-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1239"
+      "relatedSpdxElement": "SPDXRef-File-clipboard.go-1239"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
+      "spdxElementId": "SPDXRef-github.com-atotto-clipboard-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wordproperties.go-1240"
+      "relatedSpdxElement": "SPDXRef-File-clipboard-unix.go-1240"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
+      "spdxElementId": "SPDXRef-github.com-mgutz-str-40",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-word.go-1241"
+      "relatedSpdxElement": "SPDXRef-File-funcsPZ.go-1241"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
+      "spdxElementId": "SPDXRef-github.com-mgutz-str-40",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wordrules.go-1242"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1242"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
+      "spdxElementId": "SPDXRef-github.com-mgutz-str-40",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-graphemerules.go-1243"
+      "relatedSpdxElement": "SPDXRef-File-funcsAO.go-1243"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
+      "spdxElementId": "SPDXRef-github.com-golang-groupcache-23",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eastasianwidth.go-1244"
+      "relatedSpdxElement": "SPDXRef-File-lru.go-1244"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
+      "spdxElementId": "SPDXRef-golang.org-x-sync-59",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-properties.go-1245"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sentenceproperties.go-1246"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-linerules.go-1247"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-line.go-1248"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-width.go-1249"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-emojipresentation.go-1250"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-step.go-1251"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lineproperties.go-1252"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sentence.go-1253"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-grapheme.go-1254"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-12",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bytes.go-1255"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-12",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-1256"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-12",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.go-1257"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-12",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bytes-unsafe.go-1258"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-12",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fuzz.go-1259"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-happy-palettegen.go-1260"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colors.go-1261"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-soft-palettegen.go-1262"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colorgens.go-1263"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hexcolor.go-1264"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sort.go-1265"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsluv.go-1266"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warm-palettegen.go-1267"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.go-1268"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-1269"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-match.go-1270"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-operation-string.go-1271"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff.go-1272"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mathutil.go-1273"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diffmatchpatch.go-1274"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stringutil.go-1275"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-10",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logfmt-handler.go-1276"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-10",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-docker-compose-handler.go-1277"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-10",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-handler.go-1278"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-10",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-1279"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-10",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-json-handler.go-1280"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-10",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-time-parse.go-1281"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lobject.h-1282"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lua.h-1283"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lauxlib.h-1284"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lstate.h-1285"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lualib.h-1286"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzio.h-1287"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ltm.h-1288"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lmem.h-1289"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llimits.h-1290"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-luaconf.h-1291"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-walk.go-1292"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-polyfill.go-1293"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.go-1294"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-options.go-1295"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-posix.go-1296"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-chroot.go-1297"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os.go-1298"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-bound.go-1299"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fs.go-1300"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-glob.go-1301"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-chroot.go-1302"
-    },
-    {
-      "spdxElementId": "SPDXRef-fast-float-5",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fast-float-strtod.h-1303"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mattn-go-isatty-41",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1304"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mattn-go-isatty-41",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-isatty-tcgets.go-1305"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-15",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1306"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-15",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pty-linux.go-1307"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-15",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.go-1308"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-15",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-run.go-1309"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-15",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ioctl.go-1310"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-15",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ztypes-amd64.go-1311"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-enum.go-1312"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-serialize.go-1313"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1314"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-1315"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bool.go-1316"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1317"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-1318"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-int.go-1319"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-token.go-1320"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-1321"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scan.go-1322"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-set.go-1323"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read.go-1324"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-position.go-1325"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-term-63",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1326"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-term-63",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term-unix.go-1327"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-term-63",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term-unix-other.go-1328"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-term-63",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.go-1329"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1330"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-open-linux.go-1331"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vfs.go-1332"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gocompat-errors-go120.go-1333"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-procfs-linux.go-1334"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openat-linux.go-1335"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mkdir-linux.go-1336"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lookup-linux.go-1337"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gocompat-generics-go121.go-1338"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-join.go-1339"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openat2-linux.go-1340"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-54",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-todo.go-1341"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-54",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-write.go-1342"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-54",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parse.go-1343"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-19",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-latin1.go-1344"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-19",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utf8.go-1345"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-19",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1346"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-19",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ebcdic.go-1347"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-19",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ascii.go-1348"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-19",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-latin5.go-1349"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-19",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-charmap.go-1350"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-60",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context.go-1351"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-60",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-per-host.go-1352"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-60",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-direct.go-1353"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-60",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-1354"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-60",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dial.go-1355"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-60",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.go-1356"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-60",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-proxy.go-1357"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-60",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks5.go-1358"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-1359"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lists.go-1360"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-serialization.go-1361"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-arraylist.go-1362"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-comparator.go-1363"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-enumerable.go-1364"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iterator.go-1365"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sort.go-1366"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-enumerable.go-1367"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-trees.go-1368"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-containers.go-1369"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-serialization.go-1370"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-binaryheap.go-1371"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iterator.go-1372"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iterator.go-1373"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-serialization.go-1374"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-29",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-maps.go-1375"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-29",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-set.go-1376"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-29",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-orderedset.go-1377"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-skeema-knownhosts-51",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-knownhosts.go-1378"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mailru-easyjson-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writer.go-1379"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mailru-easyjson-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pool.go-1380"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-spkg-bom-53",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-discard-go15.go-1381"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-spkg-bom-53",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bom.go-1382"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-69",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read.h-1383"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-69",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-async.h-1384"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-69",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hiredis.h-1385"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-69",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-alloc.h-1386"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-69",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sds.h-1387"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-69",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sdscompat.h-1388"
-    },
-    {
-      "spdxElementId": "SPDXRef-fpconv-6",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fpconv-dtoa.h-1389"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-21",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error-1-13.go-1390"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-21",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-join-unwrap-1-20.go-1391"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-21",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parse-panic.go-1392"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-21",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error.go-1393"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-21",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stackframe.go-1394"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mib.go-1395"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iter.go-1396"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-normalize.go-1397"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-input.go-1398"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transform.go-1399"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-identifier.go-1400"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-runes.go-1401"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoding.go-1402"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transform.go-1403"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-readwriter.go-1404"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tables15.0.0.go-1405"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cond.go-1406"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-composition.go-1407"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-trie.go-1408"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-forminfo.go-1409"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cloudfoundry-jibber-jabber-14",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jibber-jabber-unix.go-1410"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cloudfoundry-jibber-jabber-14",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jibber-jabber.go-1411"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-8",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-xdg.go-1412"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-8",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-user-dirs.go-1413"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-8",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pathutil.go-1414"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-8",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1415"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-8",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pathutil-unix.go-1416"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-8",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base-dirs.go-1417"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-8",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-paths-unix.go-1418"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mattn-go-colorable-40",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noncolorable.go-1419"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mattn-go-colorable-40",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colorable-others.go-1420"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-petermattis-goid-43",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-goid.go-1421"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-petermattis-goid-43",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-goid-go1.5.go-1422"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-petermattis-goid-43",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-runtime-go1.25.go-1423"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-57",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-1424"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-57",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.go-1425"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-57",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-capvals.go-1426"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-57",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminfo.go-1427"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-57",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-caps.go-1428"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-57",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-load.go-1429"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-57",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stack.go-1430"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-57",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-param.go-1431"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xanzy-ssh-agent-56",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sshagent.go-1432"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-34",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflect.go-1433"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-34",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-id.go-1434"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-34",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-comment-extractor.go-1435"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-34",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-1436"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-kyokomi-emoji-v2-37",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-emoji.go-1437"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-kyokomi-emoji-v2-37",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-emoji-codemap.go-1438"
-    },
-    {
-      "spdxElementId": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patricia.go-1439"
-    },
-    {
-      "spdxElementId": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-children.go-1440"
-    },
-    {
-      "spdxElementId": "SPDXRef-jemalloc-70",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jemalloc.h-1441"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-fatih-color-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-1442"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-fatih-color-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1443"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-bahlo-generic-list-go-11",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list.go-1444"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-48",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deadlock.go-1445"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-48",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stacktraces.go-1446"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-48",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-trylock.go-1447"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-48",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deadlock-map.go-1448"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-jbenet-go-context-28",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ctxio.go-1449"
-    },
-    {
-      "spdxElementId": "SPDXRef-gopkg.in-warnings.v0-66",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnings.go-1450"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sahilm-fuzzy-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fuzzy.go-1451"
-    },
-    {
-      "spdxElementId": "SPDXRef-linenoise-71",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-linenoise.h-1452"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-atotto-clipboard-9",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-clipboard.go-1453"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-atotto-clipboard-9",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-clipboard-unix.go-1454"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mgutz-str-42",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-funcsPZ.go-1455"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mgutz-str-42",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1456"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mgutz-str-42",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-funcsAO.go-1457"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-golang-groupcache-25",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lru.go-1458"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-sync-61",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errgroup.go-1459"
+      "relatedSpdxElement": "SPDXRef-File-errgroup.go-1245"
     }
   ]
 }

--- a/tests/golden/spdx/go/lazygit/lazygit_build.spdx.json
+++ b/tests/golden/spdx/go/lazygit/lazygit_build.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "lazygit",
-  "documentNamespace": "https://omnibor.io/omnibor-analysis/lazygit-2aa87d4d-7ea2-48d7-9132-e5a506821c2e",
+  "documentNamespace": "https://omnibor.io/omnibor-analysis/lazygit-b175d808-9362-4a30-bf4e-730d588b147b",
   "creationInfo": {
-    "created": "2026-05-04T22:15:55Z",
+    "created": "2026-05-05T16:27:38Z",
     "creators": [
       "Tool: bomtrace3-unknown",
       "Tool: bomsh-unknown",
@@ -20,7 +20,7 @@
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": true,
       "primaryPackagePurpose": "APPLICATION",
-      "builtDate": "2026-05-04T22:15:55Z",
+      "builtDate": "2026-05-05T16:27:38Z",
       "externalRefs": [],
       "checksums": [],
       "comment": "Built on Ubuntu 22.04.5 LTS with gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
@@ -123,28 +123,7 @@
       "versionInfo": "1.0.1"
     },
     {
-      "SPDXID": "SPDXRef-fast-float-6",
-      "name": "fast_float",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/fast_float/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-fpconv-7",
-      "name": "fpconv",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/fpconv/. Source compiled into static archive and linked.",
-      "versionInfo": "1.0"
-    },
-    {
-      "SPDXID": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "SPDXID": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "name": "github.com/ProtonMail/go-crypto",
       "downloadLocation": "https://pkg.go.dev/github.com/ProtonMail/go-crypto",
       "filesAnalyzed": true,
@@ -161,7 +140,7 @@
       "versionInfo": "1.1.6"
     },
     {
-      "SPDXID": "SPDXRef-github.com-adrg-xdg-9",
+      "SPDXID": "SPDXRef-github.com-adrg-xdg-7",
       "name": "github.com/adrg/xdg",
       "downloadLocation": "https://pkg.go.dev/github.com/adrg/xdg",
       "filesAnalyzed": true,
@@ -178,7 +157,7 @@
       "versionInfo": "0.4.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-atotto-clipboard-10",
+      "SPDXID": "SPDXRef-github.com-atotto-clipboard-8",
       "name": "github.com/atotto/clipboard",
       "downloadLocation": "https://pkg.go.dev/github.com/atotto/clipboard",
       "filesAnalyzed": true,
@@ -195,7 +174,7 @@
       "versionInfo": "0.1.4"
     },
     {
-      "SPDXID": "SPDXRef-github.com-aybabtme-humanlog-11",
+      "SPDXID": "SPDXRef-github.com-aybabtme-humanlog-9",
       "name": "github.com/aybabtme/humanlog",
       "downloadLocation": "https://pkg.go.dev/github.com/aybabtme/humanlog",
       "filesAnalyzed": true,
@@ -212,7 +191,7 @@
       "versionInfo": "0.4.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-bahlo-generic-list-go-12",
+      "SPDXID": "SPDXRef-github.com-bahlo-generic-list-go-10",
       "name": "github.com/bahlo/generic-list-go",
       "downloadLocation": "https://pkg.go.dev/github.com/bahlo/generic-list-go",
       "filesAnalyzed": true,
@@ -229,7 +208,7 @@
       "versionInfo": "0.2.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-buger-jsonparser-13",
+      "SPDXID": "SPDXRef-github.com-buger-jsonparser-11",
       "name": "github.com/buger/jsonparser",
       "downloadLocation": "https://pkg.go.dev/github.com/buger/jsonparser",
       "filesAnalyzed": true,
@@ -246,7 +225,7 @@
       "versionInfo": "1.1.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-cloudflare-circl-14",
+      "SPDXID": "SPDXRef-github.com-cloudflare-circl-12",
       "name": "github.com/cloudflare/circl",
       "downloadLocation": "https://pkg.go.dev/github.com/cloudflare/circl",
       "filesAnalyzed": true,
@@ -263,7 +242,7 @@
       "versionInfo": "1.6.3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-cloudfoundry-jibber-jabber-15",
+      "SPDXID": "SPDXRef-github.com-cloudfoundry-jibber-jabber-13",
       "name": "github.com/cloudfoundry/jibber_jabber",
       "downloadLocation": "https://pkg.go.dev/github.com/cloudfoundry/jibber_jabber",
       "filesAnalyzed": true,
@@ -280,7 +259,7 @@
       "versionInfo": "0.0.0-20151120183258-bcc4c8345a21"
     },
     {
-      "SPDXID": "SPDXRef-github.com-creack-pty-16",
+      "SPDXID": "SPDXRef-github.com-creack-pty-14",
       "name": "github.com/creack/pty",
       "downloadLocation": "https://pkg.go.dev/github.com/creack/pty",
       "filesAnalyzed": true,
@@ -297,7 +276,7 @@
       "versionInfo": "1.1.11"
     },
     {
-      "SPDXID": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
+      "SPDXID": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "name": "github.com/cyphar/filepath-securejoin",
       "downloadLocation": "https://pkg.go.dev/github.com/cyphar/filepath-securejoin",
       "filesAnalyzed": true,
@@ -314,7 +293,7 @@
       "versionInfo": "0.4.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-emirpasic-gods-18",
+      "SPDXID": "SPDXRef-github.com-emirpasic-gods-16",
       "name": "github.com/emirpasic/gods",
       "downloadLocation": "https://pkg.go.dev/github.com/emirpasic/gods",
       "filesAnalyzed": true,
@@ -331,7 +310,7 @@
       "versionInfo": "1.18.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-fatih-color-19",
+      "SPDXID": "SPDXRef-github.com-fatih-color-17",
       "name": "github.com/fatih/color",
       "downloadLocation": "https://pkg.go.dev/github.com/fatih/color",
       "filesAnalyzed": true,
@@ -348,7 +327,7 @@
       "versionInfo": "1.9.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-gdamore-encoding-20",
+      "SPDXID": "SPDXRef-github.com-gdamore-encoding-18",
       "name": "github.com/gdamore/encoding",
       "downloadLocation": "https://pkg.go.dev/github.com/gdamore/encoding",
       "filesAnalyzed": true,
@@ -365,7 +344,7 @@
       "versionInfo": "1.0.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "SPDXID": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "name": "github.com/gdamore/tcell/v2",
       "downloadLocation": "https://pkg.go.dev/github.com/gdamore/tcell/v2",
       "filesAnalyzed": true,
@@ -382,7 +361,7 @@
       "versionInfo": "2.13.8"
     },
     {
-      "SPDXID": "SPDXRef-github.com-go-errors-errors-22",
+      "SPDXID": "SPDXRef-github.com-go-errors-errors-20",
       "name": "github.com/go-errors/errors",
       "downloadLocation": "https://pkg.go.dev/github.com/go-errors/errors",
       "filesAnalyzed": true,
@@ -399,7 +378,7 @@
       "versionInfo": "1.5.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-go-git-gcfg-23",
+      "SPDXID": "SPDXRef-github.com-go-git-gcfg-21",
       "name": "github.com/go-git/gcfg",
       "downloadLocation": "https://pkg.go.dev/github.com/go-git/gcfg",
       "filesAnalyzed": true,
@@ -416,7 +395,7 @@
       "versionInfo": "1.5.1-0.20230307220236-3a3c6141e376"
     },
     {
-      "SPDXID": "SPDXRef-github.com-go-git-go-billy-v5-24",
+      "SPDXID": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "name": "github.com/go-git/go-billy/v5",
       "downloadLocation": "https://pkg.go.dev/github.com/go-git/go-billy/v5",
       "filesAnalyzed": true,
@@ -433,7 +412,7 @@
       "versionInfo": "5.6.2"
     },
     {
-      "SPDXID": "SPDXRef-github.com-go-logfmt-logfmt-25",
+      "SPDXID": "SPDXRef-github.com-go-logfmt-logfmt-23",
       "name": "github.com/go-logfmt/logfmt",
       "downloadLocation": "https://pkg.go.dev/github.com/go-logfmt/logfmt",
       "filesAnalyzed": true,
@@ -450,7 +429,7 @@
       "versionInfo": "0.5.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-golang-groupcache-26",
+      "SPDXID": "SPDXRef-github.com-golang-groupcache-24",
       "name": "github.com/golang/groupcache",
       "downloadLocation": "https://pkg.go.dev/github.com/golang/groupcache",
       "filesAnalyzed": true,
@@ -467,7 +446,7 @@
       "versionInfo": "0.0.0-20241129210726-2c02b8208cf8"
     },
     {
-      "SPDXID": "SPDXRef-github.com-gookit-color-27",
+      "SPDXID": "SPDXRef-github.com-gookit-color-25",
       "name": "github.com/gookit/color",
       "downloadLocation": "https://pkg.go.dev/github.com/gookit/color",
       "filesAnalyzed": true,
@@ -484,7 +463,7 @@
       "versionInfo": "1.4.2"
     },
     {
-      "SPDXID": "SPDXRef-github.com-integrii-flaggy-28",
+      "SPDXID": "SPDXRef-github.com-integrii-flaggy-26",
       "name": "github.com/integrii/flaggy",
       "downloadLocation": "https://pkg.go.dev/github.com/integrii/flaggy",
       "filesAnalyzed": true,
@@ -501,7 +480,7 @@
       "versionInfo": "1.4.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jbenet-go-context-29",
+      "SPDXID": "SPDXRef-github.com-jbenet-go-context-27",
       "name": "github.com/jbenet/go-context",
       "downloadLocation": "https://pkg.go.dev/github.com/jbenet/go-context",
       "filesAnalyzed": true,
@@ -518,7 +497,7 @@
       "versionInfo": "0.0.0-20150711004518-d14ea06fba99"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jesseduffield-generics-30",
+      "SPDXID": "SPDXRef-github.com-jesseduffield-generics-28",
       "name": "github.com/jesseduffield/generics",
       "downloadLocation": "https://pkg.go.dev/github.com/jesseduffield/generics",
       "filesAnalyzed": true,
@@ -535,7 +514,7 @@
       "versionInfo": "0.0.0-20250517122708-b0b4a53a6f5c"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "SPDXID": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "name": "github.com/jesseduffield/go-git/v5",
       "downloadLocation": "https://pkg.go.dev/github.com/jesseduffield/go-git/v5",
       "filesAnalyzed": true,
@@ -552,7 +531,7 @@
       "versionInfo": "5.14.1-0.20250407170251-e1a013310ccd"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "SPDXID": "SPDXRef-github.com-jesseduffield-gocui-30",
       "name": "github.com/jesseduffield/gocui",
       "downloadLocation": "https://pkg.go.dev/github.com/jesseduffield/gocui",
       "filesAnalyzed": true,
@@ -569,7 +548,7 @@
       "versionInfo": "0.3.1-0.20260308162933-5e45e57b5564"
     },
     {
-      "SPDXID": "SPDXRef-github.com-jesseduffield-lazycore-33",
+      "SPDXID": "SPDXRef-github.com-jesseduffield-lazycore-31",
       "name": "github.com/jesseduffield/lazycore",
       "downloadLocation": "https://pkg.go.dev/github.com/jesseduffield/lazycore",
       "filesAnalyzed": true,
@@ -586,7 +565,7 @@
       "versionInfo": "0.0.0-20221012050358-03d2e40243c5"
     },
     {
-      "SPDXID": "SPDXRef-github.com-kardianos-osext-34",
+      "SPDXID": "SPDXRef-github.com-kardianos-osext-32",
       "name": "github.com/kardianos/osext",
       "downloadLocation": "https://pkg.go.dev/github.com/kardianos/osext",
       "filesAnalyzed": true,
@@ -603,7 +582,7 @@
       "versionInfo": "0.0.0-20190222173326-2bc1f35cddc0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-karimkhaleel-jsonschema-35",
+      "SPDXID": "SPDXRef-github.com-karimkhaleel-jsonschema-33",
       "name": "github.com/karimkhaleel/jsonschema",
       "downloadLocation": "https://pkg.go.dev/github.com/karimkhaleel/jsonschema",
       "filesAnalyzed": true,
@@ -620,7 +599,7 @@
       "versionInfo": "0.0.0-20231001195015-d933f0d94ea3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-kevinburke-ssh-config-36",
+      "SPDXID": "SPDXRef-github.com-kevinburke-ssh-config-34",
       "name": "github.com/kevinburke/ssh_config",
       "downloadLocation": "https://pkg.go.dev/github.com/kevinburke/ssh_config",
       "filesAnalyzed": true,
@@ -637,7 +616,7 @@
       "versionInfo": "1.2.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-kr-logfmt-37",
+      "SPDXID": "SPDXRef-github.com-kr-logfmt-35",
       "name": "github.com/kr/logfmt",
       "downloadLocation": "https://pkg.go.dev/github.com/kr/logfmt",
       "filesAnalyzed": true,
@@ -654,7 +633,7 @@
       "versionInfo": "0.0.0-20140226030751-b84e30acd515"
     },
     {
-      "SPDXID": "SPDXRef-github.com-kyokomi-emoji-v2-38",
+      "SPDXID": "SPDXRef-github.com-kyokomi-emoji-v2-36",
       "name": "github.com/kyokomi/emoji/v2",
       "downloadLocation": "https://pkg.go.dev/github.com/kyokomi/emoji/v2",
       "filesAnalyzed": true,
@@ -671,7 +650,7 @@
       "versionInfo": "2.2.8"
     },
     {
-      "SPDXID": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
+      "SPDXID": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "name": "github.com/lucasb-eyer/go-colorful",
       "downloadLocation": "https://pkg.go.dev/github.com/lucasb-eyer/go-colorful",
       "filesAnalyzed": true,
@@ -688,7 +667,7 @@
       "versionInfo": "1.3.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-mailru-easyjson-40",
+      "SPDXID": "SPDXRef-github.com-mailru-easyjson-38",
       "name": "github.com/mailru/easyjson",
       "downloadLocation": "https://pkg.go.dev/github.com/mailru/easyjson",
       "filesAnalyzed": true,
@@ -705,7 +684,7 @@
       "versionInfo": "0.7.7"
     },
     {
-      "SPDXID": "SPDXRef-github.com-mattn-go-colorable-41",
+      "SPDXID": "SPDXRef-github.com-mattn-go-colorable-39",
       "name": "github.com/mattn/go-colorable",
       "downloadLocation": "https://pkg.go.dev/github.com/mattn/go-colorable",
       "filesAnalyzed": true,
@@ -722,7 +701,7 @@
       "versionInfo": "0.1.11"
     },
     {
-      "SPDXID": "SPDXRef-github.com-mattn-go-isatty-42",
+      "SPDXID": "SPDXRef-github.com-mattn-go-isatty-40",
       "name": "github.com/mattn/go-isatty",
       "downloadLocation": "https://pkg.go.dev/github.com/mattn/go-isatty",
       "filesAnalyzed": true,
@@ -739,7 +718,7 @@
       "versionInfo": "0.0.14"
     },
     {
-      "SPDXID": "SPDXRef-github.com-mgutz-str-43",
+      "SPDXID": "SPDXRef-github.com-mgutz-str-41",
       "name": "github.com/mgutz/str",
       "downloadLocation": "https://pkg.go.dev/github.com/mgutz/str",
       "filesAnalyzed": true,
@@ -756,7 +735,7 @@
       "versionInfo": "1.2.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-petermattis-goid-44",
+      "SPDXID": "SPDXRef-github.com-petermattis-goid-42",
       "name": "github.com/petermattis/goid",
       "downloadLocation": "https://pkg.go.dev/github.com/petermattis/goid",
       "filesAnalyzed": true,
@@ -773,7 +752,7 @@
       "versionInfo": "0.0.0-20250813065127-a731cc31b4fe"
     },
     {
-      "SPDXID": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "SPDXID": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "name": "github.com/pjbgf/sha1cd",
       "downloadLocation": "https://pkg.go.dev/github.com/pjbgf/sha1cd",
       "filesAnalyzed": true,
@@ -790,7 +769,7 @@
       "versionInfo": "0.3.2"
     },
     {
-      "SPDXID": "SPDXRef-github.com-rivo-uniseg-46",
+      "SPDXID": "SPDXRef-github.com-rivo-uniseg-44",
       "name": "github.com/rivo/uniseg",
       "downloadLocation": "https://pkg.go.dev/github.com/rivo/uniseg",
       "filesAnalyzed": true,
@@ -807,7 +786,7 @@
       "versionInfo": "0.4.7"
     },
     {
-      "SPDXID": "SPDXRef-github.com-sahilm-fuzzy-47",
+      "SPDXID": "SPDXRef-github.com-sahilm-fuzzy-45",
       "name": "github.com/sahilm/fuzzy",
       "downloadLocation": "https://pkg.go.dev/github.com/sahilm/fuzzy",
       "filesAnalyzed": true,
@@ -824,7 +803,7 @@
       "versionInfo": "0.1.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-samber-lo-48",
+      "SPDXID": "SPDXRef-github.com-samber-lo-46",
       "name": "github.com/samber/lo",
       "downloadLocation": "https://pkg.go.dev/github.com/samber/lo",
       "filesAnalyzed": true,
@@ -841,7 +820,7 @@
       "versionInfo": "1.31.0"
     },
     {
-      "SPDXID": "SPDXRef-github.com-sasha-s-go-deadlock-49",
+      "SPDXID": "SPDXRef-github.com-sasha-s-go-deadlock-47",
       "name": "github.com/sasha-s/go-deadlock",
       "downloadLocation": "https://pkg.go.dev/github.com/sasha-s/go-deadlock",
       "filesAnalyzed": true,
@@ -858,7 +837,7 @@
       "versionInfo": "0.3.6"
     },
     {
-      "SPDXID": "SPDXRef-github.com-sergi-go-diff-50",
+      "SPDXID": "SPDXRef-github.com-sergi-go-diff-48",
       "name": "github.com/sergi/go-diff",
       "downloadLocation": "https://pkg.go.dev/github.com/sergi/go-diff",
       "filesAnalyzed": true,
@@ -875,7 +854,7 @@
       "versionInfo": "1.3.2-0.20230802210424-5b0b94c5c0d3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-sirupsen-logrus-51",
+      "SPDXID": "SPDXRef-github.com-sirupsen-logrus-49",
       "name": "github.com/sirupsen/logrus",
       "downloadLocation": "https://pkg.go.dev/github.com/sirupsen/logrus",
       "filesAnalyzed": true,
@@ -892,7 +871,7 @@
       "versionInfo": "1.9.3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-skeema-knownhosts-52",
+      "SPDXID": "SPDXRef-github.com-skeema-knownhosts-50",
       "name": "github.com/skeema/knownhosts",
       "downloadLocation": "https://pkg.go.dev/github.com/skeema/knownhosts",
       "filesAnalyzed": true,
@@ -909,7 +888,7 @@
       "versionInfo": "1.3.1"
     },
     {
-      "SPDXID": "SPDXRef-github.com-spf13-afero-53",
+      "SPDXID": "SPDXRef-github.com-spf13-afero-51",
       "name": "github.com/spf13/afero",
       "downloadLocation": "https://pkg.go.dev/github.com/spf13/afero",
       "filesAnalyzed": true,
@@ -926,7 +905,7 @@
       "versionInfo": "1.9.5"
     },
     {
-      "SPDXID": "SPDXRef-github.com-spkg-bom-54",
+      "SPDXID": "SPDXRef-github.com-spkg-bom-52",
       "name": "github.com/spkg/bom",
       "downloadLocation": "https://pkg.go.dev/github.com/spkg/bom",
       "filesAnalyzed": true,
@@ -943,7 +922,7 @@
       "versionInfo": "0.0.0-20160624110644-59b7046e48ad"
     },
     {
-      "SPDXID": "SPDXRef-github.com-stefanhaller-git-todo-parser-55",
+      "SPDXID": "SPDXRef-github.com-stefanhaller-git-todo-parser-53",
       "name": "github.com/stefanhaller/git-todo-parser",
       "downloadLocation": "https://pkg.go.dev/github.com/stefanhaller/git-todo-parser",
       "filesAnalyzed": true,
@@ -960,7 +939,7 @@
       "versionInfo": "0.0.7-0.20250905083220-c50528f08304"
     },
     {
-      "SPDXID": "SPDXRef-github.com-wk8-go-ordered-map-v2-56",
+      "SPDXID": "SPDXRef-github.com-wk8-go-ordered-map-v2-54",
       "name": "github.com/wk8/go-ordered-map/v2",
       "downloadLocation": "https://pkg.go.dev/github.com/wk8/go-ordered-map/v2",
       "filesAnalyzed": true,
@@ -977,7 +956,7 @@
       "versionInfo": "2.1.8"
     },
     {
-      "SPDXID": "SPDXRef-github.com-xanzy-ssh-agent-57",
+      "SPDXID": "SPDXRef-github.com-xanzy-ssh-agent-55",
       "name": "github.com/xanzy/ssh-agent",
       "downloadLocation": "https://pkg.go.dev/github.com/xanzy/ssh-agent",
       "filesAnalyzed": true,
@@ -994,7 +973,7 @@
       "versionInfo": "0.3.3"
     },
     {
-      "SPDXID": "SPDXRef-github.com-xo-terminfo-58",
+      "SPDXID": "SPDXRef-github.com-xo-terminfo-56",
       "name": "github.com/xo/terminfo",
       "downloadLocation": "https://pkg.go.dev/github.com/xo/terminfo",
       "filesAnalyzed": true,
@@ -1011,7 +990,7 @@
       "versionInfo": "0.0.0-20210125001918-ca9a967f8778"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-crypto-59",
+      "SPDXID": "SPDXRef-golang.org-x-crypto-57",
       "name": "golang.org/x/crypto",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/crypto",
       "filesAnalyzed": true,
@@ -1028,7 +1007,7 @@
       "versionInfo": "0.45.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-exp-60",
+      "SPDXID": "SPDXRef-golang.org-x-exp-58",
       "name": "golang.org/x/exp",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/exp",
       "filesAnalyzed": true,
@@ -1045,7 +1024,7 @@
       "versionInfo": "0.0.0-20240719175910-8a7402abbf56"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-net-61",
+      "SPDXID": "SPDXRef-golang.org-x-net-59",
       "name": "golang.org/x/net",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/net",
       "filesAnalyzed": true,
@@ -1062,7 +1041,7 @@
       "versionInfo": "0.47.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-sync-62",
+      "SPDXID": "SPDXRef-golang.org-x-sync-60",
       "name": "golang.org/x/sync",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/sync",
       "filesAnalyzed": true,
@@ -1079,7 +1058,7 @@
       "versionInfo": "0.19.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-sys-63",
+      "SPDXID": "SPDXRef-golang.org-x-sys-61",
       "name": "golang.org/x/sys",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/sys",
       "filesAnalyzed": true,
@@ -1096,7 +1075,7 @@
       "versionInfo": "0.42.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-term-64",
+      "SPDXID": "SPDXRef-golang.org-x-term-62",
       "name": "golang.org/x/term",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/term",
       "filesAnalyzed": true,
@@ -1113,7 +1092,7 @@
       "versionInfo": "0.40.0"
     },
     {
-      "SPDXID": "SPDXRef-golang.org-x-text-65",
+      "SPDXID": "SPDXRef-golang.org-x-text-63",
       "name": "golang.org/x/text",
       "downloadLocation": "https://pkg.go.dev/golang.org/x/text",
       "filesAnalyzed": true,
@@ -1130,7 +1109,7 @@
       "versionInfo": "0.34.0"
     },
     {
-      "SPDXID": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-66",
+      "SPDXID": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-64",
       "name": "gopkg.in/ozeidan/fuzzy-patricia.v3",
       "downloadLocation": "https://pkg.go.dev/gopkg.in/ozeidan/fuzzy-patricia.v3",
       "filesAnalyzed": true,
@@ -1147,7 +1126,7 @@
       "versionInfo": "3.0.0"
     },
     {
-      "SPDXID": "SPDXRef-gopkg.in-warnings.v0-67",
+      "SPDXID": "SPDXRef-gopkg.in-warnings.v0-65",
       "name": "gopkg.in/warnings.v0",
       "downloadLocation": "https://pkg.go.dev/gopkg.in/warnings.v0",
       "filesAnalyzed": true,
@@ -1164,7 +1143,7 @@
       "versionInfo": "0.1.2"
     },
     {
-      "SPDXID": "SPDXRef-gopkg.in-yaml.v3-68",
+      "SPDXID": "SPDXRef-gopkg.in-yaml.v3-66",
       "name": "gopkg.in/yaml.v3",
       "downloadLocation": "https://pkg.go.dev/gopkg.in/yaml.v3",
       "filesAnalyzed": true,
@@ -1179,85 +1158,11 @@
       "comment": "Go module (direct). 13 source files compiled into lazygit",
       "packageSourceInfo": "Vendored via go mod vendor. Source at vendor/gopkg.in/yaml.v3/.",
       "versionInfo": "3.0.1"
-    },
-    {
-      "SPDXID": "SPDXRef-hdr-histogram-69",
-      "name": "hdr_histogram",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/hdr_histogram/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-hiredis-70",
-      "name": "hiredis",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 6 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/hiredis/. Source compiled into static archive and linked.",
-      "versionInfo": "1.2.0"
-    },
-    {
-      "SPDXID": "SPDXRef-jemalloc-71",
-      "name": "jemalloc",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/jemalloc/. Source compiled into static archive and linked.",
-      "versionInfo": "5.3.0"
-    },
-    {
-      "SPDXID": "SPDXRef-linenoise-72",
-      "name": "linenoise",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 1 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/linenoise/. Source compiled into static archive and linked.",
-      "versionInfo": "1.0"
-    },
-    {
-      "SPDXID": "SPDXRef-lua-73",
-      "name": "lua",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into lazygit. 10 source files.",
-      "packageSourceInfo": "Vendored from lazygit/deps/lua/. Source compiled into static archive and linked.",
-      "versionInfo": "5.1.5"
     }
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-File-timeout.c-74",
-      "fileName": "repos/redis/src/timeout.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "01848ceecefb17f32bdbacff3495ec6153dfda9b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-eval.c-75",
-      "fileName": "repos/redis/src/eval.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0189561351452d82fba7798e23e5e4cc82f4c576"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-filtering-menu-action.go-76",
+      "SPDXID": "SPDXRef-File-filtering-menu-action.go-67",
       "fileName": "repos/lazygit/pkg/gui/controllers/filtering_menu_action.go",
       "checksums": [
         {
@@ -1267,7 +1172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sync-controller.go-77",
+      "SPDXID": "SPDXRef-File-sync-controller.go-68",
       "fileName": "repos/lazygit/pkg/gui/controllers/sync_controller.go",
       "checksums": [
         {
@@ -1277,7 +1182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-amend-helper.go-78",
+      "SPDXID": "SPDXRef-File-amend-helper.go-69",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/amend_helper.go",
       "checksums": [
         {
@@ -1287,7 +1192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-menu-controller.go-79",
+      "SPDXID": "SPDXRef-File-menu-controller.go-70",
       "fileName": "repos/lazygit/pkg/gui/controllers/menu_controller.go",
       "checksums": [
         {
@@ -1297,7 +1202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-state.go-80",
+      "SPDXID": "SPDXRef-File-state.go-71",
       "fileName": "repos/lazygit/pkg/gui/mergeconflicts/state.go",
       "checksums": [
         {
@@ -1307,7 +1212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-message-panel-driver.go-81",
+      "SPDXID": "SPDXRef-File-commit-message-panel-driver.go-72",
       "fileName": "repos/lazygit/pkg/integration/components/commit_message_panel_driver.go",
       "checksums": [
         {
@@ -1317,7 +1222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-window-arrangement-helper.go-82",
+      "SPDXID": "SPDXRef-File-window-arrangement-helper.go-73",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/window_arrangement_helper.go",
       "checksums": [
         {
@@ -1327,7 +1232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-assertion-helper.go-83",
+      "SPDXID": "SPDXRef-File-assertion-helper.go-74",
       "fileName": "repos/lazygit/pkg/integration/components/assertion_helper.go",
       "checksums": [
         {
@@ -1337,7 +1242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree.go-84",
+      "SPDXID": "SPDXRef-File-worktree.go-75",
       "fileName": "repos/lazygit/pkg/commands/models/worktree.go",
       "checksums": [
         {
@@ -1347,7 +1252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflog-commit-loader.go-85",
+      "SPDXID": "SPDXRef-File-reflog-commit-loader.go-76",
       "fileName": "repos/lazygit/pkg/commands/git_commands/reflog_commit_loader.go",
       "checksums": [
         {
@@ -1357,7 +1262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hyperlink.go-86",
+      "SPDXID": "SPDXRef-File-hyperlink.go-77",
       "fileName": "repos/lazygit/pkg/gui/style/hyperlink.go",
       "checksums": [
         {
@@ -1367,7 +1272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-default-platform.go-87",
+      "SPDXID": "SPDXRef-File-os-default-platform.go-78",
       "fileName": "repos/lazygit/pkg/commands/oscommands/os_default_platform.go",
       "checksums": [
         {
@@ -1377,7 +1282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dummies.go-88",
+      "SPDXID": "SPDXRef-File-dummies.go-79",
       "fileName": "repos/lazygit/pkg/config/dummies.go",
       "checksums": [
         {
@@ -1387,17 +1292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rax-malloc.h-89",
-      "fileName": "repos/redis/src/rax_malloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0794b05ecf639818530235d6d7e635441fe9d3a5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sub-commits-helper.go-90",
+      "SPDXID": "SPDXRef-File-sub-commits-helper.go-80",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/sub_commits_helper.go",
       "checksums": [
         {
@@ -1407,7 +1302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch-explorer-context.go-91",
+      "SPDXID": "SPDXRef-File-patch-explorer-context.go-81",
       "fileName": "repos/lazygit/pkg/gui/context/patch_explorer_context.go",
       "checksums": [
         {
@@ -1417,7 +1312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file-node.go-92",
+      "SPDXID": "SPDXRef-File-file-node.go-82",
       "fileName": "repos/lazygit/pkg/gui/filetree/file_node.go",
       "checksums": [
         {
@@ -1427,7 +1322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-upstream-helper.go-93",
+      "SPDXID": "SPDXRef-File-upstream-helper.go-83",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/upstream_helper.go",
       "checksums": [
         {
@@ -1437,17 +1332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-latency.c-94",
-      "fileName": "repos/redis/src/latency.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "09639bd50544337098770f7e04e57cc79b685389"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-menu-context.go-95",
+      "SPDXID": "SPDXRef-File-menu-context.go-84",
       "fileName": "repos/lazygit/pkg/gui/context/menu_context.go",
       "checksums": [
         {
@@ -1457,7 +1342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-app.go-96",
+      "SPDXID": "SPDXRef-File-app.go-85",
       "fileName": "repos/lazygit/pkg/app/app.go",
       "checksums": [
         {
@@ -1467,27 +1352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eventnotifier.c-97",
-      "fileName": "repos/redis/src/eventnotifier.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0a6c145c13e0f11bb1dc44b50dc1a729997b0c52"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-redismodule.h-98",
-      "fileName": "repos/redis/src/redismodule.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0b395feaf8fa59fc560517d07b566f45fb0c2210"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tags-context.go-99",
+      "SPDXID": "SPDXRef-File-tags-context.go-86",
       "fileName": "repos/lazygit/pkg/gui/context/tags_context.go",
       "checksums": [
         {
@@ -1497,17 +1362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cli-common.c-100",
-      "fileName": "repos/redis/src/cli_common.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0c269de9aa676d615d6e418b5ddf4ee7d2d27253"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-worktree-options-controller.go-101",
+      "SPDXID": "SPDXRef-File-worktree-options-controller.go-87",
       "fileName": "repos/lazygit/pkg/gui/controllers/worktree_options_controller.go",
       "checksums": [
         {
@@ -1517,7 +1372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base-controller.go-102",
+      "SPDXID": "SPDXRef-File-base-controller.go-88",
       "fileName": "repos/lazygit/pkg/gui/controllers/base_controller.go",
       "checksums": [
         {
@@ -1527,7 +1382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-loader.go-103",
+      "SPDXID": "SPDXRef-File-worktree-loader.go-89",
       "fileName": "repos/lazygit/pkg/commands/git_commands/worktree_loader.go",
       "checksums": [
         {
@@ -1537,7 +1392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stash.go-104",
+      "SPDXID": "SPDXRef-File-stash.go-90",
       "fileName": "repos/lazygit/pkg/commands/git_commands/stash.go",
       "checksums": [
         {
@@ -1547,7 +1402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slice.go-105",
+      "SPDXID": "SPDXRef-File-slice.go-91",
       "fileName": "repos/lazygit/pkg/utils/slice.go",
       "checksums": [
         {
@@ -1557,7 +1412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main-branches.go-106",
+      "SPDXID": "SPDXRef-File-main-branches.go-92",
       "fileName": "repos/lazygit/pkg/commands/git_commands/main_branches.go",
       "checksums": [
         {
@@ -1567,7 +1422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shell-command-action.go-107",
+      "SPDXID": "SPDXRef-File-shell-command-action.go-93",
       "fileName": "repos/lazygit/pkg/gui/controllers/shell_command_action.go",
       "checksums": [
         {
@@ -1577,27 +1432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-release.c-108",
-      "fileName": "repos/redis/src/release.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "11f7f5188aeda4d3ef073ce2b8f47d2246f1bf3d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-syscheck.c-109",
-      "fileName": "repos/redis/src/syscheck.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1251c1d72f471217293dd637d896d42840346e49"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-client.go-110",
+      "SPDXID": "SPDXRef-File-client.go-94",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/client.go",
       "checksums": [
         {
@@ -1607,17 +1442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-endianconv.c-111",
-      "fileName": "repos/redis/src/endianconv.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "12ee03cbd7c57c153c86857545d79e540b18d389"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-switch-to-focused-main-view-controller.go-112",
+      "SPDXID": "SPDXRef-File-switch-to-focused-main-view-controller.go-95",
       "fileName": "repos/lazygit/pkg/gui/controllers/switch_to_focused_main_view_controller.go",
       "checksums": [
         {
@@ -1627,17 +1452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sparkline.c-113",
-      "fileName": "repos/redis/src/sparkline.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "13370163716dee3f66e841ad0b8bad925bbc5074"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-commit.go-114",
+      "SPDXID": "SPDXRef-File-commit.go-96",
       "fileName": "repos/lazygit/pkg/commands/models/commit.go",
       "checksums": [
         {
@@ -1647,17 +1462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stream.h-115",
-      "fileName": "repos/redis/src/stream.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "146be3b12e4bf08dfe8e3776b992e2cbb2161657"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tasks-adapter.go-116",
+      "SPDXID": "SPDXRef-File-tasks-adapter.go-97",
       "fileName": "repos/lazygit/pkg/gui/tasks_adapter.go",
       "checksums": [
         {
@@ -1667,7 +1472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-editors.go-117",
+      "SPDXID": "SPDXRef-File-editors.go-98",
       "fileName": "repos/lazygit/pkg/gui/editors.go",
       "checksums": [
         {
@@ -1677,7 +1482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-repos-helper.go-118",
+      "SPDXID": "SPDXRef-File-repos-helper.go-99",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/repos_helper.go",
       "checksums": [
         {
@@ -1687,7 +1492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-graph.go-119",
+      "SPDXID": "SPDXRef-File-graph.go-100",
       "fileName": "repos/lazygit/pkg/gui/presentation/graph/graph.go",
       "checksums": [
         {
@@ -1697,7 +1502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-user-config-validation.go-120",
+      "SPDXID": "SPDXRef-File-user-config-validation.go-101",
       "fileName": "repos/lazygit/pkg/config/user_config_validation.go",
       "checksums": [
         {
@@ -1707,17 +1512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redisassert.h-121",
-      "fileName": "repos/redis/src/redisassert.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "17983318783a6272b66aab34f1784f23dcbc3e0a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-color.go-122",
+      "SPDXID": "SPDXRef-File-color.go-102",
       "fileName": "repos/lazygit/pkg/utils/color.go",
       "checksums": [
         {
@@ -1727,7 +1522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-user-config.go-123",
+      "SPDXID": "SPDXRef-File-user-config.go-103",
       "fileName": "repos/lazygit/pkg/config/user_config.go",
       "checksums": [
         {
@@ -1737,7 +1532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file-system.go-124",
+      "SPDXID": "SPDXRef-File-file-system.go-104",
       "fileName": "repos/lazygit/pkg/integration/components/file_system.go",
       "checksums": [
         {
@@ -1747,27 +1542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-evict.c-125",
-      "fileName": "repos/redis/src/evict.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "19e4d59f48ed42be4de8ba31efec3fbdaf314c6f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-geohash.h-126",
-      "fileName": "repos/redis/src/geohash.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "19fa5a1d0fdf74a911e9e179286b6a4d8d5b3c6d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-env.go-127",
+      "SPDXID": "SPDXRef-File-env.go-105",
       "fileName": "repos/lazygit/pkg/env/env.go",
       "checksums": [
         {
@@ -1777,7 +1552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context.go-128",
+      "SPDXID": "SPDXRef-File-context.go-106",
       "fileName": "repos/lazygit/pkg/gui/context.go",
       "checksums": [
         {
@@ -1787,7 +1562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-global-controller.go-129",
+      "SPDXID": "SPDXRef-File-global-controller.go-107",
       "fileName": "repos/lazygit/pkg/gui/controllers/global_controller.go",
       "checksums": [
         {
@@ -1797,17 +1572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sort.c-130",
-      "fileName": "repos/redis/src/sort.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1aed5977747dce1e5de4d45a933ef4778f8c2a1e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-git.go-131",
+      "SPDXID": "SPDXRef-File-git.go-108",
       "fileName": "repos/lazygit/pkg/integration/components/git.go",
       "checksums": [
         {
@@ -1817,7 +1582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.go-132",
+      "SPDXID": "SPDXRef-File-file.go-109",
       "fileName": "repos/lazygit/pkg/commands/git_commands/file.go",
       "checksums": [
         {
@@ -1827,17 +1592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut8.c-133",
-      "fileName": "repos/redis/src/lolwut8.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1be150e6e0c4892679e6caff9aa5475d1c7ebae5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hosting-service.go-134",
+      "SPDXID": "SPDXRef-File-hosting-service.go-110",
       "fileName": "repos/lazygit/pkg/commands/hosting_service/hosting_service.go",
       "checksums": [
         {
@@ -1847,7 +1602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-view-model.go-135",
+      "SPDXID": "SPDXRef-File-list-view-model.go-111",
       "fileName": "repos/lazygit/pkg/gui/context/list_view_model.go",
       "checksums": [
         {
@@ -1857,7 +1612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-io.go-136",
+      "SPDXID": "SPDXRef-File-io.go-112",
       "fileName": "repos/lazygit/pkg/utils/io.go",
       "checksums": [
         {
@@ -1867,7 +1622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-views.go-137",
+      "SPDXID": "SPDXRef-File-views.go-113",
       "fileName": "repos/lazygit/pkg/integration/components/views.go",
       "checksums": [
         {
@@ -1877,17 +1632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-anet.h-138",
-      "fileName": "repos/redis/src/anet.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1d3aec9cdf51edee5c47607a4223d1bae9654ad5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-suggestion.go-139",
+      "SPDXID": "SPDXRef-File-suggestion.go-114",
       "fileName": "repos/lazygit/pkg/gui/types/suggestion.go",
       "checksums": [
         {
@@ -1897,17 +1642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-solarisfixes.h-140",
-      "fileName": "repos/redis/src/solarisfixes.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1e757490fe9f3abfc8f9f7087c4be4db6fdfa254"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-remote-branch.go-141",
+      "SPDXID": "SPDXRef-File-remote-branch.go-115",
       "fileName": "repos/lazygit/pkg/commands/models/remote_branch.go",
       "checksums": [
         {
@@ -1917,7 +1652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tag.go-142",
+      "SPDXID": "SPDXRef-File-tag.go-116",
       "fileName": "repos/lazygit/pkg/commands/git_commands/tag.go",
       "checksums": [
         {
@@ -1927,17 +1662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commands.h-143",
-      "fileName": "repos/redis/src/commands.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1eefab4812b8ba3f065c2955ad68d9f7984f2caa"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-prompt-controller.go-144",
+      "SPDXID": "SPDXRef-File-prompt-controller.go-117",
       "fileName": "repos/lazygit/pkg/gui/controllers/prompt_controller.go",
       "checksums": [
         {
@@ -1947,7 +1672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stash-context.go-145",
+      "SPDXID": "SPDXRef-File-stash-context.go-118",
       "fileName": "repos/lazygit/pkg/gui/context/stash_context.go",
       "checksums": [
         {
@@ -1957,7 +1682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-confirmation-controller.go-146",
+      "SPDXID": "SPDXRef-File-confirmation-controller.go-119",
       "fileName": "repos/lazygit/pkg/gui/controllers/confirmation_controller.go",
       "checksums": [
         {
@@ -1967,27 +1692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crccombine.c-147",
-      "fileName": "repos/redis/src/crccombine.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "20add37eeb6ce81ef508b6ffe0802699f7f7a84a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-socket.c-148",
-      "fileName": "repos/redis/src/socket.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "226b414f85ed1ffee72b20a0b056729e1dab1fee"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-loader.go-149",
+      "SPDXID": "SPDXRef-File-loader.go-120",
       "fileName": "repos/lazygit/pkg/gui/presentation/loader.go",
       "checksums": [
         {
@@ -1997,7 +1702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git-icons.go-150",
+      "SPDXID": "SPDXRef-File-git-icons.go-121",
       "fileName": "repos/lazygit/pkg/gui/presentation/icons/git_icons.go",
       "checksums": [
         {
@@ -2007,7 +1712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-description-controller.go-151",
+      "SPDXID": "SPDXRef-File-commit-description-controller.go-122",
       "fileName": "repos/lazygit/pkg/gui/controllers/commit_description_controller.go",
       "checksums": [
         {
@@ -2017,7 +1722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmd-obj.go-152",
+      "SPDXID": "SPDXRef-File-cmd-obj.go-123",
       "fileName": "repos/lazygit/pkg/commands/oscommands/cmd_obj.go",
       "checksums": [
         {
@@ -2027,7 +1732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cached-git-config.go-153",
+      "SPDXID": "SPDXRef-File-cached-git-config.go-124",
       "fileName": "repos/lazygit/pkg/commands/git_config/cached_git_config.go",
       "checksums": [
         {
@@ -2037,7 +1742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybinding-creator.go-154",
+      "SPDXID": "SPDXRef-File-keybinding-creator.go-125",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/keybinding_creator.go",
       "checksums": [
         {
@@ -2047,7 +1752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-definitions.go-155",
+      "SPDXID": "SPDXRef-File-definitions.go-126",
       "fileName": "repos/lazygit/pkg/commands/hosting_service/definitions.go",
       "checksums": [
         {
@@ -2057,27 +1762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-geohash-helper.h-156",
-      "fileName": "repos/redis/src/geohash_helper.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "262bd8e8da3f9985dcc320a1608606beeffc26a7"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-foo.c-157",
-      "fileName": "repos/redis/src/foo.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2643cf37b3f62703653fb0ffd4c9641058979129"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-common.go-158",
+      "SPDXID": "SPDXRef-File-common.go-127",
       "fileName": "repos/lazygit/pkg/commands/git_commands/common.go",
       "checksums": [
         {
@@ -2087,47 +1772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut5.c-159",
-      "fileName": "repos/redis/src/lolwut5.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "29f0a2f8d144e3de631804ca67dfb20137e9f715"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-functions.h-160",
-      "fileName": "repos/redis/src/functions.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a487da74accbc22e7f3bcc243d3e02196b4fba1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-call-reply.c-161",
-      "fileName": "repos/redis/src/call_reply.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a4f7100d8fc77ce8e95d63bfca5a935cd6ce964"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-server.h-162",
-      "fileName": "repos/redis/src/server.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a70b28379be19f46b1c8982f7a91e43b46d3f62"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch.go-163",
+      "SPDXID": "SPDXRef-File-patch.go-128",
       "fileName": "repos/lazygit/pkg/commands/git_commands/patch.go",
       "checksums": [
         {
@@ -2137,7 +1782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-conflicts-context.go-164",
+      "SPDXID": "SPDXRef-File-merge-conflicts-context.go-129",
       "fileName": "repos/lazygit/pkg/gui/context/merge_conflicts_context.go",
       "checksums": [
         {
@@ -2147,7 +1792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cherry-picking.go-165",
+      "SPDXID": "SPDXRef-File-cherry-picking.go-130",
       "fileName": "repos/lazygit/pkg/gui/modes/cherrypicking/cherry_picking.go",
       "checksums": [
         {
@@ -2157,7 +1802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-166",
+      "SPDXID": "SPDXRef-File-color.go-131",
       "fileName": "repos/lazygit/pkg/gui/style/color.go",
       "checksums": [
         {
@@ -2167,7 +1812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-prompt-driver.go-167",
+      "SPDXID": "SPDXRef-File-prompt-driver.go-132",
       "fileName": "repos/lazygit/pkg/integration/components/prompt_driver.go",
       "checksums": [
         {
@@ -2177,17 +1822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-listpack.h-168",
-      "fileName": "repos/redis/src/listpack.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2c3b789337dd566192d4ec0be6b48a7195ec5cb6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-side-window-controller.go-169",
+      "SPDXID": "SPDXRef-File-side-window-controller.go-133",
       "fileName": "repos/lazygit/pkg/gui/controllers/side_window_controller.go",
       "checksums": [
         {
@@ -2197,7 +1832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-regexp.go-170",
+      "SPDXID": "SPDXRef-File-regexp.go-134",
       "fileName": "repos/lazygit/pkg/utils/regexp.go",
       "checksums": [
         {
@@ -2207,7 +1842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflog-commits-controller.go-171",
+      "SPDXID": "SPDXRef-File-reflog-commits-controller.go-135",
       "fileName": "repos/lazygit/pkg/gui/controllers/reflog_commits_controller.go",
       "checksums": [
         {
@@ -2217,7 +1852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rename-similarity-threshold-controller.go-172",
+      "SPDXID": "SPDXRef-File-rename-similarity-threshold-controller.go-136",
       "fileName": "repos/lazygit/pkg/gui/controllers/rename_similarity_threshold_controller.go",
       "checksums": [
         {
@@ -2227,7 +1862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-173",
+      "SPDXID": "SPDXRef-File-common.go-137",
       "fileName": "repos/lazygit/pkg/integration/components/common.go",
       "checksums": [
         {
@@ -2237,7 +1872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dummies.go-174",
+      "SPDXID": "SPDXRef-File-dummies.go-138",
       "fileName": "repos/lazygit/pkg/utils/dummies.go",
       "checksums": [
         {
@@ -2247,17 +1882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redis-benchmark.c-175",
-      "fileName": "repos/redis/src/redis-benchmark.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2dbdbd6a1cb7f348323e5ec4c84a62682ecde250"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-copy.go-176",
+      "SPDXID": "SPDXRef-File-copy.go-139",
       "fileName": "repos/lazygit/pkg/commands/oscommands/copy.go",
       "checksums": [
         {
@@ -2267,17 +1892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slowlog.h-177",
-      "fileName": "repos/redis/src/slowlog.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2e284201c0922be34e47ce3f58cf007200b2d1dc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-shell.go-178",
+      "SPDXID": "SPDXRef-File-shell.go-140",
       "fileName": "repos/lazygit/pkg/integration/components/shell.go",
       "checksums": [
         {
@@ -2287,7 +1902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote-loader.go-179",
+      "SPDXID": "SPDXRef-File-remote-loader.go-141",
       "fileName": "repos/lazygit/pkg/commands/git_commands/remote_loader.go",
       "checksums": [
         {
@@ -2297,7 +1912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main-panels.go-180",
+      "SPDXID": "SPDXRef-File-main-panels.go-142",
       "fileName": "repos/lazygit/pkg/gui/main_panels.go",
       "checksums": [
         {
@@ -2307,7 +1922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-command-log-controller.go-181",
+      "SPDXID": "SPDXRef-File-command-log-controller.go-143",
       "fileName": "repos/lazygit/pkg/gui/controllers/command_log_controller.go",
       "checksums": [
         {
@@ -2317,7 +1932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff.go-182",
+      "SPDXID": "SPDXRef-File-diff.go-144",
       "fileName": "repos/lazygit/pkg/commands/git_commands/diff.go",
       "checksums": [
         {
@@ -2327,7 +1942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-refresh-helper.go-183",
+      "SPDXID": "SPDXRef-File-refresh-helper.go-145",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/refresh_helper.go",
       "checksums": [
         {
@@ -2337,7 +1952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file-loader.go-184",
+      "SPDXID": "SPDXRef-File-commit-file-loader.go-146",
       "fileName": "repos/lazygit/pkg/commands/git_commands/commit_file_loader.go",
       "checksums": [
         {
@@ -2347,7 +1962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-random.go-185",
+      "SPDXID": "SPDXRef-File-random.go-147",
       "fileName": "repos/lazygit/pkg/integration/components/random.go",
       "checksums": [
         {
@@ -2357,7 +1972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-186",
+      "SPDXID": "SPDXRef-File-common.go-148",
       "fileName": "repos/lazygit/pkg/gui/controllers/common.go",
       "checksums": [
         {
@@ -2367,7 +1982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui.go-187",
+      "SPDXID": "SPDXRef-File-gui.go-149",
       "fileName": "repos/lazygit/pkg/gui/gui.go",
       "checksums": [
         {
@@ -2377,17 +1992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bio.c-188",
-      "fileName": "repos/redis/src/bio.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "34e3ac1e9727e31d1ba17ce3abe239459fba243b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cherry-pick-helper.go-189",
+      "SPDXID": "SPDXRef-File-cherry-pick-helper.go-150",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/cherry_pick_helper.go",
       "checksums": [
         {
@@ -2397,7 +2002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui-driver.go-190",
+      "SPDXID": "SPDXRef-File-gui-driver.go-151",
       "fileName": "repos/lazygit/pkg/gui/gui_driver.go",
       "checksums": [
         {
@@ -2407,17 +2012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mstr.c-191",
-      "fileName": "repos/redis/src/mstr.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3648806eb7ac1d953aa98f82ff57c7d8b7ce9b34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-confirmation-helper.go-192",
+      "SPDXID": "SPDXRef-File-confirmation-helper.go-152",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/confirmation_helper.go",
       "checksums": [
         {
@@ -2427,7 +2022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file-loader.go-193",
+      "SPDXID": "SPDXRef-File-file-loader.go-153",
       "fileName": "repos/lazygit/pkg/commands/git_commands/file_loader.go",
       "checksums": [
         {
@@ -2437,7 +2032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-record-directory-helper.go-194",
+      "SPDXID": "SPDXRef-File-record-directory-helper.go-154",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/record_directory_helper.go",
       "checksums": [
         {
@@ -2447,7 +2042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-status-controller.go-195",
+      "SPDXID": "SPDXRef-File-status-controller.go-155",
       "fileName": "repos/lazygit/pkg/gui/controllers/status_controller.go",
       "checksums": [
         {
@@ -2457,17 +2052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.h-196",
-      "fileName": "repos/redis/src/rand.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "37b03f41f18b91ac4dd141d645096a3437717d68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-state.go-197",
+      "SPDXID": "SPDXRef-File-state.go-156",
       "fileName": "repos/lazygit/pkg/gui/patch_exploring/state.go",
       "checksums": [
         {
@@ -2477,7 +2062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-inline-status-helper.go-198",
+      "SPDXID": "SPDXRef-File-inline-status-helper.go-157",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/inline_status_helper.go",
       "checksums": [
         {
@@ -2487,7 +2072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch.go-199",
+      "SPDXID": "SPDXRef-File-patch.go-158",
       "fileName": "repos/lazygit/pkg/commands/patch/patch.go",
       "checksums": [
         {
@@ -2497,7 +2082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-controller.go-200",
+      "SPDXID": "SPDXRef-File-search-controller.go-159",
       "fileName": "repos/lazygit/pkg/gui/controllers/search_controller.go",
       "checksums": [
         {
@@ -2507,7 +2092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-text-matcher.go-201",
+      "SPDXID": "SPDXRef-File-text-matcher.go-160",
       "fileName": "repos/lazygit/pkg/integration/components/text_matcher.go",
       "checksums": [
         {
@@ -2517,7 +2102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote-branches-controller.go-202",
+      "SPDXID": "SPDXRef-File-remote-branches-controller.go-161",
       "fileName": "repos/lazygit/pkg/gui/controllers/remote_branches_controller.go",
       "checksums": [
         {
@@ -2527,7 +2112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-entry-point.go-203",
+      "SPDXID": "SPDXRef-File-entry-point.go-162",
       "fileName": "repos/lazygit/pkg/app/entry_point.go",
       "checksums": [
         {
@@ -2537,7 +2122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diffing-menu-action.go-204",
+      "SPDXID": "SPDXRef-File-diffing-menu-action.go-163",
       "fileName": "repos/lazygit/pkg/gui/controllers/diffing_menu_action.go",
       "checksums": [
         {
@@ -2547,7 +2132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-cursor.go-205",
+      "SPDXID": "SPDXRef-File-list-cursor.go-164",
       "fileName": "repos/lazygit/pkg/gui/context/traits/list_cursor.go",
       "checksums": [
         {
@@ -2557,17 +2142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha256.c-206",
-      "fileName": "repos/redis/src/sha256.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3b53c45c41458245e5ef18e72d68c02656b7ef0a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-popup.go-207",
+      "SPDXID": "SPDXRef-File-popup.go-165",
       "fileName": "repos/lazygit/pkg/integration/components/popup.go",
       "checksums": [
         {
@@ -2577,17 +2152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cluster.c-208",
-      "fileName": "repos/redis/src/cluster.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3d0e7840468cc91804a9061372175e2d81ab747c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-logs-default.go-209",
+      "SPDXID": "SPDXRef-File-logs-default.go-166",
       "fileName": "repos/lazygit/pkg/logs/tail/logs_default.go",
       "checksums": [
         {
@@ -2597,7 +2162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktrees-context.go-210",
+      "SPDXID": "SPDXRef-File-worktrees-context.go-167",
       "fileName": "repos/lazygit/pkg/gui/context/worktrees_context.go",
       "checksums": [
         {
@@ -2607,7 +2172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-working-tree-state.go-211",
+      "SPDXID": "SPDXRef-File-working-tree-state.go-168",
       "fileName": "repos/lazygit/pkg/commands/models/working_tree_state.go",
       "checksums": [
         {
@@ -2617,17 +2182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dict.c-212",
-      "fileName": "repos/redis/src/dict.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3f60bd165e2a7f979bd60e9838eceb3e3d5056dd"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-status-manager.go-213",
+      "SPDXID": "SPDXRef-File-status-manager.go-169",
       "fileName": "repos/lazygit/pkg/gui/status/status_manager.go",
       "checksums": [
         {
@@ -2637,7 +2192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signal-handling.go-214",
+      "SPDXID": "SPDXRef-File-signal-handling.go-170",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/signal_handling.go",
       "checksums": [
         {
@@ -2647,7 +2202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit.go-215",
+      "SPDXID": "SPDXRef-File-commit.go-171",
       "fileName": "repos/lazygit/pkg/commands/git_commands/commit.go",
       "checksums": [
         {
@@ -2657,7 +2212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote.go-216",
+      "SPDXID": "SPDXRef-File-remote.go-172",
       "fileName": "repos/lazygit/pkg/commands/models/remote.go",
       "checksums": [
         {
@@ -2667,7 +2222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-host-helper.go-217",
+      "SPDXID": "SPDXRef-File-host-helper.go-173",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/host_helper.go",
       "checksums": [
         {
@@ -2677,17 +2232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-intset.h-218",
-      "fileName": "repos/redis/src/intset.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4259aaa7930400c70849761e13cad09d3b84841e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-suggestions.go-219",
+      "SPDXID": "SPDXRef-File-suggestions.go-174",
       "fileName": "repos/lazygit/pkg/gui/presentation/suggestions.go",
       "checksums": [
         {
@@ -2697,7 +2242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ref-range.go-220",
+      "SPDXID": "SPDXRef-File-ref-range.go-175",
       "fileName": "repos/lazygit/pkg/gui/types/ref_range.go",
       "checksums": [
         {
@@ -2707,7 +2252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-style.go-221",
+      "SPDXID": "SPDXRef-File-style.go-176",
       "fileName": "repos/lazygit/pkg/theme/style.go",
       "checksums": [
         {
@@ -2717,17 +2262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-release.h-222",
-      "fileName": "repos/redis/src/release.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "43fd0f1875e93b787f3eea9a6e8ba3347d8c91f6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-update-helper.go-223",
+      "SPDXID": "SPDXRef-File-update-helper.go-177",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/update_helper.go",
       "checksums": [
         {
@@ -2737,7 +2272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-text-style.go-224",
+      "SPDXID": "SPDXRef-File-text-style.go-178",
       "fileName": "repos/lazygit/pkg/gui/style/text_style.go",
       "checksums": [
         {
@@ -2747,7 +2282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options-map.go-225",
+      "SPDXID": "SPDXRef-File-options-map.go-179",
       "fileName": "repos/lazygit/pkg/gui/options_map.go",
       "checksums": [
         {
@@ -2757,17 +2292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lzf.h-226",
-      "fileName": "repos/redis/src/lzf.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "45ddfa8da05be7a7565e2bbe53f2a099f7a262e3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-views.go-227",
+      "SPDXID": "SPDXRef-File-views.go-180",
       "fileName": "repos/lazygit/pkg/gui/types/views.go",
       "checksums": [
         {
@@ -2777,7 +2302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-quit-actions.go-228",
+      "SPDXID": "SPDXRef-File-quit-actions.go-181",
       "fileName": "repos/lazygit/pkg/gui/controllers/quit_actions.go",
       "checksums": [
         {
@@ -2787,7 +2312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commits-helper.go-229",
+      "SPDXID": "SPDXRef-File-commits-helper.go-182",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/commits_helper.go",
       "checksums": [
         {
@@ -2797,17 +2322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.h-230",
-      "fileName": "repos/redis/src/config.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "47338554aaf3ca45c4b4b001ea43d1c35d599879"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-search-driver.go-231",
+      "SPDXID": "SPDXRef-File-search-driver.go-183",
       "fileName": "repos/lazygit/pkg/integration/components/search_driver.go",
       "checksums": [
         {
@@ -2817,7 +2332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-trait.go-232",
+      "SPDXID": "SPDXRef-File-search-trait.go-184",
       "fileName": "repos/lazygit/pkg/gui/context/search_trait.go",
       "checksums": [
         {
@@ -2827,7 +2342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remotes-context.go-233",
+      "SPDXID": "SPDXRef-File-remotes-context.go-185",
       "fileName": "repos/lazygit/pkg/gui/context/remotes_context.go",
       "checksums": [
         {
@@ -2837,27 +2352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-call-reply.h-234",
-      "fileName": "repos/redis/src/call_reply.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4ae7f3cf1fc9e2c424f747f8cd88aae948ef4766"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-script-lua.h-235",
-      "fileName": "repos/redis/src/script_lua.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4c2c3e9c281018d51ecdcfcb4efd075f012aac9a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-english.go-236",
+      "SPDXID": "SPDXRef-File-english.go-186",
       "fileName": "repos/lazygit/pkg/i18n/english.go",
       "checksums": [
         {
@@ -2867,7 +2362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-237",
+      "SPDXID": "SPDXRef-File-common.go-187",
       "fileName": "repos/lazygit/pkg/gui/types/common.go",
       "checksums": [
         {
@@ -2877,7 +2372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-helpers.go-238",
+      "SPDXID": "SPDXRef-File-helpers.go-188",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/helpers.go",
       "checksums": [
         {
@@ -2887,7 +2382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remotes.go-239",
+      "SPDXID": "SPDXRef-File-remotes.go-189",
       "fileName": "repos/lazygit/pkg/gui/presentation/remotes.go",
       "checksums": [
         {
@@ -2897,7 +2392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transform.go-240",
+      "SPDXID": "SPDXRef-File-transform.go-190",
       "fileName": "repos/lazygit/pkg/commands/patch/transform.go",
       "checksums": [
         {
@@ -2907,7 +2402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-int-matcher.go-241",
+      "SPDXID": "SPDXRef-File-int-matcher.go-191",
       "fileName": "repos/lazygit/pkg/integration/components/int_matcher.go",
       "checksums": [
         {
@@ -2917,17 +2412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bitops.c-242",
-      "fileName": "repos/redis/src/bitops.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4d33ff953ae75156b636c080e1ae369278a5e670"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch-building-controller.go-243",
+      "SPDXID": "SPDXRef-File-patch-building-controller.go-192",
       "fileName": "repos/lazygit/pkg/gui/controllers/patch_building_controller.go",
       "checksums": [
         {
@@ -2937,17 +2422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha1.c-244",
-      "fileName": "repos/redis/src/sha1.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4d8c14094d0ab217b14794029b81c27481c86b8b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branch.go-245",
+      "SPDXID": "SPDXRef-File-branch.go-193",
       "fileName": "repos/lazygit/pkg/commands/models/branch.go",
       "checksums": [
         {
@@ -2957,7 +2432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-cmd-obj-runner.go-246",
+      "SPDXID": "SPDXRef-File-fake-cmd-obj-runner.go-194",
       "fileName": "repos/lazygit/pkg/commands/oscommands/fake_cmd_obj_runner.go",
       "checksums": [
         {
@@ -2967,7 +2442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-controller-trait.go-247",
+      "SPDXID": "SPDXRef-File-list-controller-trait.go-195",
       "fileName": "repos/lazygit/pkg/gui/controllers/list_controller_trait.go",
       "checksums": [
         {
@@ -2977,17 +2452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-script.h-248",
-      "fileName": "repos/redis/src/script.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4f43c09d52217886d00ff96c3c7f4ca4c08de573"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-parent-context-mgr.go-249",
+      "SPDXID": "SPDXRef-File-parent-context-mgr.go-196",
       "fileName": "repos/lazygit/pkg/gui/context/parent_context_mgr.go",
       "checksums": [
         {
@@ -2997,7 +2462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-250",
+      "SPDXID": "SPDXRef-File-errors.go-197",
       "fileName": "repos/lazygit/pkg/app/errors.go",
       "checksums": [
         {
@@ -3007,17 +2472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-db.c-251",
-      "fileName": "repos/redis/src/db.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "508c342fb33a599a8a65db805792ccb78f20f8fc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-local-commits-controller.go-252",
+      "SPDXID": "SPDXRef-File-local-commits-controller.go-198",
       "fileName": "repos/lazygit/pkg/gui/controllers/local_commits_controller.go",
       "checksums": [
         {
@@ -3027,27 +2482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zipmap.c-253",
-      "fileName": "repos/redis/src/zipmap.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "51c64ca81274424d81c921651912ee69ea6018a3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-intset.c-254",
-      "fileName": "repos/redis/src/intset.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5216251eb52a5e5e0d9ff006710ffe1e7f323631"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-submodules-context.go-255",
+      "SPDXID": "SPDXRef-File-submodules-context.go-199",
       "fileName": "repos/lazygit/pkg/gui/context/submodules_context.go",
       "checksums": [
         {
@@ -3057,7 +2492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-branches-helper.go-256",
+      "SPDXID": "SPDXRef-File-branches-helper.go-200",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/branches_helper.go",
       "checksums": [
         {
@@ -3067,7 +2502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-staging-helper.go-257",
+      "SPDXID": "SPDXRef-File-staging-helper.go-201",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/staging_helper.go",
       "checksums": [
         {
@@ -3077,7 +2512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-i18n.go-258",
+      "SPDXID": "SPDXRef-File-i18n.go-202",
       "fileName": "repos/lazygit/pkg/i18n/i18n.go",
       "checksums": [
         {
@@ -3087,7 +2522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote-branches.go-259",
+      "SPDXID": "SPDXRef-File-remote-branches.go-203",
       "fileName": "repos/lazygit/pkg/gui/presentation/remote_branches.go",
       "checksums": [
         {
@@ -3097,27 +2532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lzfP.h-260",
-      "fileName": "repos/redis/src/lzfP.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "567f5a201918ab32ddc085b2f8e3f7c4fb7adf64"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-server.c-261",
-      "fileName": "repos/redis/src/server.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "56f2c9e93883af1c49a0ae5c72eb0c7911e199a9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-app-status-helper.go-262",
+      "SPDXID": "SPDXRef-File-app-status-helper.go-204",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/app_status_helper.go",
       "checksums": [
         {
@@ -3127,7 +2542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basic-styles.go-263",
+      "SPDXID": "SPDXRef-File-basic-styles.go-205",
       "fileName": "repos/lazygit/pkg/gui/style/basic_styles.go",
       "checksums": [
         {
@@ -3137,27 +2552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sdsalloc.h-264",
-      "fileName": "repos/redis/src/sdsalloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5a53d4de836ddc212b086333b8a76a3c1e1c3e10"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-pqsort.h-265",
-      "fileName": "repos/redis/src/pqsort.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5a87e55b085be30f51deefe48a6849322095e0da"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tasks.go-266",
+      "SPDXID": "SPDXRef-File-tasks.go-206",
       "fileName": "repos/lazygit/pkg/tasks/tasks.go",
       "checksums": [
         {
@@ -3167,27 +2562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-t-hash.c-267",
-      "fileName": "repos/redis/src/t_hash.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5dc6ea418444a79eee82a954be6d6e1b50683340"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-commands.c-268",
-      "fileName": "repos/redis/src/commands.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5dcfe1973899eb88d5bdd8c51e154151eb81f464"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-git-command-builder.go-269",
+      "SPDXID": "SPDXRef-File-git-command-builder.go-207",
       "fileName": "repos/lazygit/pkg/commands/git_commands/git_command_builder.go",
       "checksums": [
         {
@@ -3197,7 +2572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-extras-panel.go-270",
+      "SPDXID": "SPDXRef-File-extras-panel.go-208",
       "fileName": "repos/lazygit/pkg/gui/extras_panel.go",
       "checksums": [
         {
@@ -3207,17 +2582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rax.c-271",
-      "fileName": "repos/redis/src/rax.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5f3a8c17617b851ccc7023d66d3caf5a039819b2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-gocui.go-272",
+      "SPDXID": "SPDXRef-File-gocui.go-209",
       "fileName": "repos/lazygit/pkg/theme/gocui.go",
       "checksums": [
         {
@@ -3227,17 +2592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-replication.c-273",
-      "fileName": "repos/redis/src/replication.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5fab23b1c7cde1630082bb948648f133496dcd81"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-editor-presets.go-274",
+      "SPDXID": "SPDXRef-File-editor-presets.go-210",
       "fileName": "repos/lazygit/pkg/config/editor_presets.go",
       "checksums": [
         {
@@ -3247,27 +2602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rdb.h-275",
-      "fileName": "repos/redis/src/rdb.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "602b075c1dd3590cc239a3eff51704ed1acf78ea"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-threads-mngr.c-276",
-      "fileName": "repos/redis/src/threads_mngr.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "606f39c2fdf92949f97476c1caa9edcd7dd45ff7"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-updates.go-277",
+      "SPDXID": "SPDXRef-File-updates.go-211",
       "fileName": "repos/lazygit/pkg/updates/updates.go",
       "checksums": [
         {
@@ -3277,17 +2612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bio.h-278",
-      "fileName": "repos/redis/src/bio.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "615cf45b8ca2d79e496a5dd890fe7b7fdcbd2952"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-icons.go-279",
+      "SPDXID": "SPDXRef-File-icons.go-212",
       "fileName": "repos/lazygit/pkg/gui/presentation/icons/icons.go",
       "checksums": [
         {
@@ -3297,27 +2622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pqsort.c-280",
-      "fileName": "repos/redis/src/pqsort.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "62527170573de87c2cc1c60ca8b3fd3c75199696"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rand.c-281",
-      "fileName": "repos/redis/src/rand.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6256c3bc3c26c75cb995ee2172c5369229277abf"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-snake.go-282",
+      "SPDXID": "SPDXRef-File-snake.go-213",
       "fileName": "repos/lazygit/pkg/snake/snake.go",
       "checksums": [
         {
@@ -3327,7 +2632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflog-commits-context.go-283",
+      "SPDXID": "SPDXRef-File-reflog-commits-context.go-214",
       "fileName": "repos/lazygit/pkg/gui/context/reflog_commits_context.go",
       "checksums": [
         {
@@ -3337,7 +2642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-selection-controller.go-284",
+      "SPDXID": "SPDXRef-File-view-selection-controller.go-215",
       "fileName": "repos/lazygit/pkg/gui/controllers/view_selection_controller.go",
       "checksums": [
         {
@@ -3347,7 +2652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-async-handler.go-285",
+      "SPDXID": "SPDXRef-File-async-handler.go-216",
       "fileName": "repos/lazygit/pkg/tasks/async_handler.go",
       "checksums": [
         {
@@ -3357,17 +2662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-module.c-286",
-      "fileName": "repos/redis/src/module.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "65d77f2e0e8007383a82942f4bf60bef9e16b31c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-remote-branches-context.go-287",
+      "SPDXID": "SPDXRef-File-remote-branches-context.go-217",
       "fileName": "repos/lazygit/pkg/gui/context/remote_branches_context.go",
       "checksums": [
         {
@@ -3377,7 +2672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-types.go-288",
+      "SPDXID": "SPDXRef-File-types.go-218",
       "fileName": "repos/lazygit/pkg/app/types/types.go",
       "checksums": [
         {
@@ -3387,7 +2682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff-helper.go-289",
+      "SPDXID": "SPDXRef-File-diff-helper.go-219",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/diff_helper.go",
       "checksums": [
         {
@@ -3397,17 +2692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rax.h-290",
-      "fileName": "repos/redis/src/rax.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "66afe4085ef6f253b64cd42d6baac2ff8e89922e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-pty.go-291",
+      "SPDXID": "SPDXRef-File-pty.go-220",
       "fileName": "repos/lazygit/pkg/gui/pty.go",
       "checksums": [
         {
@@ -3417,7 +2702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-history-buffer.go-292",
+      "SPDXID": "SPDXRef-File-history-buffer.go-221",
       "fileName": "repos/lazygit/pkg/utils/history_buffer.go",
       "checksums": [
         {
@@ -3427,7 +2712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-helper.go-293",
+      "SPDXID": "SPDXRef-File-worktree-helper.go-222",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/worktree_helper.go",
       "checksums": [
         {
@@ -3437,7 +2722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commits.go-294",
+      "SPDXID": "SPDXRef-File-commits.go-223",
       "fileName": "repos/lazygit/pkg/gui/presentation/commits.go",
       "checksums": [
         {
@@ -3447,17 +2732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adlist.c-295",
-      "fileName": "repos/redis/src/adlist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "68a5d70f7c420c062bbd1eb8948ad241cb8d1299"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-confirmation-context.go-296",
+      "SPDXID": "SPDXRef-File-confirmation-context.go-224",
       "fileName": "repos/lazygit/pkg/gui/context/confirmation_context.go",
       "checksums": [
         {
@@ -3467,7 +2742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui-io.go-297",
+      "SPDXID": "SPDXRef-File-gui-io.go-225",
       "fileName": "repos/lazygit/pkg/commands/oscommands/gui_io.go",
       "checksums": [
         {
@@ -3477,7 +2752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tags-helper.go-298",
+      "SPDXID": "SPDXRef-File-tags-helper.go-226",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/tags_helper.go",
       "checksums": [
         {
@@ -3487,27 +2762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connection.c-299",
-      "fileName": "repos/redis/src/connection.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6ac1b99d9aec356e51cb18a2bcd9c292a3383d4e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ae-epoll.c-300",
-      "fileName": "repos/redis/src/ae_epoll.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6b916618bb7eec1be1eb7f39abcfda0988d57e6e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-bisect-helper.go-301",
+      "SPDXID": "SPDXRef-File-bisect-helper.go-227",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/bisect_helper.go",
       "checksums": [
         {
@@ -3517,7 +2772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hunk.go-302",
+      "SPDXID": "SPDXRef-File-hunk.go-228",
       "fileName": "repos/lazygit/pkg/commands/patch/hunk.go",
       "checksums": [
         {
@@ -3527,17 +2782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-monotonic.c-303",
-      "fileName": "repos/redis/src/monotonic.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6da03677bdac00f64666e770336d4e82a967debc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-list-controller.go-304",
+      "SPDXID": "SPDXRef-File-list-controller.go-229",
       "fileName": "repos/lazygit/pkg/gui/controllers/list_controller.go",
       "checksums": [
         {
@@ -3547,7 +2792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-conflicts-helper.go-305",
+      "SPDXID": "SPDXRef-File-merge-conflicts-helper.go-230",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/merge_conflicts_helper.go",
       "checksums": [
         {
@@ -3557,7 +2802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-test.go-306",
+      "SPDXID": "SPDXRef-File-test.go-231",
       "fileName": "repos/lazygit/pkg/integration/components/test.go",
       "checksums": [
         {
@@ -3567,7 +2812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ref.go-307",
+      "SPDXID": "SPDXRef-File-ref.go-232",
       "fileName": "repos/lazygit/pkg/commands/models/ref.go",
       "checksums": [
         {
@@ -3577,27 +2822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cluster-legacy.c-308",
-      "fileName": "repos/redis/src/cluster_legacy.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6f1635e9e5da171c1780a23f56d6bde0a2b21204"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-syscheck.h-309",
-      "fileName": "repos/redis/src/syscheck.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "6f324d151e8f8720cb624132e289b45dc970c2e9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-stash-controller.go-310",
+      "SPDXID": "SPDXRef-File-stash-controller.go-233",
       "fileName": "repos/lazygit/pkg/gui/controllers/stash_controller.go",
       "checksums": [
         {
@@ -3607,7 +2832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-controllers.go-311",
+      "SPDXID": "SPDXRef-File-controllers.go-234",
       "fileName": "repos/lazygit/pkg/gui/controllers.go",
       "checksums": [
         {
@@ -3617,7 +2842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rendering.go-312",
+      "SPDXID": "SPDXRef-File-rendering.go-235",
       "fileName": "repos/lazygit/pkg/gui/types/rendering.go",
       "checksums": [
         {
@@ -3627,27 +2852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adlist.h-313",
-      "fileName": "repos/redis/src/adlist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "712c03fd71ec074fe5c0976df6eaa4031ae1b761"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ziplist.c-314",
-      "fileName": "repos/redis/src/ziplist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "712d259a942945260ea06cdd8867d88945c6a897"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-suggestions-controller.go-315",
+      "SPDXID": "SPDXRef-File-suggestions-controller.go-236",
       "fileName": "repos/lazygit/pkg/gui/controllers/suggestions_controller.go",
       "checksums": [
         {
@@ -3657,7 +2862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main-context.go-316",
+      "SPDXID": "SPDXRef-File-main-context.go-237",
       "fileName": "repos/lazygit/pkg/gui/context/main_context.go",
       "checksums": [
         {
@@ -3667,7 +2872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmd-obj-runner-default.go-317",
+      "SPDXID": "SPDXRef-File-cmd-obj-runner-default.go-238",
       "fileName": "repos/lazygit/pkg/commands/oscommands/cmd_obj_runner_default.go",
       "checksums": [
         {
@@ -3677,17 +2882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ae.c-318",
-      "fileName": "repos/redis/src/ae.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "733c88d52d3105e31c0460490b19d3e22f0df70b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-get-key.go-319",
+      "SPDXID": "SPDXRef-File-get-key.go-239",
       "fileName": "repos/lazygit/pkg/commands/git_config/get_key.go",
       "checksums": [
         {
@@ -3697,17 +2892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-asciilogo.h-320",
-      "fileName": "repos/redis/src/asciilogo.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "73a99777835544022b224021c609597418de7c32"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file-tree-view-model.go-321",
+      "SPDXID": "SPDXRef-File-file-tree-view-model.go-240",
       "fileName": "repos/lazygit/pkg/gui/filetree/file_tree_view_model.go",
       "checksums": [
         {
@@ -3717,7 +2902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common-commands.go-322",
+      "SPDXID": "SPDXRef-File-common-commands.go-241",
       "fileName": "repos/lazygit/pkg/gui/types/common_commands.go",
       "checksums": [
         {
@@ -3727,7 +2912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git-cmd-obj-builder.go-323",
+      "SPDXID": "SPDXRef-File-git-cmd-obj-builder.go-242",
       "fileName": "repos/lazygit/pkg/commands/git_cmd_obj_builder.go",
       "checksums": [
         {
@@ -3737,17 +2922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vset.c-324",
-      "fileName": "repos/redis/src/../modules/vector-sets/vset.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "75de692562ff060978a028a3a8c220d6029eb514"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-information-panel.go-325",
+      "SPDXID": "SPDXRef-File-information-panel.go-243",
       "fileName": "repos/lazygit/pkg/gui/information_panel.go",
       "checksums": [
         {
@@ -3757,7 +2932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybindings.go-326",
+      "SPDXID": "SPDXRef-File-keybindings.go-244",
       "fileName": "repos/lazygit/pkg/gui/keybindings/keybindings.go",
       "checksums": [
         {
@@ -3767,7 +2942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lines.go-327",
+      "SPDXID": "SPDXRef-File-lines.go-245",
       "fileName": "repos/lazygit/pkg/utils/lines.go",
       "checksums": [
         {
@@ -3777,67 +2952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sparkline.h-328",
-      "fileName": "repos/redis/src/sparkline.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7769fdb852f362b2246ca3d3df907f8c265c2c12"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-object.c-329",
-      "fileName": "repos/redis/src/object.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "779a2b0142e174fb6167bae71fa43c276d0acbc2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-debug.c-330",
-      "fileName": "repos/redis/src/debug.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "77a4cf78cc397df8ece6771b220109181a518caf"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-setcpuaffinity.c-331",
-      "fileName": "repos/redis/src/setcpuaffinity.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "77b162103ec2714f5a937a030872e3b820969159"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-function-lua.c-332",
-      "fileName": "repos/redis/src/function_lua.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "785f825f354a869022731f58ce317117ba366b68"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fastjson.c-333",
-      "fileName": "repos/redis/src/../modules/vector-sets/fastjson.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "78926e256f8b2cca384d367fc6f819211b879633"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch-line.go-334",
+      "SPDXID": "SPDXRef-File-patch-line.go-246",
       "fileName": "repos/lazygit/pkg/commands/patch/patch_line.go",
       "checksums": [
         {
@@ -3847,7 +2962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context.go-335",
+      "SPDXID": "SPDXRef-File-context.go-247",
       "fileName": "repos/lazygit/pkg/gui/types/context.go",
       "checksums": [
         {
@@ -3857,7 +2972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-confirmation-driver.go-336",
+      "SPDXID": "SPDXRef-File-confirmation-driver.go-248",
       "fileName": "repos/lazygit/pkg/integration/components/confirmation_driver.go",
       "checksums": [
         {
@@ -3867,17 +2982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-geo.h-337",
-      "fileName": "repos/redis/src/geo.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "79d0a6a4aa27040754aa42821113c803951b5086"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branches.go-338",
+      "SPDXID": "SPDXRef-File-branches.go-249",
       "fileName": "repos/lazygit/pkg/gui/presentation/branches.go",
       "checksums": [
         {
@@ -3887,17 +2992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-expire.c-339",
-      "fileName": "repos/redis/src/expire.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7a5cdce81b783f9121f62a85ccd9945d566cec54"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-working-tree.go-340",
+      "SPDXID": "SPDXRef-File-working-tree.go-250",
       "fileName": "repos/lazygit/pkg/commands/git_commands/working_tree.go",
       "checksums": [
         {
@@ -3907,7 +3002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-layout.go-341",
+      "SPDXID": "SPDXRef-File-layout.go-251",
       "fileName": "repos/lazygit/pkg/gui/layout.go",
       "checksums": [
         {
@@ -3917,7 +3012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base-context.go-342",
+      "SPDXID": "SPDXRef-File-base-context.go-252",
       "fileName": "repos/lazygit/pkg/gui/context/base_context.go",
       "checksums": [
         {
@@ -3927,17 +3022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lzf-c.c-343",
-      "fileName": "repos/redis/src/lzf_c.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7cbbc82fa4674ff2d09f8ef012af9f6d20de70ae"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-authors.go-344",
+      "SPDXID": "SPDXRef-File-authors.go-253",
       "fileName": "repos/lazygit/pkg/gui/presentation/authors/authors.go",
       "checksums": [
         {
@@ -3947,7 +3032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-and-rebase-helper.go-345",
+      "SPDXID": "SPDXRef-File-merge-and-rebase-helper.go-254",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/merge_and_rebase_helper.go",
       "checksums": [
         {
@@ -3957,7 +3042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commits-files-controller.go-346",
+      "SPDXID": "SPDXRef-File-commits-files-controller.go-255",
       "fileName": "repos/lazygit/pkg/gui/controllers/commits_files_controller.go",
       "checksums": [
         {
@@ -3967,7 +3052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodule-config.go-347",
+      "SPDXID": "SPDXRef-File-submodule-config.go-256",
       "fileName": "repos/lazygit/pkg/commands/models/submodule_config.go",
       "checksums": [
         {
@@ -3977,7 +3062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sub-commits-context.go-348",
+      "SPDXID": "SPDXRef-File-sub-commits-context.go-257",
       "fileName": "repos/lazygit/pkg/gui/context/sub_commits_context.go",
       "checksums": [
         {
@@ -3987,7 +3072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-349",
+      "SPDXID": "SPDXRef-File-utils.go-258",
       "fileName": "repos/lazygit/pkg/utils/utils.go",
       "checksums": [
         {
@@ -3997,7 +3082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logs.go-350",
+      "SPDXID": "SPDXRef-File-logs.go-259",
       "fileName": "repos/lazygit/pkg/logs/logs.go",
       "checksums": [
         {
@@ -4007,27 +3092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sds.c-351",
-      "fileName": "repos/redis/src/sds.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7f1429c46b869f38a67712b7b10269680c5d2754"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-quicklist.c-352",
-      "fileName": "repos/redis/src/quicklist.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "81bc706468eb17d9493687c126e35b37f91fa3c9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-files-helper.go-353",
+      "SPDXID": "SPDXRef-File-files-helper.go-260",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/files_helper.go",
       "checksums": [
         {
@@ -4037,7 +3102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-app-config.go-354",
+      "SPDXID": "SPDXRef-File-app-config.go-261",
       "fileName": "repos/lazygit/pkg/config/app_config.go",
       "checksums": [
         {
@@ -4047,7 +3112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-workspace-reset-controller.go-355",
+      "SPDXID": "SPDXRef-File-workspace-reset-controller.go-262",
       "fileName": "repos/lazygit/pkg/gui/controllers/workspace_reset_controller.go",
       "checksums": [
         {
@@ -4057,17 +3122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-functions.c-356",
-      "fileName": "repos/redis/src/functions.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "82ab2e09ce0162b94f9a2460b9a5e9ed2c4a5ca4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-common.go-357",
+      "SPDXID": "SPDXRef-File-common.go-263",
       "fileName": "repos/lazygit/pkg/common/common.go",
       "checksums": [
         {
@@ -4077,7 +3132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-runner.go-358",
+      "SPDXID": "SPDXRef-File-runner.go-264",
       "fileName": "repos/lazygit/pkg/integration/components/runner.go",
       "checksums": [
         {
@@ -4087,7 +3142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context-config.go-359",
+      "SPDXID": "SPDXRef-File-context-config.go-265",
       "fileName": "repos/lazygit/pkg/gui/context_config.go",
       "checksums": [
         {
@@ -4097,17 +3152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut.c-360",
-      "fileName": "repos/redis/src/lolwut.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8467c7803bb1dc3a79192a09179a0c0d59744b0b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-snake-helper.go-361",
+      "SPDXID": "SPDXRef-File-snake-helper.go-266",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/snake_helper.go",
       "checksums": [
         {
@@ -4117,17 +3162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blocked.c-362",
-      "fileName": "repos/redis/src/blocked.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "86cff0b7facdd3ee3dc7be4692a0e3518e1040a3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tag.go-363",
+      "SPDXID": "SPDXRef-File-tag.go-267",
       "fileName": "repos/lazygit/pkg/commands/models/tag.go",
       "checksums": [
         {
@@ -4137,7 +3172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sub-commits-controller.go-364",
+      "SPDXID": "SPDXRef-File-sub-commits-controller.go-268",
       "fileName": "repos/lazygit/pkg/gui/controllers/sub_commits_controller.go",
       "checksums": [
         {
@@ -4147,17 +3182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hnsw.h-365",
-      "fileName": "repos/redis/src/../modules/vector-sets/hnsw.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8935521a63ff31441bda8e4ca704306212946ca1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-context.go-366",
+      "SPDXID": "SPDXRef-File-context.go-269",
       "fileName": "repos/lazygit/pkg/gui/context/context.go",
       "checksums": [
         {
@@ -4167,7 +3192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filter-controller.go-367",
+      "SPDXID": "SPDXRef-File-filter-controller.go-270",
       "fileName": "repos/lazygit/pkg/gui/controllers/filter_controller.go",
       "checksums": [
         {
@@ -4177,7 +3202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-loader.go-368",
+      "SPDXID": "SPDXRef-File-commit-loader.go-271",
       "fileName": "repos/lazygit/pkg/commands/git_commands/commit_loader.go",
       "checksums": [
         {
@@ -4187,17 +3212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-resp-parser.c-369",
-      "fileName": "repos/redis/src/resp_parser.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8c0f17d394b1cd624a6755231af78cb3912bcb34"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-attach.go-370",
+      "SPDXID": "SPDXRef-File-attach.go-272",
       "fileName": "repos/lazygit/pkg/gui/controllers/attach.go",
       "checksums": [
         {
@@ -4207,7 +3222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-files-controller.go-371",
+      "SPDXID": "SPDXRef-File-files-controller.go-273",
       "fileName": "repos/lazygit/pkg/gui/controllers/files_controller.go",
       "checksums": [
         {
@@ -4217,27 +3232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connhelpers.h-372",
-      "fileName": "repos/redis/src/connhelpers.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8d6f4b90c0715a7d6a49a6f71797beb32a745ed0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-crccombine.h-373",
-      "fileName": "repos/redis/src/crccombine.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "8da7c5fe6ace5ee22f35c611af37788f99da567f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file-icons.go-374",
+      "SPDXID": "SPDXRef-File-file-icons.go-274",
       "fileName": "repos/lazygit/pkg/gui/presentation/icons/file_icons.go",
       "checksums": [
         {
@@ -4247,7 +3242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-setup.go-375",
+      "SPDXID": "SPDXRef-File-setup.go-275",
       "fileName": "repos/lazygit/pkg/gui/context/setup.go",
       "checksums": [
         {
@@ -4257,7 +3252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-description-panel-driver.go-376",
+      "SPDXID": "SPDXRef-File-commit-description-panel-driver.go-276",
       "fileName": "repos/lazygit/pkg/integration/components/commit_description_panel_driver.go",
       "checksums": [
         {
@@ -4267,7 +3262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git.go-377",
+      "SPDXID": "SPDXRef-File-git.go-277",
       "fileName": "repos/lazygit/pkg/commands/git.go",
       "checksums": [
         {
@@ -4277,7 +3272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file.go-378",
+      "SPDXID": "SPDXRef-File-commit-file.go-278",
       "fileName": "repos/lazygit/pkg/commands/models/commit_file.go",
       "checksums": [
         {
@@ -4287,27 +3282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut.h-379",
-      "fileName": "repos/redis/src/lolwut.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "914db0d7e50bb907a878e0fbd01b88066d2609db"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-aof.c-380",
-      "fileName": "repos/redis/src/aof.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "91a21617b263d942f6b418d8308067cd6238d362"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-build-tree.go-381",
+      "SPDXID": "SPDXRef-File-build-tree.go-279",
       "fileName": "repos/lazygit/pkg/gui/filetree/build_tree.go",
       "checksums": [
         {
@@ -4317,7 +3292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-switch-to-sub-commits-controller.go-382",
+      "SPDXID": "SPDXRef-File-switch-to-sub-commits-controller.go-280",
       "fileName": "repos/lazygit/pkg/gui/controllers/switch_to_sub_commits_controller.go",
       "checksums": [
         {
@@ -4327,7 +3302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybindings.go-383",
+      "SPDXID": "SPDXRef-File-keybindings.go-281",
       "fileName": "repos/lazygit/pkg/gui/types/keybindings.go",
       "checksums": [
         {
@@ -4337,7 +3312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context-common.go-384",
+      "SPDXID": "SPDXRef-File-context-common.go-282",
       "fileName": "repos/lazygit/pkg/gui/context/context_common.go",
       "checksums": [
         {
@@ -4347,17 +3322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-latency.h-385",
-      "fileName": "repos/redis/src/latency.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "945004a484c853b2e9f92314e712c6d518593506"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dummies.go-386",
+      "SPDXID": "SPDXRef-File-dummies.go-283",
       "fileName": "repos/lazygit/pkg/commands/oscommands/dummies.go",
       "checksums": [
         {
@@ -4367,7 +3332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-working-tree-helper.go-387",
+      "SPDXID": "SPDXRef-File-working-tree-helper.go-284",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/working_tree_helper.go",
       "checksums": [
         {
@@ -4377,7 +3342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-menu-generator.go-388",
+      "SPDXID": "SPDXRef-File-menu-generator.go-285",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/menu_generator.go",
       "checksums": [
         {
@@ -4387,17 +3352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-childinfo.c-389",
-      "fileName": "repos/redis/src/childinfo.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "95cbbbb1c0606646cfaf46bf9c1378d3b1092799"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-menu-driver.go-390",
+      "SPDXID": "SPDXRef-File-menu-driver.go-286",
       "fileName": "repos/lazygit/pkg/integration/components/menu_driver.go",
       "checksums": [
         {
@@ -4407,17 +3362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cluster.h-391",
-      "fileName": "repos/redis/src/cluster.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9710e5d92e41e85b9cae632b6af867140cfd4ff1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dummies.go-392",
+      "SPDXID": "SPDXRef-File-dummies.go-287",
       "fileName": "repos/lazygit/pkg/gui/dummies.go",
       "checksums": [
         {
@@ -4427,7 +3372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-suggestions-context.go-393",
+      "SPDXID": "SPDXRef-File-suggestions-context.go-288",
       "fileName": "repos/lazygit/pkg/gui/context/suggestions_context.go",
       "checksums": [
         {
@@ -4437,7 +3382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rebase.go-394",
+      "SPDXID": "SPDXRef-File-rebase.go-289",
       "fileName": "repos/lazygit/pkg/commands/git_commands/rebase.go",
       "checksums": [
         {
@@ -4447,7 +3392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-node.go-395",
+      "SPDXID": "SPDXRef-File-node.go-290",
       "fileName": "repos/lazygit/pkg/gui/filetree/node.go",
       "checksums": [
         {
@@ -4457,17 +3402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logreqres.c-396",
-      "fileName": "repos/redis/src/logreqres.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "97d594823f2f538691d212cb21fddf2b0a9e03b5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-file-tree.go-397",
+      "SPDXID": "SPDXRef-File-file-tree.go-291",
       "fileName": "repos/lazygit/pkg/gui/filetree/file_tree.go",
       "checksums": [
         {
@@ -4477,7 +3412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree.go-398",
+      "SPDXID": "SPDXRef-File-worktree.go-292",
       "fileName": "repos/lazygit/pkg/commands/git_commands/worktree.go",
       "checksums": [
         {
@@ -4487,7 +3422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-context-trait.go-399",
+      "SPDXID": "SPDXRef-File-list-context-trait.go-293",
       "fileName": "repos/lazygit/pkg/gui/context/list_context_trait.go",
       "checksums": [
         {
@@ -4497,7 +3432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-string-pool.go-400",
+      "SPDXID": "SPDXRef-File-string-pool.go-294",
       "fileName": "repos/lazygit/pkg/utils/string_pool.go",
       "checksums": [
         {
@@ -4507,17 +3442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ae.h-401",
-      "fileName": "repos/redis/src/ae.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "996d48b0f838e771a3751bde522c7bbea773006e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-bisect-controller.go-402",
+      "SPDXID": "SPDXRef-File-bisect-controller.go-295",
       "fileName": "repos/lazygit/pkg/gui/controllers/bisect_controller.go",
       "checksums": [
         {
@@ -4527,7 +3452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-credentials-helper.go-403",
+      "SPDXID": "SPDXRef-File-credentials-helper.go-296",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/credentials_helper.go",
       "checksums": [
         {
@@ -4537,7 +3462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-helper.go-404",
+      "SPDXID": "SPDXRef-File-search-helper.go-297",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/search_helper.go",
       "checksums": [
         {
@@ -4547,7 +3472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-global-handlers.go-405",
+      "SPDXID": "SPDXRef-File-global-handlers.go-298",
       "fileName": "repos/lazygit/pkg/gui/global_handlers.go",
       "checksums": [
         {
@@ -4557,7 +3482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-conflict.go-406",
+      "SPDXID": "SPDXRef-File-merge-conflict.go-299",
       "fileName": "repos/lazygit/pkg/gui/mergeconflicts/merge_conflict.go",
       "checksums": [
         {
@@ -4567,27 +3492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-expr.c-407",
-      "fileName": "repos/redis/src/../modules/vector-sets/expr.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9be54eb261c1d21f1de57bbe46830239a3111a35"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-siphash.c-408",
-      "fileName": "repos/redis/src/siphash.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9c3e6ce9e197c9234621dfff4ce64c93c67b57bd"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-types.go-409",
+      "SPDXID": "SPDXRef-File-types.go-300",
       "fileName": "repos/lazygit/pkg/integration/types/types.go",
       "checksums": [
         {
@@ -4597,27 +3502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-threads-mngr.h-410",
-      "fileName": "repos/redis/src/threads_mngr.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9c585c0bd1a0e3079e7db0898d4a66ac4a208c86"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rio.h-411",
-      "fileName": "repos/redis/src/rio.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9cd24cdab62f6c3f9306eb85da28d8593c17c9b8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-date.go-412",
+      "SPDXID": "SPDXRef-File-date.go-301",
       "fileName": "repos/lazygit/pkg/utils/date.go",
       "checksums": [
         {
@@ -4627,7 +3512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-prompt-controller.go-413",
+      "SPDXID": "SPDXRef-File-search-prompt-controller.go-302",
       "fileName": "repos/lazygit/pkg/gui/controllers/search_prompt_controller.go",
       "checksums": [
         {
@@ -4637,7 +3522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybindings.go-414",
+      "SPDXID": "SPDXRef-File-keybindings.go-303",
       "fileName": "repos/lazygit/pkg/gui/keybindings.go",
       "checksums": [
         {
@@ -4647,17 +3532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tls.c-415",
-      "fileName": "repos/redis/src/tls.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a0733a4b636a2be7ad3beb0f905dcb9b6d05b088"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-screen-mode-actions.go-416",
+      "SPDXID": "SPDXRef-File-screen-mode-actions.go-304",
       "fileName": "repos/lazygit/pkg/gui/controllers/screen_mode_actions.go",
       "checksums": [
         {
@@ -4667,27 +3542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mt19937-64.c-417",
-      "fileName": "repos/redis/src/mt19937-64.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a0c897ff6ddb0770df1949a46fd89d468f00c9b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sha256.h-418",
-      "fileName": "repos/redis/src/sha256.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a0d90a714f0df241c39358f326900c297ea0ad5f"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-handler-creator.go-419",
+      "SPDXID": "SPDXRef-File-handler-creator.go-305",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/handler_creator.go",
       "checksums": [
         {
@@ -4697,7 +3552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-modes.go-420",
+      "SPDXID": "SPDXRef-File-modes.go-306",
       "fileName": "repos/lazygit/pkg/gui/types/modes.go",
       "checksums": [
         {
@@ -4707,7 +3562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-test-driver.go-421",
+      "SPDXID": "SPDXRef-File-test-driver.go-307",
       "fileName": "repos/lazygit/pkg/integration/components/test_driver.go",
       "checksums": [
         {
@@ -4717,17 +3572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-networking.c-422",
-      "fileName": "repos/redis/src/networking.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a18c6815333de1682676d837f7b0456522a549d0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-toggle-whitespace-action.go-423",
+      "SPDXID": "SPDXRef-File-toggle-whitespace-action.go-308",
       "fileName": "repos/lazygit/pkg/gui/controllers/toggle_whitespace_action.go",
       "checksums": [
         {
@@ -4737,7 +3582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context-lines-controller.go-424",
+      "SPDXID": "SPDXRef-File-context-lines-controller.go-309",
       "fileName": "repos/lazygit/pkg/gui/controllers/context_lines_controller.go",
       "checksums": [
         {
@@ -4747,7 +3592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stash-loader.go-425",
+      "SPDXID": "SPDXRef-File-stash-loader.go-310",
       "fileName": "repos/lazygit/pkg/commands/git_commands/stash_loader.go",
       "checksums": [
         {
@@ -4757,7 +3602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-snake-controller.go-426",
+      "SPDXID": "SPDXRef-File-snake-controller.go-311",
       "fileName": "repos/lazygit/pkg/gui/controllers/snake_controller.go",
       "checksums": [
         {
@@ -4767,17 +3612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zipmap.h-427",
-      "fileName": "repos/redis/src/zipmap.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a3e7aea34fc27632c6b588234d180850094bd117"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branch-loader.go-428",
+      "SPDXID": "SPDXRef-File-branch-loader.go-312",
       "fileName": "repos/lazygit/pkg/commands/git_commands/branch_loader.go",
       "checksums": [
         {
@@ -4787,17 +3622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tracking.c-429",
-      "fileName": "repos/redis/src/tracking.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a50b512326e0d7f739998b8a37f2cb8d45eab414"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branch.go-430",
+      "SPDXID": "SPDXRef-File-branch.go-313",
       "fileName": "repos/lazygit/pkg/commands/git_commands/branch.go",
       "checksums": [
         {
@@ -4807,27 +3632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cli-common.h-431",
-      "fileName": "repos/redis/src/cli_common.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a5b8e44a28cc1528dd27290e73355144f9459454"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sha1.h-432",
-      "fileName": "repos/redis/src/sha1.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a6cb6e885787bae370b4e03cc4fa6b20dee27274"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-thread-safe-map.go-433",
+      "SPDXID": "SPDXRef-File-thread-safe-map.go-314",
       "fileName": "repos/lazygit/pkg/utils/thread_safe_map.go",
       "checksums": [
         {
@@ -4837,7 +3642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-local-commits-context.go-434",
+      "SPDXID": "SPDXRef-File-local-commits-context.go-315",
       "fileName": "repos/lazygit/pkg/gui/context/local_commits_context.go",
       "checksums": [
         {
@@ -4847,7 +3652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-435",
+      "SPDXID": "SPDXRef-File-config.go-316",
       "fileName": "repos/lazygit/pkg/commands/git_commands/config.go",
       "checksums": [
         {
@@ -4857,7 +3662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diffing.go-436",
+      "SPDXID": "SPDXRef-File-diffing.go-317",
       "fileName": "repos/lazygit/pkg/gui/modes/diffing/diffing.go",
       "checksums": [
         {
@@ -4867,7 +3672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config-linux.go-437",
+      "SPDXID": "SPDXRef-File-config-linux.go-318",
       "fileName": "repos/lazygit/pkg/config/config_linux.go",
       "checksums": [
         {
@@ -4877,7 +3682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version.go-438",
+      "SPDXID": "SPDXRef-File-version.go-319",
       "fileName": "repos/lazygit/pkg/commands/git_commands/version.go",
       "checksums": [
         {
@@ -4887,7 +3692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blame.go-439",
+      "SPDXID": "SPDXRef-File-blame.go-320",
       "fileName": "repos/lazygit/pkg/commands/git_commands/blame.go",
       "checksums": [
         {
@@ -4897,7 +3702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-theme.go-440",
+      "SPDXID": "SPDXRef-File-theme.go-321",
       "fileName": "repos/lazygit/pkg/theme/theme.go",
       "checksums": [
         {
@@ -4907,7 +3712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filtering.go-441",
+      "SPDXID": "SPDXRef-File-filtering.go-322",
       "fileName": "repos/lazygit/pkg/gui/modes/filtering/filtering.go",
       "checksums": [
         {
@@ -4917,7 +3722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-marked-base-commit.go-442",
+      "SPDXID": "SPDXRef-File-marked-base-commit.go-323",
       "fileName": "repos/lazygit/pkg/gui/modes/marked_base_commit/marked_base_commit.go",
       "checksums": [
         {
@@ -4927,7 +3732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version-number.go-443",
+      "SPDXID": "SPDXRef-File-version-number.go-324",
       "fileName": "repos/lazygit/pkg/gui/types/version_number.go",
       "checksums": [
         {
@@ -4937,17 +3742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-testhelp.h-444",
-      "fileName": "repos/redis/src/testhelp.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "aeae372dd6c16e66813bc4779535231c411e67a8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-once-writer.go-445",
+      "SPDXID": "SPDXRef-File-once-writer.go-325",
       "fileName": "repos/lazygit/pkg/utils/once_writer.go",
       "checksums": [
         {
@@ -4957,7 +3752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-search-state.go-446",
+      "SPDXID": "SPDXRef-File-search-state.go-326",
       "fileName": "repos/lazygit/pkg/gui/types/search_state.go",
       "checksums": [
         {
@@ -4967,7 +3762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gpg-helper.go-447",
+      "SPDXID": "SPDXRef-File-gpg-helper.go-327",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/gpg_helper.go",
       "checksums": [
         {
@@ -4977,7 +3772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-format.go-448",
+      "SPDXID": "SPDXRef-File-format.go-328",
       "fileName": "repos/lazygit/pkg/commands/patch/format.go",
       "checksums": [
         {
@@ -4987,7 +3782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-menu-panel.go-449",
+      "SPDXID": "SPDXRef-File-menu-panel.go-329",
       "fileName": "repos/lazygit/pkg/gui/menu_panel.go",
       "checksums": [
         {
@@ -4997,7 +3792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tail.go-450",
+      "SPDXID": "SPDXRef-File-tail.go-330",
       "fileName": "repos/lazygit/pkg/logs/tail/tail.go",
       "checksums": [
         {
@@ -5007,7 +3802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-session-state-loader.go-451",
+      "SPDXID": "SPDXRef-File-session-state-loader.go-331",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/session_state_loader.go",
       "checksums": [
         {
@@ -5017,17 +3812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ebuckets.c-452",
-      "fileName": "repos/redis/src/ebuckets.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b2c955b3f4964f53923472e4bdc392e074ee7a0a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-worktrees.go-453",
+      "SPDXID": "SPDXRef-File-worktrees.go-332",
       "fileName": "repos/lazygit/pkg/gui/presentation/worktrees.go",
       "checksums": [
         {
@@ -5037,17 +3822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zmalloc.c-454",
-      "fileName": "repos/redis/src/zmalloc.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b2f57184fbf9d5a25671621cd872bdbe24f10908"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-item-operations.go-455",
+      "SPDXID": "SPDXRef-File-item-operations.go-333",
       "fileName": "repos/lazygit/pkg/gui/presentation/item_operations.go",
       "checksums": [
         {
@@ -5057,27 +3832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-monotonic.h-456",
-      "fileName": "repos/redis/src/monotonic.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b465f90b10937f11a1e625c5e65de35519017af8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-dict.h-457",
-      "fileName": "repos/redis/src/dict.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b4bf581b90fa1c4f87014434271b32058fe66cba"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-decoration.go-458",
+      "SPDXID": "SPDXRef-File-decoration.go-334",
       "fileName": "repos/lazygit/pkg/gui/style/decoration.go",
       "checksums": [
         {
@@ -5087,7 +3842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-status.go-459",
+      "SPDXID": "SPDXRef-File-status.go-335",
       "fileName": "repos/lazygit/pkg/gui/presentation/status.go",
       "checksums": [
         {
@@ -5097,7 +3852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflog-commits.go-460",
+      "SPDXID": "SPDXRef-File-reflog-commits.go-336",
       "fileName": "repos/lazygit/pkg/gui/presentation/reflog_commits.go",
       "checksums": [
         {
@@ -5107,7 +3862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktrees-controller.go-461",
+      "SPDXID": "SPDXRef-File-worktrees-controller.go-337",
       "fileName": "repos/lazygit/pkg/gui/controllers/worktrees_controller.go",
       "checksums": [
         {
@@ -5117,7 +3872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vertical-scroll-controller.go-462",
+      "SPDXID": "SPDXRef-File-vertical-scroll-controller.go-338",
       "fileName": "repos/lazygit/pkg/gui/controllers/vertical_scroll_controller.go",
       "checksums": [
         {
@@ -5127,7 +3882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-paths.go-463",
+      "SPDXID": "SPDXRef-File-paths.go-339",
       "fileName": "repos/lazygit/pkg/integration/components/paths.go",
       "checksums": [
         {
@@ -5137,7 +3892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-helpers.go-464",
+      "SPDXID": "SPDXRef-File-view-helpers.go-340",
       "fileName": "repos/lazygit/pkg/gui/view_helpers.go",
       "checksums": [
         {
@@ -5147,7 +3902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmd-obj-runner.go-465",
+      "SPDXID": "SPDXRef-File-cmd-obj-runner.go-341",
       "fileName": "repos/lazygit/pkg/commands/oscommands/cmd_obj_runner.go",
       "checksums": [
         {
@@ -5157,37 +3912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mt19937-64.h-466",
-      "fileName": "repos/redis/src/mt19937-64.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "b98348fd4ffa24859c144b5973961592cde6f699"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-geohash-helper.c-467",
-      "fileName": "repos/redis/src/geohash_helper.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ba3732689214507ef25cec84690848d8e3eca70b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-util.c-468",
-      "fileName": "repos/redis/src/util.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ba3d9d072d6e43fe1a87fd2afceb7fd333cf8bd6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-views.go-469",
+      "SPDXID": "SPDXRef-File-views.go-342",
       "fileName": "repos/lazygit/pkg/gui/views.go",
       "checksums": [
         {
@@ -5197,7 +3922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-recent-repos-panel.go-470",
+      "SPDXID": "SPDXRef-File-recent-repos-panel.go-343",
       "fileName": "repos/lazygit/pkg/gui/recent_repos_panel.go",
       "checksums": [
         {
@@ -5207,17 +3932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mstr.h-471",
-      "fileName": "repos/redis/src/mstr.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bb8f9c1cfdbb316b7b5835941d655772b8124e94"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-keynames.go-472",
+      "SPDXID": "SPDXRef-File-keynames.go-344",
       "fileName": "repos/lazygit/pkg/config/keynames.go",
       "checksums": [
         {
@@ -5227,27 +3942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redis-cli.c-473",
-      "fileName": "repos/redis/src/redis-cli.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bbaabca52bac60ac00d7aca838a8c4da7b6e745e"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-zmalloc.h-474",
-      "fileName": "repos/redis/src/zmalloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bbb74a0deb1f49bf3aeb95360c6ab5a71ccbd558"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tag-loader.go-475",
+      "SPDXID": "SPDXRef-File-tag-loader.go-345",
       "fileName": "repos/lazygit/pkg/commands/git_commands/tag_loader.go",
       "checksums": [
         {
@@ -5257,17 +3952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rio.c-476",
-      "fileName": "repos/redis/src/rio.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bdab6d8c9c6b0a24f8de38a9b03b77d2c6423972"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cell.go-477",
+      "SPDXID": "SPDXRef-File-cell.go-346",
       "fileName": "repos/lazygit/pkg/gui/presentation/graph/cell.go",
       "checksums": [
         {
@@ -5277,17 +3962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pubsub.c-478",
-      "fileName": "repos/redis/src/pubsub.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "be82ced35660dacd980c4a34074b7ccd46683da3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-basic-commits-controller.go-479",
+      "SPDXID": "SPDXRef-File-basic-commits-controller.go-347",
       "fileName": "repos/lazygit/pkg/gui/controllers/basic_commits_controller.go",
       "checksums": [
         {
@@ -5297,7 +3972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file-node.go-480",
+      "SPDXID": "SPDXRef-File-commit-file-node.go-348",
       "fileName": "repos/lazygit/pkg/gui/filetree/commit_file_node.go",
       "checksums": [
         {
@@ -5307,7 +3982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file-tree.go-481",
+      "SPDXID": "SPDXRef-File-commit-file-tree.go-349",
       "fileName": "repos/lazygit/pkg/gui/filetree/commit_file_tree.go",
       "checksums": [
         {
@@ -5317,37 +3992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sentinel.c-482",
-      "fileName": "repos/redis/src/sentinel.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "bf749e9b4c19595e4ed65a4ea976f20bf684a361"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-crc64.c-483",
-      "fileName": "repos/redis/src/crc64.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c00ead4830b84b73570a21f64a8c2e1fdaf0c75a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rdb.c-484",
-      "fileName": "repos/redis/src/rdb.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c09cd14bc3e1c6b274fb0372aea3bf72901c9a21"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-jump-to-side-window-controller.go-485",
+      "SPDXID": "SPDXRef-File-jump-to-side-window-controller.go-350",
       "fileName": "repos/lazygit/pkg/gui/controllers/jump_to_side_window_controller.go",
       "checksums": [
         {
@@ -5357,7 +4002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodules-controller.go-486",
+      "SPDXID": "SPDXRef-File-submodules-controller.go-351",
       "fileName": "repos/lazygit/pkg/gui/controllers/submodules_controller.go",
       "checksums": [
         {
@@ -5367,7 +4012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-prompt-context.go-487",
+      "SPDXID": "SPDXRef-File-prompt-context.go-352",
       "fileName": "repos/lazygit/pkg/gui/context/prompt_context.go",
       "checksums": [
         {
@@ -5377,7 +4022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-refresh.go-488",
+      "SPDXID": "SPDXRef-File-refresh.go-353",
       "fileName": "repos/lazygit/pkg/gui/types/refresh.go",
       "checksums": [
         {
@@ -5387,17 +4032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crcspeed.h-489",
-      "fileName": "repos/redis/src/crcspeed.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c29f236bc0fc01425c02fd3534f4a47b669c47f7"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-string-stack.go-490",
+      "SPDXID": "SPDXRef-File-string-stack.go-354",
       "fileName": "repos/lazygit/pkg/utils/string_stack.go",
       "checksums": [
         {
@@ -5407,7 +4042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-file-tree-view-model.go-491",
+      "SPDXID": "SPDXRef-File-commit-file-tree-view-model.go-355",
       "fileName": "repos/lazygit/pkg/gui/filetree/commit_file_tree_view_model.go",
       "checksums": [
         {
@@ -5417,27 +4052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lazyfree.c-492",
-      "fileName": "repos/redis/src/lazyfree.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c33bc923e75e3ade525edbce5f80bc48e9c87b0c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-t-zset.c-493",
-      "fileName": "repos/redis/src/t_zset.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c415fdb3c7628cefe4ee1ec8fc54fb86cfb94f2d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-bisect-info.go-494",
+      "SPDXID": "SPDXRef-File-bisect-info.go-356",
       "fileName": "repos/lazygit/pkg/commands/git_commands/bisect_info.go",
       "checksums": [
         {
@@ -5447,7 +4062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stash-entries.go-495",
+      "SPDXID": "SPDXRef-File-stash-entries.go-357",
       "fileName": "repos/lazygit/pkg/gui/presentation/stash_entries.go",
       "checksums": [
         {
@@ -5457,27 +4072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-quicklist.h-496",
-      "fileName": "repos/redis/src/quicklist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c4b07e0c009c88a3820dc4b7c45d8160fd58c6e3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sds.h-497",
-      "fileName": "repos/redis/src/sds.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c4cbf6bf5babd3b0a9beb1f0525e1b454f6a35f1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-find-conflicts.go-498",
+      "SPDXID": "SPDXRef-File-find-conflicts.go-358",
       "fileName": "repos/lazygit/pkg/gui/mergeconflicts/find_conflicts.go",
       "checksums": [
         {
@@ -5487,7 +4082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-custom.go-499",
+      "SPDXID": "SPDXRef-File-custom.go-359",
       "fileName": "repos/lazygit/pkg/commands/git_commands/custom.go",
       "checksums": [
         {
@@ -5497,7 +4092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-repo-paths.go-500",
+      "SPDXID": "SPDXRef-File-repo-paths.go-360",
       "fileName": "repos/lazygit/pkg/commands/git_commands/repo_paths.go",
       "checksums": [
         {
@@ -5507,7 +4102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dummies.go-501",
+      "SPDXID": "SPDXRef-File-dummies.go-361",
       "fileName": "repos/lazygit/pkg/common/dummies.go",
       "checksums": [
         {
@@ -5517,37 +4112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connection.h-502",
-      "fileName": "repos/redis/src/connection.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c6de005c8b31947b7b059e0dc1a6f5a003ea0ed4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-t-list.c-503",
-      "fileName": "repos/redis/src/t_list.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c6fb1e76b5597df904d5167125550286603a7e9d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-crcspeed.c-504",
-      "fileName": "repos/redis/src/crcspeed.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c7073cba2f82b9b184703d533a55f6690541cfe0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-branches-controller.go-505",
+      "SPDXID": "SPDXRef-File-branches-controller.go-362",
       "fileName": "repos/lazygit/pkg/gui/controllers/branches_controller.go",
       "checksums": [
         {
@@ -5557,7 +4122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodules.go-506",
+      "SPDXID": "SPDXRef-File-submodules.go-363",
       "fileName": "repos/lazygit/pkg/gui/presentation/submodules.go",
       "checksums": [
         {
@@ -5567,17 +4132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-multi.c-507",
-      "fileName": "repos/redis/src/multi.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c8082c2974b1372d97fdd33efdd8136405732c4c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-tags-controller.go-508",
+      "SPDXID": "SPDXRef-File-tags-controller.go-364",
       "fileName": "repos/lazygit/pkg/gui/controllers/tags_controller.go",
       "checksums": [
         {
@@ -5587,7 +4142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-helper.go-509",
+      "SPDXID": "SPDXRef-File-view-helper.go-365",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/view_helper.go",
       "checksums": [
         {
@@ -5597,17 +4152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-atomicvar.h-510",
-      "fileName": "repos/redis/src/atomicvar.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c9093470a8156541e9056e4480810555c42cbdb2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-search.go-511",
+      "SPDXID": "SPDXRef-File-search.go-366",
       "fileName": "repos/lazygit/pkg/utils/search.go",
       "checksums": [
         {
@@ -5617,37 +4162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-debugmacro.h-512",
-      "fileName": "repos/redis/src/debugmacro.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c977381fc4affa790561a1207ae7e6400f11c003"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hnsw.c-513",
-      "fileName": "repos/redis/src/../modules/vector-sets/hnsw.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "cae43e305b5a0a0b7c6f474e29740a5b8fa6eeb2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-acl.c-514",
-      "fileName": "repos/redis/src/acl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "caf099c8d2d5169c80b07ddb1aa2fd43b810cedd"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-stash-entry.go-515",
+      "SPDXID": "SPDXRef-File-stash-entry.go-367",
       "fileName": "repos/lazygit/pkg/commands/models/stash_entry.go",
       "checksums": [
         {
@@ -5657,7 +4172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file-filter.go-516",
+      "SPDXID": "SPDXRef-File-file-filter.go-368",
       "fileName": "repos/lazygit/pkg/gui/filetree/file_filter.go",
       "checksums": [
         {
@@ -5667,27 +4182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-geo.c-517",
-      "fileName": "repos/redis/src/geo.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "cbb96cc25957d661901be88fe80260da65b83fd6"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-util.h-518",
-      "fileName": "repos/redis/src/util.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "cbc63ea6c5e3704e1684a6c4806dadd7a83a72bb"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-files.go-519",
+      "SPDXID": "SPDXRef-File-files.go-369",
       "fileName": "repos/lazygit/pkg/gui/presentation/files.go",
       "checksums": [
         {
@@ -5697,17 +4192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-setproctitle.c-520",
-      "fileName": "repos/redis/src/setproctitle.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "cc31845ef0656a01ac50e9a0dd30e94431e58266"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-suspend-resume-helper.go-521",
+      "SPDXID": "SPDXRef-File-suspend-resume-helper.go-370",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/suspend_resume_helper.go",
       "checksums": [
         {
@@ -5717,7 +4202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-522",
+      "SPDXID": "SPDXRef-File-errors.go-371",
       "fileName": "repos/lazygit/pkg/utils/errors.go",
       "checksums": [
         {
@@ -5727,7 +4212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-undo-controller.go-523",
+      "SPDXID": "SPDXRef-File-undo-controller.go-372",
       "fileName": "repos/lazygit/pkg/gui/controllers/undo_controller.go",
       "checksums": [
         {
@@ -5737,7 +4222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-switch-to-diff-files-controller.go-524",
+      "SPDXID": "SPDXRef-File-switch-to-diff-files-controller.go-373",
       "fileName": "repos/lazygit/pkg/gui/controllers/switch_to_diff_files_controller.go",
       "checksums": [
         {
@@ -5747,7 +4232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filtered-list-view-model.go-525",
+      "SPDXID": "SPDXRef-File-filtered-list-view-model.go-374",
       "fileName": "repos/lazygit/pkg/gui/context/filtered_list_view_model.go",
       "checksums": [
         {
@@ -5757,17 +4242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ebuckets.h-526",
-      "fileName": "repos/redis/src/ebuckets.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ce5bbb2bdd1b7a9473c804c7e9a110c14cf83ff4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-focus.go-527",
+      "SPDXID": "SPDXRef-File-focus.go-375",
       "fileName": "repos/lazygit/pkg/gui/patch_exploring/focus.go",
       "checksums": [
         {
@@ -5777,7 +4252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git-flow-controller.go-528",
+      "SPDXID": "SPDXRef-File-git-flow-controller.go-376",
       "fileName": "repos/lazygit/pkg/gui/controllers/git_flow_controller.go",
       "checksums": [
         {
@@ -5787,7 +4262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote.go-529",
+      "SPDXID": "SPDXRef-File-remote.go-377",
       "fileName": "repos/lazygit/pkg/commands/git_commands/remote.go",
       "checksums": [
         {
@@ -5797,7 +4272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-matcher.go-530",
+      "SPDXID": "SPDXRef-File-matcher.go-378",
       "fileName": "repos/lazygit/pkg/integration/components/matcher.go",
       "checksums": [
         {
@@ -5807,27 +4282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fmacros.h-531",
-      "fileName": "repos/redis/src/fmacros.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d05230dcae1ab88d4db8e85449920babec708424"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cluster-legacy.h-532",
-      "fileName": "repos/redis/src/cluster_legacy.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d0cb89d5c96f0e42cfa9dba723502a77b26728a8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-resolver.go-533",
+      "SPDXID": "SPDXRef-File-resolver.go-379",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/resolver.go",
       "checksums": [
         {
@@ -5837,7 +4292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-trait.go-534",
+      "SPDXID": "SPDXRef-File-view-trait.go-380",
       "fileName": "repos/lazygit/pkg/gui/context/view_trait.go",
       "checksums": [
         {
@@ -5847,7 +4302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bisect.go-535",
+      "SPDXID": "SPDXRef-File-bisect.go-381",
       "fileName": "repos/lazygit/pkg/commands/git_commands/bisect.go",
       "checksums": [
         {
@@ -5857,7 +4312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-command-log-panel.go-536",
+      "SPDXID": "SPDXRef-File-command-log-panel.go-382",
       "fileName": "repos/lazygit/pkg/gui/command_log_panel.go",
       "checksums": [
         {
@@ -5867,7 +4322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-refs-helper.go-537",
+      "SPDXID": "SPDXRef-File-refs-helper.go-383",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/refs_helper.go",
       "checksums": [
         {
@@ -5877,7 +4332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-message-context.go-538",
+      "SPDXID": "SPDXRef-File-commit-message-context.go-384",
       "fileName": "repos/lazygit/pkg/gui/context/commit_message_context.go",
       "checksums": [
         {
@@ -5887,17 +4342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iothread.c-539",
-      "fileName": "repos/redis/src/iothread.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d643905d6b507658cd37330fc70907acb654d5da"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sync.go-540",
+      "SPDXID": "SPDXRef-File-sync.go-385",
       "fileName": "repos/lazygit/pkg/commands/git_commands/sync.go",
       "checksums": [
         {
@@ -5907,7 +4352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-branches-context.go-541",
+      "SPDXID": "SPDXRef-File-branches-context.go-386",
       "fileName": "repos/lazygit/pkg/gui/context/branches_context.go",
       "checksums": [
         {
@@ -5917,27 +4362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mixer.h-542",
-      "fileName": "repos/redis/src/../modules/vector-sets/mixer.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d75e193f3dcc7d5cc02d0550b6f5ddad04f30d3a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-anet.c-543",
-      "fileName": "repos/redis/src/anet.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d79434cef03463649d167eacccc32d82abf7e5b8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-main.go-544",
+      "SPDXID": "SPDXRef-File-main.go-387",
       "fileName": "repos/lazygit/main.go",
       "checksums": [
         {
@@ -5947,7 +4372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-working-tree-context.go-545",
+      "SPDXID": "SPDXRef-File-working-tree-context.go-388",
       "fileName": "repos/lazygit/pkg/gui/context/working_tree_context.go",
       "checksums": [
         {
@@ -5957,7 +4382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-popup-handler.go-546",
+      "SPDXID": "SPDXRef-File-popup-handler.go-389",
       "fileName": "repos/lazygit/pkg/gui/popup/popup_handler.go",
       "checksums": [
         {
@@ -5967,17 +4392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-t-set.c-547",
-      "fileName": "repos/redis/src/t_set.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d91edcd1e8c758b567472fa5c7d0e703c41a53b4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-gui-common.go-548",
+      "SPDXID": "SPDXRef-File-gui-common.go-390",
       "fileName": "repos/lazygit/pkg/gui/gui_common.go",
       "checksums": [
         {
@@ -5987,27 +4402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc16.c-549",
-      "fileName": "repos/redis/src/crc16.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "d9e4f3f499706c4d12096b035504f19aa7674cff"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-t-stream.c-550",
-      "fileName": "repos/redis/src/t_stream.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "dae1ce372c8373f90d2d882c96d1f5ccc3e8c1d4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch-builder.go-551",
+      "SPDXID": "SPDXRef-File-patch-builder.go-391",
       "fileName": "repos/lazygit/pkg/commands/patch/patch_builder.go",
       "checksums": [
         {
@@ -6017,7 +4412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-conflicts-controller.go-552",
+      "SPDXID": "SPDXRef-File-merge-conflicts-controller.go-392",
       "fileName": "repos/lazygit/pkg/gui/controllers/merge_conflicts_controller.go",
       "checksums": [
         {
@@ -6027,7 +4422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-suggestions-helper.go-553",
+      "SPDXID": "SPDXRef-File-suggestions-helper.go-393",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/suggestions_helper.go",
       "checksums": [
         {
@@ -6037,7 +4432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-daemon.go-554",
+      "SPDXID": "SPDXRef-File-daemon.go-394",
       "fileName": "repos/lazygit/pkg/app/daemon/daemon.go",
       "checksums": [
         {
@@ -6047,17 +4442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-notify.c-555",
-      "fileName": "repos/redis/src/notify.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "df5435a087b303a3770c56b8a09eb54f18057a25"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fixup-helper.go-556",
+      "SPDXID": "SPDXRef-File-fixup-helper.go-395",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/fixup_helper.go",
       "checksums": [
         {
@@ -6067,27 +4452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redis-check-rdb.c-557",
-      "fileName": "repos/redis/src/redis-check-rdb.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e070fad9a052b59d25dbf31e581a4fae5e34edc3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-crc64.h-558",
-      "fileName": "repos/redis/src/crc64.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e0fccd98bbd657ec23af68489b8ed9510dc59a71"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-background.go-559",
+      "SPDXID": "SPDXRef-File-background.go-396",
       "fileName": "repos/lazygit/pkg/gui/background.go",
       "checksums": [
         {
@@ -6097,7 +4462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remotes-controller.go-560",
+      "SPDXID": "SPDXRef-File-remotes-controller.go-397",
       "fileName": "repos/lazygit/pkg/gui/controllers/remotes_controller.go",
       "checksums": [
         {
@@ -6107,7 +4472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-collapsed-paths.go-561",
+      "SPDXID": "SPDXRef-File-collapsed-paths.go-398",
       "fileName": "repos/lazygit/pkg/gui/filetree/collapsed_paths.go",
       "checksums": [
         {
@@ -6117,37 +4482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-kvstore.h-562",
-      "fileName": "repos/redis/src/kvstore.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e2431a94e5356e6063ae9ebed0eb38e35cc7eab2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-unix.c-563",
-      "fileName": "repos/redis/src/unix.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e26f0d27ad129112f909f87ede6cc60439905e0b"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-eventnotifier.h-564",
-      "fileName": "repos/redis/src/eventnotifier.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e2ae907380042a788836e6c650405ba8ce0907e9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-window-helper.go-565",
+      "SPDXID": "SPDXRef-File-window-helper.go-399",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/window_helper.go",
       "checksums": [
         {
@@ -6157,7 +4492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mode-helper.go-566",
+      "SPDXID": "SPDXRef-File-mode-helper.go-400",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/mode_helper.go",
       "checksums": [
         {
@@ -6167,7 +4502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.go-567",
+      "SPDXID": "SPDXRef-File-file.go-401",
       "fileName": "repos/lazygit/pkg/commands/models/file.go",
       "checksums": [
         {
@@ -6177,37 +4512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-redisassert.c-568",
-      "fileName": "repos/redis/src/redisassert.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e4918f2894aabe8711720df257b7513b59e5b4f4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fmtargs.h-569",
-      "fileName": "repos/redis/src/fmtargs.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e52d3b99c5034cb102f397c841092041ec5ee308"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cli-commands.c-570",
-      "fileName": "repos/redis/src/cli_commands.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e56d48cfaebe55f846bb210afe96fb8ef7c017a7"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-rendering.go-571",
+      "SPDXID": "SPDXRef-File-rendering.go-402",
       "fileName": "repos/lazygit/pkg/gui/mergeconflicts/rendering.go",
       "checksums": [
         {
@@ -6217,7 +4522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tags.go-572",
+      "SPDXID": "SPDXRef-File-tags.go-403",
       "fileName": "repos/lazygit/pkg/gui/presentation/tags.go",
       "checksums": [
         {
@@ -6227,7 +4532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options-menu-action.go-573",
+      "SPDXID": "SPDXRef-File-options-menu-action.go-404",
       "fileName": "repos/lazygit/pkg/gui/controllers/options_menu_action.go",
       "checksums": [
         {
@@ -6237,17 +4542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-script-lua.c-574",
-      "fileName": "repos/redis/src/script_lua.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e71312a4eb353e94f7a59672f79ae02a877c61f5"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-pager-config.go-575",
+      "SPDXID": "SPDXRef-File-pager-config.go-405",
       "fileName": "repos/lazygit/pkg/config/pager_config.go",
       "checksums": [
         {
@@ -6257,7 +4552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-models.go-576",
+      "SPDXID": "SPDXRef-File-models.go-406",
       "fileName": "repos/lazygit/pkg/gui/services/custom_commands/models.go",
       "checksums": [
         {
@@ -6267,7 +4562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-env.go-577",
+      "SPDXID": "SPDXRef-File-env.go-407",
       "fileName": "repos/lazygit/pkg/integration/components/env.go",
       "checksums": [
         {
@@ -6277,7 +4572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filtered-list.go-578",
+      "SPDXID": "SPDXRef-File-filtered-list.go-408",
       "fileName": "repos/lazygit/pkg/gui/context/filtered_list.go",
       "checksums": [
         {
@@ -6287,7 +4582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fake-git-config.go-579",
+      "SPDXID": "SPDXRef-File-fake-git-config.go-409",
       "fileName": "repos/lazygit/pkg/commands/git_config/fake_git_config.go",
       "checksums": [
         {
@@ -6297,7 +4592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list-renderer.go-580",
+      "SPDXID": "SPDXRef-File-list-renderer.go-410",
       "fileName": "repos/lazygit/pkg/gui/context/list_renderer.go",
       "checksums": [
         {
@@ -6307,37 +4602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lolwut6.c-581",
-      "fileName": "repos/redis/src/lolwut6.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e88be3b10b81ccf3bcadede81fe1d0abdca8e621"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-listpack-malloc.h-582",
-      "fileName": "repos/redis/src/listpack_malloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e9040544e22785ccc067cd1b7317f0203f864041"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-localtime.c-583",
-      "fileName": "repos/redis/src/localtime.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e95eb69116c837dd1226b573a1fdf9977837f0e0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-links.go-584",
+      "SPDXID": "SPDXRef-File-links.go-411",
       "fileName": "repos/lazygit/pkg/constants/links.go",
       "checksums": [
         {
@@ -6347,17 +4612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-geohash.c-585",
-      "fileName": "repos/redis/src/geohash.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e9f0c654dd6528043edc5d15297829bcd7795109"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-commit-message-controller.go-586",
+      "SPDXID": "SPDXRef-File-commit-message-controller.go-412",
       "fileName": "repos/lazygit/pkg/gui/controllers/commit_message_controller.go",
       "checksums": [
         {
@@ -6367,7 +4622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view-driver.go-587",
+      "SPDXID": "SPDXRef-File-view-driver.go-413",
       "fileName": "repos/lazygit/pkg/integration/components/view_driver.go",
       "checksums": [
         {
@@ -6377,47 +4632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-resp-parser.h-588",
-      "fileName": "repos/redis/src/resp_parser.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eaf1e323ecf508749f3ab3b5184428fb78db1ab1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-slowlog.c-589",
-      "fileName": "repos/redis/src/slowlog.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eaf88cc33fcf5e7ab27ce276822008079b4928e2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-script.c-590",
-      "fileName": "repos/redis/src/script.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eb45978f8fafde7af51440f13bae05b79e24d112"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-cli-commands.h-591",
-      "fileName": "repos/redis/src/cli_commands.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eb5a476e38e8d9607e92953ccd22c88c1d6c0042"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-scroll-off-margin.go-592",
+      "SPDXID": "SPDXRef-File-scroll-off-margin.go-414",
       "fileName": "repos/lazygit/pkg/gui/controllers/scroll_off_margin.go",
       "checksums": [
         {
@@ -6427,7 +4642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-author.go-593",
+      "SPDXID": "SPDXRef-File-author.go-415",
       "fileName": "repos/lazygit/pkg/commands/models/author.go",
       "checksums": [
         {
@@ -6437,7 +4652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynamic-title-builder.go-594",
+      "SPDXID": "SPDXRef-File-dynamic-title-builder.go-416",
       "fileName": "repos/lazygit/pkg/gui/context/dynamic_title_builder.go",
       "checksums": [
         {
@@ -6447,37 +4662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-listpack.c-595",
-      "fileName": "repos/redis/src/listpack.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "eef83092da44e372dc933cb774eaf876e328e590"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-kvstore.c-596",
-      "fileName": "repos/redis/src/kvstore.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ef29bd4d0996805e491d4908793ac3cb8cdf2fbb"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ziplist.h-597",
-      "fileName": "repos/redis/src/ziplist.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ef38e73aa95db4d2c182843fc339c965f5da3b92"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-test-mode.go-598",
+      "SPDXID": "SPDXRef-File-test-mode.go-417",
       "fileName": "repos/lazygit/pkg/gui/test_mode.go",
       "checksums": [
         {
@@ -6487,7 +4672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-formatting.go-599",
+      "SPDXID": "SPDXRef-File-formatting.go-418",
       "fileName": "repos/lazygit/pkg/utils/formatting.go",
       "checksums": [
         {
@@ -6497,7 +4682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodule.go-600",
+      "SPDXID": "SPDXRef-File-submodule.go-419",
       "fileName": "repos/lazygit/pkg/commands/git_commands/submodule.go",
       "checksums": [
         {
@@ -6507,7 +4692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os.go-601",
+      "SPDXID": "SPDXRef-File-os.go-420",
       "fileName": "repos/lazygit/pkg/commands/oscommands/os.go",
       "checksums": [
         {
@@ -6517,7 +4702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-alert-driver.go-602",
+      "SPDXID": "SPDXRef-File-alert-driver.go-421",
       "fileName": "repos/lazygit/pkg/integration/components/alert_driver.go",
       "checksums": [
         {
@@ -6527,7 +4712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-loading-shared.go-603",
+      "SPDXID": "SPDXRef-File-commit-loading-shared.go-422",
       "fileName": "repos/lazygit/pkg/commands/git_commands/commit_loading_shared.go",
       "checksums": [
         {
@@ -6537,17 +4722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc16-slottable.h-604",
-      "fileName": "repos/redis/src/crc16_slottable.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f25e2412e891a073c8f447b28d1f16822f65d2a2"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-simple-context.go-605",
+      "SPDXID": "SPDXRef-File-simple-context.go-423",
       "fileName": "repos/lazygit/pkg/gui/context/simple_context.go",
       "checksums": [
         {
@@ -6557,27 +4732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hyperloglog.c-606",
-      "fileName": "repos/redis/src/hyperloglog.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f52df29e25e6fc512d2b59d8f2fd9ba3aaf7dc79"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-config.c-607",
-      "fileName": "repos/redis/src/config.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f5c885ed257beae34aebb61fb093b7ab3b441b61"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-template.go-608",
+      "SPDXID": "SPDXRef-File-template.go-424",
       "fileName": "repos/lazygit/pkg/utils/template.go",
       "checksums": [
         {
@@ -6587,7 +4742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-staging-controller.go-609",
+      "SPDXID": "SPDXRef-File-staging-controller.go-425",
       "fileName": "repos/lazygit/pkg/gui/controllers/staging_controller.go",
       "checksums": [
         {
@@ -6597,47 +4752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-strl.c-610",
-      "fileName": "repos/redis/src/strl.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f73cf796c22f547f46c422237f045832d3c6e306"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-memtest.c-611",
-      "fileName": "repos/redis/src/memtest.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f75d6b21ced2157784e4197d95e5414b0becfac4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-endianconv.h-612",
-      "fileName": "repos/redis/src/endianconv.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f7cc91eca12863deda28bff7d875168ab621dda9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-redis-check-aof.c-613",
-      "fileName": "repos/redis/src/redis-check-aof.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f7cdbbc69aec9b3c402d5d7fa8d4e7a40a2b9a3d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-commit-files-context.go-614",
+      "SPDXID": "SPDXRef-File-commit-files-context.go-426",
       "fileName": "repos/lazygit/pkg/gui/context/commit_files_context.go",
       "checksums": [
         {
@@ -6647,7 +4762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-history-trait.go-615",
+      "SPDXID": "SPDXRef-File-history-trait.go-427",
       "fileName": "repos/lazygit/pkg/gui/context/history_trait.go",
       "checksums": [
         {
@@ -6657,7 +4772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yaml-utils.go-616",
+      "SPDXID": "SPDXRef-File-yaml-utils.go-428",
       "fileName": "repos/lazygit/pkg/utils/yaml_utils/yaml_utils.go",
       "checksums": [
         {
@@ -6667,17 +4782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-version.h-617",
-      "fileName": "repos/redis/src/version.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "f9e61ca71ab0118af1b0029270d701575eb60e6a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-custom-patch-options-menu-action.go-618",
+      "SPDXID": "SPDXRef-File-custom-patch-options-menu-action.go-429",
       "fileName": "repos/lazygit/pkg/gui/controllers/custom_patch_options_menu_action.go",
       "checksums": [
         {
@@ -6687,7 +4792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main-view-controller.go-619",
+      "SPDXID": "SPDXRef-File-main-view-controller.go-430",
       "fileName": "repos/lazygit/pkg/gui/controllers/main_view_controller.go",
       "checksums": [
         {
@@ -6697,7 +4802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-flow.go-620",
+      "SPDXID": "SPDXRef-File-flow.go-431",
       "fileName": "repos/lazygit/pkg/commands/git_commands/flow.go",
       "checksums": [
         {
@@ -6707,27 +4812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syncio.c-621",
-      "fileName": "repos/redis/src/syncio.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fc1f553b861e17655a469d3aeec1fb2e702437a4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-defrag.c-622",
-      "fileName": "repos/redis/src/defrag.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fc451e0b9656c2a48e44539a69032268cccdd8cc"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-patch-building-helper.go-623",
+      "SPDXID": "SPDXRef-File-patch-building-helper.go-432",
       "fileName": "repos/lazygit/pkg/gui/controllers/helpers/patch_building_helper.go",
       "checksums": [
         {
@@ -6737,7 +4822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-git-cmd-obj-runner.go-624",
+      "SPDXID": "SPDXRef-File-git-cmd-obj-runner.go-433",
       "fileName": "repos/lazygit/pkg/commands/git_cmd_obj_runner.go",
       "checksums": [
         {
@@ -6747,7 +4832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch-explorer-controller.go-625",
+      "SPDXID": "SPDXRef-File-patch-explorer-controller.go-434",
       "fileName": "repos/lazygit/pkg/gui/controllers/patch_explorer_controller.go",
       "checksums": [
         {
@@ -6757,7 +4842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rebase.go-626",
+      "SPDXID": "SPDXRef-File-rebase.go-435",
       "fileName": "repos/lazygit/pkg/app/daemon/rebase.go",
       "checksums": [
         {
@@ -6767,7 +4852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmd-obj-builder.go-627",
+      "SPDXID": "SPDXRef-File-cmd-obj-builder.go-436",
       "fileName": "repos/lazygit/pkg/commands/oscommands/cmd_obj_builder.go",
       "checksums": [
         {
@@ -6777,7 +4862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rebase-todo.go-628",
+      "SPDXID": "SPDXRef-File-rebase-todo.go-437",
       "fileName": "repos/lazygit/pkg/utils/rebase_todo.go",
       "checksums": [
         {
@@ -6787,17 +4872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-t-string.c-629",
-      "fileName": "repos/redis/src/t_string.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "fe10589827d0b0d3f682ed6e8c6529cc9d441fb9"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-parse.go-630",
+      "SPDXID": "SPDXRef-File-parse.go-438",
       "fileName": "repos/lazygit/pkg/commands/patch/parse.go",
       "checksums": [
         {
@@ -6807,7 +4882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-status.go-631",
+      "SPDXID": "SPDXRef-File-status.go-439",
       "fileName": "repos/lazygit/pkg/commands/git_commands/status.go",
       "checksums": [
         {
@@ -6817,17 +4892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lzf-d.c-632",
-      "fileName": "repos/redis/src/lzf_d.c",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ff32be892a3842ec624b2fa60971d03a92af7cd0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-const-win-unix.go-633",
+      "SPDXID": "SPDXRef-File-const-win-unix.go-440",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/const_win_unix.go",
       "checksums": [
         {
@@ -6837,7 +4902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cacheOnReadFs.go-634",
+      "SPDXID": "SPDXRef-File-cacheOnReadFs.go-441",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/cacheOnReadFs.go",
       "checksums": [
         {
@@ -6847,7 +4912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dirmap.go-635",
+      "SPDXID": "SPDXRef-File-dirmap.go-442",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/mem/dirmap.go",
       "checksums": [
         {
@@ -6857,7 +4922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-copyOnWriteFs.go-636",
+      "SPDXID": "SPDXRef-File-copyOnWriteFs.go-443",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/copyOnWriteFs.go",
       "checksums": [
         {
@@ -6867,7 +4932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-path.go-637",
+      "SPDXID": "SPDXRef-File-path.go-444",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/path.go",
       "checksums": [
         {
@@ -6877,7 +4942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-regexpfs.go-638",
+      "SPDXID": "SPDXRef-File-regexpfs.go-445",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/regexpfs.go",
       "checksums": [
         {
@@ -6887,7 +4952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-basepath.go-639",
+      "SPDXID": "SPDXRef-File-basepath.go-446",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/basepath.go",
       "checksums": [
         {
@@ -6897,7 +4962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-afero.go-640",
+      "SPDXID": "SPDXRef-File-afero.go-447",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/afero.go",
       "checksums": [
         {
@@ -6907,7 +4972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adapters.go-641",
+      "SPDXID": "SPDXRef-File-adapters.go-448",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/internal/common/adapters.go",
       "checksums": [
         {
@@ -6917,7 +4982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-unionFile.go-642",
+      "SPDXID": "SPDXRef-File-unionFile.go-449",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/unionFile.go",
       "checksums": [
         {
@@ -6927,7 +4992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.go-643",
+      "SPDXID": "SPDXRef-File-file.go-450",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/mem/file.go",
       "checksums": [
         {
@@ -6937,7 +5002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-match.go-644",
+      "SPDXID": "SPDXRef-File-match.go-451",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/match.go",
       "checksums": [
         {
@@ -6947,7 +5012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lstater.go-645",
+      "SPDXID": "SPDXRef-File-lstater.go-452",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/lstater.go",
       "checksums": [
         {
@@ -6957,7 +5022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iofs.go-646",
+      "SPDXID": "SPDXRef-File-iofs.go-453",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/iofs.go",
       "checksums": [
         {
@@ -6967,7 +5032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-util.go-647",
+      "SPDXID": "SPDXRef-File-util.go-454",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/util.go",
       "checksums": [
         {
@@ -6977,7 +5042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symlink.go-648",
+      "SPDXID": "SPDXRef-File-symlink.go-455",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/symlink.go",
       "checksums": [
         {
@@ -6987,7 +5052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-httpFs.go-649",
+      "SPDXID": "SPDXRef-File-httpFs.go-456",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/httpFs.go",
       "checksums": [
         {
@@ -6997,7 +5062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-readonlyfs.go-650",
+      "SPDXID": "SPDXRef-File-readonlyfs.go-457",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/readonlyfs.go",
       "checksums": [
         {
@@ -7007,7 +5072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dir.go-651",
+      "SPDXID": "SPDXRef-File-dir.go-458",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/mem/dir.go",
       "checksums": [
         {
@@ -7017,7 +5082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-memmap.go-652",
+      "SPDXID": "SPDXRef-File-memmap.go-459",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/memmap.go",
       "checksums": [
         {
@@ -7027,7 +5092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os.go-653",
+      "SPDXID": "SPDXRef-File-os.go-460",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/os.go",
       "checksums": [
         {
@@ -7037,7 +5102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ioutil.go-654",
+      "SPDXID": "SPDXRef-File-ioutil.go-461",
       "fileName": "repos/lazygit/vendor/github.com/spf13/afero/ioutil.go",
       "checksums": [
         {
@@ -7047,7 +5112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-osext-go18.go-655",
+      "SPDXID": "SPDXRef-File-osext-go18.go-462",
       "fileName": "repos/lazygit/vendor/github.com/kardianos/osext/osext_go18.go",
       "checksums": [
         {
@@ -7057,7 +5122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-osext.go-656",
+      "SPDXID": "SPDXRef-File-osext.go-463",
       "fileName": "repos/lazygit/vendor/github.com/kardianos/osext/osext.go",
       "checksums": [
         {
@@ -7067,7 +5132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-657",
+      "SPDXID": "SPDXRef-File-config.go-464",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/config.go",
       "checksums": [
         {
@@ -7077,7 +5142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lexer.go-658",
+      "SPDXID": "SPDXRef-File-lexer.go-465",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/lexer.go",
       "checksums": [
         {
@@ -7087,7 +5152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-659",
+      "SPDXID": "SPDXRef-File-parser.go-466",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/parser.go",
       "checksums": [
         {
@@ -7097,7 +5162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-validators.go-660",
+      "SPDXID": "SPDXRef-File-validators.go-467",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/validators.go",
       "checksums": [
         {
@@ -7107,7 +5172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-token.go-661",
+      "SPDXID": "SPDXRef-File-token.go-468",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/token.go",
       "checksums": [
         {
@@ -7117,7 +5182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-position.go-662",
+      "SPDXID": "SPDXRef-File-position.go-469",
       "fileName": "repos/lazygit/vendor/github.com/kevinburke/ssh_config/position.go",
       "checksums": [
         {
@@ -7127,7 +5192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cast5.go-663",
+      "SPDXID": "SPDXRef-File-cast5.go-470",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/cast5/cast5.go",
       "checksums": [
         {
@@ -7137,7 +5202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve25519.go-664",
+      "SPDXID": "SPDXRef-File-curve25519.go-471",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/curve25519/curve25519.go",
       "checksums": [
         {
@@ -7147,7 +5212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blamka-amd64.go-665",
+      "SPDXID": "SPDXRef-File-blamka-amd64.go-472",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/argon2/blamka_amd64.go",
       "checksums": [
         {
@@ -7157,7 +5222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-666",
+      "SPDXID": "SPDXRef-File-server.go-473",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/server.go",
       "checksums": [
         {
@@ -7167,7 +5232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cipher.go-667",
+      "SPDXID": "SPDXRef-File-cipher.go-474",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blowfish/cipher.go",
       "checksums": [
         {
@@ -7177,7 +5242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-legacy-keccakf.go-668",
+      "SPDXID": "SPDXRef-File-legacy-keccakf.go-475",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/sha3/legacy_keccakf.go",
       "checksums": [
         {
@@ -7187,7 +5252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2b.go-669",
+      "SPDXID": "SPDXRef-File-blake2b.go-476",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/argon2/blake2b.go",
       "checksums": [
         {
@@ -7197,7 +5262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-certs.go-670",
+      "SPDXID": "SPDXRef-File-certs.go-477",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/certs.go",
       "checksums": [
         {
@@ -7207,7 +5272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-streamlocal.go-671",
+      "SPDXID": "SPDXRef-File-streamlocal.go-478",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/streamlocal.go",
       "checksums": [
         {
@@ -7217,7 +5282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2bAVX2-amd64.go-672",
+      "SPDXID": "SPDXRef-File-blake2bAVX2-amd64.go-479",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/blake2bAVX2_amd64.go",
       "checksums": [
         {
@@ -7227,7 +5292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-buffer.go-673",
+      "SPDXID": "SPDXRef-File-buffer.go-480",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/buffer.go",
       "checksums": [
         {
@@ -7237,7 +5302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-knownhosts.go-674",
+      "SPDXID": "SPDXRef-File-knownhosts.go-481",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/knownhosts/knownhosts.go",
       "checksums": [
         {
@@ -7247,7 +5312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-argon2.go-675",
+      "SPDXID": "SPDXRef-File-argon2.go-482",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/argon2/argon2.go",
       "checksums": [
         {
@@ -7257,7 +5322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-676",
+      "SPDXID": "SPDXRef-File-common.go-483",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/common.go",
       "checksums": [
         {
@@ -7267,7 +5332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client-auth.go-677",
+      "SPDXID": "SPDXRef-File-client-auth.go-484",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/client_auth.go",
       "checksums": [
         {
@@ -7277,7 +5342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2b-generic.go-678",
+      "SPDXID": "SPDXRef-File-blake2b-generic.go-485",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/blake2b_generic.go",
       "checksums": [
         {
@@ -7287,7 +5352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-679",
+      "SPDXID": "SPDXRef-File-client.go-486",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/client.go",
       "checksums": [
         {
@@ -7297,7 +5362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hkdf.go-680",
+      "SPDXID": "SPDXRef-File-hkdf.go-487",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/hkdf/hkdf.go",
       "checksums": [
         {
@@ -7307,7 +5372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keys.go-681",
+      "SPDXID": "SPDXRef-File-keys.go-488",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/keys.go",
       "checksums": [
         {
@@ -7317,7 +5382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-handshake.go-682",
+      "SPDXID": "SPDXRef-File-handshake.go-489",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/handshake.go",
       "checksums": [
         {
@@ -7327,7 +5392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-683",
+      "SPDXID": "SPDXRef-File-server.go-490",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/agent/server.go",
       "checksums": [
         {
@@ -7337,7 +5402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-register.go-684",
+      "SPDXID": "SPDXRef-File-register.go-491",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/register.go",
       "checksums": [
         {
@@ -7347,7 +5412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-685",
+      "SPDXID": "SPDXRef-File-doc.go-492",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/doc.go",
       "checksums": [
         {
@@ -7357,7 +5422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-kex.go-686",
+      "SPDXID": "SPDXRef-File-kex.go-493",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/kex.go",
       "checksums": [
         {
@@ -7367,7 +5432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-connection.go-687",
+      "SPDXID": "SPDXRef-File-connection.go-494",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/connection.go",
       "checksums": [
         {
@@ -7377,7 +5442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-go125.go-688",
+      "SPDXID": "SPDXRef-File-go125.go-495",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/go125.go",
       "checksums": [
         {
@@ -7387,7 +5452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shake.go-689",
+      "SPDXID": "SPDXRef-File-shake.go-496",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/sha3/shake.go",
       "checksums": [
         {
@@ -7397,7 +5462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cipher.go-690",
+      "SPDXID": "SPDXRef-File-cipher.go-497",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/cipher.go",
       "checksums": [
         {
@@ -7407,7 +5472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2x.go-691",
+      "SPDXID": "SPDXRef-File-blake2x.go-498",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/blake2x.go",
       "checksums": [
         {
@@ -7417,7 +5482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tcpip.go-692",
+      "SPDXID": "SPDXRef-File-tcpip.go-499",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/tcpip.go",
       "checksums": [
         {
@@ -7427,7 +5492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mac.go-693",
+      "SPDXID": "SPDXRef-File-mac.go-500",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/mac.go",
       "checksums": [
         {
@@ -7437,7 +5502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-block.go-694",
+      "SPDXID": "SPDXRef-File-block.go-501",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blowfish/block.go",
       "checksums": [
         {
@@ -7447,7 +5512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blamka-generic.go-695",
+      "SPDXID": "SPDXRef-File-blamka-generic.go-502",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/argon2/blamka_generic.go",
       "checksums": [
         {
@@ -7457,7 +5522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hashes.go-696",
+      "SPDXID": "SPDXRef-File-hashes.go-503",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/sha3/hashes.go",
       "checksums": [
         {
@@ -7467,7 +5532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ssh-gss.go-697",
+      "SPDXID": "SPDXRef-File-ssh-gss.go-504",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/ssh_gss.go",
       "checksums": [
         {
@@ -7477,7 +5542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-messages.go-698",
+      "SPDXID": "SPDXRef-File-messages.go-505",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/messages.go",
       "checksums": [
         {
@@ -7487,7 +5552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-session.go-699",
+      "SPDXID": "SPDXRef-File-session.go-506",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/session.go",
       "checksums": [
         {
@@ -7497,7 +5562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bcrypt-pbkdf.go-700",
+      "SPDXID": "SPDXRef-File-bcrypt-pbkdf.go-507",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/internal/bcrypt_pbkdf/bcrypt_pbkdf.go",
       "checksums": [
         {
@@ -7507,7 +5572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-701",
+      "SPDXID": "SPDXRef-File-client.go-508",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/agent/client.go",
       "checksums": [
         {
@@ -7517,7 +5582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-legacy-hash.go-702",
+      "SPDXID": "SPDXRef-File-legacy-hash.go-509",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/sha3/legacy_hash.go",
       "checksums": [
         {
@@ -7527,7 +5592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-channel.go-703",
+      "SPDXID": "SPDXRef-File-channel.go-510",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/channel.go",
       "checksums": [
         {
@@ -7537,7 +5602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-const.go-704",
+      "SPDXID": "SPDXRef-File-const.go-511",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blowfish/const.go",
       "checksums": [
         {
@@ -7547,7 +5612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keyring.go-705",
+      "SPDXID": "SPDXRef-File-keyring.go-512",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/agent/keyring.go",
       "checksums": [
         {
@@ -7557,7 +5622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mux.go-706",
+      "SPDXID": "SPDXRef-File-mux.go-513",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/mux.go",
       "checksums": [
         {
@@ -7567,7 +5632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blake2b.go-707",
+      "SPDXID": "SPDXRef-File-blake2b.go-514",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/blake2b/blake2b.go",
       "checksums": [
         {
@@ -7577,7 +5642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mlkem.go-708",
+      "SPDXID": "SPDXRef-File-mlkem.go-515",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/mlkem.go",
       "checksums": [
         {
@@ -7587,7 +5652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transport.go-709",
+      "SPDXID": "SPDXRef-File-transport.go-516",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/transport.go",
       "checksums": [
         {
@@ -7597,7 +5662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-forward.go-710",
+      "SPDXID": "SPDXRef-File-forward.go-517",
       "fileName": "repos/lazygit/vendor/golang.org/x/crypto/ssh/agent/forward.go",
       "checksums": [
         {
@@ -7607,7 +5672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decode.go-711",
+      "SPDXID": "SPDXRef-File-decode.go-518",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/decode.go",
       "checksums": [
         {
@@ -7617,7 +5682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-emitterc.go-712",
+      "SPDXID": "SPDXRef-File-emitterc.go-519",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/emitterc.go",
       "checksums": [
         {
@@ -7627,7 +5692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parserc.go-713",
+      "SPDXID": "SPDXRef-File-parserc.go-520",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/parserc.go",
       "checksums": [
         {
@@ -7637,7 +5702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-resolve.go-714",
+      "SPDXID": "SPDXRef-File-resolve.go-521",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/resolve.go",
       "checksums": [
         {
@@ -7647,7 +5712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yamlh.go-715",
+      "SPDXID": "SPDXRef-File-yamlh.go-522",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/yamlh.go",
       "checksums": [
         {
@@ -7657,7 +5722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yaml.go-716",
+      "SPDXID": "SPDXRef-File-yaml.go-523",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/yaml.go",
       "checksums": [
         {
@@ -7667,7 +5732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sorter.go-717",
+      "SPDXID": "SPDXRef-File-sorter.go-524",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/sorter.go",
       "checksums": [
         {
@@ -7677,7 +5742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-apic.go-718",
+      "SPDXID": "SPDXRef-File-apic.go-525",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/apic.go",
       "checksums": [
         {
@@ -7687,7 +5752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-readerc.go-719",
+      "SPDXID": "SPDXRef-File-readerc.go-526",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/readerc.go",
       "checksums": [
         {
@@ -7697,7 +5762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writerc.go-720",
+      "SPDXID": "SPDXRef-File-writerc.go-527",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/writerc.go",
       "checksums": [
         {
@@ -7707,7 +5772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scannerc.go-721",
+      "SPDXID": "SPDXRef-File-scannerc.go-528",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/scannerc.go",
       "checksums": [
         {
@@ -7717,7 +5782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encode.go-722",
+      "SPDXID": "SPDXRef-File-encode.go-529",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/encode.go",
       "checksums": [
         {
@@ -7727,7 +5792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yamlprivateh.go-723",
+      "SPDXID": "SPDXRef-File-yamlprivateh.go-530",
       "fileName": "repos/lazygit/vendor/gopkg.in/yaml.v3/yamlprivateh.go",
       "checksums": [
         {
@@ -7737,7 +5802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-exported.go-724",
+      "SPDXID": "SPDXRef-File-exported.go-531",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/exported.go",
       "checksums": [
         {
@@ -7747,7 +5812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal-check-unix.go-725",
+      "SPDXID": "SPDXRef-File-terminal-check-unix.go-532",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/terminal_check_unix.go",
       "checksums": [
         {
@@ -7757,7 +5822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writer.go-726",
+      "SPDXID": "SPDXRef-File-writer.go-533",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/writer.go",
       "checksums": [
         {
@@ -7767,7 +5832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logrus.go-727",
+      "SPDXID": "SPDXRef-File-logrus.go-534",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/logrus.go",
       "checksums": [
         {
@@ -7777,7 +5842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal-check-notappengine.go-728",
+      "SPDXID": "SPDXRef-File-terminal-check-notappengine.go-535",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/terminal_check_notappengine.go",
       "checksums": [
         {
@@ -7787,7 +5852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hooks.go-729",
+      "SPDXID": "SPDXRef-File-hooks.go-536",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/hooks.go",
       "checksums": [
         {
@@ -7797,7 +5862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-formatter.go-730",
+      "SPDXID": "SPDXRef-File-formatter.go-537",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/formatter.go",
       "checksums": [
         {
@@ -7807,7 +5872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logger.go-731",
+      "SPDXID": "SPDXRef-File-logger.go-538",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/logger.go",
       "checksums": [
         {
@@ -7817,7 +5882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-entry.go-732",
+      "SPDXID": "SPDXRef-File-entry.go-539",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/entry.go",
       "checksums": [
         {
@@ -7827,7 +5892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-alt-exit.go-733",
+      "SPDXID": "SPDXRef-File-alt-exit.go-540",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/alt_exit.go",
       "checksums": [
         {
@@ -7837,7 +5902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-text-formatter.go-734",
+      "SPDXID": "SPDXRef-File-text-formatter.go-541",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/text_formatter.go",
       "checksums": [
         {
@@ -7847,7 +5912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-buffer-pool.go-735",
+      "SPDXID": "SPDXRef-File-buffer-pool.go-542",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/buffer_pool.go",
       "checksums": [
         {
@@ -7857,7 +5922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-json-formatter.go-736",
+      "SPDXID": "SPDXRef-File-json-formatter.go-543",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/json_formatter.go",
       "checksums": [
         {
@@ -7867,7 +5932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-737",
+      "SPDXID": "SPDXRef-File-doc.go-544",
       "fileName": "repos/lazygit/vendor/github.com/sirupsen/logrus/doc.go",
       "checksums": [
         {
@@ -7877,17 +5942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hdr-histogram.h-738",
-      "fileName": "repos/redis/src/../deps/hdr_histogram/hdr_histogram.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "01b1e086cae8365d5ebee885ac3b47a70d43bfb0"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-private-key-test-data.go-739",
+      "SPDXID": "SPDXRef-File-private-key-test-data.go-545",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/private_key_test_data.go",
       "checksums": [
         {
@@ -7897,7 +5952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mpi.go-740",
+      "SPDXID": "SPDXRef-File-mpi.go-546",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/encoding/mpi.go",
       "checksums": [
         {
@@ -7907,7 +5962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-compressed.go-741",
+      "SPDXID": "SPDXRef-File-compressed.go-547",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/compressed.go",
       "checksums": [
         {
@@ -7917,7 +5972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-info.go-742",
+      "SPDXID": "SPDXRef-File-curve-info.go-548",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/curve_info.go",
       "checksums": [
         {
@@ -7927,7 +5982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symmetrically-encrypted.go-743",
+      "SPDXID": "SPDXRef-File-symmetrically-encrypted.go-549",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/symmetrically_encrypted.go",
       "checksums": [
         {
@@ -7937,7 +5992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-random-vectors.go-744",
+      "SPDXID": "SPDXRef-File-random-vectors.go-550",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/ocb/random_vectors.go",
       "checksums": [
         {
@@ -7947,7 +6002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keys-test-data.go-745",
+      "SPDXID": "SPDXRef-File-keys-test-data.go-551",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/keys_test_data.go",
       "checksums": [
         {
@@ -7957,7 +6012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rfc7253-test-vectors-suite-b.go-746",
+      "SPDXID": "SPDXRef-File-rfc7253-test-vectors-suite-b.go-552",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/ocb/rfc7253_test_vectors_suite_b.go",
       "checksums": [
         {
@@ -7967,7 +6022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-packet.go-747",
+      "SPDXID": "SPDXRef-File-packet.go-553",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/packet.go",
       "checksums": [
         {
@@ -7977,7 +6032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-marker.go-748",
+      "SPDXID": "SPDXRef-File-marker.go-554",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/marker.go",
       "checksums": [
         {
@@ -7987,7 +6042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ocb.go-749",
+      "SPDXID": "SPDXRef-File-ocb.go-555",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/ocb/ocb.go",
       "checksums": [
         {
@@ -7997,7 +6052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-750",
+      "SPDXID": "SPDXRef-File-config.go-556",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/config.go",
       "checksums": [
         {
@@ -8007,7 +6062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symmetric-key-encrypted.go-751",
+      "SPDXID": "SPDXRef-File-symmetric-key-encrypted.go-557",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/symmetric_key_encrypted.go",
       "checksums": [
         {
@@ -8017,7 +6072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-notation.go-752",
+      "SPDXID": "SPDXRef-File-notation.go-558",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/notation.go",
       "checksums": [
         {
@@ -8027,7 +6082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-packet-unsupported.go-753",
+      "SPDXID": "SPDXRef-File-packet-unsupported.go-559",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/packet_unsupported.go",
       "checksums": [
         {
@@ -8037,7 +6092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rfc7253-test-vectors-suite-a.go-754",
+      "SPDXID": "SPDXRef-File-rfc7253-test-vectors-suite-a.go-560",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/ocb/rfc7253_test_vectors_suite_a.go",
       "checksums": [
         {
@@ -8047,7 +6102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x25519.go-755",
+      "SPDXID": "SPDXRef-File-x25519.go-561",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/x25519/x25519.go",
       "checksums": [
         {
@@ -8057,7 +6112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eax.go-756",
+      "SPDXID": "SPDXRef-File-eax.go-562",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/eax/eax.go",
       "checksums": [
         {
@@ -8067,7 +6122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-padding.go-757",
+      "SPDXID": "SPDXRef-File-padding.go-563",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/padding.go",
       "checksums": [
         {
@@ -8077,7 +6132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keywrap.go-758",
+      "SPDXID": "SPDXRef-File-keywrap.go-564",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/aes/keywrap/keywrap.go",
       "checksums": [
         {
@@ -8087,7 +6142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-userid.go-759",
+      "SPDXID": "SPDXRef-File-userid.go-565",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/userid.go",
       "checksums": [
         {
@@ -8097,7 +6152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symmetrically-encrypted-aead.go-760",
+      "SPDXID": "SPDXRef-File-symmetrically-encrypted-aead.go-566",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/symmetrically_encrypted_aead.go",
       "checksums": [
         {
@@ -8107,7 +6162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-random-vectors.go-761",
+      "SPDXID": "SPDXRef-File-random-vectors.go-567",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/eax/random_vectors.go",
       "checksums": [
         {
@@ -8117,7 +6172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ocfb.go-762",
+      "SPDXID": "SPDXRef-File-ocfb.go-568",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/ocfb.go",
       "checksums": [
         {
@@ -8127,7 +6182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.go-763",
+      "SPDXID": "SPDXRef-File-hash.go-569",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/hash.go",
       "checksums": [
         {
@@ -8137,7 +6192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encode.go-764",
+      "SPDXID": "SPDXRef-File-encode.go-570",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/armor/encode.go",
       "checksums": [
         {
@@ -8147,7 +6202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-packet-sequence.go-765",
+      "SPDXID": "SPDXRef-File-packet-sequence.go-571",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/packet_sequence.go",
       "checksums": [
         {
@@ -8157,7 +6212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aead-encrypted.go-766",
+      "SPDXID": "SPDXRef-File-aead-encrypted.go-572",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/aead_encrypted.go",
       "checksums": [
         {
@@ -8167,7 +6222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed25519.go-767",
+      "SPDXID": "SPDXRef-File-ed25519.go-573",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/ed25519.go",
       "checksums": [
         {
@@ -8177,7 +6232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-canonical-text.go-768",
+      "SPDXID": "SPDXRef-File-canonical-text.go-574",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/canonical_text.go",
       "checksums": [
         {
@@ -8187,7 +6242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aead-crypter.go-769",
+      "SPDXID": "SPDXRef-File-aead-crypter.go-575",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/aead_crypter.go",
       "checksums": [
         {
@@ -8197,7 +6252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curves.go-770",
+      "SPDXID": "SPDXRef-File-curves.go-576",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/curves.go",
       "checksums": [
         {
@@ -8207,7 +6262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-s2k-cache.go-771",
+      "SPDXID": "SPDXRef-File-s2k-cache.go-577",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/s2k/s2k_cache.go",
       "checksums": [
         {
@@ -8217,7 +6272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-userattribute.go-772",
+      "SPDXID": "SPDXRef-File-userattribute.go-578",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/userattribute.go",
       "checksums": [
         {
@@ -8227,7 +6282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x448.go-773",
+      "SPDXID": "SPDXRef-File-x448.go-579",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/x448/x448.go",
       "checksums": [
         {
@@ -8237,7 +6292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read-write-test-data.go-774",
+      "SPDXID": "SPDXRef-File-read-write-test-data.go-580",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/read_write_test_data.go",
       "checksums": [
         {
@@ -8247,7 +6302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-s2k.go-775",
+      "SPDXID": "SPDXRef-File-s2k.go-581",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/s2k/s2k.go",
       "checksums": [
         {
@@ -8257,7 +6312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed25519.go-776",
+      "SPDXID": "SPDXRef-File-ed25519.go-582",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/ed25519/ed25519.go",
       "checksums": [
         {
@@ -8267,7 +6322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoding.go-777",
+      "SPDXID": "SPDXRef-File-encoding.go-583",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/encoding/encoding.go",
       "checksums": [
         {
@@ -8277,7 +6332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-key-generation.go-778",
+      "SPDXID": "SPDXRef-File-key-generation.go-584",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/key_generation.go",
       "checksums": [
         {
@@ -8287,7 +6342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rcurve.go-779",
+      "SPDXID": "SPDXRef-File-rcurve.go-585",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/brainpool/rcurve.go",
       "checksums": [
         {
@@ -8297,7 +6352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signature.go-780",
+      "SPDXID": "SPDXRef-File-signature.go-586",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/signature.go",
       "checksums": [
         {
@@ -8307,7 +6362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve25519.go-781",
+      "SPDXID": "SPDXRef-File-curve25519.go-587",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/curve25519.go",
       "checksums": [
         {
@@ -8317,7 +6372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-literal.go-782",
+      "SPDXID": "SPDXRef-File-literal.go-588",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/literal.go",
       "checksums": [
         {
@@ -8327,7 +6382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-symmetrically-encrypted-mdc.go-783",
+      "SPDXID": "SPDXRef-File-symmetrically-encrypted-mdc.go-589",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/symmetrically_encrypted_mdc.go",
       "checksums": [
         {
@@ -8337,7 +6392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eddsa.go-784",
+      "SPDXID": "SPDXRef-File-eddsa.go-590",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/eddsa/eddsa.go",
       "checksums": [
         {
@@ -8347,7 +6402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keys.go-785",
+      "SPDXID": "SPDXRef-File-keys.go-591",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/keys.go",
       "checksums": [
         {
@@ -8357,7 +6412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-write.go-786",
+      "SPDXID": "SPDXRef-File-write.go-592",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/write.go",
       "checksums": [
         {
@@ -8367,7 +6422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed448.go-787",
+      "SPDXID": "SPDXRef-File-ed448.go-593",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/ed448/ed448.go",
       "checksums": [
         {
@@ -8377,7 +6432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-public-key-test-data.go-788",
+      "SPDXID": "SPDXRef-File-public-key-test-data.go-594",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/public_key_test_data.go",
       "checksums": [
         {
@@ -8387,7 +6442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed448.go-789",
+      "SPDXID": "SPDXRef-File-ed448.go-595",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/ed448.go",
       "checksums": [
         {
@@ -8397,7 +6452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encrypted-key.go-790",
+      "SPDXID": "SPDXRef-File-encrypted-key.go-596",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/encrypted_key.go",
       "checksums": [
         {
@@ -8407,7 +6462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-s2k-config.go-791",
+      "SPDXID": "SPDXRef-File-s2k-config.go-597",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/s2k/s2k_config.go",
       "checksums": [
         {
@@ -8417,7 +6472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-elgamal.go-792",
+      "SPDXID": "SPDXRef-File-elgamal.go-598",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/elgamal/elgamal.go",
       "checksums": [
         {
@@ -8427,7 +6482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cipher.go-793",
+      "SPDXID": "SPDXRef-File-cipher.go-599",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/algorithm/cipher.go",
       "checksums": [
         {
@@ -8437,7 +6492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bitcurve.go-794",
+      "SPDXID": "SPDXRef-File-bitcurve.go-600",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/bitcurves/bitcurve.go",
       "checksums": [
         {
@@ -8447,7 +6502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-oid.go-795",
+      "SPDXID": "SPDXRef-File-oid.go-601",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/encoding/oid.go",
       "checksums": [
         {
@@ -8457,7 +6512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-brainpool.go-796",
+      "SPDXID": "SPDXRef-File-brainpool.go-602",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/brainpool/brainpool.go",
       "checksums": [
         {
@@ -8467,7 +6522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-opaque.go-797",
+      "SPDXID": "SPDXRef-File-opaque.go-603",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/opaque.go",
       "checksums": [
         {
@@ -8477,7 +6532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aead.go-798",
+      "SPDXID": "SPDXRef-File-aead.go-604",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/algorithm/aead.go",
       "checksums": [
         {
@@ -8487,7 +6542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.go-799",
+      "SPDXID": "SPDXRef-File-hash.go-605",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/algorithm/hash.go",
       "checksums": [
         {
@@ -8497,7 +6552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-byteutil.go-800",
+      "SPDXID": "SPDXRef-File-byteutil.go-606",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/internal/byteutil/byteutil.go",
       "checksums": [
         {
@@ -8507,7 +6562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ecdh.go-801",
+      "SPDXID": "SPDXRef-File-ecdh.go-607",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/ecdh/ecdh.go",
       "checksums": [
         {
@@ -8517,7 +6572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reader.go-802",
+      "SPDXID": "SPDXRef-File-reader.go-608",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/reader.go",
       "checksums": [
         {
@@ -8527,7 +6582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eax-test-vectors.go-803",
+      "SPDXID": "SPDXRef-File-eax-test-vectors.go-609",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/eax/eax_test_vectors.go",
       "checksums": [
         {
@@ -8537,7 +6592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-x448.go-804",
+      "SPDXID": "SPDXRef-File-x448.go-610",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/x448.go",
       "checksums": [
         {
@@ -8547,7 +6602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-armor.go-805",
+      "SPDXID": "SPDXRef-File-armor.go-611",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/armor/armor.go",
       "checksums": [
         {
@@ -8557,7 +6612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-public-key.go-806",
+      "SPDXID": "SPDXRef-File-public-key.go-612",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/public_key.go",
       "checksums": [
         {
@@ -8567,7 +6622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-generic.go-807",
+      "SPDXID": "SPDXRef-File-generic.go-613",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/internal/ecc/generic.go",
       "checksums": [
         {
@@ -8577,7 +6632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-808",
+      "SPDXID": "SPDXRef-File-errors.go-614",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/errors/errors.go",
       "checksums": [
         {
@@ -8587,7 +6642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read.go-809",
+      "SPDXID": "SPDXRef-File-read.go-615",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/read.go",
       "checksums": [
         {
@@ -8597,7 +6652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-private-key.go-810",
+      "SPDXID": "SPDXRef-File-private-key.go-616",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/private_key.go",
       "checksums": [
         {
@@ -8607,7 +6662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config-v5.go-811",
+      "SPDXID": "SPDXRef-File-config-v5.go-617",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/config_v5.go",
       "checksums": [
         {
@@ -8617,7 +6672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-one-pass-signature.go-812",
+      "SPDXID": "SPDXRef-File-one-pass-signature.go-618",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/one_pass_signature.go",
       "checksums": [
         {
@@ -8627,7 +6682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ecdsa.go-813",
+      "SPDXID": "SPDXRef-File-ecdsa.go-619",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/ecdsa/ecdsa.go",
       "checksums": [
         {
@@ -8637,7 +6692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-recipient.go-814",
+      "SPDXID": "SPDXRef-File-recipient.go-620",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/recipient.go",
       "checksums": [
         {
@@ -8647,7 +6702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aead-config.go-815",
+      "SPDXID": "SPDXRef-File-aead-config.go-621",
       "fileName": "repos/lazygit/vendor/github.com/ProtonMail/go-crypto/openpgp/packet/aead_config.go",
       "checksums": [
         {
@@ -8657,7 +6712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-jsonstring.go-816",
+      "SPDXID": "SPDXRef-File-jsonstring.go-622",
       "fileName": "repos/lazygit/vendor/github.com/go-logfmt/logfmt/jsonstring.go",
       "checksums": [
         {
@@ -8667,7 +6722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decode.go-817",
+      "SPDXID": "SPDXRef-File-decode.go-623",
       "fileName": "repos/lazygit/vendor/github.com/go-logfmt/logfmt/decode.go",
       "checksums": [
         {
@@ -8677,7 +6732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-818",
+      "SPDXID": "SPDXRef-File-doc.go-624",
       "fileName": "repos/lazygit/vendor/github.com/go-logfmt/logfmt/doc.go",
       "checksums": [
         {
@@ -8687,7 +6742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encode.go-819",
+      "SPDXID": "SPDXRef-File-encode.go-625",
       "fileName": "repos/lazygit/vendor/github.com/go-logfmt/logfmt/encode.go",
       "checksums": [
         {
@@ -8697,7 +6752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pagesize-unix.go-820",
+      "SPDXID": "SPDXRef-File-pagesize-unix.go-626",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/pagesize_unix.go",
       "checksums": [
         {
@@ -8707,7 +6762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-unix-gc.go-821",
+      "SPDXID": "SPDXRef-File-syscall-unix-gc.go-627",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_unix_gc.go",
       "checksums": [
         {
@@ -8717,7 +6772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux.go-822",
+      "SPDXID": "SPDXRef-File-syscall-linux.go-628",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux.go",
       "checksums": [
         {
@@ -8727,7 +6782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vgetrandom-linux.go-823",
+      "SPDXID": "SPDXRef-File-vgetrandom-linux.go-629",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/vgetrandom_linux.go",
       "checksums": [
         {
@@ -8737,7 +6792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zerrors-linux.go-824",
+      "SPDXID": "SPDXRef-File-zerrors-linux.go-630",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zerrors_linux.go",
       "checksums": [
         {
@@ -8747,7 +6802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dirent.go-825",
+      "SPDXID": "SPDXRef-File-dirent.go-631",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/dirent.go",
       "checksums": [
         {
@@ -8757,7 +6812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsysnum-linux-amd64.go-826",
+      "SPDXID": "SPDXRef-File-zsysnum-linux-amd64.go-632",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go",
       "checksums": [
         {
@@ -8767,7 +6822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ifreq-linux.go-827",
+      "SPDXID": "SPDXRef-File-ifreq-linux.go-633",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ifreq_linux.go",
       "checksums": [
         {
@@ -8777,7 +6832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-auxv.go-828",
+      "SPDXID": "SPDXRef-File-auxv.go-634",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/auxv.go",
       "checksums": [
         {
@@ -8787,7 +6842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux-alarm.go-829",
+      "SPDXID": "SPDXRef-File-syscall-linux-alarm.go-635",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux_alarm.go",
       "checksums": [
         {
@@ -8797,7 +6852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mremap.go-830",
+      "SPDXID": "SPDXRef-File-mremap.go-636",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/mremap.go",
       "checksums": [
         {
@@ -8807,7 +6862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-execabs.go-831",
+      "SPDXID": "SPDXRef-File-execabs.go-637",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/execabs/execabs.go",
       "checksums": [
         {
@@ -8817,7 +6872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-affinity-linux.go-832",
+      "SPDXID": "SPDXRef-File-affinity-linux.go-638",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/affinity_linux.go",
       "checksums": [
         {
@@ -8827,7 +6882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ztypes-linux.go-833",
+      "SPDXID": "SPDXRef-File-ztypes-linux.go-639",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ztypes_linux.go",
       "checksums": [
         {
@@ -8837,7 +6892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockcmsg-unix-other.go-834",
+      "SPDXID": "SPDXRef-File-sockcmsg-unix-other.go-640",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sockcmsg_unix_other.go",
       "checksums": [
         {
@@ -8847,7 +6902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-race0.go-835",
+      "SPDXID": "SPDXRef-File-race0.go-641",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/race0.go",
       "checksums": [
         {
@@ -8857,7 +6912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sysvshm-linux.go-836",
+      "SPDXID": "SPDXRef-File-sysvshm-linux.go-642",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sysvshm_linux.go",
       "checksums": [
         {
@@ -8867,7 +6922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zptrace-x86-linux.go-837",
+      "SPDXID": "SPDXRef-File-zptrace-x86-linux.go-643",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zptrace_x86_linux.go",
       "checksums": [
         {
@@ -8877,7 +6932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall.go-838",
+      "SPDXID": "SPDXRef-File-syscall.go-644",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall.go",
       "checksums": [
         {
@@ -8887,7 +6942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockcmsg-linux.go-839",
+      "SPDXID": "SPDXRef-File-sockcmsg-linux.go-645",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sockcmsg_linux.go",
       "checksums": [
         {
@@ -8897,7 +6952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fcntl.go-840",
+      "SPDXID": "SPDXRef-File-fcntl.go-646",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/fcntl.go",
       "checksums": [
         {
@@ -8907,7 +6962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fdset.go-841",
+      "SPDXID": "SPDXRef-File-fdset.go-647",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/fdset.go",
       "checksums": [
         {
@@ -8917,7 +6972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sysvshm-unix.go-842",
+      "SPDXID": "SPDXRef-File-sysvshm-unix.go-648",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sysvshm_unix.go",
       "checksums": [
         {
@@ -8927,7 +6982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-constants.go-843",
+      "SPDXID": "SPDXRef-File-constants.go-649",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/constants.go",
       "checksums": [
         {
@@ -8937,7 +6992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-timestruct.go-844",
+      "SPDXID": "SPDXRef-File-timestruct.go-650",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/timestruct.go",
       "checksums": [
         {
@@ -8947,7 +7002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ioctl-linux.go-845",
+      "SPDXID": "SPDXRef-File-ioctl-linux.go-651",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ioctl_linux.go",
       "checksums": [
         {
@@ -8957,7 +7012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsyscall-linux.go-846",
+      "SPDXID": "SPDXRef-File-zsyscall-linux.go-652",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zsyscall_linux.go",
       "checksums": [
         {
@@ -8967,7 +7022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zerrors-linux-amd64.go-847",
+      "SPDXID": "SPDXRef-File-zerrors-linux-amd64.go-653",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go",
       "checksums": [
         {
@@ -8977,7 +7032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bluetooth-linux.go-848",
+      "SPDXID": "SPDXRef-File-bluetooth-linux.go-654",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/bluetooth_linux.go",
       "checksums": [
         {
@@ -8987,7 +7042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-env-unix.go-849",
+      "SPDXID": "SPDXRef-File-env-unix.go-655",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/env_unix.go",
       "checksums": [
         {
@@ -8997,7 +7052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-aliases.go-850",
+      "SPDXID": "SPDXRef-File-aliases.go-656",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/aliases.go",
       "checksums": [
         {
@@ -9007,7 +7062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-endian-little.go-851",
+      "SPDXID": "SPDXRef-File-endian-little.go-657",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/endian_little.go",
       "checksums": [
         {
@@ -9017,7 +7072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sockcmsg-unix.go-852",
+      "SPDXID": "SPDXRef-File-sockcmsg-unix.go-658",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/sockcmsg_unix.go",
       "checksums": [
         {
@@ -9027,7 +7082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dev-linux.go-853",
+      "SPDXID": "SPDXRef-File-dev-linux.go-659",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/dev_linux.go",
       "checksums": [
         {
@@ -9037,7 +7092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux-amd64.go-854",
+      "SPDXID": "SPDXRef-File-syscall-linux-amd64.go-660",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux_amd64.go",
       "checksums": [
         {
@@ -9047,7 +7102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-execabs-go119.go-855",
+      "SPDXID": "SPDXRef-File-execabs-go119.go-661",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/execabs/execabs_go119.go",
       "checksums": [
         {
@@ -9057,7 +7112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-readdirent-getdents.go-856",
+      "SPDXID": "SPDXRef-File-readdirent-getdents.go-662",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/readdirent_getdents.go",
       "checksums": [
         {
@@ -9067,7 +7122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-unix.go-857",
+      "SPDXID": "SPDXRef-File-syscall-unix.go-663",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_unix.go",
       "checksums": [
         {
@@ -9077,7 +7132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ztypes-linux-amd64.go-858",
+      "SPDXID": "SPDXRef-File-ztypes-linux-amd64.go-664",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go",
       "checksums": [
         {
@@ -9087,7 +7142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ioctl-unsigned.go-859",
+      "SPDXID": "SPDXRef-File-ioctl-unsigned.go-665",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/ioctl_unsigned.go",
       "checksums": [
         {
@@ -9097,7 +7152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-x86.go-860",
+      "SPDXID": "SPDXRef-File-cpu-x86.go-666",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/cpu/cpu_x86.go",
       "checksums": [
         {
@@ -9107,7 +7162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux-amd64-gc.go-861",
+      "SPDXID": "SPDXRef-File-syscall-linux-amd64-gc.go-667",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux_amd64_gc.go",
       "checksums": [
         {
@@ -9117,7 +7172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsyscall-linux-amd64.go-862",
+      "SPDXID": "SPDXRef-File-zsyscall-linux-amd64.go-668",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/zsyscall_linux_amd64.go",
       "checksums": [
         {
@@ -9127,7 +7182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-syscall-linux-gc.go-863",
+      "SPDXID": "SPDXRef-File-syscall-linux-gc.go-669",
       "fileName": "repos/lazygit/vendor/golang.org/x/sys/unix/syscall_linux_gc.go",
       "checksums": [
         {
@@ -9137,7 +7192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parsedValue.go-864",
+      "SPDXID": "SPDXRef-File-parsedValue.go-670",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/parsedValue.go",
       "checksums": [
         {
@@ -9147,7 +7202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-argumentParser.go-865",
+      "SPDXID": "SPDXRef-File-argumentParser.go-671",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/argumentParser.go",
       "checksums": [
         {
@@ -9157,7 +7212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-help.go-866",
+      "SPDXID": "SPDXRef-File-help.go-672",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/help.go",
       "checksums": [
         {
@@ -9167,7 +7222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-flag.go-867",
+      "SPDXID": "SPDXRef-File-flag.go-673",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/flag.go",
       "checksums": [
         {
@@ -9177,7 +7232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-868",
+      "SPDXID": "SPDXRef-File-parser.go-674",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/parser.go",
       "checksums": [
         {
@@ -9187,7 +7242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-subCommand.go-869",
+      "SPDXID": "SPDXRef-File-subCommand.go-675",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/subCommand.go",
       "checksums": [
         {
@@ -9197,7 +7252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-main.go-870",
+      "SPDXID": "SPDXRef-File-main.go-676",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/main.go",
       "checksums": [
         {
@@ -9207,7 +7262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-positionalValue.go-871",
+      "SPDXID": "SPDXRef-File-positionalValue.go-677",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/positionalValue.go",
       "checksums": [
         {
@@ -9217,7 +7272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-helpValues.go-872",
+      "SPDXID": "SPDXRef-File-helpValues.go-678",
       "fileName": "repos/lazygit/vendor/github.com/integrii/flaggy/helpValues.go",
       "checksums": [
         {
@@ -9227,7 +7282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color-tag.go-873",
+      "SPDXID": "SPDXRef-File-color-tag.go-679",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color_tag.go",
       "checksums": [
         {
@@ -9237,7 +7292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color-16.go-874",
+      "SPDXID": "SPDXRef-File-color-16.go-680",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color_16.go",
       "checksums": [
         {
@@ -9247,7 +7302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-printer.go-875",
+      "SPDXID": "SPDXRef-File-printer.go-681",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/printer.go",
       "checksums": [
         {
@@ -9257,7 +7312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-quickstart.go-876",
+      "SPDXID": "SPDXRef-File-quickstart.go-682",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/quickstart.go",
       "checksums": [
         {
@@ -9267,7 +7322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-detect-nonwin.go-877",
+      "SPDXID": "SPDXRef-File-detect-nonwin.go-683",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/detect_nonwin.go",
       "checksums": [
         {
@@ -9277,7 +7332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color-rgb.go-878",
+      "SPDXID": "SPDXRef-File-color-rgb.go-684",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color_rgb.go",
       "checksums": [
         {
@@ -9287,7 +7342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-convert.go-879",
+      "SPDXID": "SPDXRef-File-convert.go-685",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/convert.go",
       "checksums": [
         {
@@ -9297,7 +7352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-880",
+      "SPDXID": "SPDXRef-File-utils.go-686",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/utils.go",
       "checksums": [
         {
@@ -9307,7 +7362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-881",
+      "SPDXID": "SPDXRef-File-color.go-687",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color.go",
       "checksums": [
         {
@@ -9317,7 +7372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color-256.go-882",
+      "SPDXID": "SPDXRef-File-color-256.go-688",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/color_256.go",
       "checksums": [
         {
@@ -9327,7 +7382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-detect-env.go-883",
+      "SPDXID": "SPDXRef-File-detect-env.go-689",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/detect_env.go",
       "checksums": [
         {
@@ -9337,7 +7392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-style.go-884",
+      "SPDXID": "SPDXRef-File-style.go-690",
       "fileName": "repos/lazygit/vendor/github.com/gookit/color/style.go",
       "checksums": [
         {
@@ -9347,7 +7402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.go-885",
+      "SPDXID": "SPDXRef-File-hash.go-691",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/hash.go",
       "checksums": [
         {
@@ -9357,7 +7412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-886",
+      "SPDXID": "SPDXRef-File-config.go-692",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/config.go",
       "checksums": [
         {
@@ -9367,7 +7422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filter.go-887",
+      "SPDXID": "SPDXRef-File-filter.go-693",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/filter.go",
       "checksums": [
         {
@@ -9377,7 +7432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-commit.go-888",
+      "SPDXID": "SPDXRef-File-worktree-commit.go-694",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/worktree_commit.go",
       "checksums": [
         {
@@ -9387,7 +7442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-index.go-889",
+      "SPDXID": "SPDXRef-File-index.go-695",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/index.go",
       "checksums": [
         {
@@ -9397,7 +7452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writer.go-890",
+      "SPDXID": "SPDXRef-File-writer.go-696",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/objfile/writer.go",
       "checksums": [
         {
@@ -9407,7 +7462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-options.go-891",
+      "SPDXID": "SPDXRef-File-options.go-697",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/options.go",
       "checksums": [
         {
@@ -9417,7 +7472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-892",
+      "SPDXID": "SPDXRef-File-client.go-698",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/client/client.go",
       "checksums": [
         {
@@ -9427,7 +7482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-893",
+      "SPDXID": "SPDXRef-File-client.go-699",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/file/client.go",
       "checksums": [
         {
@@ -9437,7 +7492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-delta-selector.go-894",
+      "SPDXID": "SPDXRef-File-delta-selector.go-700",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/delta_selector.go",
       "checksums": [
         {
@@ -9447,7 +7502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-895",
+      "SPDXID": "SPDXRef-File-encoder.go-701",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/encoder.go",
       "checksums": [
         {
@@ -9457,7 +7512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-896",
+      "SPDXID": "SPDXRef-File-doc.go-702",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/doc.go",
       "checksums": [
         {
@@ -9467,7 +7522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-897",
+      "SPDXID": "SPDXRef-File-server.go-703",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/internal/common/server.go",
       "checksums": [
         {
@@ -9477,7 +7532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-auth-method.go-898",
+      "SPDXID": "SPDXRef-File-auth-method.go-704",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/ssh/auth_method.go",
       "checksums": [
         {
@@ -9487,7 +7542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colorconfig.go-899",
+      "SPDXID": "SPDXRef-File-colorconfig.go-705",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/diff/colorconfig.go",
       "checksums": [
         {
@@ -9497,7 +7552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-status.go-900",
+      "SPDXID": "SPDXRef-File-worktree-status.go-706",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/worktree_status.go",
       "checksums": [
         {
@@ -9507,7 +7562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-901",
+      "SPDXID": "SPDXRef-File-common.go-707",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/ioutil/common.go",
       "checksums": [
         {
@@ -9517,7 +7572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dotgit.go-902",
+      "SPDXID": "SPDXRef-File-dotgit.go-708",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/dotgit.go",
       "checksums": [
         {
@@ -9527,7 +7582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-903",
+      "SPDXID": "SPDXRef-File-scanner.go-709",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/revision/scanner.go",
       "checksums": [
         {
@@ -9537,7 +7592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-limit.go-904",
+      "SPDXID": "SPDXRef-File-commit-walker-limit.go-710",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_limit.go",
       "checksums": [
         {
@@ -9547,7 +7602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-url.go-905",
+      "SPDXID": "SPDXRef-File-url.go-711",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/url/url.go",
       "checksums": [
         {
@@ -9557,7 +7612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-906",
+      "SPDXID": "SPDXRef-File-doc.go-712",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/doc.go",
       "checksums": [
         {
@@ -9567,7 +7622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-match.go-907",
+      "SPDXID": "SPDXRef-File-match.go-713",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/match.go",
       "checksums": [
         {
@@ -9577,7 +7632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reader.go-908",
+      "SPDXID": "SPDXRef-File-reader.go-714",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/reader.go",
       "checksums": [
         {
@@ -9587,7 +7642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doubleiter.go-909",
+      "SPDXID": "SPDXRef-File-doubleiter.go-715",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/doubleiter.go",
       "checksums": [
         {
@@ -9597,7 +7652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-error.go-910",
+      "SPDXID": "SPDXRef-File-error.go-716",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/pktline/error.go",
       "checksums": [
         {
@@ -9607,7 +7662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-911",
+      "SPDXID": "SPDXRef-File-color.go-717",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/color/color.go",
       "checksums": [
         {
@@ -9617,7 +7672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-912",
+      "SPDXID": "SPDXRef-File-server.go-718",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/server/server.go",
       "checksums": [
         {
@@ -9627,7 +7682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blame.go-913",
+      "SPDXID": "SPDXRef-File-blame.go-719",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/blame.go",
       "checksums": [
         {
@@ -9637,7 +7692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object-walker.go-914",
+      "SPDXID": "SPDXRef-File-object-walker.go-720",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/object_walker.go",
       "checksums": [
         {
@@ -9647,7 +7702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-index.go-915",
+      "SPDXID": "SPDXRef-File-index.go-721",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/index.go",
       "checksums": [
         {
@@ -9657,7 +7712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree.go-916",
+      "SPDXID": "SPDXRef-File-worktree.go-722",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/worktree.go",
       "checksums": [
         {
@@ -9667,7 +7722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dotgit-setref.go-917",
+      "SPDXID": "SPDXRef-File-dotgit-setref.go-723",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/dotgit_setref.go",
       "checksums": [
         {
@@ -9677,7 +7732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mocks.go-918",
+      "SPDXID": "SPDXRef-File-mocks.go-724",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/internal/common/mocks.go",
       "checksums": [
         {
@@ -9687,7 +7742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch.go-919",
+      "SPDXID": "SPDXRef-File-patch.go-725",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/diff/patch.go",
       "checksums": [
         {
@@ -9697,7 +7752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge-base.go-920",
+      "SPDXID": "SPDXRef-File-merge-base.go-726",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/merge_base.go",
       "checksums": [
         {
@@ -9707,7 +7762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ulreq-encode.go-921",
+      "SPDXID": "SPDXRef-File-ulreq-encode.go-727",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/ulreq_encode.go",
       "checksums": [
         {
@@ -9717,7 +7772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tree.go-922",
+      "SPDXID": "SPDXRef-File-tree.go-728",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/tree.go",
       "checksums": [
         {
@@ -9727,7 +7782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-storage.go-923",
+      "SPDXID": "SPDXRef-File-storage.go-729",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/storage.go",
       "checksums": [
         {
@@ -9737,7 +7792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-924",
+      "SPDXID": "SPDXRef-File-doc.go-730",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/doc.go",
       "checksums": [
         {
@@ -9747,7 +7802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-925",
+      "SPDXID": "SPDXRef-File-doc.go-731",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/doc.go",
       "checksums": [
         {
@@ -9757,7 +7812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-926",
+      "SPDXID": "SPDXRef-File-parser.go-732",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/parser.go",
       "checksums": [
         {
@@ -9767,7 +7822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-url.go-927",
+      "SPDXID": "SPDXRef-File-url.go-733",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/url.go",
       "checksums": [
         {
@@ -9777,7 +7832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reference.go-928",
+      "SPDXID": "SPDXRef-File-reference.go-734",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/reference.go",
       "checksums": [
         {
@@ -9787,7 +7842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-929",
+      "SPDXID": "SPDXRef-File-doc.go-735",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/doc.go",
       "checksums": [
         {
@@ -9797,7 +7852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-trace.go-930",
+      "SPDXID": "SPDXRef-File-trace.go-736",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/trace/trace.go",
       "checksums": [
         {
@@ -9807,7 +7862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object.go-931",
+      "SPDXID": "SPDXRef-File-object.go-737",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object.go",
       "checksums": [
         {
@@ -9817,7 +7872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shallow.go-932",
+      "SPDXID": "SPDXRef-File-shallow.go-738",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/shallow.go",
       "checksums": [
         {
@@ -9827,7 +7882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bufio.go-933",
+      "SPDXID": "SPDXRef-File-bufio.go-739",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/sync/bufio.go",
       "checksums": [
         {
@@ -9837,7 +7892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reader.go-934",
+      "SPDXID": "SPDXRef-File-reader.go-740",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/objfile/reader.go",
       "checksums": [
         {
@@ -9847,7 +7902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pattern.go-935",
+      "SPDXID": "SPDXRef-File-pattern.go-741",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/gitignore/pattern.go",
       "checksums": [
         {
@@ -9857,7 +7912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-section.go-936",
+      "SPDXID": "SPDXRef-File-section.go-742",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/section.go",
       "checksums": [
         {
@@ -9867,7 +7922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uppackresp.go-937",
+      "SPDXID": "SPDXRef-File-uppackresp.go-743",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/uppackresp.go",
       "checksums": [
         {
@@ -9877,7 +7932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-938",
+      "SPDXID": "SPDXRef-File-scanner.go-744",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/scanner.go",
       "checksums": [
         {
@@ -9887,7 +7942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object-pack.go-939",
+      "SPDXID": "SPDXRef-File-object-pack.go-745",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/object_pack.go",
       "checksums": [
         {
@@ -9897,7 +7952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-format.go-940",
+      "SPDXID": "SPDXRef-File-format.go-746",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/format.go",
       "checksums": [
         {
@@ -9907,7 +7962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-path-util.go-941",
+      "SPDXID": "SPDXRef-File-path-util.go-747",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/path_util/path_util.go",
       "checksums": [
         {
@@ -9917,7 +7972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-942",
+      "SPDXID": "SPDXRef-File-doc.go-748",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/doc.go",
       "checksums": [
         {
@@ -9927,7 +7982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-943",
+      "SPDXID": "SPDXRef-File-doc.go-749",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/doc.go",
       "checksums": [
         {
@@ -9937,7 +7992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reference.go-944",
+      "SPDXID": "SPDXRef-File-reference.go-750",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/reference.go",
       "checksums": [
         {
@@ -9947,7 +8002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-945",
+      "SPDXID": "SPDXRef-File-doc.go-751",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/doc.go",
       "checksums": [
         {
@@ -9957,7 +8012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-status.go-946",
+      "SPDXID": "SPDXRef-File-status.go-752",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/status.go",
       "checksums": [
         {
@@ -9967,7 +8022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch-delta.go-947",
+      "SPDXID": "SPDXRef-File-patch-delta.go-753",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/patch_delta.go",
       "checksums": [
         {
@@ -9977,7 +8032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list.go-948",
+      "SPDXID": "SPDXRef-File-list.go-754",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/capability/list.go",
       "checksums": [
         {
@@ -9987,7 +8042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-remote.go-949",
+      "SPDXID": "SPDXRef-File-remote.go-755",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/remote.go",
       "checksums": [
         {
@@ -9997,7 +8052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-950",
+      "SPDXID": "SPDXRef-File-encoder.go-756",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/pktline/encoder.go",
       "checksums": [
         {
@@ -10007,7 +8062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-node.go-951",
+      "SPDXID": "SPDXRef-File-node.go-757",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/index/node.go",
       "checksums": [
         {
@@ -10017,7 +8072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-receive-pack.go-952",
+      "SPDXID": "SPDXRef-File-receive-pack.go-758",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/http/receive_pack.go",
       "checksums": [
         {
@@ -10027,7 +8082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-muxer.go-953",
+      "SPDXID": "SPDXRef-File-muxer.go-759",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/sideband/muxer.go",
       "checksums": [
         {
@@ -10037,7 +8092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-change.go-954",
+      "SPDXID": "SPDXRef-File-change.go-760",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/change.go",
       "checksums": [
         {
@@ -10047,7 +8102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-revision.go-955",
+      "SPDXID": "SPDXRef-File-revision.go-761",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/revision.go",
       "checksums": [
         {
@@ -10057,7 +8112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shallow.go-956",
+      "SPDXID": "SPDXRef-File-shallow.go-762",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/shallow.go",
       "checksums": [
         {
@@ -10067,7 +8122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker.go-957",
+      "SPDXID": "SPDXRef-File-commit-walker.go-763",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker.go",
       "checksums": [
         {
@@ -10077,7 +8132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-958",
+      "SPDXID": "SPDXRef-File-common.go-764",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/common.go",
       "checksums": [
         {
@@ -10087,7 +8142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-storer.go-959",
+      "SPDXID": "SPDXRef-File-storer.go-765",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/storer.go",
       "checksums": [
         {
@@ -10097,7 +8152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fsobject.go-960",
+      "SPDXID": "SPDXRef-File-fsobject.go-766",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/fsobject.go",
       "checksums": [
         {
@@ -10107,7 +8162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object.go-961",
+      "SPDXID": "SPDXRef-File-object.go-767",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/object.go",
       "checksums": [
         {
@@ -10117,7 +8172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deltaobject.go-962",
+      "SPDXID": "SPDXRef-File-deltaobject.go-768",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/deltaobject.go",
       "checksums": [
         {
@@ -10127,7 +8182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read.go-963",
+      "SPDXID": "SPDXRef-File-read.go-769",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/binary/read.go",
       "checksums": [
         {
@@ -10137,7 +8192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-ctime.go-964",
+      "SPDXID": "SPDXRef-File-commit-walker-ctime.go-770",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_ctime.go",
       "checksums": [
         {
@@ -10147,7 +8202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decoder.go-965",
+      "SPDXID": "SPDXRef-File-decoder.go-771",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/decoder.go",
       "checksums": [
         {
@@ -10157,7 +8212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-path.go-966",
+      "SPDXID": "SPDXRef-File-path.go-772",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/noder/path.go",
       "checksums": [
         {
@@ -10167,7 +8222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-967",
+      "SPDXID": "SPDXRef-File-common.go-773",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/internal/common/common.go",
       "checksums": [
         {
@@ -10177,7 +8232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-memory.go-968",
+      "SPDXID": "SPDXRef-File-memory.go-774",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/memory.go",
       "checksums": [
         {
@@ -10187,7 +8242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noder.go-969",
+      "SPDXID": "SPDXRef-File-noder.go-775",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/noder/noder.go",
       "checksums": [
         {
@@ -10197,7 +8252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-970",
+      "SPDXID": "SPDXRef-File-common.go-776",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/common.go",
       "checksums": [
         {
@@ -10207,7 +8262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tag.go-971",
+      "SPDXID": "SPDXRef-File-tag.go-777",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/tag.go",
       "checksums": [
         {
@@ -10217,7 +8272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writers.go-972",
+      "SPDXID": "SPDXRef-File-writers.go-778",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/writers.go",
       "checksums": [
         {
@@ -10227,7 +8282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff.go-973",
+      "SPDXID": "SPDXRef-File-diff.go-779",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/diff/diff.go",
       "checksums": [
         {
@@ -10237,7 +8292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-bfs-filtered.go-974",
+      "SPDXID": "SPDXRef-File-commit-walker-bfs-filtered.go-780",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_bfs_filtered.go",
       "checksums": [
         {
@@ -10247,7 +8302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ulreq.go-975",
+      "SPDXID": "SPDXRef-File-ulreq.go-781",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/ulreq.go",
       "checksums": [
         {
@@ -10257,7 +8312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-file.go-976",
+      "SPDXID": "SPDXRef-File-file.go-782",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/file.go",
       "checksums": [
         {
@@ -10267,7 +8322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object-lru.go-977",
+      "SPDXID": "SPDXRef-File-object-lru.go-783",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/cache/object_lru.go",
       "checksums": [
         {
@@ -10277,7 +8332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-module.go-978",
+      "SPDXID": "SPDXRef-File-module.go-784",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/module.go",
       "checksums": [
         {
@@ -10287,7 +8342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-979",
+      "SPDXID": "SPDXRef-File-common.go-785",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/cache/common.go",
       "checksums": [
         {
@@ -10297,7 +8352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-server.go-980",
+      "SPDXID": "SPDXRef-File-server.go-786",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/file/server.go",
       "checksums": [
         {
@@ -10307,7 +8362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch.go-981",
+      "SPDXID": "SPDXRef-File-patch.go-787",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/patch.go",
       "checksums": [
         {
@@ -10317,7 +8372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-advrefs.go-982",
+      "SPDXID": "SPDXRef-File-advrefs.go-788",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/advrefs.go",
       "checksums": [
         {
@@ -10327,7 +8382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-blob.go-983",
+      "SPDXID": "SPDXRef-File-blob.go-789",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/blob.go",
       "checksums": [
         {
@@ -10337,7 +8392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-unified-encoder.go-984",
+      "SPDXID": "SPDXRef-File-unified-encoder.go-790",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/diff/unified_encoder.go",
       "checksums": [
         {
@@ -10347,7 +8402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-985",
+      "SPDXID": "SPDXRef-File-common.go-791",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/git/common.go",
       "checksums": [
         {
@@ -10357,7 +8412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash.go-986",
+      "SPDXID": "SPDXRef-File-hash.go-792",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/hash/hash.go",
       "checksums": [
         {
@@ -10367,7 +8422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object.go-987",
+      "SPDXID": "SPDXRef-File-object.go-793",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/object.go",
       "checksums": [
         {
@@ -10377,7 +8432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-modules.go-988",
+      "SPDXID": "SPDXRef-File-modules.go-794",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/modules.go",
       "checksums": [
         {
@@ -10387,7 +8442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-989",
+      "SPDXID": "SPDXRef-File-parser.go-795",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/revision/parser.go",
       "checksums": [
         {
@@ -10397,7 +8452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-index.go-990",
+      "SPDXID": "SPDXRef-File-index.go-796",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/index.go",
       "checksums": [
         {
@@ -10407,7 +8462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-repository-filesystem.go-991",
+      "SPDXID": "SPDXRef-File-repository-filesystem.go-797",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/repository_filesystem.go",
       "checksums": [
         {
@@ -10417,7 +8472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decoder.go-992",
+      "SPDXID": "SPDXRef-File-decoder.go-798",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/decoder.go",
       "checksums": [
         {
@@ -10427,7 +8482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-submodule.go-993",
+      "SPDXID": "SPDXRef-File-submodule.go-799",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/submodule.go",
       "checksums": [
         {
@@ -10437,7 +8492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-994",
+      "SPDXID": "SPDXRef-File-common.go-800",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/common.go",
       "checksums": [
         {
@@ -10447,7 +8502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-repository.go-995",
+      "SPDXID": "SPDXRef-File-repository.go-801",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/repository.go",
       "checksums": [
         {
@@ -10457,7 +8512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-996",
+      "SPDXID": "SPDXRef-File-common.go-802",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/common.go",
       "checksums": [
         {
@@ -10467,7 +8522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-997",
+      "SPDXID": "SPDXRef-File-common.go-803",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/http/common.go",
       "checksums": [
         {
@@ -10477,7 +8532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-998",
+      "SPDXID": "SPDXRef-File-encoder.go-804",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/index/encoder.go",
       "checksums": [
         {
@@ -10487,7 +8542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-upload-pack.go-999",
+      "SPDXID": "SPDXRef-File-upload-pack.go-805",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/http/upload_pack.go",
       "checksums": [
         {
@@ -10497,7 +8552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-revlist.go-1000",
+      "SPDXID": "SPDXRef-File-revlist.go-806",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/revlist/revlist.go",
       "checksums": [
         {
@@ -10507,7 +8562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-idxfile.go-1001",
+      "SPDXID": "SPDXRef-File-idxfile.go-807",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/idxfile.go",
       "checksums": [
         {
@@ -10517,7 +8572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rename.go-1002",
+      "SPDXID": "SPDXRef-File-rename.go-808",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/rename.go",
       "checksums": [
         {
@@ -10527,7 +8582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-advrefs-encode.go-1003",
+      "SPDXID": "SPDXRef-File-advrefs-encode.go-809",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/advrefs_encode.go",
       "checksums": [
         {
@@ -10537,7 +8592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-refspec.go-1004",
+      "SPDXID": "SPDXRef-File-refspec.go-810",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/refspec.go",
       "checksums": [
         {
@@ -10547,7 +8602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-1005",
+      "SPDXID": "SPDXRef-File-encoder.go-811",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/encoder.go",
       "checksums": [
         {
@@ -10557,7 +8612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-difftree.go-1006",
+      "SPDXID": "SPDXRef-File-difftree.go-812",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/difftree.go",
       "checksums": [
         {
@@ -10567,7 +8622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-error.go-1007",
+      "SPDXID": "SPDXRef-File-error.go-813",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/error.go",
       "checksums": [
         {
@@ -10577,7 +8632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-delta-index.go-1008",
+      "SPDXID": "SPDXRef-File-delta-index.go-814",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/delta_index.go",
       "checksums": [
         {
@@ -10587,7 +8642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-updreq-encode.go-1009",
+      "SPDXID": "SPDXRef-File-updreq-encode.go-815",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/updreq_encode.go",
       "checksums": [
         {
@@ -10597,7 +8652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1010",
+      "SPDXID": "SPDXRef-File-doc.go-816",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/objfile/doc.go",
       "checksums": [
         {
@@ -10607,7 +8662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-1011",
+      "SPDXID": "SPDXRef-File-common.go-817",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/common.go",
       "checksums": [
         {
@@ -10617,7 +8672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-1012",
+      "SPDXID": "SPDXRef-File-scanner.go-818",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/pktline/scanner.go",
       "checksums": [
         {
@@ -10627,7 +8682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-demux.go-1013",
+      "SPDXID": "SPDXRef-File-demux.go-819",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/sideband/demux.go",
       "checksums": [
         {
@@ -10637,7 +8692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-report-status.go-1014",
+      "SPDXID": "SPDXRef-File-report-status.go-820",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/report_status.go",
       "checksums": [
         {
@@ -10647,7 +8702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-node.go-1015",
+      "SPDXID": "SPDXRef-File-node.go-821",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/filesystem/node.go",
       "checksums": [
         {
@@ -10657,7 +8712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-token.go-1016",
+      "SPDXID": "SPDXRef-File-token.go-822",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/internal/revision/token.go",
       "checksums": [
         {
@@ -10667,7 +8722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-buffer-lru.go-1017",
+      "SPDXID": "SPDXRef-File-buffer-lru.go-823",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/cache/buffer_lru.go",
       "checksums": [
         {
@@ -10677,7 +8732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-treenoder.go-1018",
+      "SPDXID": "SPDXRef-File-treenoder.go-824",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/treenoder.go",
       "checksums": [
         {
@@ -10687,7 +8742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dir.go-1019",
+      "SPDXID": "SPDXRef-File-dir.go-825",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/gitignore/dir.go",
       "checksums": [
         {
@@ -10697,7 +8752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shallowupd.go-1020",
+      "SPDXID": "SPDXRef-File-shallowupd.go-826",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/shallowupd.go",
       "checksums": [
         {
@@ -10707,7 +8762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-frame.go-1021",
+      "SPDXID": "SPDXRef-File-frame.go-827",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/internal/frame/frame.go",
       "checksums": [
         {
@@ -10717,7 +8772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-capability.go-1022",
+      "SPDXID": "SPDXRef-File-capability.go-828",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/capability/capability.go",
       "checksums": [
         {
@@ -10727,7 +8782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-path.go-1023",
+      "SPDXID": "SPDXRef-File-commit-walker-path.go-829",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_path.go",
       "checksums": [
         {
@@ -10737,7 +8792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writer.go-1024",
+      "SPDXID": "SPDXRef-File-writer.go-830",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/writer.go",
       "checksums": [
         {
@@ -10747,7 +8802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff-delta.go-1025",
+      "SPDXID": "SPDXRef-File-diff-delta.go-831",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/diff_delta.go",
       "checksums": [
         {
@@ -10757,7 +8812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-matcher.go-1026",
+      "SPDXID": "SPDXRef-File-matcher.go-832",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/gitignore/matcher.go",
       "checksums": [
         {
@@ -10767,7 +8822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-difftree.go-1027",
+      "SPDXID": "SPDXRef-File-difftree.go-833",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/difftree.go",
       "checksums": [
         {
@@ -10777,7 +8832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-write.go-1028",
+      "SPDXID": "SPDXRef-File-write.go-834",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/binary/write.go",
       "checksums": [
         {
@@ -10787,7 +8842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-error.go-1029",
+      "SPDXID": "SPDXRef-File-error.go-835",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/error.go",
       "checksums": [
         {
@@ -10797,7 +8852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-change-adaptor.go-1030",
+      "SPDXID": "SPDXRef-File-change-adaptor.go-836",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/change_adaptor.go",
       "checksums": [
         {
@@ -10807,7 +8862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1031",
+      "SPDXID": "SPDXRef-File-doc.go-837",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/sideband/doc.go",
       "checksums": [
         {
@@ -10817,7 +8872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bytes.go-1032",
+      "SPDXID": "SPDXRef-File-bytes.go-838",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/sync/bytes.go",
       "checksums": [
         {
@@ -10827,7 +8882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-storer.go-1033",
+      "SPDXID": "SPDXRef-File-storer.go-839",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/storer/storer.go",
       "checksums": [
         {
@@ -10837,7 +8892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transport.go-1034",
+      "SPDXID": "SPDXRef-File-transport.go-840",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/http/transport.go",
       "checksums": [
         {
@@ -10847,7 +8902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit-walker-bfs.go-1035",
+      "SPDXID": "SPDXRef-File-commit-walker-bfs.go-841",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit_walker_bfs.go",
       "checksums": [
         {
@@ -10857,7 +8912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-option.go-1036",
+      "SPDXID": "SPDXRef-File-option.go-842",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/option.go",
       "checksums": [
         {
@@ -10867,7 +8922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gitproto.go-1037",
+      "SPDXID": "SPDXRef-File-gitproto.go-843",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/gitproto.go",
       "checksums": [
         {
@@ -10877,7 +8932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-updreq.go-1038",
+      "SPDXID": "SPDXRef-File-updreq.go-844",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/updreq.go",
       "checksums": [
         {
@@ -10887,7 +8942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signer.go-1039",
+      "SPDXID": "SPDXRef-File-signer.go-845",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/signer.go",
       "checksums": [
         {
@@ -10897,7 +8952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-updreq-decode.go-1040",
+      "SPDXID": "SPDXRef-File-updreq-decode.go-846",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/updreq_decode.go",
       "checksums": [
         {
@@ -10907,7 +8962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dotgit-rewrite-packed-refs.go-1041",
+      "SPDXID": "SPDXRef-File-dotgit-rewrite-packed-refs.go-847",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go",
       "checksums": [
         {
@@ -10917,7 +8972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decoder.go-1042",
+      "SPDXID": "SPDXRef-File-decoder.go-848",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/idxfile/decoder.go",
       "checksums": [
         {
@@ -10927,7 +8982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-advrefs-decode.go-1043",
+      "SPDXID": "SPDXRef-File-advrefs-decode.go-849",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/advrefs_decode.go",
       "checksums": [
         {
@@ -10937,7 +8992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-1044",
+      "SPDXID": "SPDXRef-File-common.go-850",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/ssh/common.go",
       "checksums": [
         {
@@ -10947,7 +9002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reference.go-1045",
+      "SPDXID": "SPDXRef-File-reference.go-851",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/reference.go",
       "checksums": [
         {
@@ -10957,7 +9012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-object.go-1046",
+      "SPDXID": "SPDXRef-File-object.go-852",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/object.go",
       "checksums": [
         {
@@ -10967,7 +9022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-packfile.go-1047",
+      "SPDXID": "SPDXRef-File-packfile.go-853",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/packfile/packfile.go",
       "checksums": [
         {
@@ -10977,7 +9032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-prune.go-1048",
+      "SPDXID": "SPDXRef-File-prune.go-854",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/prune.go",
       "checksums": [
         {
@@ -10987,7 +9042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iter.go-1049",
+      "SPDXID": "SPDXRef-File-iter.go-855",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/iter.go",
       "checksums": [
         {
@@ -10997,7 +9052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-storage.go-1050",
+      "SPDXID": "SPDXRef-File-storage.go-856",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/memory/storage.go",
       "checksums": [
         {
@@ -11007,7 +9062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoder.go-1051",
+      "SPDXID": "SPDXRef-File-encoder.go-857",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/config/encoder.go",
       "checksums": [
         {
@@ -11017,7 +9072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common.go-1052",
+      "SPDXID": "SPDXRef-File-common.go-858",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/sideband/common.go",
       "checksums": [
         {
@@ -11027,7 +9082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-loader.go-1053",
+      "SPDXID": "SPDXRef-File-loader.go-859",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/transport/server/loader.go",
       "checksums": [
         {
@@ -11037,7 +9092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-srvresp.go-1054",
+      "SPDXID": "SPDXRef-File-srvresp.go-860",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/srvresp.go",
       "checksums": [
         {
@@ -11047,7 +9102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hash-sha1.go-1055",
+      "SPDXID": "SPDXRef-File-hash-sha1.go-861",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/hash/hash_sha1.go",
       "checksums": [
         {
@@ -11057,7 +9112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-filemode.go-1056",
+      "SPDXID": "SPDXRef-File-filemode.go-862",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/filemode/filemode.go",
       "checksums": [
         {
@@ -11067,7 +9122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ulreq-decode.go-1057",
+      "SPDXID": "SPDXRef-File-ulreq-decode.go-863",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/ulreq_decode.go",
       "checksums": [
         {
@@ -11077,7 +9132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zlib.go-1058",
+      "SPDXID": "SPDXRef-File-zlib.go-864",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/sync/zlib.go",
       "checksums": [
         {
@@ -11087,7 +9142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-worktree-linux.go-1059",
+      "SPDXID": "SPDXRef-File-worktree-linux.go-865",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/worktree_linux.go",
       "checksums": [
         {
@@ -11097,7 +9152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1060",
+      "SPDXID": "SPDXRef-File-doc.go-866",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/format/gitignore/doc.go",
       "checksums": [
         {
@@ -11107,7 +9162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-change.go-1061",
+      "SPDXID": "SPDXRef-File-change.go-867",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/utils/merkletrie/change.go",
       "checksums": [
         {
@@ -11117,7 +9172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-commit.go-1062",
+      "SPDXID": "SPDXRef-File-commit.go-868",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/commit.go",
       "checksums": [
         {
@@ -11127,7 +9182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-branch.go-1063",
+      "SPDXID": "SPDXRef-File-branch.go-869",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/config/branch.go",
       "checksums": [
         {
@@ -11137,7 +9192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signature.go-1064",
+      "SPDXID": "SPDXRef-File-signature.go-870",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/object/signature.go",
       "checksums": [
         {
@@ -11147,7 +9202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-config.go-1065",
+      "SPDXID": "SPDXRef-File-config.go-871",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/storage/filesystem/config.go",
       "checksums": [
         {
@@ -11157,7 +9212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-uppackreq.go-1066",
+      "SPDXID": "SPDXRef-File-uppackreq.go-872",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/go-git/v5/plumbing/protocol/packp/uppackreq.go",
       "checksums": [
         {
@@ -11167,7 +9222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp-amd64.go-1067",
+      "SPDXID": "SPDXRef-File-fp-amd64.go-873",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp25519/fp_amd64.go",
       "checksums": [
         {
@@ -11177,7 +9232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-xor-unaligned.go-1068",
+      "SPDXID": "SPDXRef-File-xor-unaligned.go-874",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/xor_unaligned.go",
       "checksums": [
         {
@@ -11187,7 +9242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-modular.go-1069",
+      "SPDXID": "SPDXRef-File-modular.go-875",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/modular.go",
       "checksums": [
         {
@@ -11197,7 +9252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-point.go-1070",
+      "SPDXID": "SPDXRef-File-point.go-876",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/point.go",
       "checksums": [
         {
@@ -11207,7 +9262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sign.go-1071",
+      "SPDXID": "SPDXRef-File-sign.go-877",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/sign.go",
       "checksums": [
         {
@@ -11217,7 +9272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-primes.go-1072",
+      "SPDXID": "SPDXRef-File-primes.go-878",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/primes.go",
       "checksums": [
         {
@@ -11227,7 +9282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keccakf.go-1073",
+      "SPDXID": "SPDXRef-File-keccakf.go-879",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/keccakf.go",
       "checksums": [
         {
@@ -11237,7 +9292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve.go-1074",
+      "SPDXID": "SPDXRef-File-curve.go-880",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/curve.go",
       "checksums": [
         {
@@ -11247,7 +9302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signapi.go-1075",
+      "SPDXID": "SPDXRef-File-signapi.go-881",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed448/signapi.go",
       "checksums": [
         {
@@ -11257,7 +9312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-table.go-1076",
+      "SPDXID": "SPDXRef-File-table.go-882",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/table.go",
       "checksums": [
         {
@@ -11267,7 +9322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed25519.go-1077",
+      "SPDXID": "SPDXRef-File-ed25519.go-883",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/ed25519.go",
       "checksums": [
         {
@@ -11277,7 +9332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-key.go-1078",
+      "SPDXID": "SPDXRef-File-key.go-884",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/key.go",
       "checksums": [
         {
@@ -11287,7 +9342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mult.go-1079",
+      "SPDXID": "SPDXRef-File-mult.go-885",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/mult.go",
       "checksums": [
         {
@@ -11297,7 +9352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp-generic.go-1080",
+      "SPDXID": "SPDXRef-File-fp-generic.go-886",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp25519/fp_generic.go",
       "checksums": [
         {
@@ -11307,7 +9362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1081",
+      "SPDXID": "SPDXRef-File-doc.go-887",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/doc.go",
       "checksums": [
         {
@@ -11317,7 +9372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-power.go-1082",
+      "SPDXID": "SPDXRef-File-power.go-888",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/mlsbset/power.go",
       "checksums": [
         {
@@ -11327,7 +9382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-conv.go-1083",
+      "SPDXID": "SPDXRef-File-conv.go-889",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/conv/conv.go",
       "checksums": [
         {
@@ -11337,7 +9392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp-generic.go-1084",
+      "SPDXID": "SPDXRef-File-fp-generic.go-890",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp448/fp_generic.go",
       "checksums": [
         {
@@ -11347,7 +9402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp.go-1085",
+      "SPDXID": "SPDXRef-File-fp.go-891",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp25519/fp.go",
       "checksums": [
         {
@@ -11357,7 +9412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp-amd64.go-1086",
+      "SPDXID": "SPDXRef-File-fp-amd64.go-892",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp448/fp_amd64.go",
       "checksums": [
         {
@@ -11367,7 +9422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rc.go-1087",
+      "SPDXID": "SPDXRef-File-rc.go-893",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/rc.go",
       "checksums": [
         {
@@ -11377,7 +9432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-shake.go-1088",
+      "SPDXID": "SPDXRef-File-shake.go-894",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/shake.go",
       "checksums": [
         {
@@ -11387,7 +9442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hashes.go-1089",
+      "SPDXID": "SPDXRef-File-hashes.go-895",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/hashes.go",
       "checksums": [
         {
@@ -11397,7 +9452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1090",
+      "SPDXID": "SPDXRef-File-doc.go-896",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/doc.go",
       "checksums": [
         {
@@ -11407,7 +9462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-twist.go-1091",
+      "SPDXID": "SPDXRef-File-twist.go-897",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/twist.go",
       "checksums": [
         {
@@ -11417,7 +9472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tables.go-1092",
+      "SPDXID": "SPDXRef-File-tables.go-898",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/tables.go",
       "checksums": [
         {
@@ -11427,7 +9482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-amd64.go-1093",
+      "SPDXID": "SPDXRef-File-curve-amd64.go-899",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/curve_amd64.go",
       "checksums": [
         {
@@ -11437,7 +9492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wnaf.go-1094",
+      "SPDXID": "SPDXRef-File-wnaf.go-900",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/wnaf.go",
       "checksums": [
         {
@@ -11447,7 +9502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-integer.go-1095",
+      "SPDXID": "SPDXRef-File-integer.go-901",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/integer.go",
       "checksums": [
         {
@@ -11457,7 +9512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-amd64.go-1096",
+      "SPDXID": "SPDXRef-File-curve-amd64.go-902",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/curve_amd64.go",
       "checksums": [
         {
@@ -11467,7 +9522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha3.go-1097",
+      "SPDXID": "SPDXRef-File-sha3.go-903",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/internal/sha3/sha3.go",
       "checksums": [
         {
@@ -11477,7 +9532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mlsbset.go-1098",
+      "SPDXID": "SPDXRef-File-mlsbset.go-904",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/mlsbset/mlsbset.go",
       "checksums": [
         {
@@ -11487,7 +9542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fp.go-1099",
+      "SPDXID": "SPDXRef-File-fp.go-905",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/math/fp448/fp.go",
       "checksums": [
         {
@@ -11497,7 +9552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-generic.go-1100",
+      "SPDXID": "SPDXRef-File-curve-generic.go-906",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/curve_generic.go",
       "checksums": [
         {
@@ -11507,7 +9562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-isogeny.go-1101",
+      "SPDXID": "SPDXRef-File-isogeny.go-907",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/isogeny.go",
       "checksums": [
         {
@@ -11517,7 +9572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-constants.go-1102",
+      "SPDXID": "SPDXRef-File-constants.go-908",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/constants.go",
       "checksums": [
         {
@@ -11527,7 +9582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1103",
+      "SPDXID": "SPDXRef-File-doc.go-909",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/doc.go",
       "checksums": [
         {
@@ -11537,7 +9592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pubkey.go-1104",
+      "SPDXID": "SPDXRef-File-pubkey.go-910",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/pubkey.go",
       "checksums": [
         {
@@ -11547,7 +9602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ed448.go-1105",
+      "SPDXID": "SPDXRef-File-ed448.go-911",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed448/ed448.go",
       "checksums": [
         {
@@ -11557,7 +9612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-twistPoint.go-1106",
+      "SPDXID": "SPDXRef-File-twistPoint.go-912",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/twistPoint.go",
       "checksums": [
         {
@@ -11567,7 +9622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-key.go-1107",
+      "SPDXID": "SPDXRef-File-key.go-913",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/key.go",
       "checksums": [
         {
@@ -11577,7 +9632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-point.go-1108",
+      "SPDXID": "SPDXRef-File-point.go-914",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/point.go",
       "checksums": [
         {
@@ -11587,7 +9642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve.go-1109",
+      "SPDXID": "SPDXRef-File-curve.go-915",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/curve.go",
       "checksums": [
         {
@@ -11597,7 +9652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve-generic.go-1110",
+      "SPDXID": "SPDXRef-File-curve-generic.go-916",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/curve_generic.go",
       "checksums": [
         {
@@ -11607,7 +9662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-signapi.go-1111",
+      "SPDXID": "SPDXRef-File-signapi.go-917",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/sign/ed25519/signapi.go",
       "checksums": [
         {
@@ -11617,7 +9672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-twistTables.go-1112",
+      "SPDXID": "SPDXRef-File-twistTables.go-918",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/twistTables.go",
       "checksums": [
         {
@@ -11627,7 +9682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-table.go-1113",
+      "SPDXID": "SPDXRef-File-table.go-919",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x448/table.go",
       "checksums": [
         {
@@ -11637,7 +9692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-twist-basemult.go-1114",
+      "SPDXID": "SPDXRef-File-twist-basemult.go-920",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/twist_basemult.go",
       "checksums": [
         {
@@ -11647,7 +9702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-curve.go-1115",
+      "SPDXID": "SPDXRef-File-curve.go-921",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/dh/x25519/curve.go",
       "checksums": [
         {
@@ -11657,7 +9712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scalar.go-1116",
+      "SPDXID": "SPDXRef-File-scalar.go-922",
       "fileName": "repos/lazygit/vendor/github.com/cloudflare/circl/ecc/goldilocks/scalar.go",
       "checksums": [
         {
@@ -11667,7 +9722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-attr.go-1117",
+      "SPDXID": "SPDXRef-File-attr.go-923",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/attr.go",
       "checksums": [
         {
@@ -11677,7 +9732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1118",
+      "SPDXID": "SPDXRef-File-term.go-924",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/a/alacritty/term.go",
       "checksums": [
         {
@@ -11687,7 +9742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-nonblock-unix.go-1119",
+      "SPDXID": "SPDXRef-File-nonblock-unix.go-925",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/nonblock_unix.go",
       "checksums": [
         {
@@ -11697,7 +9752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-direct.go-1120",
+      "SPDXID": "SPDXRef-File-direct.go-926",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xterm/direct.go",
       "checksums": [
         {
@@ -11707,7 +9762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1121",
+      "SPDXID": "SPDXRef-File-term.go-927",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xfce/term.go",
       "checksums": [
         {
@@ -11717,7 +9772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1122",
+      "SPDXID": "SPDXRef-File-term.go-928",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/r/rxvt/term.go",
       "checksums": [
         {
@@ -11727,7 +9782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1123",
+      "SPDXID": "SPDXRef-File-term.go-929",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/c/cygwin/term.go",
       "checksums": [
         {
@@ -11737,7 +9792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-1124",
+      "SPDXID": "SPDXRef-File-errors.go-930",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/errors.go",
       "checksums": [
         {
@@ -11747,7 +9802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1125",
+      "SPDXID": "SPDXRef-File-term.go-931",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/a/ansi/term.go",
       "checksums": [
         {
@@ -11757,7 +9812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1126",
+      "SPDXID": "SPDXRef-File-term.go-932",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/l/linux/term.go",
       "checksums": [
         {
@@ -11767,7 +9822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1127",
+      "SPDXID": "SPDXRef-File-term.go-933",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt420/term.go",
       "checksums": [
         {
@@ -11777,7 +9832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tscreen-unix.go-1128",
+      "SPDXID": "SPDXRef-File-tscreen-unix.go-934",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/tscreen_unix.go",
       "checksums": [
         {
@@ -11787,7 +9842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1129",
+      "SPDXID": "SPDXRef-File-term.go-935",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/g/gnome/term.go",
       "checksums": [
         {
@@ -11797,7 +9852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mouse.go-1130",
+      "SPDXID": "SPDXRef-File-mouse.go-936",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/mouse.go",
       "checksums": [
         {
@@ -11807,7 +9862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminfo.go-1131",
+      "SPDXID": "SPDXRef-File-terminfo.go-937",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/terminfo.go",
       "checksums": [
         {
@@ -11817,7 +9872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-extended.go-1132",
+      "SPDXID": "SPDXRef-File-extended.go-938",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/extended/extended.go",
       "checksums": [
         {
@@ -11827,7 +9882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1133",
+      "SPDXID": "SPDXRef-File-term.go-939",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/s/screen/term.go",
       "checksums": [
         {
@@ -11837,7 +9892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1134",
+      "SPDXID": "SPDXRef-File-term.go-940",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/a/aixterm/term.go",
       "checksums": [
         {
@@ -11847,7 +9902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1135",
+      "SPDXID": "SPDXRef-File-term.go-941",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/s/sun/term.go",
       "checksums": [
         {
@@ -11857,7 +9912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eastasian.go-1136",
+      "SPDXID": "SPDXRef-File-eastasian.go-942",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/eastasian.go",
       "checksums": [
         {
@@ -11867,7 +9922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1137",
+      "SPDXID": "SPDXRef-File-term.go-943",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt400/term.go",
       "checksums": [
         {
@@ -11877,7 +9932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-key.go-1138",
+      "SPDXID": "SPDXRef-File-key.go-944",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/key.go",
       "checksums": [
         {
@@ -11887,7 +9942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1139",
+      "SPDXID": "SPDXRef-File-term.go-945",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/t/tmux/term.go",
       "checksums": [
         {
@@ -11897,7 +9952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1140",
+      "SPDXID": "SPDXRef-File-doc.go-946",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/doc.go",
       "checksums": [
         {
@@ -11907,7 +9962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-console-stub.go-1141",
+      "SPDXID": "SPDXRef-File-console-stub.go-947",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/console_stub.go",
       "checksums": [
         {
@@ -11917,7 +9972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-interrupt.go-1142",
+      "SPDXID": "SPDXRef-File-interrupt.go-948",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/interrupt.go",
       "checksums": [
         {
@@ -11927,7 +9982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-style.go-1143",
+      "SPDXID": "SPDXRef-File-style.go-949",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/style.go",
       "checksums": [
         {
@@ -11937,7 +9992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1144",
+      "SPDXID": "SPDXRef-File-term.go-950",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xterm/term.go",
       "checksums": [
         {
@@ -11947,7 +10002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base.go-1145",
+      "SPDXID": "SPDXRef-File-base.go-951",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/base/base.go",
       "checksums": [
         {
@@ -11957,7 +10012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tscreen.go-1146",
+      "SPDXID": "SPDXRef-File-tscreen.go-952",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/tscreen.go",
       "checksums": [
         {
@@ -11967,7 +10022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-direct.go-1147",
+      "SPDXID": "SPDXRef-File-direct.go-953",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/a/alacritty/direct.go",
       "checksums": [
         {
@@ -11977,7 +10032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1148",
+      "SPDXID": "SPDXRef-File-term.go-954",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/e/emacs/term.go",
       "checksums": [
         {
@@ -11987,7 +10042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1149",
+      "SPDXID": "SPDXRef-File-term.go-955",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/k/konsole/term.go",
       "checksums": [
         {
@@ -11997,7 +10052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tty.go-1150",
+      "SPDXID": "SPDXRef-File-tty.go-956",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/tty.go",
       "checksums": [
         {
@@ -12007,7 +10062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-charset-unix.go-1151",
+      "SPDXID": "SPDXRef-File-charset-unix.go-957",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/charset_unix.go",
       "checksums": [
         {
@@ -12017,7 +10072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dynamic.go-1152",
+      "SPDXID": "SPDXRef-File-dynamic.go-958",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/dynamic/dynamic.go",
       "checksums": [
         {
@@ -12027,7 +10082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-1153",
+      "SPDXID": "SPDXRef-File-color.go-959",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/color.go",
       "checksums": [
         {
@@ -12037,7 +10092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-simulation.go-1154",
+      "SPDXID": "SPDXRef-File-simulation.go-960",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/simulation.go",
       "checksums": [
         {
@@ -12047,7 +10102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terms-dynamic.go-1155",
+      "SPDXID": "SPDXRef-File-terms-dynamic.go-961",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terms_dynamic.go",
       "checksums": [
         {
@@ -12057,7 +10112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1156",
+      "SPDXID": "SPDXRef-File-term.go-962",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/s/simpleterm/term.go",
       "checksums": [
         {
@@ -12067,7 +10122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-foot.go-1157",
+      "SPDXID": "SPDXRef-File-foot.go-963",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/f/foot/foot.go",
       "checksums": [
         {
@@ -12077,7 +10132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-event.go-1158",
+      "SPDXID": "SPDXRef-File-event.go-964",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/event.go",
       "checksums": [
         {
@@ -12087,7 +10142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1159",
+      "SPDXID": "SPDXRef-File-term.go-965",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/k/kterm/term.go",
       "checksums": [
         {
@@ -12097,7 +10152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1160",
+      "SPDXID": "SPDXRef-File-term.go-966",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/p/pcansi/term.go",
       "checksums": [
         {
@@ -12107,7 +10162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stdin-unix.go-1161",
+      "SPDXID": "SPDXRef-File-stdin-unix.go-967",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/stdin_unix.go",
       "checksums": [
         {
@@ -12117,7 +10172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1162",
+      "SPDXID": "SPDXRef-File-term.go-968",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/d/dtterm/term.go",
       "checksums": [
         {
@@ -12127,7 +10182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoding.go-1163",
+      "SPDXID": "SPDXRef-File-encoding.go-969",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/encoding.go",
       "checksums": [
         {
@@ -12137,7 +10192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1164",
+      "SPDXID": "SPDXRef-File-term.go-970",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt220/term.go",
       "checksums": [
         {
@@ -12147,7 +10202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cell.go-1165",
+      "SPDXID": "SPDXRef-File-cell.go-971",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/cell.go",
       "checksums": [
         {
@@ -12157,7 +10212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1166",
+      "SPDXID": "SPDXRef-File-term.go-972",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xterm_ghostty/term.go",
       "checksums": [
         {
@@ -12167,7 +10222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tty-unix.go-1167",
+      "SPDXID": "SPDXRef-File-tty-unix.go-973",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/tty_unix.go",
       "checksums": [
         {
@@ -12177,7 +10232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1168",
+      "SPDXID": "SPDXRef-File-term.go-974",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt320/term.go",
       "checksums": [
         {
@@ -12187,7 +10242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-input.go-1169",
+      "SPDXID": "SPDXRef-File-input.go-975",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/input.go",
       "checksums": [
         {
@@ -12197,7 +10252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-screen.go-1170",
+      "SPDXID": "SPDXRef-File-screen.go-976",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/screen.go",
       "checksums": [
         {
@@ -12207,7 +10262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1171",
+      "SPDXID": "SPDXRef-File-term.go-977",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt100/term.go",
       "checksums": [
         {
@@ -12217,7 +10272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1172",
+      "SPDXID": "SPDXRef-File-term.go-978",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/v/vt102/term.go",
       "checksums": [
         {
@@ -12227,7 +10282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-focus.go-1173",
+      "SPDXID": "SPDXRef-File-focus.go-979",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/focus.go",
       "checksums": [
         {
@@ -12237,7 +10292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-runes.go-1174",
+      "SPDXID": "SPDXRef-File-runes.go-980",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/runes.go",
       "checksums": [
         {
@@ -12247,7 +10302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-resize.go-1175",
+      "SPDXID": "SPDXRef-File-resize.go-981",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/resize.go",
       "checksums": [
         {
@@ -12257,7 +10312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-paste.go-1176",
+      "SPDXID": "SPDXRef-File-paste.go-982",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/paste.go",
       "checksums": [
         {
@@ -12267,7 +10322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colorfit.go-1177",
+      "SPDXID": "SPDXRef-File-colorfit.go-983",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/colorfit.go",
       "checksums": [
         {
@@ -12277,7 +10332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1178",
+      "SPDXID": "SPDXRef-File-term.go-984",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terminfo/x/xterm_kitty/term.go",
       "checksums": [
         {
@@ -12287,7 +10342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terms-default.go-1179",
+      "SPDXID": "SPDXRef-File-terms-default.go-985",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/tcell/v2/terms_default.go",
       "checksums": [
         {
@@ -12297,7 +10352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-orderedmap.go-1180",
+      "SPDXID": "SPDXRef-File-orderedmap.go-986",
       "fileName": "repos/lazygit/vendor/github.com/wk8/go-ordered-map/v2/orderedmap.go",
       "checksums": [
         {
@@ -12307,7 +10362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-yaml.go-1181",
+      "SPDXID": "SPDXRef-File-yaml.go-987",
       "fileName": "repos/lazygit/vendor/github.com/wk8/go-ordered-map/v2/yaml.go",
       "checksums": [
         {
@@ -12317,7 +10372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-json.go-1182",
+      "SPDXID": "SPDXRef-File-json.go-988",
       "fileName": "repos/lazygit/vendor/github.com/wk8/go-ordered-map/v2/json.go",
       "checksums": [
         {
@@ -12327,7 +10382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-1183",
+      "SPDXID": "SPDXRef-File-utils.go-989",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/lazycore/pkg/utils/utils.go",
       "checksums": [
         {
@@ -12337,7 +10392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-boxlayout.go-1184",
+      "SPDXID": "SPDXRef-File-boxlayout.go-990",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/lazycore/pkg/boxlayout/boxlayout.go",
       "checksums": [
         {
@@ -12347,7 +10402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsortanyfunc.go-1185",
+      "SPDXID": "SPDXRef-File-zsortanyfunc.go-991",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/zsortanyfunc.go",
       "checksums": [
         {
@@ -12357,7 +10412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-constraints.go-1186",
+      "SPDXID": "SPDXRef-File-constraints.go-992",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/constraints/constraints.go",
       "checksums": [
         {
@@ -12367,7 +10422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slices.go-1187",
+      "SPDXID": "SPDXRef-File-slices.go-993",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/slices.go",
       "checksums": [
         {
@@ -12377,7 +10432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zsortordered.go-1188",
+      "SPDXID": "SPDXRef-File-zsortordered.go-994",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/zsortordered.go",
       "checksums": [
         {
@@ -12387,7 +10442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sort.go-1189",
+      "SPDXID": "SPDXRef-File-sort.go-995",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/sort.go",
       "checksums": [
         {
@@ -12397,7 +10452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cmp.go-1190",
+      "SPDXID": "SPDXRef-File-cmp.go-996",
       "fileName": "repos/lazygit/vendor/golang.org/x/exp/slices/cmp.go",
       "checksums": [
         {
@@ -12407,7 +10462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ubc-amd64.go-1191",
+      "SPDXID": "SPDXRef-File-ubc-amd64.go-997",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/ubc/ubc_amd64.go",
       "checksums": [
         {
@@ -12417,7 +10472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha1cd.go-1192",
+      "SPDXID": "SPDXRef-File-sha1cd.go-998",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/sha1cd.go",
       "checksums": [
         {
@@ -12427,7 +10482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-const.go-1193",
+      "SPDXID": "SPDXRef-File-const.go-999",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/internal/const.go",
       "checksums": [
         {
@@ -12437,7 +10492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha1cdblock-amd64.go-1194",
+      "SPDXID": "SPDXRef-File-sha1cdblock-amd64.go-1000",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/sha1cdblock_amd64.go",
       "checksums": [
         {
@@ -12447,7 +10502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-detection.go-1195",
+      "SPDXID": "SPDXRef-File-detection.go-1001",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/detection.go",
       "checksums": [
         {
@@ -12457,7 +10512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ubc.go-1196",
+      "SPDXID": "SPDXRef-File-ubc.go-1002",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/ubc/ubc.go",
       "checksums": [
         {
@@ -12467,7 +10522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sha1cdblock-generic.go-1197",
+      "SPDXID": "SPDXRef-File-sha1cdblock-generic.go-1003",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/sha1cdblock_generic.go",
       "checksums": [
         {
@@ -12477,7 +10532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-const.go-1198",
+      "SPDXID": "SPDXRef-File-const.go-1004",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/ubc/const.go",
       "checksums": [
         {
@@ -12487,7 +10542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ubc-generic.go-1199",
+      "SPDXID": "SPDXRef-File-ubc-generic.go-1005",
       "fileName": "repos/lazygit/vendor/github.com/pjbgf/sha1cd/ubc/ubc_generic.go",
       "checksums": [
         {
@@ -12497,7 +10552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-1200",
+      "SPDXID": "SPDXRef-File-scanner.go-1006",
       "fileName": "repos/lazygit/vendor/github.com/kr/logfmt/scanner.go",
       "checksums": [
         {
@@ -12507,7 +10562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decode.go-1201",
+      "SPDXID": "SPDXRef-File-decode.go-1007",
       "fileName": "repos/lazygit/vendor/github.com/kr/logfmt/decode.go",
       "checksums": [
         {
@@ -12517,7 +10572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-unquote.go-1202",
+      "SPDXID": "SPDXRef-File-unquote.go-1008",
       "fileName": "repos/lazygit/vendor/github.com/kr/logfmt/unquote.go",
       "checksums": [
         {
@@ -12527,7 +10582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-1203",
+      "SPDXID": "SPDXRef-File-errors.go-1009",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/errors.go",
       "checksums": [
         {
@@ -12537,7 +10592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-intersect.go-1204",
+      "SPDXID": "SPDXRef-File-intersect.go-1010",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/intersect.go",
       "checksums": [
         {
@@ -12547,7 +10602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-condition.go-1205",
+      "SPDXID": "SPDXRef-File-condition.go-1011",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/condition.go",
       "checksums": [
         {
@@ -12557,7 +10612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-test.go-1206",
+      "SPDXID": "SPDXRef-File-test.go-1012",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/test.go",
       "checksums": [
         {
@@ -12567,7 +10622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-concurrency.go-1207",
+      "SPDXID": "SPDXRef-File-concurrency.go-1013",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/concurrency.go",
       "checksums": [
         {
@@ -12577,7 +10632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-math.go-1208",
+      "SPDXID": "SPDXRef-File-math.go-1014",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/math.go",
       "checksums": [
         {
@@ -12587,7 +10642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-slice.go-1209",
+      "SPDXID": "SPDXRef-File-slice.go-1015",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/slice.go",
       "checksums": [
         {
@@ -12597,7 +10652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-types.go-1210",
+      "SPDXID": "SPDXRef-File-types.go-1016",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/types.go",
       "checksums": [
         {
@@ -12607,7 +10662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-map.go-1211",
+      "SPDXID": "SPDXRef-File-map.go-1017",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/map.go",
       "checksums": [
         {
@@ -12617,7 +10672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-func.go-1212",
+      "SPDXID": "SPDXRef-File-func.go-1018",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/func.go",
       "checksums": [
         {
@@ -12627,7 +10682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-string.go-1213",
+      "SPDXID": "SPDXRef-File-string.go-1019",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/string.go",
       "checksums": [
         {
@@ -12637,7 +10692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-retry.go-1214",
+      "SPDXID": "SPDXRef-File-retry.go-1020",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/retry.go",
       "checksums": [
         {
@@ -12647,7 +10702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-constraints.go-1215",
+      "SPDXID": "SPDXRef-File-constraints.go-1021",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/constraints.go",
       "checksums": [
         {
@@ -12657,7 +10712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-channel.go-1216",
+      "SPDXID": "SPDXRef-File-channel.go-1022",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/channel.go",
       "checksums": [
         {
@@ -12667,7 +10722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-find.go-1217",
+      "SPDXID": "SPDXRef-File-find.go-1023",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/find.go",
       "checksums": [
         {
@@ -12677,7 +10732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tuples.go-1218",
+      "SPDXID": "SPDXRef-File-tuples.go-1024",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/tuples.go",
       "checksums": [
         {
@@ -12687,7 +10742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-type-manipulation.go-1219",
+      "SPDXID": "SPDXRef-File-type-manipulation.go-1025",
       "fileName": "repos/lazygit/vendor/github.com/samber/lo/type_manipulation.go",
       "checksums": [
         {
@@ -12697,7 +10752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mergo.go-1220",
+      "SPDXID": "SPDXRef-File-mergo.go-1026",
       "fileName": "repos/lazygit/vendor/dario.cat/mergo/mergo.go",
       "checksums": [
         {
@@ -12707,7 +10762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-map.go-1221",
+      "SPDXID": "SPDXRef-File-map.go-1027",
       "fileName": "repos/lazygit/vendor/dario.cat/mergo/map.go",
       "checksums": [
         {
@@ -12717,7 +10772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1222",
+      "SPDXID": "SPDXRef-File-doc.go-1028",
       "fileName": "repos/lazygit/vendor/dario.cat/mergo/doc.go",
       "checksums": [
         {
@@ -12727,7 +10782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-merge.go-1223",
+      "SPDXID": "SPDXRef-File-merge.go-1029",
       "fileName": "repos/lazygit/vendor/dario.cat/mergo/merge.go",
       "checksums": [
         {
@@ -12737,7 +10792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-keybinding.go-1224",
+      "SPDXID": "SPDXRef-File-keybinding.go-1030",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/keybinding.go",
       "checksums": [
         {
@@ -12747,7 +10802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui-others.go-1225",
+      "SPDXID": "SPDXRef-File-gui-others.go-1031",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/gui_others.go",
       "checksums": [
         {
@@ -12757,7 +10812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-loader.go-1226",
+      "SPDXID": "SPDXRef-File-loader.go-1032",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/loader.go",
       "checksums": [
         {
@@ -12767,7 +10822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scrollbar.go-1227",
+      "SPDXID": "SPDXRef-File-scrollbar.go-1033",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/scrollbar.go",
       "checksums": [
         {
@@ -12777,7 +10832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tcell-driver.go-1228",
+      "SPDXID": "SPDXRef-File-tcell-driver.go-1034",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/tcell_driver.go",
       "checksums": [
         {
@@ -12787,7 +10842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gui.go-1229",
+      "SPDXID": "SPDXRef-File-gui.go-1035",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/gui.go",
       "checksums": [
         {
@@ -12797,7 +10852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-view.go-1230",
+      "SPDXID": "SPDXRef-File-view.go-1036",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/view.go",
       "checksums": [
         {
@@ -12807,7 +10862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-text-area.go-1231",
+      "SPDXID": "SPDXRef-File-text-area.go-1037",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/text_area.go",
       "checksums": [
         {
@@ -12817,7 +10872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-edit.go-1232",
+      "SPDXID": "SPDXRef-File-edit.go-1038",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/edit.go",
       "checksums": [
         {
@@ -12827,7 +10882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-task.go-1233",
+      "SPDXID": "SPDXRef-File-task.go-1039",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/task.go",
       "checksums": [
         {
@@ -12837,7 +10892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1234",
+      "SPDXID": "SPDXRef-File-doc.go-1040",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/doc.go",
       "checksums": [
         {
@@ -12847,7 +10902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-attribute.go-1235",
+      "SPDXID": "SPDXRef-File-attribute.go-1041",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/attribute.go",
       "checksums": [
         {
@@ -12857,7 +10912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-escape.go-1236",
+      "SPDXID": "SPDXRef-File-escape.go-1042",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/escape.go",
       "checksums": [
         {
@@ -12867,7 +10922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-task-manager.go-1237",
+      "SPDXID": "SPDXRef-File-task-manager.go-1043",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/gocui/task_manager.go",
       "checksums": [
         {
@@ -12877,7 +10932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-graphemeproperties.go-1238",
+      "SPDXID": "SPDXRef-File-graphemeproperties.go-1044",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/graphemeproperties.go",
       "checksums": [
         {
@@ -12887,7 +10942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sentencerules.go-1239",
+      "SPDXID": "SPDXRef-File-sentencerules.go-1045",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/sentencerules.go",
       "checksums": [
         {
@@ -12897,7 +10952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1240",
+      "SPDXID": "SPDXRef-File-doc.go-1046",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/doc.go",
       "checksums": [
         {
@@ -12907,7 +10962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wordproperties.go-1241",
+      "SPDXID": "SPDXRef-File-wordproperties.go-1047",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/wordproperties.go",
       "checksums": [
         {
@@ -12917,7 +10972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-word.go-1242",
+      "SPDXID": "SPDXRef-File-word.go-1048",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/word.go",
       "checksums": [
         {
@@ -12927,7 +10982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-wordrules.go-1243",
+      "SPDXID": "SPDXRef-File-wordrules.go-1049",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/wordrules.go",
       "checksums": [
         {
@@ -12937,7 +10992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-graphemerules.go-1244",
+      "SPDXID": "SPDXRef-File-graphemerules.go-1050",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/graphemerules.go",
       "checksums": [
         {
@@ -12947,7 +11002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-eastasianwidth.go-1245",
+      "SPDXID": "SPDXRef-File-eastasianwidth.go-1051",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/eastasianwidth.go",
       "checksums": [
         {
@@ -12957,7 +11012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-properties.go-1246",
+      "SPDXID": "SPDXRef-File-properties.go-1052",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/properties.go",
       "checksums": [
         {
@@ -12967,7 +11022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sentenceproperties.go-1247",
+      "SPDXID": "SPDXRef-File-sentenceproperties.go-1053",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/sentenceproperties.go",
       "checksums": [
         {
@@ -12977,7 +11032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-linerules.go-1248",
+      "SPDXID": "SPDXRef-File-linerules.go-1054",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/linerules.go",
       "checksums": [
         {
@@ -12987,7 +11042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-line.go-1249",
+      "SPDXID": "SPDXRef-File-line.go-1055",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/line.go",
       "checksums": [
         {
@@ -12997,7 +11052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-width.go-1250",
+      "SPDXID": "SPDXRef-File-width.go-1056",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/width.go",
       "checksums": [
         {
@@ -13007,7 +11062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-emojipresentation.go-1251",
+      "SPDXID": "SPDXRef-File-emojipresentation.go-1057",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/emojipresentation.go",
       "checksums": [
         {
@@ -13017,7 +11072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-step.go-1252",
+      "SPDXID": "SPDXRef-File-step.go-1058",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/step.go",
       "checksums": [
         {
@@ -13027,7 +11082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lineproperties.go-1253",
+      "SPDXID": "SPDXRef-File-lineproperties.go-1059",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/lineproperties.go",
       "checksums": [
         {
@@ -13037,7 +11092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sentence.go-1254",
+      "SPDXID": "SPDXRef-File-sentence.go-1060",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/sentence.go",
       "checksums": [
         {
@@ -13047,7 +11102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-grapheme.go-1255",
+      "SPDXID": "SPDXRef-File-grapheme.go-1061",
       "fileName": "repos/lazygit/vendor/github.com/rivo/uniseg/grapheme.go",
       "checksums": [
         {
@@ -13057,7 +11112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bytes.go-1256",
+      "SPDXID": "SPDXRef-File-bytes.go-1062",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/bytes.go",
       "checksums": [
         {
@@ -13067,7 +11122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parser.go-1257",
+      "SPDXID": "SPDXRef-File-parser.go-1063",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/parser.go",
       "checksums": [
         {
@@ -13077,7 +11132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-escape.go-1258",
+      "SPDXID": "SPDXRef-File-escape.go-1064",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/escape.go",
       "checksums": [
         {
@@ -13087,7 +11142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bytes-unsafe.go-1259",
+      "SPDXID": "SPDXRef-File-bytes-unsafe.go-1065",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/bytes_unsafe.go",
       "checksums": [
         {
@@ -13097,7 +11152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fuzz.go-1260",
+      "SPDXID": "SPDXRef-File-fuzz.go-1066",
       "fileName": "repos/lazygit/vendor/github.com/buger/jsonparser/fuzz.go",
       "checksums": [
         {
@@ -13107,7 +11162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-happy-palettegen.go-1261",
+      "SPDXID": "SPDXRef-File-happy-palettegen.go-1067",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/happy_palettegen.go",
       "checksums": [
         {
@@ -13117,7 +11172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colors.go-1262",
+      "SPDXID": "SPDXRef-File-colors.go-1068",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/colors.go",
       "checksums": [
         {
@@ -13127,7 +11182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-soft-palettegen.go-1263",
+      "SPDXID": "SPDXRef-File-soft-palettegen.go-1069",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/soft_palettegen.go",
       "checksums": [
         {
@@ -13137,7 +11192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colorgens.go-1264",
+      "SPDXID": "SPDXRef-File-colorgens.go-1070",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/colorgens.go",
       "checksums": [
         {
@@ -13147,7 +11202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hexcolor.go-1265",
+      "SPDXID": "SPDXRef-File-hexcolor.go-1071",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/hexcolor.go",
       "checksums": [
         {
@@ -13157,7 +11212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sort.go-1266",
+      "SPDXID": "SPDXRef-File-sort.go-1072",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/sort.go",
       "checksums": [
         {
@@ -13167,7 +11222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hsluv.go-1267",
+      "SPDXID": "SPDXRef-File-hsluv.go-1073",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/hsluv.go",
       "checksums": [
         {
@@ -13177,7 +11232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warm-palettegen.go-1268",
+      "SPDXID": "SPDXRef-File-warm-palettegen.go-1074",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/warm_palettegen.go",
       "checksums": [
         {
@@ -13187,7 +11242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-rand.go-1269",
+      "SPDXID": "SPDXRef-File-rand.go-1075",
       "fileName": "repos/lazygit/vendor/github.com/lucasb-eyer/go-colorful/rand.go",
       "checksums": [
         {
@@ -13197,7 +11252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patch.go-1270",
+      "SPDXID": "SPDXRef-File-patch.go-1076",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/patch.go",
       "checksums": [
         {
@@ -13207,7 +11262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-match.go-1271",
+      "SPDXID": "SPDXRef-File-match.go-1077",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/match.go",
       "checksums": [
         {
@@ -13217,7 +11272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-operation-string.go-1272",
+      "SPDXID": "SPDXRef-File-operation-string.go-1078",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/operation_string.go",
       "checksums": [
         {
@@ -13227,7 +11282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diff.go-1273",
+      "SPDXID": "SPDXRef-File-diff.go-1079",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/diff.go",
       "checksums": [
         {
@@ -13237,7 +11292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mathutil.go-1274",
+      "SPDXID": "SPDXRef-File-mathutil.go-1080",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/mathutil.go",
       "checksums": [
         {
@@ -13247,7 +11302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-diffmatchpatch.go-1275",
+      "SPDXID": "SPDXRef-File-diffmatchpatch.go-1081",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/diffmatchpatch.go",
       "checksums": [
         {
@@ -13257,7 +11312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stringutil.go-1276",
+      "SPDXID": "SPDXRef-File-stringutil.go-1082",
       "fileName": "repos/lazygit/vendor/github.com/sergi/go-diff/diffmatchpatch/stringutil.go",
       "checksums": [
         {
@@ -13267,7 +11322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-logfmt-handler.go-1277",
+      "SPDXID": "SPDXRef-File-logfmt-handler.go-1083",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/logfmt_handler.go",
       "checksums": [
         {
@@ -13277,7 +11332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-docker-compose-handler.go-1278",
+      "SPDXID": "SPDXRef-File-docker-compose-handler.go-1084",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/docker_compose_handler.go",
       "checksums": [
         {
@@ -13287,7 +11342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-handler.go-1279",
+      "SPDXID": "SPDXRef-File-handler.go-1085",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/handler.go",
       "checksums": [
         {
@@ -13297,7 +11352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-1280",
+      "SPDXID": "SPDXRef-File-scanner.go-1086",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/scanner.go",
       "checksums": [
         {
@@ -13307,7 +11362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-json-handler.go-1281",
+      "SPDXID": "SPDXRef-File-json-handler.go-1087",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/json_handler.go",
       "checksums": [
         {
@@ -13317,7 +11372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-time-parse.go-1282",
+      "SPDXID": "SPDXRef-File-time-parse.go-1088",
       "fileName": "repos/lazygit/vendor/github.com/aybabtme/humanlog/time_parse.go",
       "checksums": [
         {
@@ -13327,107 +11382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lobject.h-1283",
-      "fileName": "repos/redis/src/../deps/lua/src/lobject.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "10e46b178022f6a4046a8b973ba10c3d9df5e3fa"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lua.h-1284",
-      "fileName": "repos/redis/src/../deps/lua/src/lua.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "280ef23821ab3480e95a2d918d35c290061fd174"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lauxlib.h-1285",
-      "fileName": "repos/redis/src/../deps/lua/src/lauxlib.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "34258235dbebff581b08a09d3acff87204cd5406"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lstate.h-1286",
-      "fileName": "repos/redis/src/../deps/lua/src/lstate.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "3bc575b6bc8cdef8286ea4d8d539a4ee4fe5a180"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lualib.h-1287",
-      "fileName": "repos/redis/src/../deps/lua/src/lualib.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "469417f6703eb65a4559188f4febabac1a2ce01c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lzio.h-1288",
-      "fileName": "repos/redis/src/../deps/lua/src/lzio.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "51d695d8c1d5a26ba2146d5b1866c00c52771499"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-ltm.h-1289",
-      "fileName": "repos/redis/src/../deps/lua/src/ltm.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "64343b781b6498930c30abc8f56ce2f7c5ede1ac"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lmem.h-1290",
-      "fileName": "repos/redis/src/../deps/lua/src/lmem.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7c2dcb32207a0438684eb0566ce769f47d895cf4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-llimits.h-1291",
-      "fileName": "repos/redis/src/../deps/lua/src/llimits.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ca8dcb72244bae473d27e605395b17a7d95c9c1c"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-luaconf.h-1292",
-      "fileName": "repos/redis/src/../deps/lua/src/luaconf.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e2cb26163a2320cd5e27c89ba1e32cedbad41049"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-walk.go-1293",
+      "SPDXID": "SPDXRef-File-walk.go-1089",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/util/walk.go",
       "checksums": [
         {
@@ -13437,7 +11392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-polyfill.go-1294",
+      "SPDXID": "SPDXRef-File-polyfill.go-1090",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/helper/polyfill/polyfill.go",
       "checksums": [
         {
@@ -13447,7 +11402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-util.go-1295",
+      "SPDXID": "SPDXRef-File-util.go-1091",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/util/util.go",
       "checksums": [
         {
@@ -13457,7 +11412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-options.go-1296",
+      "SPDXID": "SPDXRef-File-os-options.go-1092",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os_options.go",
       "checksums": [
         {
@@ -13467,7 +11422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-posix.go-1297",
+      "SPDXID": "SPDXRef-File-os-posix.go-1093",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os_posix.go",
       "checksums": [
         {
@@ -13477,7 +11432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-chroot.go-1298",
+      "SPDXID": "SPDXRef-File-chroot.go-1094",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/helper/chroot/chroot.go",
       "checksums": [
         {
@@ -13487,7 +11442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os.go-1299",
+      "SPDXID": "SPDXRef-File-os.go-1095",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os.go",
       "checksums": [
         {
@@ -13497,7 +11452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-bound.go-1300",
+      "SPDXID": "SPDXRef-File-os-bound.go-1096",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os_bound.go",
       "checksums": [
         {
@@ -13507,7 +11462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fs.go-1301",
+      "SPDXID": "SPDXRef-File-fs.go-1097",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/fs.go",
       "checksums": [
         {
@@ -13517,7 +11472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-glob.go-1302",
+      "SPDXID": "SPDXRef-File-glob.go-1098",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/util/glob.go",
       "checksums": [
         {
@@ -13527,7 +11482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-os-chroot.go-1303",
+      "SPDXID": "SPDXRef-File-os-chroot.go-1099",
       "fileName": "repos/lazygit/vendor/github.com/go-git/go-billy/v5/osfs/os_chroot.go",
       "checksums": [
         {
@@ -13537,17 +11492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fast-float-strtod.h-1304",
-      "fileName": "repos/redis/src/../deps/fast_float/fast_float_strtod.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1755076a1d8525cb895df2824bbe44aabca26d0a"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-doc.go-1305",
+      "SPDXID": "SPDXRef-File-doc.go-1100",
       "fileName": "repos/lazygit/vendor/github.com/mattn/go-isatty/doc.go",
       "checksums": [
         {
@@ -13557,7 +11502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-isatty-tcgets.go-1306",
+      "SPDXID": "SPDXRef-File-isatty-tcgets.go-1101",
       "fileName": "repos/lazygit/vendor/github.com/mattn/go-isatty/isatty_tcgets.go",
       "checksums": [
         {
@@ -13567,7 +11512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1307",
+      "SPDXID": "SPDXRef-File-doc.go-1102",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/doc.go",
       "checksums": [
         {
@@ -13577,7 +11522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pty-linux.go-1308",
+      "SPDXID": "SPDXRef-File-pty-linux.go-1103",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/pty_linux.go",
       "checksums": [
         {
@@ -13587,7 +11532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-util.go-1309",
+      "SPDXID": "SPDXRef-File-util.go-1104",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/util.go",
       "checksums": [
         {
@@ -13597,7 +11542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-run.go-1310",
+      "SPDXID": "SPDXRef-File-run.go-1105",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/run.go",
       "checksums": [
         {
@@ -13607,7 +11552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ioctl.go-1311",
+      "SPDXID": "SPDXRef-File-ioctl.go-1106",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/ioctl.go",
       "checksums": [
         {
@@ -13617,7 +11562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ztypes-amd64.go-1312",
+      "SPDXID": "SPDXRef-File-ztypes-amd64.go-1107",
       "fileName": "repos/lazygit/vendor/github.com/creack/pty/ztypes_amd64.go",
       "checksums": [
         {
@@ -13627,7 +11572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-enum.go-1313",
+      "SPDXID": "SPDXRef-File-enum.go-1108",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/enum.go",
       "checksums": [
         {
@@ -13637,7 +11582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-serialize.go-1314",
+      "SPDXID": "SPDXRef-File-serialize.go-1109",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/token/serialize.go",
       "checksums": [
         {
@@ -13647,7 +11592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1315",
+      "SPDXID": "SPDXRef-File-doc.go-1110",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/doc.go",
       "checksums": [
         {
@@ -13657,7 +11602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-1316",
+      "SPDXID": "SPDXRef-File-errors.go-1111",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/errors.go",
       "checksums": [
         {
@@ -13667,7 +11612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bool.go-1317",
+      "SPDXID": "SPDXRef-File-bool.go-1112",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/bool.go",
       "checksums": [
         {
@@ -13677,7 +11622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1318",
+      "SPDXID": "SPDXRef-File-doc.go-1113",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/doc.go",
       "checksums": [
         {
@@ -13687,7 +11632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errors.go-1319",
+      "SPDXID": "SPDXRef-File-errors.go-1114",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/scanner/errors.go",
       "checksums": [
         {
@@ -13697,7 +11642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-int.go-1320",
+      "SPDXID": "SPDXRef-File-int.go-1115",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/int.go",
       "checksums": [
         {
@@ -13707,7 +11652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-token.go-1321",
+      "SPDXID": "SPDXRef-File-token.go-1116",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/token/token.go",
       "checksums": [
         {
@@ -13717,7 +11662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scanner.go-1322",
+      "SPDXID": "SPDXRef-File-scanner.go-1117",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/scanner/scanner.go",
       "checksums": [
         {
@@ -13727,7 +11672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-scan.go-1323",
+      "SPDXID": "SPDXRef-File-scan.go-1118",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/types/scan.go",
       "checksums": [
         {
@@ -13737,7 +11682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-set.go-1324",
+      "SPDXID": "SPDXRef-File-set.go-1119",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/set.go",
       "checksums": [
         {
@@ -13747,7 +11692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read.go-1325",
+      "SPDXID": "SPDXRef-File-read.go-1120",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/read.go",
       "checksums": [
         {
@@ -13757,7 +11702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-position.go-1326",
+      "SPDXID": "SPDXRef-File-position.go-1121",
       "fileName": "repos/lazygit/vendor/github.com/go-git/gcfg/token/position.go",
       "checksums": [
         {
@@ -13767,7 +11712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term.go-1327",
+      "SPDXID": "SPDXRef-File-term.go-1122",
       "fileName": "repos/lazygit/vendor/golang.org/x/term/term.go",
       "checksums": [
         {
@@ -13777,7 +11722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term-unix.go-1328",
+      "SPDXID": "SPDXRef-File-term-unix.go-1123",
       "fileName": "repos/lazygit/vendor/golang.org/x/term/term_unix.go",
       "checksums": [
         {
@@ -13787,7 +11732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-term-unix-other.go-1329",
+      "SPDXID": "SPDXRef-File-term-unix-other.go-1124",
       "fileName": "repos/lazygit/vendor/golang.org/x/term/term_unix_other.go",
       "checksums": [
         {
@@ -13797,7 +11742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminal.go-1330",
+      "SPDXID": "SPDXRef-File-terminal.go-1125",
       "fileName": "repos/lazygit/vendor/golang.org/x/term/terminal.go",
       "checksums": [
         {
@@ -13807,7 +11752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1331",
+      "SPDXID": "SPDXRef-File-doc.go-1126",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/doc.go",
       "checksums": [
         {
@@ -13817,7 +11762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-open-linux.go-1332",
+      "SPDXID": "SPDXRef-File-open-linux.go-1127",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/open_linux.go",
       "checksums": [
         {
@@ -13827,7 +11772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-vfs.go-1333",
+      "SPDXID": "SPDXRef-File-vfs.go-1128",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/vfs.go",
       "checksums": [
         {
@@ -13837,7 +11782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gocompat-errors-go120.go-1334",
+      "SPDXID": "SPDXRef-File-gocompat-errors-go120.go-1129",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/gocompat_errors_go120.go",
       "checksums": [
         {
@@ -13847,7 +11792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-procfs-linux.go-1335",
+      "SPDXID": "SPDXRef-File-procfs-linux.go-1130",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/procfs_linux.go",
       "checksums": [
         {
@@ -13857,7 +11802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-openat-linux.go-1336",
+      "SPDXID": "SPDXRef-File-openat-linux.go-1131",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/openat_linux.go",
       "checksums": [
         {
@@ -13867,7 +11812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mkdir-linux.go-1337",
+      "SPDXID": "SPDXRef-File-mkdir-linux.go-1132",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/mkdir_linux.go",
       "checksums": [
         {
@@ -13877,7 +11822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lookup-linux.go-1338",
+      "SPDXID": "SPDXRef-File-lookup-linux.go-1133",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/lookup_linux.go",
       "checksums": [
         {
@@ -13887,7 +11832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gocompat-generics-go121.go-1339",
+      "SPDXID": "SPDXRef-File-gocompat-generics-go121.go-1134",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/gocompat_generics_go121.go",
       "checksums": [
         {
@@ -13897,7 +11842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-join.go-1340",
+      "SPDXID": "SPDXRef-File-join.go-1135",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/join.go",
       "checksums": [
         {
@@ -13907,7 +11852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-openat2-linux.go-1341",
+      "SPDXID": "SPDXRef-File-openat2-linux.go-1136",
       "fileName": "repos/lazygit/vendor/github.com/cyphar/filepath-securejoin/openat2_linux.go",
       "checksums": [
         {
@@ -13917,7 +11862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-todo.go-1342",
+      "SPDXID": "SPDXRef-File-todo.go-1137",
       "fileName": "repos/lazygit/vendor/github.com/stefanhaller/git-todo-parser/todo/todo.go",
       "checksums": [
         {
@@ -13927,7 +11872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-write.go-1343",
+      "SPDXID": "SPDXRef-File-write.go-1138",
       "fileName": "repos/lazygit/vendor/github.com/stefanhaller/git-todo-parser/todo/write.go",
       "checksums": [
         {
@@ -13937,7 +11882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parse.go-1344",
+      "SPDXID": "SPDXRef-File-parse.go-1139",
       "fileName": "repos/lazygit/vendor/github.com/stefanhaller/git-todo-parser/todo/parse.go",
       "checksums": [
         {
@@ -13947,7 +11892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-latin1.go-1345",
+      "SPDXID": "SPDXRef-File-latin1.go-1140",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/latin1.go",
       "checksums": [
         {
@@ -13957,7 +11902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utf8.go-1346",
+      "SPDXID": "SPDXRef-File-utf8.go-1141",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/utf8.go",
       "checksums": [
         {
@@ -13967,7 +11912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1347",
+      "SPDXID": "SPDXRef-File-doc.go-1142",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/doc.go",
       "checksums": [
         {
@@ -13977,7 +11922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ebcdic.go-1348",
+      "SPDXID": "SPDXRef-File-ebcdic.go-1143",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/ebcdic.go",
       "checksums": [
         {
@@ -13987,7 +11932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ascii.go-1349",
+      "SPDXID": "SPDXRef-File-ascii.go-1144",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/ascii.go",
       "checksums": [
         {
@@ -13997,7 +11942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-latin5.go-1350",
+      "SPDXID": "SPDXRef-File-latin5.go-1145",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/latin5.go",
       "checksums": [
         {
@@ -14007,7 +11952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-charmap.go-1351",
+      "SPDXID": "SPDXRef-File-charmap.go-1146",
       "fileName": "repos/lazygit/vendor/github.com/gdamore/encoding/charmap.go",
       "checksums": [
         {
@@ -14017,7 +11962,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-context.go-1352",
+      "SPDXID": "SPDXRef-File-context.go-1147",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/context/context.go",
       "checksums": [
         {
@@ -14027,7 +11972,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-per-host.go-1353",
+      "SPDXID": "SPDXRef-File-per-host.go-1148",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/per_host.go",
       "checksums": [
         {
@@ -14037,7 +11982,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-direct.go-1354",
+      "SPDXID": "SPDXRef-File-direct.go-1149",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/direct.go",
       "checksums": [
         {
@@ -14047,7 +11992,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-client.go-1355",
+      "SPDXID": "SPDXRef-File-client.go-1150",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/internal/socks/client.go",
       "checksums": [
         {
@@ -14057,7 +12002,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-dial.go-1356",
+      "SPDXID": "SPDXRef-File-dial.go-1151",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/dial.go",
       "checksums": [
         {
@@ -14067,7 +12012,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks.go-1357",
+      "SPDXID": "SPDXRef-File-socks.go-1152",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/internal/socks/socks.go",
       "checksums": [
         {
@@ -14077,7 +12022,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-proxy.go-1358",
+      "SPDXID": "SPDXRef-File-proxy.go-1153",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/proxy.go",
       "checksums": [
         {
@@ -14087,7 +12032,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-socks5.go-1359",
+      "SPDXID": "SPDXRef-File-socks5.go-1154",
       "fileName": "repos/lazygit/vendor/golang.org/x/net/proxy/socks5.go",
       "checksums": [
         {
@@ -14097,7 +12042,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-1360",
+      "SPDXID": "SPDXRef-File-utils.go-1155",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/utils/utils.go",
       "checksums": [
         {
@@ -14107,7 +12052,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lists.go-1361",
+      "SPDXID": "SPDXRef-File-lists.go-1156",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/lists.go",
       "checksums": [
         {
@@ -14117,7 +12062,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-serialization.go-1362",
+      "SPDXID": "SPDXRef-File-serialization.go-1157",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/arraylist/serialization.go",
       "checksums": [
         {
@@ -14127,7 +12072,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-arraylist.go-1363",
+      "SPDXID": "SPDXRef-File-arraylist.go-1158",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/arraylist/arraylist.go",
       "checksums": [
         {
@@ -14137,7 +12082,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-comparator.go-1364",
+      "SPDXID": "SPDXRef-File-comparator.go-1159",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/utils/comparator.go",
       "checksums": [
         {
@@ -14147,7 +12092,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-enumerable.go-1365",
+      "SPDXID": "SPDXRef-File-enumerable.go-1160",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/containers/enumerable.go",
       "checksums": [
         {
@@ -14157,7 +12102,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iterator.go-1366",
+      "SPDXID": "SPDXRef-File-iterator.go-1161",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/containers/iterator.go",
       "checksums": [
         {
@@ -14167,7 +12112,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sort.go-1367",
+      "SPDXID": "SPDXRef-File-sort.go-1162",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/utils/sort.go",
       "checksums": [
         {
@@ -14177,7 +12122,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-enumerable.go-1368",
+      "SPDXID": "SPDXRef-File-enumerable.go-1163",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/arraylist/enumerable.go",
       "checksums": [
         {
@@ -14187,7 +12132,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-trees.go-1369",
+      "SPDXID": "SPDXRef-File-trees.go-1164",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/trees/trees.go",
       "checksums": [
         {
@@ -14197,7 +12142,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-containers.go-1370",
+      "SPDXID": "SPDXRef-File-containers.go-1165",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/containers/containers.go",
       "checksums": [
         {
@@ -14207,7 +12152,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-serialization.go-1371",
+      "SPDXID": "SPDXRef-File-serialization.go-1166",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/trees/binaryheap/serialization.go",
       "checksums": [
         {
@@ -14217,7 +12162,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-binaryheap.go-1372",
+      "SPDXID": "SPDXRef-File-binaryheap.go-1167",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/trees/binaryheap/binaryheap.go",
       "checksums": [
         {
@@ -14227,7 +12172,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iterator.go-1373",
+      "SPDXID": "SPDXRef-File-iterator.go-1168",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/trees/binaryheap/iterator.go",
       "checksums": [
         {
@@ -14237,7 +12182,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iterator.go-1374",
+      "SPDXID": "SPDXRef-File-iterator.go-1169",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/lists/arraylist/iterator.go",
       "checksums": [
         {
@@ -14247,7 +12192,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-serialization.go-1375",
+      "SPDXID": "SPDXRef-File-serialization.go-1170",
       "fileName": "repos/lazygit/vendor/github.com/emirpasic/gods/containers/serialization.go",
       "checksums": [
         {
@@ -14257,7 +12202,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-maps.go-1376",
+      "SPDXID": "SPDXRef-File-maps.go-1171",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/generics/maps/maps.go",
       "checksums": [
         {
@@ -14267,7 +12212,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-set.go-1377",
+      "SPDXID": "SPDXRef-File-set.go-1172",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/generics/set/set.go",
       "checksums": [
         {
@@ -14277,7 +12222,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-orderedset.go-1378",
+      "SPDXID": "SPDXRef-File-orderedset.go-1173",
       "fileName": "repos/lazygit/vendor/github.com/jesseduffield/generics/orderedset/orderedset.go",
       "checksums": [
         {
@@ -14287,7 +12232,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-knownhosts.go-1379",
+      "SPDXID": "SPDXRef-File-knownhosts.go-1174",
       "fileName": "repos/lazygit/vendor/github.com/skeema/knownhosts/knownhosts.go",
       "checksums": [
         {
@@ -14297,7 +12242,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-writer.go-1380",
+      "SPDXID": "SPDXRef-File-writer.go-1175",
       "fileName": "repos/lazygit/vendor/github.com/mailru/easyjson/jwriter/writer.go",
       "checksums": [
         {
@@ -14307,7 +12252,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pool.go-1381",
+      "SPDXID": "SPDXRef-File-pool.go-1176",
       "fileName": "repos/lazygit/vendor/github.com/mailru/easyjson/buffer/pool.go",
       "checksums": [
         {
@@ -14317,7 +12262,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-discard-go15.go-1382",
+      "SPDXID": "SPDXRef-File-discard-go15.go-1177",
       "fileName": "repos/lazygit/vendor/github.com/spkg/bom/discard_go15.go",
       "checksums": [
         {
@@ -14327,7 +12272,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bom.go-1383",
+      "SPDXID": "SPDXRef-File-bom.go-1178",
       "fileName": "repos/lazygit/vendor/github.com/spkg/bom/bom.go",
       "checksums": [
         {
@@ -14337,77 +12282,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-read.h-1384",
-      "fileName": "repos/redis/src/../deps/hiredis/read.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2d74d77a5b41d067537587f3a34565fed4bb1da3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-async.h-1385",
-      "fileName": "repos/redis/src/../deps/hiredis/async.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "4f94660b123ed530169027b1dbe82b99deedd30d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-hiredis.h-1386",
-      "fileName": "repos/redis/src/../deps/hiredis/hiredis.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "635988b7e1c41f7d5c07b5010b6f334672eac570"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-alloc.h-1387",
-      "fileName": "repos/redis/src/../deps/hiredis/alloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "771f9fee53fe1fe2230a28fa36349cfc14940868"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sds.h-1388",
-      "fileName": "repos/redis/src/../deps/hiredis/sds.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "80784bc838aed591073fe489dc3c5a4e68df5eb3"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-sdscompat.h-1389",
-      "fileName": "repos/redis/src/../deps/hiredis/sdscompat.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "e5a2574f31e51d74ed43ad935b12f4ccf12096a8"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-fpconv-dtoa.h-1390",
-      "fileName": "repos/redis/src/../deps/fpconv/fpconv_dtoa.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "328ed83f0383ca446798496cd8ff79a76c97308d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-error-1-13.go-1391",
+      "SPDXID": "SPDXRef-File-error-1-13.go-1179",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/error_1_13.go",
       "checksums": [
         {
@@ -14417,7 +12292,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-join-unwrap-1-20.go-1392",
+      "SPDXID": "SPDXRef-File-join-unwrap-1-20.go-1180",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/join_unwrap_1_20.go",
       "checksums": [
         {
@@ -14427,7 +12302,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-parse-panic.go-1393",
+      "SPDXID": "SPDXRef-File-parse-panic.go-1181",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/parse_panic.go",
       "checksums": [
         {
@@ -14437,7 +12312,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-error.go-1394",
+      "SPDXID": "SPDXRef-File-error.go-1182",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/error.go",
       "checksums": [
         {
@@ -14447,7 +12322,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stackframe.go-1395",
+      "SPDXID": "SPDXRef-File-stackframe.go-1183",
       "fileName": "repos/lazygit/vendor/github.com/go-errors/errors/stackframe.go",
       "checksums": [
         {
@@ -14457,7 +12332,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-mib.go-1396",
+      "SPDXID": "SPDXRef-File-mib.go-1184",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/encoding/internal/identifier/mib.go",
       "checksums": [
         {
@@ -14467,7 +12342,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-iter.go-1397",
+      "SPDXID": "SPDXRef-File-iter.go-1185",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/iter.go",
       "checksums": [
         {
@@ -14477,7 +12352,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-normalize.go-1398",
+      "SPDXID": "SPDXRef-File-normalize.go-1186",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/normalize.go",
       "checksums": [
         {
@@ -14487,7 +12362,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-input.go-1399",
+      "SPDXID": "SPDXRef-File-input.go-1187",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/input.go",
       "checksums": [
         {
@@ -14497,7 +12372,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transform.go-1400",
+      "SPDXID": "SPDXRef-File-transform.go-1188",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/transform/transform.go",
       "checksums": [
         {
@@ -14507,7 +12382,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-identifier.go-1401",
+      "SPDXID": "SPDXRef-File-identifier.go-1189",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/encoding/internal/identifier/identifier.go",
       "checksums": [
         {
@@ -14517,7 +12392,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-runes.go-1402",
+      "SPDXID": "SPDXRef-File-runes.go-1190",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/runes/runes.go",
       "checksums": [
         {
@@ -14527,7 +12402,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-encoding.go-1403",
+      "SPDXID": "SPDXRef-File-encoding.go-1191",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/encoding/encoding.go",
       "checksums": [
         {
@@ -14537,7 +12412,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-transform.go-1404",
+      "SPDXID": "SPDXRef-File-transform.go-1192",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/transform.go",
       "checksums": [
         {
@@ -14547,7 +12422,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-readwriter.go-1405",
+      "SPDXID": "SPDXRef-File-readwriter.go-1193",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/readwriter.go",
       "checksums": [
         {
@@ -14557,7 +12432,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-tables15.0.0.go-1406",
+      "SPDXID": "SPDXRef-File-tables15.0.0.go-1194",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/tables15.0.0.go",
       "checksums": [
         {
@@ -14567,7 +12442,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cond.go-1407",
+      "SPDXID": "SPDXRef-File-cond.go-1195",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/runes/cond.go",
       "checksums": [
         {
@@ -14577,7 +12452,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-composition.go-1408",
+      "SPDXID": "SPDXRef-File-composition.go-1196",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/composition.go",
       "checksums": [
         {
@@ -14587,7 +12462,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-trie.go-1409",
+      "SPDXID": "SPDXRef-File-trie.go-1197",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/trie.go",
       "checksums": [
         {
@@ -14597,7 +12472,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-forminfo.go-1410",
+      "SPDXID": "SPDXRef-File-forminfo.go-1198",
       "fileName": "repos/lazygit/vendor/golang.org/x/text/unicode/norm/forminfo.go",
       "checksums": [
         {
@@ -14607,7 +12482,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-jibber-jabber-unix.go-1411",
+      "SPDXID": "SPDXRef-File-jibber-jabber-unix.go-1199",
       "fileName": "repos/lazygit/vendor/github.com/cloudfoundry/jibber_jabber/jibber_jabber_unix.go",
       "checksums": [
         {
@@ -14617,7 +12492,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-jibber-jabber.go-1412",
+      "SPDXID": "SPDXRef-File-jibber-jabber.go-1200",
       "fileName": "repos/lazygit/vendor/github.com/cloudfoundry/jibber_jabber/jibber_jabber.go",
       "checksums": [
         {
@@ -14627,7 +12502,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-xdg.go-1413",
+      "SPDXID": "SPDXRef-File-xdg.go-1201",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/xdg.go",
       "checksums": [
         {
@@ -14637,7 +12512,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-user-dirs.go-1414",
+      "SPDXID": "SPDXRef-File-user-dirs.go-1202",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/user_dirs.go",
       "checksums": [
         {
@@ -14647,7 +12522,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pathutil.go-1415",
+      "SPDXID": "SPDXRef-File-pathutil.go-1203",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/internal/pathutil/pathutil.go",
       "checksums": [
         {
@@ -14657,7 +12532,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1416",
+      "SPDXID": "SPDXRef-File-doc.go-1204",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/doc.go",
       "checksums": [
         {
@@ -14667,7 +12542,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-pathutil-unix.go-1417",
+      "SPDXID": "SPDXRef-File-pathutil-unix.go-1205",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/internal/pathutil/pathutil_unix.go",
       "checksums": [
         {
@@ -14677,7 +12552,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-base-dirs.go-1418",
+      "SPDXID": "SPDXRef-File-base-dirs.go-1206",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/base_dirs.go",
       "checksums": [
         {
@@ -14687,7 +12562,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-paths-unix.go-1419",
+      "SPDXID": "SPDXRef-File-paths-unix.go-1207",
       "fileName": "repos/lazygit/vendor/github.com/adrg/xdg/paths_unix.go",
       "checksums": [
         {
@@ -14697,7 +12572,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-noncolorable.go-1420",
+      "SPDXID": "SPDXRef-File-noncolorable.go-1208",
       "fileName": "repos/lazygit/vendor/github.com/mattn/go-colorable/noncolorable.go",
       "checksums": [
         {
@@ -14707,7 +12582,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-colorable-others.go-1421",
+      "SPDXID": "SPDXRef-File-colorable-others.go-1209",
       "fileName": "repos/lazygit/vendor/github.com/mattn/go-colorable/colorable_others.go",
       "checksums": [
         {
@@ -14717,7 +12592,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-goid.go-1422",
+      "SPDXID": "SPDXRef-File-goid.go-1210",
       "fileName": "repos/lazygit/vendor/github.com/petermattis/goid/goid.go",
       "checksums": [
         {
@@ -14727,7 +12602,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-goid-go1.5.go-1423",
+      "SPDXID": "SPDXRef-File-goid-go1.5.go-1211",
       "fileName": "repos/lazygit/vendor/github.com/petermattis/goid/goid_go1.5.go",
       "checksums": [
         {
@@ -14737,7 +12612,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-runtime-go1.25.go-1424",
+      "SPDXID": "SPDXRef-File-runtime-go1.25.go-1212",
       "fileName": "repos/lazygit/vendor/github.com/petermattis/goid/runtime_go1.25.go",
       "checksums": [
         {
@@ -14747,7 +12622,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-color.go-1425",
+      "SPDXID": "SPDXRef-File-color.go-1213",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/color.go",
       "checksums": [
         {
@@ -14757,7 +12632,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-util.go-1426",
+      "SPDXID": "SPDXRef-File-util.go-1214",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/util.go",
       "checksums": [
         {
@@ -14767,7 +12642,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-capvals.go-1427",
+      "SPDXID": "SPDXRef-File-capvals.go-1215",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/capvals.go",
       "checksums": [
         {
@@ -14777,7 +12652,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-terminfo.go-1428",
+      "SPDXID": "SPDXRef-File-terminfo.go-1216",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/terminfo.go",
       "checksums": [
         {
@@ -14787,7 +12662,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-caps.go-1429",
+      "SPDXID": "SPDXRef-File-caps.go-1217",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/caps.go",
       "checksums": [
         {
@@ -14797,7 +12672,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-load.go-1430",
+      "SPDXID": "SPDXRef-File-load.go-1218",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/load.go",
       "checksums": [
         {
@@ -14807,7 +12682,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stack.go-1431",
+      "SPDXID": "SPDXRef-File-stack.go-1219",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/stack.go",
       "checksums": [
         {
@@ -14817,7 +12692,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-param.go-1432",
+      "SPDXID": "SPDXRef-File-param.go-1220",
       "fileName": "repos/lazygit/vendor/github.com/xo/terminfo/param.go",
       "checksums": [
         {
@@ -14827,7 +12702,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-sshagent.go-1433",
+      "SPDXID": "SPDXRef-File-sshagent.go-1221",
       "fileName": "repos/lazygit/vendor/github.com/xanzy/ssh-agent/sshagent.go",
       "checksums": [
         {
@@ -14837,7 +12712,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-reflect.go-1434",
+      "SPDXID": "SPDXRef-File-reflect.go-1222",
       "fileName": "repos/lazygit/vendor/github.com/karimkhaleel/jsonschema/reflect.go",
       "checksums": [
         {
@@ -14847,7 +12722,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-id.go-1435",
+      "SPDXID": "SPDXRef-File-id.go-1223",
       "fileName": "repos/lazygit/vendor/github.com/karimkhaleel/jsonschema/id.go",
       "checksums": [
         {
@@ -14857,7 +12732,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-comment-extractor.go-1436",
+      "SPDXID": "SPDXRef-File-comment-extractor.go-1224",
       "fileName": "repos/lazygit/vendor/github.com/karimkhaleel/jsonschema/comment_extractor.go",
       "checksums": [
         {
@@ -14867,7 +12742,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.go-1437",
+      "SPDXID": "SPDXRef-File-utils.go-1225",
       "fileName": "repos/lazygit/vendor/github.com/karimkhaleel/jsonschema/utils.go",
       "checksums": [
         {
@@ -14877,7 +12752,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-emoji.go-1438",
+      "SPDXID": "SPDXRef-File-emoji.go-1226",
       "fileName": "repos/lazygit/vendor/github.com/kyokomi/emoji/v2/emoji.go",
       "checksums": [
         {
@@ -14887,7 +12762,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-emoji-codemap.go-1439",
+      "SPDXID": "SPDXRef-File-emoji-codemap.go-1227",
       "fileName": "repos/lazygit/vendor/github.com/kyokomi/emoji/v2/emoji_codemap.go",
       "checksums": [
         {
@@ -14897,7 +12772,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-patricia.go-1440",
+      "SPDXID": "SPDXRef-File-patricia.go-1228",
       "fileName": "repos/lazygit/vendor/gopkg.in/ozeidan/fuzzy-patricia.v3/patricia/patricia.go",
       "checksums": [
         {
@@ -14907,7 +12782,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-children.go-1441",
+      "SPDXID": "SPDXRef-File-children.go-1229",
       "fileName": "repos/lazygit/vendor/gopkg.in/ozeidan/fuzzy-patricia.v3/patricia/children.go",
       "checksums": [
         {
@@ -14917,17 +12792,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-jemalloc.h-1442",
-      "fileName": "repos/redis/src/../deps/jemalloc/include/jemalloc/jemalloc.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "86c5d64ab67e5678cb94f1dce310c4637130dff4"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-color.go-1443",
+      "SPDXID": "SPDXRef-File-color.go-1230",
       "fileName": "repos/lazygit/vendor/github.com/fatih/color/color.go",
       "checksums": [
         {
@@ -14937,7 +12802,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1444",
+      "SPDXID": "SPDXRef-File-doc.go-1231",
       "fileName": "repos/lazygit/vendor/github.com/fatih/color/doc.go",
       "checksums": [
         {
@@ -14947,7 +12812,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-list.go-1445",
+      "SPDXID": "SPDXRef-File-list.go-1232",
       "fileName": "repos/lazygit/vendor/github.com/bahlo/generic-list-go/list.go",
       "checksums": [
         {
@@ -14957,7 +12822,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deadlock.go-1446",
+      "SPDXID": "SPDXRef-File-deadlock.go-1233",
       "fileName": "repos/lazygit/vendor/github.com/sasha-s/go-deadlock/deadlock.go",
       "checksums": [
         {
@@ -14967,7 +12832,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-stacktraces.go-1447",
+      "SPDXID": "SPDXRef-File-stacktraces.go-1234",
       "fileName": "repos/lazygit/vendor/github.com/sasha-s/go-deadlock/stacktraces.go",
       "checksums": [
         {
@@ -14977,7 +12842,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-trylock.go-1448",
+      "SPDXID": "SPDXRef-File-trylock.go-1235",
       "fileName": "repos/lazygit/vendor/github.com/sasha-s/go-deadlock/trylock.go",
       "checksums": [
         {
@@ -14987,7 +12852,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deadlock-map.go-1449",
+      "SPDXID": "SPDXRef-File-deadlock-map.go-1236",
       "fileName": "repos/lazygit/vendor/github.com/sasha-s/go-deadlock/deadlock_map.go",
       "checksums": [
         {
@@ -14997,7 +12862,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ctxio.go-1450",
+      "SPDXID": "SPDXRef-File-ctxio.go-1237",
       "fileName": "repos/lazygit/vendor/github.com/jbenet/go-context/io/ctxio.go",
       "checksums": [
         {
@@ -15007,7 +12872,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-warnings.go-1451",
+      "SPDXID": "SPDXRef-File-warnings.go-1238",
       "fileName": "repos/lazygit/vendor/gopkg.in/warnings.v0/warnings.go",
       "checksums": [
         {
@@ -15017,7 +12882,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-fuzzy.go-1452",
+      "SPDXID": "SPDXRef-File-fuzzy.go-1239",
       "fileName": "repos/lazygit/vendor/github.com/sahilm/fuzzy/fuzzy.go",
       "checksums": [
         {
@@ -15027,17 +12892,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-linenoise.h-1453",
-      "fileName": "repos/redis/src/../deps/linenoise/linenoise.h",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "beac6df467a04748fc6625659856dda7b5ac2d82"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-clipboard.go-1454",
+      "SPDXID": "SPDXRef-File-clipboard.go-1240",
       "fileName": "repos/lazygit/vendor/github.com/atotto/clipboard/clipboard.go",
       "checksums": [
         {
@@ -15047,7 +12902,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-clipboard-unix.go-1455",
+      "SPDXID": "SPDXRef-File-clipboard-unix.go-1241",
       "fileName": "repos/lazygit/vendor/github.com/atotto/clipboard/clipboard_unix.go",
       "checksums": [
         {
@@ -15057,7 +12912,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-funcsPZ.go-1456",
+      "SPDXID": "SPDXRef-File-funcsPZ.go-1242",
       "fileName": "repos/lazygit/vendor/github.com/mgutz/str/funcsPZ.go",
       "checksums": [
         {
@@ -15067,7 +12922,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-doc.go-1457",
+      "SPDXID": "SPDXRef-File-doc.go-1243",
       "fileName": "repos/lazygit/vendor/github.com/mgutz/str/doc.go",
       "checksums": [
         {
@@ -15077,7 +12932,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-funcsAO.go-1458",
+      "SPDXID": "SPDXRef-File-funcsAO.go-1244",
       "fileName": "repos/lazygit/vendor/github.com/mgutz/str/funcsAO.go",
       "checksums": [
         {
@@ -15087,7 +12942,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lru.go-1459",
+      "SPDXID": "SPDXRef-File-lru.go-1245",
       "fileName": "repos/lazygit/vendor/github.com/golang/groupcache/lru/lru.go",
       "checksums": [
         {
@@ -15097,7 +12952,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-errgroup.go-1460",
+      "SPDXID": "SPDXRef-File-errgroup.go-1246",
       "fileName": "repos/lazygit/vendor/golang.org/x/sync/errgroup/errgroup.go",
       "checksums": [
         {
@@ -15140,7313 +12995,6208 @@
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-fast-float-6"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-fast-float-6"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-fpconv-7"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-fpconv-7"
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-github.com-ProtonMail-go-crypto-6"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-ProtonMail-go-crypto-8"
+      "relatedSpdxElement": "SPDXRef-github.com-adrg-xdg-7"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-adrg-xdg-9"
+      "relatedSpdxElement": "SPDXRef-github.com-atotto-clipboard-8"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-atotto-clipboard-10"
+      "relatedSpdxElement": "SPDXRef-github.com-aybabtme-humanlog-9"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-aybabtme-humanlog-11"
+      "relatedSpdxElement": "SPDXRef-github.com-bahlo-generic-list-go-10"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-bahlo-generic-list-go-12"
+      "relatedSpdxElement": "SPDXRef-github.com-buger-jsonparser-11"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-buger-jsonparser-13"
+      "relatedSpdxElement": "SPDXRef-github.com-cloudflare-circl-12"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-cloudflare-circl-14"
+      "relatedSpdxElement": "SPDXRef-github.com-cloudfoundry-jibber-jabber-13"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-cloudfoundry-jibber-jabber-15"
+      "relatedSpdxElement": "SPDXRef-github.com-creack-pty-14"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-creack-pty-16"
+      "relatedSpdxElement": "SPDXRef-github.com-cyphar-filepath-securejoin-15"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-cyphar-filepath-securejoin-17"
+      "relatedSpdxElement": "SPDXRef-github.com-emirpasic-gods-16"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-emirpasic-gods-18"
+      "relatedSpdxElement": "SPDXRef-github.com-fatih-color-17"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-fatih-color-19"
+      "relatedSpdxElement": "SPDXRef-github.com-gdamore-encoding-18"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-gdamore-encoding-20"
+      "relatedSpdxElement": "SPDXRef-github.com-gdamore-tcell-v2-19"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-gdamore-tcell-v2-21"
+      "relatedSpdxElement": "SPDXRef-github.com-go-errors-errors-20"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-go-errors-errors-22"
+      "relatedSpdxElement": "SPDXRef-github.com-go-git-gcfg-21"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-go-git-gcfg-23"
+      "relatedSpdxElement": "SPDXRef-github.com-go-git-go-billy-v5-22"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-go-git-go-billy-v5-24"
+      "relatedSpdxElement": "SPDXRef-github.com-go-logfmt-logfmt-23"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-go-logfmt-logfmt-25"
+      "relatedSpdxElement": "SPDXRef-github.com-golang-groupcache-24"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-golang-groupcache-26"
+      "relatedSpdxElement": "SPDXRef-github.com-gookit-color-25"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-gookit-color-27"
+      "relatedSpdxElement": "SPDXRef-github.com-integrii-flaggy-26"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-integrii-flaggy-28"
+      "relatedSpdxElement": "SPDXRef-github.com-jbenet-go-context-27"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jbenet-go-context-29"
+      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-generics-28"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-generics-30"
+      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-go-git-v5-29"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-go-git-v5-31"
+      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-gocui-30"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-gocui-32"
+      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-lazycore-31"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-jesseduffield-lazycore-33"
+      "relatedSpdxElement": "SPDXRef-github.com-kardianos-osext-32"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-kardianos-osext-34"
+      "relatedSpdxElement": "SPDXRef-github.com-karimkhaleel-jsonschema-33"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-karimkhaleel-jsonschema-35"
+      "relatedSpdxElement": "SPDXRef-github.com-kevinburke-ssh-config-34"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-kevinburke-ssh-config-36"
+      "relatedSpdxElement": "SPDXRef-github.com-kr-logfmt-35"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-kr-logfmt-37"
+      "relatedSpdxElement": "SPDXRef-github.com-kyokomi-emoji-v2-36"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-kyokomi-emoji-v2-38"
+      "relatedSpdxElement": "SPDXRef-github.com-lucasb-eyer-go-colorful-37"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-lucasb-eyer-go-colorful-39"
+      "relatedSpdxElement": "SPDXRef-github.com-mailru-easyjson-38"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-mailru-easyjson-40"
+      "relatedSpdxElement": "SPDXRef-github.com-mattn-go-colorable-39"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-mattn-go-colorable-41"
+      "relatedSpdxElement": "SPDXRef-github.com-mattn-go-isatty-40"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-mattn-go-isatty-42"
+      "relatedSpdxElement": "SPDXRef-github.com-mgutz-str-41"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-mgutz-str-43"
+      "relatedSpdxElement": "SPDXRef-github.com-petermattis-goid-42"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-petermattis-goid-44"
+      "relatedSpdxElement": "SPDXRef-github.com-pjbgf-sha1cd-43"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-pjbgf-sha1cd-45"
+      "relatedSpdxElement": "SPDXRef-github.com-rivo-uniseg-44"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-rivo-uniseg-46"
+      "relatedSpdxElement": "SPDXRef-github.com-sahilm-fuzzy-45"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-sahilm-fuzzy-47"
+      "relatedSpdxElement": "SPDXRef-github.com-samber-lo-46"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-samber-lo-48"
+      "relatedSpdxElement": "SPDXRef-github.com-sasha-s-go-deadlock-47"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-sasha-s-go-deadlock-49"
+      "relatedSpdxElement": "SPDXRef-github.com-sergi-go-diff-48"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-sergi-go-diff-50"
+      "relatedSpdxElement": "SPDXRef-github.com-sirupsen-logrus-49"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-sirupsen-logrus-51"
+      "relatedSpdxElement": "SPDXRef-github.com-skeema-knownhosts-50"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-skeema-knownhosts-52"
+      "relatedSpdxElement": "SPDXRef-github.com-spf13-afero-51"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-spf13-afero-53"
+      "relatedSpdxElement": "SPDXRef-github.com-spkg-bom-52"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-spkg-bom-54"
+      "relatedSpdxElement": "SPDXRef-github.com-stefanhaller-git-todo-parser-53"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-stefanhaller-git-todo-parser-55"
+      "relatedSpdxElement": "SPDXRef-github.com-wk8-go-ordered-map-v2-54"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-wk8-go-ordered-map-v2-56"
+      "relatedSpdxElement": "SPDXRef-github.com-xanzy-ssh-agent-55"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-xanzy-ssh-agent-57"
+      "relatedSpdxElement": "SPDXRef-github.com-xo-terminfo-56"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-github.com-xo-terminfo-58"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-crypto-57"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-crypto-59"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-exp-58"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-exp-60"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-net-59"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-net-61"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-sync-60"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-sync-62"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-sys-61"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-sys-63"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-term-62"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-term-64"
+      "relatedSpdxElement": "SPDXRef-golang.org-x-text-63"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-golang.org-x-text-65"
+      "relatedSpdxElement": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-64"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-66"
+      "relatedSpdxElement": "SPDXRef-gopkg.in-warnings.v0-65"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-gopkg.in-warnings.v0-67"
+      "relatedSpdxElement": "SPDXRef-gopkg.in-yaml.v3-66"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-gopkg.in-yaml.v3-68"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-hdr-histogram-69"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-hdr-histogram-69"
+      "relatedSpdxElement": "SPDXRef-File-filtering-menu-action.go-67"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-hiredis-70"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-hiredis-70"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-jemalloc-71"
+      "relatedSpdxElement": "SPDXRef-File-sync-controller.go-68"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-jemalloc-71"
+      "relatedSpdxElement": "SPDXRef-File-amend-helper.go-69"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-linenoise-72"
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-menu-controller.go-70"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-linenoise-72"
+      "relatedSpdxElement": "SPDXRef-File-state.go-71"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-lua-73"
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-commit-message-panel-driver.go-72"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-lua-73"
+      "relatedSpdxElement": "SPDXRef-File-window-arrangement-helper.go-73"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timeout.c-74"
+      "relatedSpdxElement": "SPDXRef-File-assertion-helper.go-74"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eval.c-75"
+      "relatedSpdxElement": "SPDXRef-File-worktree.go-75"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filtering-menu-action.go-76"
+      "relatedSpdxElement": "SPDXRef-File-reflog-commit-loader.go-76"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sync-controller.go-77"
+      "relatedSpdxElement": "SPDXRef-File-hyperlink.go-77"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-amend-helper.go-78"
+      "relatedSpdxElement": "SPDXRef-File-os-default-platform.go-78"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-controller.go-79"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-79"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-state.go-80"
+      "relatedSpdxElement": "SPDXRef-File-sub-commits-helper.go-80"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-message-panel-driver.go-81"
+      "relatedSpdxElement": "SPDXRef-File-patch-explorer-context.go-81"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-window-arrangement-helper.go-82"
+      "relatedSpdxElement": "SPDXRef-File-file-node.go-82"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-assertion-helper.go-83"
+      "relatedSpdxElement": "SPDXRef-File-upstream-helper.go-83"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree.go-84"
+      "relatedSpdxElement": "SPDXRef-File-menu-context.go-84"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflog-commit-loader.go-85"
+      "relatedSpdxElement": "SPDXRef-File-app.go-85"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hyperlink.go-86"
+      "relatedSpdxElement": "SPDXRef-File-tags-context.go-86"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-default-platform.go-87"
+      "relatedSpdxElement": "SPDXRef-File-worktree-options-controller.go-87"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-88"
+      "relatedSpdxElement": "SPDXRef-File-base-controller.go-88"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rax-malloc.h-89"
+      "relatedSpdxElement": "SPDXRef-File-worktree-loader.go-89"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sub-commits-helper.go-90"
+      "relatedSpdxElement": "SPDXRef-File-stash.go-90"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-explorer-context.go-91"
+      "relatedSpdxElement": "SPDXRef-File-slice.go-91"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-node.go-92"
+      "relatedSpdxElement": "SPDXRef-File-main-branches.go-92"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-upstream-helper.go-93"
+      "relatedSpdxElement": "SPDXRef-File-shell-command-action.go-93"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-latency.c-94"
+      "relatedSpdxElement": "SPDXRef-File-client.go-94"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-context.go-95"
+      "relatedSpdxElement": "SPDXRef-File-switch-to-focused-main-view-controller.go-95"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-app.go-96"
+      "relatedSpdxElement": "SPDXRef-File-commit.go-96"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eventnotifier.c-97"
+      "relatedSpdxElement": "SPDXRef-File-tasks-adapter.go-97"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redismodule.h-98"
+      "relatedSpdxElement": "SPDXRef-File-editors.go-98"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tags-context.go-99"
+      "relatedSpdxElement": "SPDXRef-File-repos-helper.go-99"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cli-common.c-100"
+      "relatedSpdxElement": "SPDXRef-File-graph.go-100"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-options-controller.go-101"
+      "relatedSpdxElement": "SPDXRef-File-user-config-validation.go-101"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base-controller.go-102"
+      "relatedSpdxElement": "SPDXRef-File-color.go-102"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-loader.go-103"
+      "relatedSpdxElement": "SPDXRef-File-user-config.go-103"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash.go-104"
+      "relatedSpdxElement": "SPDXRef-File-file-system.go-104"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slice.go-105"
+      "relatedSpdxElement": "SPDXRef-File-env.go-105"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main-branches.go-106"
+      "relatedSpdxElement": "SPDXRef-File-context.go-106"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shell-command-action.go-107"
+      "relatedSpdxElement": "SPDXRef-File-global-controller.go-107"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-release.c-108"
+      "relatedSpdxElement": "SPDXRef-File-git.go-108"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscheck.c-109"
+      "relatedSpdxElement": "SPDXRef-File-file.go-109"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-110"
+      "relatedSpdxElement": "SPDXRef-File-hosting-service.go-110"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-endianconv.c-111"
+      "relatedSpdxElement": "SPDXRef-File-list-view-model.go-111"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-switch-to-focused-main-view-controller.go-112"
+      "relatedSpdxElement": "SPDXRef-File-io.go-112"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sparkline.c-113"
+      "relatedSpdxElement": "SPDXRef-File-views.go-113"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit.go-114"
+      "relatedSpdxElement": "SPDXRef-File-suggestion.go-114"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stream.h-115"
+      "relatedSpdxElement": "SPDXRef-File-remote-branch.go-115"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tasks-adapter.go-116"
+      "relatedSpdxElement": "SPDXRef-File-tag.go-116"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-editors.go-117"
+      "relatedSpdxElement": "SPDXRef-File-prompt-controller.go-117"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-repos-helper.go-118"
+      "relatedSpdxElement": "SPDXRef-File-stash-context.go-118"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-graph.go-119"
+      "relatedSpdxElement": "SPDXRef-File-confirmation-controller.go-119"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-user-config-validation.go-120"
+      "relatedSpdxElement": "SPDXRef-File-loader.go-120"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redisassert.h-121"
+      "relatedSpdxElement": "SPDXRef-File-git-icons.go-121"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-122"
+      "relatedSpdxElement": "SPDXRef-File-commit-description-controller.go-122"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-user-config.go-123"
+      "relatedSpdxElement": "SPDXRef-File-cmd-obj.go-123"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-system.go-124"
+      "relatedSpdxElement": "SPDXRef-File-cached-git-config.go-124"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-evict.c-125"
+      "relatedSpdxElement": "SPDXRef-File-keybinding-creator.go-125"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geohash.h-126"
+      "relatedSpdxElement": "SPDXRef-File-definitions.go-126"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-env.go-127"
+      "relatedSpdxElement": "SPDXRef-File-common.go-127"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context.go-128"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-128"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-global-controller.go-129"
+      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-context.go-129"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sort.c-130"
+      "relatedSpdxElement": "SPDXRef-File-cherry-picking.go-130"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git.go-131"
+      "relatedSpdxElement": "SPDXRef-File-color.go-131"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.go-132"
+      "relatedSpdxElement": "SPDXRef-File-prompt-driver.go-132"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut8.c-133"
+      "relatedSpdxElement": "SPDXRef-File-side-window-controller.go-133"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hosting-service.go-134"
+      "relatedSpdxElement": "SPDXRef-File-regexp.go-134"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-view-model.go-135"
+      "relatedSpdxElement": "SPDXRef-File-reflog-commits-controller.go-135"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-io.go-136"
+      "relatedSpdxElement": "SPDXRef-File-rename-similarity-threshold-controller.go-136"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-views.go-137"
+      "relatedSpdxElement": "SPDXRef-File-common.go-137"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-anet.h-138"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-138"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestion.go-139"
+      "relatedSpdxElement": "SPDXRef-File-copy.go-139"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-solarisfixes.h-140"
+      "relatedSpdxElement": "SPDXRef-File-shell.go-140"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-branch.go-141"
+      "relatedSpdxElement": "SPDXRef-File-remote-loader.go-141"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tag.go-142"
+      "relatedSpdxElement": "SPDXRef-File-main-panels.go-142"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commands.h-143"
+      "relatedSpdxElement": "SPDXRef-File-command-log-controller.go-143"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-prompt-controller.go-144"
+      "relatedSpdxElement": "SPDXRef-File-diff.go-144"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-context.go-145"
+      "relatedSpdxElement": "SPDXRef-File-refresh-helper.go-145"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-confirmation-controller.go-146"
+      "relatedSpdxElement": "SPDXRef-File-commit-file-loader.go-146"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crccombine.c-147"
+      "relatedSpdxElement": "SPDXRef-File-random.go-147"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socket.c-148"
+      "relatedSpdxElement": "SPDXRef-File-common.go-148"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-loader.go-149"
+      "relatedSpdxElement": "SPDXRef-File-gui.go-149"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-icons.go-150"
+      "relatedSpdxElement": "SPDXRef-File-cherry-pick-helper.go-150"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-description-controller.go-151"
+      "relatedSpdxElement": "SPDXRef-File-gui-driver.go-151"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmd-obj.go-152"
+      "relatedSpdxElement": "SPDXRef-File-confirmation-helper.go-152"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cached-git-config.go-153"
+      "relatedSpdxElement": "SPDXRef-File-file-loader.go-153"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybinding-creator.go-154"
+      "relatedSpdxElement": "SPDXRef-File-record-directory-helper.go-154"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-definitions.go-155"
+      "relatedSpdxElement": "SPDXRef-File-status-controller.go-155"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geohash-helper.h-156"
+      "relatedSpdxElement": "SPDXRef-File-state.go-156"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-foo.c-157"
+      "relatedSpdxElement": "SPDXRef-File-inline-status-helper.go-157"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-158"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-158"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut5.c-159"
+      "relatedSpdxElement": "SPDXRef-File-search-controller.go-159"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-functions.h-160"
+      "relatedSpdxElement": "SPDXRef-File-text-matcher.go-160"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-call-reply.c-161"
+      "relatedSpdxElement": "SPDXRef-File-remote-branches-controller.go-161"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.h-162"
+      "relatedSpdxElement": "SPDXRef-File-entry-point.go-162"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-163"
+      "relatedSpdxElement": "SPDXRef-File-diffing-menu-action.go-163"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-context.go-164"
+      "relatedSpdxElement": "SPDXRef-File-list-cursor.go-164"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cherry-picking.go-165"
+      "relatedSpdxElement": "SPDXRef-File-popup.go-165"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-166"
+      "relatedSpdxElement": "SPDXRef-File-logs-default.go-166"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-prompt-driver.go-167"
+      "relatedSpdxElement": "SPDXRef-File-worktrees-context.go-167"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-listpack.h-168"
+      "relatedSpdxElement": "SPDXRef-File-working-tree-state.go-168"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-side-window-controller.go-169"
+      "relatedSpdxElement": "SPDXRef-File-status-manager.go-169"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-regexp.go-170"
+      "relatedSpdxElement": "SPDXRef-File-signal-handling.go-170"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflog-commits-controller.go-171"
+      "relatedSpdxElement": "SPDXRef-File-commit.go-171"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rename-similarity-threshold-controller.go-172"
+      "relatedSpdxElement": "SPDXRef-File-remote.go-172"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-173"
+      "relatedSpdxElement": "SPDXRef-File-host-helper.go-173"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-174"
+      "relatedSpdxElement": "SPDXRef-File-suggestions.go-174"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redis-benchmark.c-175"
+      "relatedSpdxElement": "SPDXRef-File-ref-range.go-175"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-copy.go-176"
+      "relatedSpdxElement": "SPDXRef-File-style.go-176"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slowlog.h-177"
+      "relatedSpdxElement": "SPDXRef-File-update-helper.go-177"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shell.go-178"
+      "relatedSpdxElement": "SPDXRef-File-text-style.go-178"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-loader.go-179"
+      "relatedSpdxElement": "SPDXRef-File-options-map.go-179"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main-panels.go-180"
+      "relatedSpdxElement": "SPDXRef-File-views.go-180"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-command-log-controller.go-181"
+      "relatedSpdxElement": "SPDXRef-File-quit-actions.go-181"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff.go-182"
+      "relatedSpdxElement": "SPDXRef-File-commits-helper.go-182"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-refresh-helper.go-183"
+      "relatedSpdxElement": "SPDXRef-File-search-driver.go-183"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file-loader.go-184"
+      "relatedSpdxElement": "SPDXRef-File-search-trait.go-184"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-random.go-185"
+      "relatedSpdxElement": "SPDXRef-File-remotes-context.go-185"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-186"
+      "relatedSpdxElement": "SPDXRef-File-english.go-186"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui.go-187"
+      "relatedSpdxElement": "SPDXRef-File-common.go-187"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bio.c-188"
+      "relatedSpdxElement": "SPDXRef-File-helpers.go-188"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cherry-pick-helper.go-189"
+      "relatedSpdxElement": "SPDXRef-File-remotes.go-189"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui-driver.go-190"
+      "relatedSpdxElement": "SPDXRef-File-transform.go-190"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mstr.c-191"
+      "relatedSpdxElement": "SPDXRef-File-int-matcher.go-191"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-confirmation-helper.go-192"
+      "relatedSpdxElement": "SPDXRef-File-patch-building-controller.go-192"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-loader.go-193"
+      "relatedSpdxElement": "SPDXRef-File-branch.go-193"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-record-directory-helper.go-194"
+      "relatedSpdxElement": "SPDXRef-File-fake-cmd-obj-runner.go-194"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status-controller.go-195"
+      "relatedSpdxElement": "SPDXRef-File-list-controller-trait.go-195"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.h-196"
+      "relatedSpdxElement": "SPDXRef-File-parent-context-mgr.go-196"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-state.go-197"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-197"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-inline-status-helper.go-198"
+      "relatedSpdxElement": "SPDXRef-File-local-commits-controller.go-198"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-199"
+      "relatedSpdxElement": "SPDXRef-File-submodules-context.go-199"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-controller.go-200"
+      "relatedSpdxElement": "SPDXRef-File-branches-helper.go-200"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-text-matcher.go-201"
+      "relatedSpdxElement": "SPDXRef-File-staging-helper.go-201"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-branches-controller.go-202"
+      "relatedSpdxElement": "SPDXRef-File-i18n.go-202"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-entry-point.go-203"
+      "relatedSpdxElement": "SPDXRef-File-remote-branches.go-203"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diffing-menu-action.go-204"
+      "relatedSpdxElement": "SPDXRef-File-app-status-helper.go-204"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-cursor.go-205"
+      "relatedSpdxElement": "SPDXRef-File-basic-styles.go-205"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha256.c-206"
+      "relatedSpdxElement": "SPDXRef-File-tasks.go-206"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-popup.go-207"
+      "relatedSpdxElement": "SPDXRef-File-git-command-builder.go-207"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cluster.c-208"
+      "relatedSpdxElement": "SPDXRef-File-extras-panel.go-208"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logs-default.go-209"
+      "relatedSpdxElement": "SPDXRef-File-gocui.go-209"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktrees-context.go-210"
+      "relatedSpdxElement": "SPDXRef-File-editor-presets.go-210"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-working-tree-state.go-211"
+      "relatedSpdxElement": "SPDXRef-File-updates.go-211"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.c-212"
+      "relatedSpdxElement": "SPDXRef-File-icons.go-212"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status-manager.go-213"
+      "relatedSpdxElement": "SPDXRef-File-snake.go-213"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signal-handling.go-214"
+      "relatedSpdxElement": "SPDXRef-File-reflog-commits-context.go-214"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit.go-215"
+      "relatedSpdxElement": "SPDXRef-File-view-selection-controller.go-215"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote.go-216"
+      "relatedSpdxElement": "SPDXRef-File-async-handler.go-216"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-host-helper.go-217"
+      "relatedSpdxElement": "SPDXRef-File-remote-branches-context.go-217"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-intset.h-218"
+      "relatedSpdxElement": "SPDXRef-File-types.go-218"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestions.go-219"
+      "relatedSpdxElement": "SPDXRef-File-diff-helper.go-219"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ref-range.go-220"
+      "relatedSpdxElement": "SPDXRef-File-pty.go-220"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-style.go-221"
+      "relatedSpdxElement": "SPDXRef-File-history-buffer.go-221"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-release.h-222"
+      "relatedSpdxElement": "SPDXRef-File-worktree-helper.go-222"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-update-helper.go-223"
+      "relatedSpdxElement": "SPDXRef-File-commits.go-223"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-text-style.go-224"
+      "relatedSpdxElement": "SPDXRef-File-confirmation-context.go-224"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options-map.go-225"
+      "relatedSpdxElement": "SPDXRef-File-gui-io.go-225"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzf.h-226"
+      "relatedSpdxElement": "SPDXRef-File-tags-helper.go-226"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-views.go-227"
+      "relatedSpdxElement": "SPDXRef-File-bisect-helper.go-227"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-quit-actions.go-228"
+      "relatedSpdxElement": "SPDXRef-File-hunk.go-228"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commits-helper.go-229"
+      "relatedSpdxElement": "SPDXRef-File-list-controller.go-229"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.h-230"
+      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-helper.go-230"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-driver.go-231"
+      "relatedSpdxElement": "SPDXRef-File-test.go-231"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-trait.go-232"
+      "relatedSpdxElement": "SPDXRef-File-ref.go-232"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remotes-context.go-233"
+      "relatedSpdxElement": "SPDXRef-File-stash-controller.go-233"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-call-reply.h-234"
+      "relatedSpdxElement": "SPDXRef-File-controllers.go-234"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-script-lua.h-235"
+      "relatedSpdxElement": "SPDXRef-File-rendering.go-235"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-english.go-236"
+      "relatedSpdxElement": "SPDXRef-File-suggestions-controller.go-236"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-237"
+      "relatedSpdxElement": "SPDXRef-File-main-context.go-237"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-helpers.go-238"
+      "relatedSpdxElement": "SPDXRef-File-cmd-obj-runner-default.go-238"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remotes.go-239"
+      "relatedSpdxElement": "SPDXRef-File-get-key.go-239"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transform.go-240"
+      "relatedSpdxElement": "SPDXRef-File-file-tree-view-model.go-240"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-int-matcher.go-241"
+      "relatedSpdxElement": "SPDXRef-File-common-commands.go-241"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bitops.c-242"
+      "relatedSpdxElement": "SPDXRef-File-git-cmd-obj-builder.go-242"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-building-controller.go-243"
+      "relatedSpdxElement": "SPDXRef-File-information-panel.go-243"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1.c-244"
+      "relatedSpdxElement": "SPDXRef-File-keybindings.go-244"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branch.go-245"
+      "relatedSpdxElement": "SPDXRef-File-lines.go-245"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-cmd-obj-runner.go-246"
+      "relatedSpdxElement": "SPDXRef-File-patch-line.go-246"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-controller-trait.go-247"
+      "relatedSpdxElement": "SPDXRef-File-context.go-247"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-script.h-248"
+      "relatedSpdxElement": "SPDXRef-File-confirmation-driver.go-248"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parent-context-mgr.go-249"
+      "relatedSpdxElement": "SPDXRef-File-branches.go-249"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-250"
+      "relatedSpdxElement": "SPDXRef-File-working-tree.go-250"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-db.c-251"
+      "relatedSpdxElement": "SPDXRef-File-layout.go-251"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-local-commits-controller.go-252"
+      "relatedSpdxElement": "SPDXRef-File-base-context.go-252"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zipmap.c-253"
+      "relatedSpdxElement": "SPDXRef-File-authors.go-253"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-intset.c-254"
+      "relatedSpdxElement": "SPDXRef-File-merge-and-rebase-helper.go-254"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodules-context.go-255"
+      "relatedSpdxElement": "SPDXRef-File-commits-files-controller.go-255"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branches-helper.go-256"
+      "relatedSpdxElement": "SPDXRef-File-submodule-config.go-256"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-staging-helper.go-257"
+      "relatedSpdxElement": "SPDXRef-File-sub-commits-context.go-257"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-i18n.go-258"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-258"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-branches.go-259"
+      "relatedSpdxElement": "SPDXRef-File-logs.go-259"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzfP.h-260"
+      "relatedSpdxElement": "SPDXRef-File-files-helper.go-260"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.c-261"
+      "relatedSpdxElement": "SPDXRef-File-app-config.go-261"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-app-status-helper.go-262"
+      "relatedSpdxElement": "SPDXRef-File-workspace-reset-controller.go-262"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basic-styles.go-263"
+      "relatedSpdxElement": "SPDXRef-File-common.go-263"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sdsalloc.h-264"
+      "relatedSpdxElement": "SPDXRef-File-runner.go-264"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pqsort.h-265"
+      "relatedSpdxElement": "SPDXRef-File-context-config.go-265"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tasks.go-266"
+      "relatedSpdxElement": "SPDXRef-File-snake-helper.go-266"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-hash.c-267"
+      "relatedSpdxElement": "SPDXRef-File-tag.go-267"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commands.c-268"
+      "relatedSpdxElement": "SPDXRef-File-sub-commits-controller.go-268"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-command-builder.go-269"
+      "relatedSpdxElement": "SPDXRef-File-context.go-269"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-extras-panel.go-270"
+      "relatedSpdxElement": "SPDXRef-File-filter-controller.go-270"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rax.c-271"
+      "relatedSpdxElement": "SPDXRef-File-commit-loader.go-271"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gocui.go-272"
+      "relatedSpdxElement": "SPDXRef-File-attach.go-272"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-replication.c-273"
+      "relatedSpdxElement": "SPDXRef-File-files-controller.go-273"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-editor-presets.go-274"
+      "relatedSpdxElement": "SPDXRef-File-file-icons.go-274"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rdb.h-275"
+      "relatedSpdxElement": "SPDXRef-File-setup.go-275"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-threads-mngr.c-276"
+      "relatedSpdxElement": "SPDXRef-File-commit-description-panel-driver.go-276"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-updates.go-277"
+      "relatedSpdxElement": "SPDXRef-File-git.go-277"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bio.h-278"
+      "relatedSpdxElement": "SPDXRef-File-commit-file.go-278"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-icons.go-279"
+      "relatedSpdxElement": "SPDXRef-File-build-tree.go-279"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pqsort.c-280"
+      "relatedSpdxElement": "SPDXRef-File-switch-to-sub-commits-controller.go-280"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.c-281"
+      "relatedSpdxElement": "SPDXRef-File-keybindings.go-281"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snake.go-282"
+      "relatedSpdxElement": "SPDXRef-File-context-common.go-282"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflog-commits-context.go-283"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-283"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-selection-controller.go-284"
+      "relatedSpdxElement": "SPDXRef-File-working-tree-helper.go-284"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-async-handler.go-285"
+      "relatedSpdxElement": "SPDXRef-File-menu-generator.go-285"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-module.c-286"
+      "relatedSpdxElement": "SPDXRef-File-menu-driver.go-286"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote-branches-context.go-287"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-287"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-types.go-288"
+      "relatedSpdxElement": "SPDXRef-File-suggestions-context.go-288"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff-helper.go-289"
+      "relatedSpdxElement": "SPDXRef-File-rebase.go-289"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rax.h-290"
+      "relatedSpdxElement": "SPDXRef-File-node.go-290"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pty.go-291"
+      "relatedSpdxElement": "SPDXRef-File-file-tree.go-291"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-history-buffer.go-292"
+      "relatedSpdxElement": "SPDXRef-File-worktree.go-292"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-helper.go-293"
+      "relatedSpdxElement": "SPDXRef-File-list-context-trait.go-293"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commits.go-294"
+      "relatedSpdxElement": "SPDXRef-File-string-pool.go-294"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adlist.c-295"
+      "relatedSpdxElement": "SPDXRef-File-bisect-controller.go-295"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-confirmation-context.go-296"
+      "relatedSpdxElement": "SPDXRef-File-credentials-helper.go-296"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui-io.go-297"
+      "relatedSpdxElement": "SPDXRef-File-search-helper.go-297"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tags-helper.go-298"
+      "relatedSpdxElement": "SPDXRef-File-global-handlers.go-298"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connection.c-299"
+      "relatedSpdxElement": "SPDXRef-File-merge-conflict.go-299"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ae-epoll.c-300"
+      "relatedSpdxElement": "SPDXRef-File-types.go-300"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bisect-helper.go-301"
+      "relatedSpdxElement": "SPDXRef-File-date.go-301"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hunk.go-302"
+      "relatedSpdxElement": "SPDXRef-File-search-prompt-controller.go-302"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-monotonic.c-303"
+      "relatedSpdxElement": "SPDXRef-File-keybindings.go-303"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-controller.go-304"
+      "relatedSpdxElement": "SPDXRef-File-screen-mode-actions.go-304"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-helper.go-305"
+      "relatedSpdxElement": "SPDXRef-File-handler-creator.go-305"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-test.go-306"
+      "relatedSpdxElement": "SPDXRef-File-modes.go-306"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ref.go-307"
+      "relatedSpdxElement": "SPDXRef-File-test-driver.go-307"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cluster-legacy.c-308"
+      "relatedSpdxElement": "SPDXRef-File-toggle-whitespace-action.go-308"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscheck.h-309"
+      "relatedSpdxElement": "SPDXRef-File-context-lines-controller.go-309"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-controller.go-310"
+      "relatedSpdxElement": "SPDXRef-File-stash-loader.go-310"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-controllers.go-311"
+      "relatedSpdxElement": "SPDXRef-File-snake-controller.go-311"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rendering.go-312"
+      "relatedSpdxElement": "SPDXRef-File-branch-loader.go-312"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adlist.h-313"
+      "relatedSpdxElement": "SPDXRef-File-branch.go-313"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ziplist.c-314"
+      "relatedSpdxElement": "SPDXRef-File-thread-safe-map.go-314"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestions-controller.go-315"
+      "relatedSpdxElement": "SPDXRef-File-local-commits-context.go-315"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main-context.go-316"
+      "relatedSpdxElement": "SPDXRef-File-config.go-316"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmd-obj-runner-default.go-317"
+      "relatedSpdxElement": "SPDXRef-File-diffing.go-317"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ae.c-318"
+      "relatedSpdxElement": "SPDXRef-File-config-linux.go-318"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-get-key.go-319"
+      "relatedSpdxElement": "SPDXRef-File-version.go-319"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-asciilogo.h-320"
+      "relatedSpdxElement": "SPDXRef-File-blame.go-320"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-tree-view-model.go-321"
+      "relatedSpdxElement": "SPDXRef-File-theme.go-321"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common-commands.go-322"
+      "relatedSpdxElement": "SPDXRef-File-filtering.go-322"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-cmd-obj-builder.go-323"
+      "relatedSpdxElement": "SPDXRef-File-marked-base-commit.go-323"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vset.c-324"
+      "relatedSpdxElement": "SPDXRef-File-version-number.go-324"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-information-panel.go-325"
+      "relatedSpdxElement": "SPDXRef-File-once-writer.go-325"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybindings.go-326"
+      "relatedSpdxElement": "SPDXRef-File-search-state.go-326"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lines.go-327"
+      "relatedSpdxElement": "SPDXRef-File-gpg-helper.go-327"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sparkline.h-328"
+      "relatedSpdxElement": "SPDXRef-File-format.go-328"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.c-329"
+      "relatedSpdxElement": "SPDXRef-File-menu-panel.go-329"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-debug.c-330"
+      "relatedSpdxElement": "SPDXRef-File-tail.go-330"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setcpuaffinity.c-331"
+      "relatedSpdxElement": "SPDXRef-File-session-state-loader.go-331"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-function-lua.c-332"
+      "relatedSpdxElement": "SPDXRef-File-worktrees.go-332"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fastjson.c-333"
+      "relatedSpdxElement": "SPDXRef-File-item-operations.go-333"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-line.go-334"
+      "relatedSpdxElement": "SPDXRef-File-decoration.go-334"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context.go-335"
+      "relatedSpdxElement": "SPDXRef-File-status.go-335"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-confirmation-driver.go-336"
+      "relatedSpdxElement": "SPDXRef-File-reflog-commits.go-336"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geo.h-337"
+      "relatedSpdxElement": "SPDXRef-File-worktrees-controller.go-337"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branches.go-338"
+      "relatedSpdxElement": "SPDXRef-File-vertical-scroll-controller.go-338"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-expire.c-339"
+      "relatedSpdxElement": "SPDXRef-File-paths.go-339"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-working-tree.go-340"
+      "relatedSpdxElement": "SPDXRef-File-view-helpers.go-340"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-layout.go-341"
+      "relatedSpdxElement": "SPDXRef-File-cmd-obj-runner.go-341"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base-context.go-342"
+      "relatedSpdxElement": "SPDXRef-File-views.go-342"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzf-c.c-343"
+      "relatedSpdxElement": "SPDXRef-File-recent-repos-panel.go-343"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-authors.go-344"
+      "relatedSpdxElement": "SPDXRef-File-keynames.go-344"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-and-rebase-helper.go-345"
+      "relatedSpdxElement": "SPDXRef-File-tag-loader.go-345"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commits-files-controller.go-346"
+      "relatedSpdxElement": "SPDXRef-File-cell.go-346"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodule-config.go-347"
+      "relatedSpdxElement": "SPDXRef-File-basic-commits-controller.go-347"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sub-commits-context.go-348"
+      "relatedSpdxElement": "SPDXRef-File-commit-file-node.go-348"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-349"
+      "relatedSpdxElement": "SPDXRef-File-commit-file-tree.go-349"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logs.go-350"
+      "relatedSpdxElement": "SPDXRef-File-jump-to-side-window-controller.go-350"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sds.c-351"
+      "relatedSpdxElement": "SPDXRef-File-submodules-controller.go-351"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-quicklist.c-352"
+      "relatedSpdxElement": "SPDXRef-File-prompt-context.go-352"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-files-helper.go-353"
+      "relatedSpdxElement": "SPDXRef-File-refresh.go-353"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-app-config.go-354"
+      "relatedSpdxElement": "SPDXRef-File-string-stack.go-354"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-workspace-reset-controller.go-355"
+      "relatedSpdxElement": "SPDXRef-File-commit-file-tree-view-model.go-355"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-functions.c-356"
+      "relatedSpdxElement": "SPDXRef-File-bisect-info.go-356"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-357"
+      "relatedSpdxElement": "SPDXRef-File-stash-entries.go-357"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-runner.go-358"
+      "relatedSpdxElement": "SPDXRef-File-find-conflicts.go-358"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context-config.go-359"
+      "relatedSpdxElement": "SPDXRef-File-custom.go-359"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut.c-360"
+      "relatedSpdxElement": "SPDXRef-File-repo-paths.go-360"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snake-helper.go-361"
+      "relatedSpdxElement": "SPDXRef-File-dummies.go-361"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blocked.c-362"
+      "relatedSpdxElement": "SPDXRef-File-branches-controller.go-362"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tag.go-363"
+      "relatedSpdxElement": "SPDXRef-File-submodules.go-363"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sub-commits-controller.go-364"
+      "relatedSpdxElement": "SPDXRef-File-tags-controller.go-364"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hnsw.h-365"
+      "relatedSpdxElement": "SPDXRef-File-view-helper.go-365"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context.go-366"
+      "relatedSpdxElement": "SPDXRef-File-search.go-366"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filter-controller.go-367"
+      "relatedSpdxElement": "SPDXRef-File-stash-entry.go-367"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-loader.go-368"
+      "relatedSpdxElement": "SPDXRef-File-file-filter.go-368"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resp-parser.c-369"
+      "relatedSpdxElement": "SPDXRef-File-files.go-369"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-attach.go-370"
+      "relatedSpdxElement": "SPDXRef-File-suspend-resume-helper.go-370"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-files-controller.go-371"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-371"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connhelpers.h-372"
+      "relatedSpdxElement": "SPDXRef-File-undo-controller.go-372"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crccombine.h-373"
+      "relatedSpdxElement": "SPDXRef-File-switch-to-diff-files-controller.go-373"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-icons.go-374"
+      "relatedSpdxElement": "SPDXRef-File-filtered-list-view-model.go-374"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setup.go-375"
+      "relatedSpdxElement": "SPDXRef-File-focus.go-375"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-description-panel-driver.go-376"
+      "relatedSpdxElement": "SPDXRef-File-git-flow-controller.go-376"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git.go-377"
+      "relatedSpdxElement": "SPDXRef-File-remote.go-377"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file.go-378"
+      "relatedSpdxElement": "SPDXRef-File-matcher.go-378"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut.h-379"
+      "relatedSpdxElement": "SPDXRef-File-resolver.go-379"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aof.c-380"
+      "relatedSpdxElement": "SPDXRef-File-view-trait.go-380"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build-tree.go-381"
+      "relatedSpdxElement": "SPDXRef-File-bisect.go-381"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-switch-to-sub-commits-controller.go-382"
+      "relatedSpdxElement": "SPDXRef-File-command-log-panel.go-382"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybindings.go-383"
+      "relatedSpdxElement": "SPDXRef-File-refs-helper.go-383"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context-common.go-384"
+      "relatedSpdxElement": "SPDXRef-File-commit-message-context.go-384"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-latency.h-385"
+      "relatedSpdxElement": "SPDXRef-File-sync.go-385"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-386"
+      "relatedSpdxElement": "SPDXRef-File-branches-context.go-386"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-working-tree-helper.go-387"
+      "relatedSpdxElement": "SPDXRef-File-main.go-387"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-generator.go-388"
+      "relatedSpdxElement": "SPDXRef-File-working-tree-context.go-388"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-childinfo.c-389"
+      "relatedSpdxElement": "SPDXRef-File-popup-handler.go-389"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-driver.go-390"
+      "relatedSpdxElement": "SPDXRef-File-gui-common.go-390"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cluster.h-391"
+      "relatedSpdxElement": "SPDXRef-File-patch-builder.go-391"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-392"
+      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-controller.go-392"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestions-context.go-393"
+      "relatedSpdxElement": "SPDXRef-File-suggestions-helper.go-393"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rebase.go-394"
+      "relatedSpdxElement": "SPDXRef-File-daemon.go-394"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-node.go-395"
+      "relatedSpdxElement": "SPDXRef-File-fixup-helper.go-395"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logreqres.c-396"
+      "relatedSpdxElement": "SPDXRef-File-background.go-396"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-tree.go-397"
+      "relatedSpdxElement": "SPDXRef-File-remotes-controller.go-397"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree.go-398"
+      "relatedSpdxElement": "SPDXRef-File-collapsed-paths.go-398"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-context-trait.go-399"
+      "relatedSpdxElement": "SPDXRef-File-window-helper.go-399"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-string-pool.go-400"
+      "relatedSpdxElement": "SPDXRef-File-mode-helper.go-400"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ae.h-401"
+      "relatedSpdxElement": "SPDXRef-File-file.go-401"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bisect-controller.go-402"
+      "relatedSpdxElement": "SPDXRef-File-rendering.go-402"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-credentials-helper.go-403"
+      "relatedSpdxElement": "SPDXRef-File-tags.go-403"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-helper.go-404"
+      "relatedSpdxElement": "SPDXRef-File-options-menu-action.go-404"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-global-handlers.go-405"
+      "relatedSpdxElement": "SPDXRef-File-pager-config.go-405"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-conflict.go-406"
+      "relatedSpdxElement": "SPDXRef-File-models.go-406"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-expr.c-407"
+      "relatedSpdxElement": "SPDXRef-File-env.go-407"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-siphash.c-408"
+      "relatedSpdxElement": "SPDXRef-File-filtered-list.go-408"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-types.go-409"
+      "relatedSpdxElement": "SPDXRef-File-fake-git-config.go-409"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-threads-mngr.h-410"
+      "relatedSpdxElement": "SPDXRef-File-list-renderer.go-410"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rio.h-411"
+      "relatedSpdxElement": "SPDXRef-File-links.go-411"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-date.go-412"
+      "relatedSpdxElement": "SPDXRef-File-commit-message-controller.go-412"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-prompt-controller.go-413"
+      "relatedSpdxElement": "SPDXRef-File-view-driver.go-413"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybindings.go-414"
+      "relatedSpdxElement": "SPDXRef-File-scroll-off-margin.go-414"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tls.c-415"
+      "relatedSpdxElement": "SPDXRef-File-author.go-415"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-screen-mode-actions.go-416"
+      "relatedSpdxElement": "SPDXRef-File-dynamic-title-builder.go-416"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mt19937-64.c-417"
+      "relatedSpdxElement": "SPDXRef-File-test-mode.go-417"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha256.h-418"
+      "relatedSpdxElement": "SPDXRef-File-formatting.go-418"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-handler-creator.go-419"
+      "relatedSpdxElement": "SPDXRef-File-submodule.go-419"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-modes.go-420"
+      "relatedSpdxElement": "SPDXRef-File-os.go-420"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-test-driver.go-421"
+      "relatedSpdxElement": "SPDXRef-File-alert-driver.go-421"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-networking.c-422"
+      "relatedSpdxElement": "SPDXRef-File-commit-loading-shared.go-422"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-toggle-whitespace-action.go-423"
+      "relatedSpdxElement": "SPDXRef-File-simple-context.go-423"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context-lines-controller.go-424"
+      "relatedSpdxElement": "SPDXRef-File-template.go-424"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-loader.go-425"
+      "relatedSpdxElement": "SPDXRef-File-staging-controller.go-425"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-snake-controller.go-426"
+      "relatedSpdxElement": "SPDXRef-File-commit-files-context.go-426"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zipmap.h-427"
+      "relatedSpdxElement": "SPDXRef-File-history-trait.go-427"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branch-loader.go-428"
+      "relatedSpdxElement": "SPDXRef-File-yaml-utils.go-428"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tracking.c-429"
+      "relatedSpdxElement": "SPDXRef-File-custom-patch-options-menu-action.go-429"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branch.go-430"
+      "relatedSpdxElement": "SPDXRef-File-main-view-controller.go-430"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cli-common.h-431"
+      "relatedSpdxElement": "SPDXRef-File-flow.go-431"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1.h-432"
+      "relatedSpdxElement": "SPDXRef-File-patch-building-helper.go-432"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-thread-safe-map.go-433"
+      "relatedSpdxElement": "SPDXRef-File-git-cmd-obj-runner.go-433"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-local-commits-context.go-434"
+      "relatedSpdxElement": "SPDXRef-File-patch-explorer-controller.go-434"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-435"
+      "relatedSpdxElement": "SPDXRef-File-rebase.go-435"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diffing.go-436"
+      "relatedSpdxElement": "SPDXRef-File-cmd-obj-builder.go-436"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config-linux.go-437"
+      "relatedSpdxElement": "SPDXRef-File-rebase-todo.go-437"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version.go-438"
+      "relatedSpdxElement": "SPDXRef-File-parse.go-438"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blame.go-439"
+      "relatedSpdxElement": "SPDXRef-File-status.go-439"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-theme.go-440"
+      "relatedSpdxElement": "SPDXRef-File-const-win-unix.go-440"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filtering.go-441"
+      "relatedSpdxElement": "SPDXRef-File-cacheOnReadFs.go-441"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-marked-base-commit.go-442"
+      "relatedSpdxElement": "SPDXRef-File-dirmap.go-442"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version-number.go-443"
+      "relatedSpdxElement": "SPDXRef-File-copyOnWriteFs.go-443"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-testhelp.h-444"
+      "relatedSpdxElement": "SPDXRef-File-path.go-444"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-once-writer.go-445"
+      "relatedSpdxElement": "SPDXRef-File-regexpfs.go-445"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search-state.go-446"
+      "relatedSpdxElement": "SPDXRef-File-basepath.go-446"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gpg-helper.go-447"
+      "relatedSpdxElement": "SPDXRef-File-afero.go-447"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-format.go-448"
+      "relatedSpdxElement": "SPDXRef-File-adapters.go-448"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-menu-panel.go-449"
+      "relatedSpdxElement": "SPDXRef-File-unionFile.go-449"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tail.go-450"
+      "relatedSpdxElement": "SPDXRef-File-file.go-450"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-session-state-loader.go-451"
+      "relatedSpdxElement": "SPDXRef-File-match.go-451"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ebuckets.c-452"
+      "relatedSpdxElement": "SPDXRef-File-lstater.go-452"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktrees.go-453"
+      "relatedSpdxElement": "SPDXRef-File-iofs.go-453"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zmalloc.c-454"
+      "relatedSpdxElement": "SPDXRef-File-util.go-454"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-item-operations.go-455"
+      "relatedSpdxElement": "SPDXRef-File-symlink.go-455"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-monotonic.h-456"
+      "relatedSpdxElement": "SPDXRef-File-httpFs.go-456"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dict.h-457"
+      "relatedSpdxElement": "SPDXRef-File-readonlyfs.go-457"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decoration.go-458"
+      "relatedSpdxElement": "SPDXRef-File-dir.go-458"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status.go-459"
+      "relatedSpdxElement": "SPDXRef-File-memmap.go-459"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflog-commits.go-460"
+      "relatedSpdxElement": "SPDXRef-File-os.go-460"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-spf13-afero-51",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktrees-controller.go-461"
+      "relatedSpdxElement": "SPDXRef-File-ioutil.go-461"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kardianos-osext-32",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vertical-scroll-controller.go-462"
+      "relatedSpdxElement": "SPDXRef-File-osext-go18.go-462"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kardianos-osext-32",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-paths.go-463"
+      "relatedSpdxElement": "SPDXRef-File-osext.go-463"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-helpers.go-464"
+      "relatedSpdxElement": "SPDXRef-File-config.go-464"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmd-obj-runner.go-465"
+      "relatedSpdxElement": "SPDXRef-File-lexer.go-465"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mt19937-64.h-466"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-466"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geohash-helper.c-467"
+      "relatedSpdxElement": "SPDXRef-File-validators.go-467"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.c-468"
+      "relatedSpdxElement": "SPDXRef-File-token.go-468"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-views.go-469"
+      "relatedSpdxElement": "SPDXRef-File-position.go-469"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-recent-repos-panel.go-470"
+      "relatedSpdxElement": "SPDXRef-File-cast5.go-470"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mstr.h-471"
+      "relatedSpdxElement": "SPDXRef-File-curve25519.go-471"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keynames.go-472"
+      "relatedSpdxElement": "SPDXRef-File-blamka-amd64.go-472"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redis-cli.c-473"
+      "relatedSpdxElement": "SPDXRef-File-server.go-473"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zmalloc.h-474"
+      "relatedSpdxElement": "SPDXRef-File-cipher.go-474"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tag-loader.go-475"
+      "relatedSpdxElement": "SPDXRef-File-legacy-keccakf.go-475"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rio.c-476"
+      "relatedSpdxElement": "SPDXRef-File-blake2b.go-476"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cell.go-477"
+      "relatedSpdxElement": "SPDXRef-File-certs.go-477"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pubsub.c-478"
+      "relatedSpdxElement": "SPDXRef-File-streamlocal.go-478"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basic-commits-controller.go-479"
+      "relatedSpdxElement": "SPDXRef-File-blake2bAVX2-amd64.go-479"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file-node.go-480"
+      "relatedSpdxElement": "SPDXRef-File-buffer.go-480"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file-tree.go-481"
+      "relatedSpdxElement": "SPDXRef-File-knownhosts.go-481"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sentinel.c-482"
+      "relatedSpdxElement": "SPDXRef-File-argon2.go-482"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc64.c-483"
+      "relatedSpdxElement": "SPDXRef-File-common.go-483"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rdb.c-484"
+      "relatedSpdxElement": "SPDXRef-File-client-auth.go-484"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jump-to-side-window-controller.go-485"
+      "relatedSpdxElement": "SPDXRef-File-blake2b-generic.go-485"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodules-controller.go-486"
+      "relatedSpdxElement": "SPDXRef-File-client.go-486"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-prompt-context.go-487"
+      "relatedSpdxElement": "SPDXRef-File-hkdf.go-487"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-refresh.go-488"
+      "relatedSpdxElement": "SPDXRef-File-keys.go-488"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crcspeed.h-489"
+      "relatedSpdxElement": "SPDXRef-File-handshake.go-489"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-string-stack.go-490"
+      "relatedSpdxElement": "SPDXRef-File-server.go-490"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-file-tree-view-model.go-491"
+      "relatedSpdxElement": "SPDXRef-File-register.go-491"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lazyfree.c-492"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-492"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-zset.c-493"
+      "relatedSpdxElement": "SPDXRef-File-kex.go-493"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bisect-info.go-494"
+      "relatedSpdxElement": "SPDXRef-File-connection.go-494"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-entries.go-495"
+      "relatedSpdxElement": "SPDXRef-File-go125.go-495"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-quicklist.h-496"
+      "relatedSpdxElement": "SPDXRef-File-shake.go-496"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sds.h-497"
+      "relatedSpdxElement": "SPDXRef-File-cipher.go-497"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-find-conflicts.go-498"
+      "relatedSpdxElement": "SPDXRef-File-blake2x.go-498"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-custom.go-499"
+      "relatedSpdxElement": "SPDXRef-File-tcpip.go-499"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-repo-paths.go-500"
+      "relatedSpdxElement": "SPDXRef-File-mac.go-500"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dummies.go-501"
+      "relatedSpdxElement": "SPDXRef-File-block.go-501"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connection.h-502"
+      "relatedSpdxElement": "SPDXRef-File-blamka-generic.go-502"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-list.c-503"
+      "relatedSpdxElement": "SPDXRef-File-hashes.go-503"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crcspeed.c-504"
+      "relatedSpdxElement": "SPDXRef-File-ssh-gss.go-504"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branches-controller.go-505"
+      "relatedSpdxElement": "SPDXRef-File-messages.go-505"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodules.go-506"
+      "relatedSpdxElement": "SPDXRef-File-session.go-506"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-multi.c-507"
+      "relatedSpdxElement": "SPDXRef-File-bcrypt-pbkdf.go-507"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tags-controller.go-508"
+      "relatedSpdxElement": "SPDXRef-File-client.go-508"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-helper.go-509"
+      "relatedSpdxElement": "SPDXRef-File-legacy-hash.go-509"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-atomicvar.h-510"
+      "relatedSpdxElement": "SPDXRef-File-channel.go-510"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-search.go-511"
+      "relatedSpdxElement": "SPDXRef-File-const.go-511"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-debugmacro.h-512"
+      "relatedSpdxElement": "SPDXRef-File-keyring.go-512"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hnsw.c-513"
+      "relatedSpdxElement": "SPDXRef-File-mux.go-513"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-acl.c-514"
+      "relatedSpdxElement": "SPDXRef-File-blake2b.go-514"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stash-entry.go-515"
+      "relatedSpdxElement": "SPDXRef-File-mlkem.go-515"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file-filter.go-516"
+      "relatedSpdxElement": "SPDXRef-File-transport.go-516"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-crypto-57",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geo.c-517"
+      "relatedSpdxElement": "SPDXRef-File-forward.go-517"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.h-518"
+      "relatedSpdxElement": "SPDXRef-File-decode.go-518"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-files.go-519"
+      "relatedSpdxElement": "SPDXRef-File-emitterc.go-519"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-setproctitle.c-520"
+      "relatedSpdxElement": "SPDXRef-File-parserc.go-520"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suspend-resume-helper.go-521"
+      "relatedSpdxElement": "SPDXRef-File-resolve.go-521"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-522"
+      "relatedSpdxElement": "SPDXRef-File-yamlh.go-522"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-undo-controller.go-523"
+      "relatedSpdxElement": "SPDXRef-File-yaml.go-523"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-switch-to-diff-files-controller.go-524"
+      "relatedSpdxElement": "SPDXRef-File-sorter.go-524"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filtered-list-view-model.go-525"
+      "relatedSpdxElement": "SPDXRef-File-apic.go-525"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ebuckets.h-526"
+      "relatedSpdxElement": "SPDXRef-File-readerc.go-526"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-focus.go-527"
+      "relatedSpdxElement": "SPDXRef-File-writerc.go-527"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-flow-controller.go-528"
+      "relatedSpdxElement": "SPDXRef-File-scannerc.go-528"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote.go-529"
+      "relatedSpdxElement": "SPDXRef-File-encode.go-529"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-66",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-matcher.go-530"
+      "relatedSpdxElement": "SPDXRef-File-yamlprivateh.go-530"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fmacros.h-531"
+      "relatedSpdxElement": "SPDXRef-File-exported.go-531"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cluster-legacy.h-532"
+      "relatedSpdxElement": "SPDXRef-File-terminal-check-unix.go-532"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resolver.go-533"
+      "relatedSpdxElement": "SPDXRef-File-writer.go-533"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-trait.go-534"
+      "relatedSpdxElement": "SPDXRef-File-logrus.go-534"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bisect.go-535"
+      "relatedSpdxElement": "SPDXRef-File-terminal-check-notappengine.go-535"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-command-log-panel.go-536"
+      "relatedSpdxElement": "SPDXRef-File-hooks.go-536"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-refs-helper.go-537"
+      "relatedSpdxElement": "SPDXRef-File-formatter.go-537"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-message-context.go-538"
+      "relatedSpdxElement": "SPDXRef-File-logger.go-538"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iothread.c-539"
+      "relatedSpdxElement": "SPDXRef-File-entry.go-539"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sync.go-540"
+      "relatedSpdxElement": "SPDXRef-File-alt-exit.go-540"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branches-context.go-541"
+      "relatedSpdxElement": "SPDXRef-File-text-formatter.go-541"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mixer.h-542"
+      "relatedSpdxElement": "SPDXRef-File-buffer-pool.go-542"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-anet.c-543"
+      "relatedSpdxElement": "SPDXRef-File-json-formatter.go-543"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-49",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main.go-544"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-544"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-working-tree-context.go-545"
+      "relatedSpdxElement": "SPDXRef-File-private-key-test-data.go-545"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-popup-handler.go-546"
+      "relatedSpdxElement": "SPDXRef-File-mpi.go-546"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-set.c-547"
+      "relatedSpdxElement": "SPDXRef-File-compressed.go-547"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui-common.go-548"
+      "relatedSpdxElement": "SPDXRef-File-curve-info.go-548"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc16.c-549"
+      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted.go-549"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-stream.c-550"
+      "relatedSpdxElement": "SPDXRef-File-random-vectors.go-550"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-builder.go-551"
+      "relatedSpdxElement": "SPDXRef-File-keys-test-data.go-551"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-conflicts-controller.go-552"
+      "relatedSpdxElement": "SPDXRef-File-rfc7253-test-vectors-suite-b.go-552"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-suggestions-helper.go-553"
+      "relatedSpdxElement": "SPDXRef-File-packet.go-553"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-daemon.go-554"
+      "relatedSpdxElement": "SPDXRef-File-marker.go-554"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-notify.c-555"
+      "relatedSpdxElement": "SPDXRef-File-ocb.go-555"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fixup-helper.go-556"
+      "relatedSpdxElement": "SPDXRef-File-config.go-556"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redis-check-rdb.c-557"
+      "relatedSpdxElement": "SPDXRef-File-symmetric-key-encrypted.go-557"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc64.h-558"
+      "relatedSpdxElement": "SPDXRef-File-notation.go-558"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-background.go-559"
+      "relatedSpdxElement": "SPDXRef-File-packet-unsupported.go-559"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remotes-controller.go-560"
+      "relatedSpdxElement": "SPDXRef-File-rfc7253-test-vectors-suite-a.go-560"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-collapsed-paths.go-561"
+      "relatedSpdxElement": "SPDXRef-File-x25519.go-561"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-kvstore.h-562"
+      "relatedSpdxElement": "SPDXRef-File-eax.go-562"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-unix.c-563"
+      "relatedSpdxElement": "SPDXRef-File-padding.go-563"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eventnotifier.h-564"
+      "relatedSpdxElement": "SPDXRef-File-keywrap.go-564"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-window-helper.go-565"
+      "relatedSpdxElement": "SPDXRef-File-userid.go-565"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mode-helper.go-566"
+      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted-aead.go-566"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.go-567"
+      "relatedSpdxElement": "SPDXRef-File-random-vectors.go-567"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redisassert.c-568"
+      "relatedSpdxElement": "SPDXRef-File-ocfb.go-568"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fmtargs.h-569"
+      "relatedSpdxElement": "SPDXRef-File-hash.go-569"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cli-commands.c-570"
+      "relatedSpdxElement": "SPDXRef-File-encode.go-570"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rendering.go-571"
+      "relatedSpdxElement": "SPDXRef-File-packet-sequence.go-571"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tags.go-572"
+      "relatedSpdxElement": "SPDXRef-File-aead-encrypted.go-572"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options-menu-action.go-573"
+      "relatedSpdxElement": "SPDXRef-File-ed25519.go-573"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-script-lua.c-574"
+      "relatedSpdxElement": "SPDXRef-File-canonical-text.go-574"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pager-config.go-575"
+      "relatedSpdxElement": "SPDXRef-File-aead-crypter.go-575"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-models.go-576"
+      "relatedSpdxElement": "SPDXRef-File-curves.go-576"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-env.go-577"
+      "relatedSpdxElement": "SPDXRef-File-s2k-cache.go-577"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filtered-list.go-578"
+      "relatedSpdxElement": "SPDXRef-File-userattribute.go-578"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fake-git-config.go-579"
+      "relatedSpdxElement": "SPDXRef-File-x448.go-579"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list-renderer.go-580"
+      "relatedSpdxElement": "SPDXRef-File-read-write-test-data.go-580"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lolwut6.c-581"
+      "relatedSpdxElement": "SPDXRef-File-s2k.go-581"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-listpack-malloc.h-582"
+      "relatedSpdxElement": "SPDXRef-File-ed25519.go-582"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-localtime.c-583"
+      "relatedSpdxElement": "SPDXRef-File-encoding.go-583"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-links.go-584"
+      "relatedSpdxElement": "SPDXRef-File-key-generation.go-584"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-geohash.c-585"
+      "relatedSpdxElement": "SPDXRef-File-rcurve.go-585"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-message-controller.go-586"
+      "relatedSpdxElement": "SPDXRef-File-signature.go-586"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view-driver.go-587"
+      "relatedSpdxElement": "SPDXRef-File-curve25519.go-587"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resp-parser.h-588"
+      "relatedSpdxElement": "SPDXRef-File-literal.go-588"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slowlog.c-589"
+      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted-mdc.go-589"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-script.c-590"
+      "relatedSpdxElement": "SPDXRef-File-eddsa.go-590"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cli-commands.h-591"
+      "relatedSpdxElement": "SPDXRef-File-keys.go-591"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scroll-off-margin.go-592"
+      "relatedSpdxElement": "SPDXRef-File-write.go-592"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-author.go-593"
+      "relatedSpdxElement": "SPDXRef-File-ed448.go-593"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynamic-title-builder.go-594"
+      "relatedSpdxElement": "SPDXRef-File-public-key-test-data.go-594"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-listpack.c-595"
+      "relatedSpdxElement": "SPDXRef-File-ed448.go-595"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-kvstore.c-596"
+      "relatedSpdxElement": "SPDXRef-File-encrypted-key.go-596"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ziplist.h-597"
+      "relatedSpdxElement": "SPDXRef-File-s2k-config.go-597"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-test-mode.go-598"
+      "relatedSpdxElement": "SPDXRef-File-elgamal.go-598"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formatting.go-599"
+      "relatedSpdxElement": "SPDXRef-File-cipher.go-599"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodule.go-600"
+      "relatedSpdxElement": "SPDXRef-File-bitcurve.go-600"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os.go-601"
+      "relatedSpdxElement": "SPDXRef-File-oid.go-601"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-alert-driver.go-602"
+      "relatedSpdxElement": "SPDXRef-File-brainpool.go-602"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-loading-shared.go-603"
+      "relatedSpdxElement": "SPDXRef-File-opaque.go-603"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc16-slottable.h-604"
+      "relatedSpdxElement": "SPDXRef-File-aead.go-604"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-simple-context.go-605"
+      "relatedSpdxElement": "SPDXRef-File-hash.go-605"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hyperloglog.c-606"
+      "relatedSpdxElement": "SPDXRef-File-byteutil.go-606"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.c-607"
+      "relatedSpdxElement": "SPDXRef-File-ecdh.go-607"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-template.go-608"
+      "relatedSpdxElement": "SPDXRef-File-reader.go-608"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-staging-controller.go-609"
+      "relatedSpdxElement": "SPDXRef-File-eax-test-vectors.go-609"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-strl.c-610"
+      "relatedSpdxElement": "SPDXRef-File-x448.go-610"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memtest.c-611"
+      "relatedSpdxElement": "SPDXRef-File-armor.go-611"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-endianconv.h-612"
+      "relatedSpdxElement": "SPDXRef-File-public-key.go-612"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-redis-check-aof.c-613"
+      "relatedSpdxElement": "SPDXRef-File-generic.go-613"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-files-context.go-614"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-614"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-history-trait.go-615"
+      "relatedSpdxElement": "SPDXRef-File-read.go-615"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yaml-utils.go-616"
+      "relatedSpdxElement": "SPDXRef-File-private-key.go-616"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-version.h-617"
+      "relatedSpdxElement": "SPDXRef-File-config-v5.go-617"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-custom-patch-options-menu-action.go-618"
+      "relatedSpdxElement": "SPDXRef-File-one-pass-signature.go-618"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main-view-controller.go-619"
+      "relatedSpdxElement": "SPDXRef-File-ecdsa.go-619"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-flow.go-620"
+      "relatedSpdxElement": "SPDXRef-File-recipient.go-620"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syncio.c-621"
+      "relatedSpdxElement": "SPDXRef-File-aead-config.go-621"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-23",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-defrag.c-622"
+      "relatedSpdxElement": "SPDXRef-File-jsonstring.go-622"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-23",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-building-helper.go-623"
+      "relatedSpdxElement": "SPDXRef-File-decode.go-623"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-23",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-git-cmd-obj-runner.go-624"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-624"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-23",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-explorer-controller.go-625"
+      "relatedSpdxElement": "SPDXRef-File-encode.go-625"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rebase.go-626"
+      "relatedSpdxElement": "SPDXRef-File-pagesize-unix.go-626"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmd-obj-builder.go-627"
+      "relatedSpdxElement": "SPDXRef-File-syscall-unix-gc.go-627"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rebase-todo.go-628"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux.go-628"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-t-string.c-629"
+      "relatedSpdxElement": "SPDXRef-File-vgetrandom-linux.go-629"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parse.go-630"
+      "relatedSpdxElement": "SPDXRef-File-zerrors-linux.go-630"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status.go-631"
+      "relatedSpdxElement": "SPDXRef-File-dirent.go-631"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzf-d.c-632"
+      "relatedSpdxElement": "SPDXRef-File-zsysnum-linux-amd64.go-632"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-const-win-unix.go-633"
+      "relatedSpdxElement": "SPDXRef-File-ifreq-linux.go-633"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cacheOnReadFs.go-634"
+      "relatedSpdxElement": "SPDXRef-File-auxv.go-634"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dirmap.go-635"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux-alarm.go-635"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-copyOnWriteFs.go-636"
+      "relatedSpdxElement": "SPDXRef-File-mremap.go-636"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-path.go-637"
+      "relatedSpdxElement": "SPDXRef-File-execabs.go-637"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-regexpfs.go-638"
+      "relatedSpdxElement": "SPDXRef-File-affinity-linux.go-638"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-basepath.go-639"
+      "relatedSpdxElement": "SPDXRef-File-ztypes-linux.go-639"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-afero.go-640"
+      "relatedSpdxElement": "SPDXRef-File-sockcmsg-unix-other.go-640"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adapters.go-641"
+      "relatedSpdxElement": "SPDXRef-File-race0.go-641"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-unionFile.go-642"
+      "relatedSpdxElement": "SPDXRef-File-sysvshm-linux.go-642"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.go-643"
+      "relatedSpdxElement": "SPDXRef-File-zptrace-x86-linux.go-643"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-match.go-644"
+      "relatedSpdxElement": "SPDXRef-File-syscall.go-644"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lstater.go-645"
+      "relatedSpdxElement": "SPDXRef-File-sockcmsg-linux.go-645"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iofs.go-646"
+      "relatedSpdxElement": "SPDXRef-File-fcntl.go-646"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.go-647"
+      "relatedSpdxElement": "SPDXRef-File-fdset.go-647"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symlink.go-648"
+      "relatedSpdxElement": "SPDXRef-File-sysvshm-unix.go-648"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-httpFs.go-649"
+      "relatedSpdxElement": "SPDXRef-File-constants.go-649"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-readonlyfs.go-650"
+      "relatedSpdxElement": "SPDXRef-File-timestruct.go-650"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dir.go-651"
+      "relatedSpdxElement": "SPDXRef-File-ioctl-linux.go-651"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memmap.go-652"
+      "relatedSpdxElement": "SPDXRef-File-zsyscall-linux.go-652"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os.go-653"
+      "relatedSpdxElement": "SPDXRef-File-zerrors-linux-amd64.go-653"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-spf13-afero-53",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ioutil.go-654"
+      "relatedSpdxElement": "SPDXRef-File-bluetooth-linux.go-654"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kardianos-osext-34",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-osext-go18.go-655"
+      "relatedSpdxElement": "SPDXRef-File-env-unix.go-655"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kardianos-osext-34",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-osext.go-656"
+      "relatedSpdxElement": "SPDXRef-File-aliases.go-656"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-36",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-657"
+      "relatedSpdxElement": "SPDXRef-File-endian-little.go-657"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-36",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lexer.go-658"
+      "relatedSpdxElement": "SPDXRef-File-sockcmsg-unix.go-658"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-36",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-659"
+      "relatedSpdxElement": "SPDXRef-File-dev-linux.go-659"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-36",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-validators.go-660"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux-amd64.go-660"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-36",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-token.go-661"
+      "relatedSpdxElement": "SPDXRef-File-execabs-go119.go-661"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kevinburke-ssh-config-36",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-position.go-662"
+      "relatedSpdxElement": "SPDXRef-File-readdirent-getdents.go-662"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cast5.go-663"
+      "relatedSpdxElement": "SPDXRef-File-syscall-unix.go-663"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve25519.go-664"
+      "relatedSpdxElement": "SPDXRef-File-ztypes-linux-amd64.go-664"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blamka-amd64.go-665"
+      "relatedSpdxElement": "SPDXRef-File-ioctl-unsigned.go-665"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-666"
+      "relatedSpdxElement": "SPDXRef-File-cpu-x86.go-666"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher.go-667"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux-amd64-gc.go-667"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-legacy-keccakf.go-668"
+      "relatedSpdxElement": "SPDXRef-File-zsyscall-linux-amd64.go-668"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-golang.org-x-sys-61",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2b.go-669"
+      "relatedSpdxElement": "SPDXRef-File-syscall-linux-gc.go-669"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-certs.go-670"
+      "relatedSpdxElement": "SPDXRef-File-parsedValue.go-670"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-streamlocal.go-671"
+      "relatedSpdxElement": "SPDXRef-File-argumentParser.go-671"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2bAVX2-amd64.go-672"
+      "relatedSpdxElement": "SPDXRef-File-help.go-672"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-buffer.go-673"
+      "relatedSpdxElement": "SPDXRef-File-flag.go-673"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-knownhosts.go-674"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-674"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-argon2.go-675"
+      "relatedSpdxElement": "SPDXRef-File-subCommand.go-675"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-676"
+      "relatedSpdxElement": "SPDXRef-File-main.go-676"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client-auth.go-677"
+      "relatedSpdxElement": "SPDXRef-File-positionalValue.go-677"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2b-generic.go-678"
+      "relatedSpdxElement": "SPDXRef-File-helpValues.go-678"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-679"
+      "relatedSpdxElement": "SPDXRef-File-color-tag.go-679"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hkdf.go-680"
+      "relatedSpdxElement": "SPDXRef-File-color-16.go-680"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keys.go-681"
+      "relatedSpdxElement": "SPDXRef-File-printer.go-681"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-handshake.go-682"
+      "relatedSpdxElement": "SPDXRef-File-quickstart.go-682"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-683"
+      "relatedSpdxElement": "SPDXRef-File-detect-nonwin.go-683"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-register.go-684"
+      "relatedSpdxElement": "SPDXRef-File-color-rgb.go-684"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-685"
+      "relatedSpdxElement": "SPDXRef-File-convert.go-685"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-kex.go-686"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-686"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-connection.go-687"
+      "relatedSpdxElement": "SPDXRef-File-color.go-687"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-go125.go-688"
+      "relatedSpdxElement": "SPDXRef-File-color-256.go-688"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shake.go-689"
+      "relatedSpdxElement": "SPDXRef-File-detect-env.go-689"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-gookit-color-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher.go-690"
+      "relatedSpdxElement": "SPDXRef-File-style.go-690"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2x.go-691"
+      "relatedSpdxElement": "SPDXRef-File-hash.go-691"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tcpip.go-692"
+      "relatedSpdxElement": "SPDXRef-File-config.go-692"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mac.go-693"
+      "relatedSpdxElement": "SPDXRef-File-filter.go-693"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-block.go-694"
+      "relatedSpdxElement": "SPDXRef-File-worktree-commit.go-694"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blamka-generic.go-695"
+      "relatedSpdxElement": "SPDXRef-File-index.go-695"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hashes.go-696"
+      "relatedSpdxElement": "SPDXRef-File-writer.go-696"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ssh-gss.go-697"
+      "relatedSpdxElement": "SPDXRef-File-options.go-697"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-messages.go-698"
+      "relatedSpdxElement": "SPDXRef-File-client.go-698"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-session.go-699"
+      "relatedSpdxElement": "SPDXRef-File-client.go-699"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bcrypt-pbkdf.go-700"
+      "relatedSpdxElement": "SPDXRef-File-delta-selector.go-700"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-701"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-701"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-legacy-hash.go-702"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-702"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-channel.go-703"
+      "relatedSpdxElement": "SPDXRef-File-server.go-703"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-const.go-704"
+      "relatedSpdxElement": "SPDXRef-File-auth-method.go-704"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keyring.go-705"
+      "relatedSpdxElement": "SPDXRef-File-colorconfig.go-705"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mux.go-706"
+      "relatedSpdxElement": "SPDXRef-File-worktree-status.go-706"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blake2b.go-707"
+      "relatedSpdxElement": "SPDXRef-File-common.go-707"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mlkem.go-708"
+      "relatedSpdxElement": "SPDXRef-File-dotgit.go-708"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transport.go-709"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-709"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-crypto-59",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-forward.go-710"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-limit.go-710"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decode.go-711"
+      "relatedSpdxElement": "SPDXRef-File-url.go-711"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-emitterc.go-712"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-712"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parserc.go-713"
+      "relatedSpdxElement": "SPDXRef-File-match.go-713"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resolve.go-714"
+      "relatedSpdxElement": "SPDXRef-File-reader.go-714"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yamlh.go-715"
+      "relatedSpdxElement": "SPDXRef-File-doubleiter.go-715"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yaml.go-716"
+      "relatedSpdxElement": "SPDXRef-File-error.go-716"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sorter.go-717"
+      "relatedSpdxElement": "SPDXRef-File-color.go-717"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-apic.go-718"
+      "relatedSpdxElement": "SPDXRef-File-server.go-718"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-readerc.go-719"
+      "relatedSpdxElement": "SPDXRef-File-blame.go-719"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writerc.go-720"
+      "relatedSpdxElement": "SPDXRef-File-object-walker.go-720"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scannerc.go-721"
+      "relatedSpdxElement": "SPDXRef-File-index.go-721"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encode.go-722"
+      "relatedSpdxElement": "SPDXRef-File-worktree.go-722"
     },
     {
-      "spdxElementId": "SPDXRef-gopkg.in-yaml.v3-68",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yamlprivateh.go-723"
+      "relatedSpdxElement": "SPDXRef-File-dotgit-setref.go-723"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-exported.go-724"
+      "relatedSpdxElement": "SPDXRef-File-mocks.go-724"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal-check-unix.go-725"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-725"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writer.go-726"
+      "relatedSpdxElement": "SPDXRef-File-merge-base.go-726"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logrus.go-727"
+      "relatedSpdxElement": "SPDXRef-File-ulreq-encode.go-727"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal-check-notappengine.go-728"
+      "relatedSpdxElement": "SPDXRef-File-tree.go-728"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hooks.go-729"
+      "relatedSpdxElement": "SPDXRef-File-storage.go-729"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-formatter.go-730"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-730"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logger.go-731"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-731"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-entry.go-732"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-732"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-alt-exit.go-733"
+      "relatedSpdxElement": "SPDXRef-File-url.go-733"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-text-formatter.go-734"
+      "relatedSpdxElement": "SPDXRef-File-reference.go-734"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-buffer-pool.go-735"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-735"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-json-formatter.go-736"
+      "relatedSpdxElement": "SPDXRef-File-trace.go-736"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-sirupsen-logrus-51",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-737"
+      "relatedSpdxElement": "SPDXRef-File-object.go-737"
     },
     {
-      "spdxElementId": "SPDXRef-hdr-histogram-69",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hdr-histogram.h-738"
+      "relatedSpdxElement": "SPDXRef-File-shallow.go-738"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-private-key-test-data.go-739"
+      "relatedSpdxElement": "SPDXRef-File-bufio.go-739"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mpi.go-740"
+      "relatedSpdxElement": "SPDXRef-File-reader.go-740"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-compressed.go-741"
+      "relatedSpdxElement": "SPDXRef-File-pattern.go-741"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-info.go-742"
+      "relatedSpdxElement": "SPDXRef-File-section.go-742"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted.go-743"
+      "relatedSpdxElement": "SPDXRef-File-uppackresp.go-743"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-random-vectors.go-744"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-744"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keys-test-data.go-745"
+      "relatedSpdxElement": "SPDXRef-File-object-pack.go-745"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rfc7253-test-vectors-suite-b.go-746"
+      "relatedSpdxElement": "SPDXRef-File-format.go-746"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-packet.go-747"
+      "relatedSpdxElement": "SPDXRef-File-path-util.go-747"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-marker.go-748"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-748"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ocb.go-749"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-749"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-750"
+      "relatedSpdxElement": "SPDXRef-File-reference.go-750"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symmetric-key-encrypted.go-751"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-751"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-notation.go-752"
+      "relatedSpdxElement": "SPDXRef-File-status.go-752"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-packet-unsupported.go-753"
+      "relatedSpdxElement": "SPDXRef-File-patch-delta.go-753"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rfc7253-test-vectors-suite-a.go-754"
+      "relatedSpdxElement": "SPDXRef-File-list.go-754"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x25519.go-755"
+      "relatedSpdxElement": "SPDXRef-File-remote.go-755"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eax.go-756"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-756"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-padding.go-757"
+      "relatedSpdxElement": "SPDXRef-File-node.go-757"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keywrap.go-758"
+      "relatedSpdxElement": "SPDXRef-File-receive-pack.go-758"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-userid.go-759"
+      "relatedSpdxElement": "SPDXRef-File-muxer.go-759"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted-aead.go-760"
+      "relatedSpdxElement": "SPDXRef-File-change.go-760"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-random-vectors.go-761"
+      "relatedSpdxElement": "SPDXRef-File-revision.go-761"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ocfb.go-762"
+      "relatedSpdxElement": "SPDXRef-File-shallow.go-762"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.go-763"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker.go-763"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encode.go-764"
+      "relatedSpdxElement": "SPDXRef-File-common.go-764"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-packet-sequence.go-765"
+      "relatedSpdxElement": "SPDXRef-File-storer.go-765"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aead-encrypted.go-766"
+      "relatedSpdxElement": "SPDXRef-File-fsobject.go-766"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed25519.go-767"
+      "relatedSpdxElement": "SPDXRef-File-object.go-767"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-canonical-text.go-768"
+      "relatedSpdxElement": "SPDXRef-File-deltaobject.go-768"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aead-crypter.go-769"
+      "relatedSpdxElement": "SPDXRef-File-read.go-769"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curves.go-770"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-ctime.go-770"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-s2k-cache.go-771"
+      "relatedSpdxElement": "SPDXRef-File-decoder.go-771"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-userattribute.go-772"
+      "relatedSpdxElement": "SPDXRef-File-path.go-772"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x448.go-773"
+      "relatedSpdxElement": "SPDXRef-File-common.go-773"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read-write-test-data.go-774"
+      "relatedSpdxElement": "SPDXRef-File-memory.go-774"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-s2k.go-775"
+      "relatedSpdxElement": "SPDXRef-File-noder.go-775"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed25519.go-776"
+      "relatedSpdxElement": "SPDXRef-File-common.go-776"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoding.go-777"
+      "relatedSpdxElement": "SPDXRef-File-tag.go-777"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-key-generation.go-778"
+      "relatedSpdxElement": "SPDXRef-File-writers.go-778"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rcurve.go-779"
+      "relatedSpdxElement": "SPDXRef-File-diff.go-779"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signature.go-780"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-bfs-filtered.go-780"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve25519.go-781"
+      "relatedSpdxElement": "SPDXRef-File-ulreq.go-781"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-literal.go-782"
+      "relatedSpdxElement": "SPDXRef-File-file.go-782"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-symmetrically-encrypted-mdc.go-783"
+      "relatedSpdxElement": "SPDXRef-File-object-lru.go-783"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eddsa.go-784"
+      "relatedSpdxElement": "SPDXRef-File-module.go-784"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keys.go-785"
+      "relatedSpdxElement": "SPDXRef-File-common.go-785"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-write.go-786"
+      "relatedSpdxElement": "SPDXRef-File-server.go-786"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed448.go-787"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-787"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-public-key-test-data.go-788"
+      "relatedSpdxElement": "SPDXRef-File-advrefs.go-788"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed448.go-789"
+      "relatedSpdxElement": "SPDXRef-File-blob.go-789"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encrypted-key.go-790"
+      "relatedSpdxElement": "SPDXRef-File-unified-encoder.go-790"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-s2k-config.go-791"
+      "relatedSpdxElement": "SPDXRef-File-common.go-791"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-elgamal.go-792"
+      "relatedSpdxElement": "SPDXRef-File-hash.go-792"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cipher.go-793"
+      "relatedSpdxElement": "SPDXRef-File-object.go-793"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bitcurve.go-794"
+      "relatedSpdxElement": "SPDXRef-File-modules.go-794"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-oid.go-795"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-795"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-brainpool.go-796"
+      "relatedSpdxElement": "SPDXRef-File-index.go-796"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-opaque.go-797"
+      "relatedSpdxElement": "SPDXRef-File-repository-filesystem.go-797"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aead.go-798"
+      "relatedSpdxElement": "SPDXRef-File-decoder.go-798"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.go-799"
+      "relatedSpdxElement": "SPDXRef-File-submodule.go-799"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-byteutil.go-800"
+      "relatedSpdxElement": "SPDXRef-File-common.go-800"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ecdh.go-801"
+      "relatedSpdxElement": "SPDXRef-File-repository.go-801"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reader.go-802"
+      "relatedSpdxElement": "SPDXRef-File-common.go-802"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eax-test-vectors.go-803"
+      "relatedSpdxElement": "SPDXRef-File-common.go-803"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-x448.go-804"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-804"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-armor.go-805"
+      "relatedSpdxElement": "SPDXRef-File-upload-pack.go-805"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-public-key.go-806"
+      "relatedSpdxElement": "SPDXRef-File-revlist.go-806"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-generic.go-807"
+      "relatedSpdxElement": "SPDXRef-File-idxfile.go-807"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-808"
+      "relatedSpdxElement": "SPDXRef-File-rename.go-808"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read.go-809"
+      "relatedSpdxElement": "SPDXRef-File-advrefs-encode.go-809"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-private-key.go-810"
+      "relatedSpdxElement": "SPDXRef-File-refspec.go-810"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config-v5.go-811"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-811"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-one-pass-signature.go-812"
+      "relatedSpdxElement": "SPDXRef-File-difftree.go-812"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ecdsa.go-813"
+      "relatedSpdxElement": "SPDXRef-File-error.go-813"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-recipient.go-814"
+      "relatedSpdxElement": "SPDXRef-File-delta-index.go-814"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-ProtonMail-go-crypto-8",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aead-config.go-815"
+      "relatedSpdxElement": "SPDXRef-File-updreq-encode.go-815"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-25",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jsonstring.go-816"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-816"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-25",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decode.go-817"
+      "relatedSpdxElement": "SPDXRef-File-common.go-817"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-25",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-818"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-818"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-go-logfmt-logfmt-25",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encode.go-819"
+      "relatedSpdxElement": "SPDXRef-File-demux.go-819"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pagesize-unix.go-820"
+      "relatedSpdxElement": "SPDXRef-File-report-status.go-820"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-unix-gc.go-821"
+      "relatedSpdxElement": "SPDXRef-File-node.go-821"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux.go-822"
+      "relatedSpdxElement": "SPDXRef-File-token.go-822"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vgetrandom-linux.go-823"
+      "relatedSpdxElement": "SPDXRef-File-buffer-lru.go-823"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zerrors-linux.go-824"
+      "relatedSpdxElement": "SPDXRef-File-treenoder.go-824"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dirent.go-825"
+      "relatedSpdxElement": "SPDXRef-File-dir.go-825"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsysnum-linux-amd64.go-826"
+      "relatedSpdxElement": "SPDXRef-File-shallowupd.go-826"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ifreq-linux.go-827"
+      "relatedSpdxElement": "SPDXRef-File-frame.go-827"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-auxv.go-828"
+      "relatedSpdxElement": "SPDXRef-File-capability.go-828"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux-alarm.go-829"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-path.go-829"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mremap.go-830"
+      "relatedSpdxElement": "SPDXRef-File-writer.go-830"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-execabs.go-831"
+      "relatedSpdxElement": "SPDXRef-File-diff-delta.go-831"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-affinity-linux.go-832"
+      "relatedSpdxElement": "SPDXRef-File-matcher.go-832"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ztypes-linux.go-833"
+      "relatedSpdxElement": "SPDXRef-File-difftree.go-833"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockcmsg-unix-other.go-834"
+      "relatedSpdxElement": "SPDXRef-File-write.go-834"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-race0.go-835"
+      "relatedSpdxElement": "SPDXRef-File-error.go-835"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sysvshm-linux.go-836"
+      "relatedSpdxElement": "SPDXRef-File-change-adaptor.go-836"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zptrace-x86-linux.go-837"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-837"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall.go-838"
+      "relatedSpdxElement": "SPDXRef-File-bytes.go-838"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockcmsg-linux.go-839"
+      "relatedSpdxElement": "SPDXRef-File-storer.go-839"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fcntl.go-840"
+      "relatedSpdxElement": "SPDXRef-File-transport.go-840"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fdset.go-841"
+      "relatedSpdxElement": "SPDXRef-File-commit-walker-bfs.go-841"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sysvshm-unix.go-842"
+      "relatedSpdxElement": "SPDXRef-File-option.go-842"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-constants.go-843"
+      "relatedSpdxElement": "SPDXRef-File-gitproto.go-843"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-timestruct.go-844"
+      "relatedSpdxElement": "SPDXRef-File-updreq.go-844"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ioctl-linux.go-845"
+      "relatedSpdxElement": "SPDXRef-File-signer.go-845"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsyscall-linux.go-846"
+      "relatedSpdxElement": "SPDXRef-File-updreq-decode.go-846"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zerrors-linux-amd64.go-847"
+      "relatedSpdxElement": "SPDXRef-File-dotgit-rewrite-packed-refs.go-847"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bluetooth-linux.go-848"
+      "relatedSpdxElement": "SPDXRef-File-decoder.go-848"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-env-unix.go-849"
+      "relatedSpdxElement": "SPDXRef-File-advrefs-decode.go-849"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-aliases.go-850"
+      "relatedSpdxElement": "SPDXRef-File-common.go-850"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-endian-little.go-851"
+      "relatedSpdxElement": "SPDXRef-File-reference.go-851"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sockcmsg-unix.go-852"
+      "relatedSpdxElement": "SPDXRef-File-object.go-852"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dev-linux.go-853"
+      "relatedSpdxElement": "SPDXRef-File-packfile.go-853"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux-amd64.go-854"
+      "relatedSpdxElement": "SPDXRef-File-prune.go-854"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-execabs-go119.go-855"
+      "relatedSpdxElement": "SPDXRef-File-iter.go-855"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-readdirent-getdents.go-856"
+      "relatedSpdxElement": "SPDXRef-File-storage.go-856"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-unix.go-857"
+      "relatedSpdxElement": "SPDXRef-File-encoder.go-857"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ztypes-linux-amd64.go-858"
+      "relatedSpdxElement": "SPDXRef-File-common.go-858"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ioctl-unsigned.go-859"
+      "relatedSpdxElement": "SPDXRef-File-loader.go-859"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-x86.go-860"
+      "relatedSpdxElement": "SPDXRef-File-srvresp.go-860"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux-amd64-gc.go-861"
+      "relatedSpdxElement": "SPDXRef-File-hash-sha1.go-861"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsyscall-linux-amd64.go-862"
+      "relatedSpdxElement": "SPDXRef-File-filemode.go-862"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-sys-63",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-syscall-linux-gc.go-863"
+      "relatedSpdxElement": "SPDXRef-File-ulreq-decode.go-863"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-28",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parsedValue.go-864"
+      "relatedSpdxElement": "SPDXRef-File-zlib.go-864"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-28",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-argumentParser.go-865"
+      "relatedSpdxElement": "SPDXRef-File-worktree-linux.go-865"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-28",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-help.go-866"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-866"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-28",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-flag.go-867"
+      "relatedSpdxElement": "SPDXRef-File-change.go-867"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-28",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-868"
+      "relatedSpdxElement": "SPDXRef-File-commit.go-868"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-28",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-subCommand.go-869"
+      "relatedSpdxElement": "SPDXRef-File-branch.go-869"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-28",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main.go-870"
+      "relatedSpdxElement": "SPDXRef-File-signature.go-870"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-28",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-positionalValue.go-871"
+      "relatedSpdxElement": "SPDXRef-File-config.go-871"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-integrii-flaggy-28",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-helpValues.go-872"
+      "relatedSpdxElement": "SPDXRef-File-uppackreq.go-872"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color-tag.go-873"
+      "relatedSpdxElement": "SPDXRef-File-fp-amd64.go-873"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color-16.go-874"
+      "relatedSpdxElement": "SPDXRef-File-xor-unaligned.go-874"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-printer.go-875"
+      "relatedSpdxElement": "SPDXRef-File-modular.go-875"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-quickstart.go-876"
+      "relatedSpdxElement": "SPDXRef-File-point.go-876"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-detect-nonwin.go-877"
+      "relatedSpdxElement": "SPDXRef-File-sign.go-877"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color-rgb.go-878"
+      "relatedSpdxElement": "SPDXRef-File-primes.go-878"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-convert.go-879"
+      "relatedSpdxElement": "SPDXRef-File-keccakf.go-879"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-880"
+      "relatedSpdxElement": "SPDXRef-File-curve.go-880"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-881"
+      "relatedSpdxElement": "SPDXRef-File-signapi.go-881"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color-256.go-882"
+      "relatedSpdxElement": "SPDXRef-File-table.go-882"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-detect-env.go-883"
+      "relatedSpdxElement": "SPDXRef-File-ed25519.go-883"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gookit-color-27",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-style.go-884"
+      "relatedSpdxElement": "SPDXRef-File-key.go-884"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.go-885"
+      "relatedSpdxElement": "SPDXRef-File-mult.go-885"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-886"
+      "relatedSpdxElement": "SPDXRef-File-fp-generic.go-886"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filter.go-887"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-887"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-commit.go-888"
+      "relatedSpdxElement": "SPDXRef-File-power.go-888"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-index.go-889"
+      "relatedSpdxElement": "SPDXRef-File-conv.go-889"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writer.go-890"
+      "relatedSpdxElement": "SPDXRef-File-fp-generic.go-890"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-options.go-891"
+      "relatedSpdxElement": "SPDXRef-File-fp.go-891"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-892"
+      "relatedSpdxElement": "SPDXRef-File-fp-amd64.go-892"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-893"
+      "relatedSpdxElement": "SPDXRef-File-rc.go-893"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-delta-selector.go-894"
+      "relatedSpdxElement": "SPDXRef-File-shake.go-894"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-895"
+      "relatedSpdxElement": "SPDXRef-File-hashes.go-895"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
       "relatedSpdxElement": "SPDXRef-File-doc.go-896"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-897"
+      "relatedSpdxElement": "SPDXRef-File-twist.go-897"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-auth-method.go-898"
+      "relatedSpdxElement": "SPDXRef-File-tables.go-898"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colorconfig.go-899"
+      "relatedSpdxElement": "SPDXRef-File-curve-amd64.go-899"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-status.go-900"
+      "relatedSpdxElement": "SPDXRef-File-wnaf.go-900"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-901"
+      "relatedSpdxElement": "SPDXRef-File-integer.go-901"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dotgit.go-902"
+      "relatedSpdxElement": "SPDXRef-File-curve-amd64.go-902"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-903"
+      "relatedSpdxElement": "SPDXRef-File-sha3.go-903"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-limit.go-904"
+      "relatedSpdxElement": "SPDXRef-File-mlsbset.go-904"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.go-905"
+      "relatedSpdxElement": "SPDXRef-File-fp.go-905"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-906"
+      "relatedSpdxElement": "SPDXRef-File-curve-generic.go-906"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-match.go-907"
+      "relatedSpdxElement": "SPDXRef-File-isogeny.go-907"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reader.go-908"
+      "relatedSpdxElement": "SPDXRef-File-constants.go-908"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doubleiter.go-909"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-909"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error.go-910"
+      "relatedSpdxElement": "SPDXRef-File-pubkey.go-910"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-911"
+      "relatedSpdxElement": "SPDXRef-File-ed448.go-911"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-912"
+      "relatedSpdxElement": "SPDXRef-File-twistPoint.go-912"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blame.go-913"
+      "relatedSpdxElement": "SPDXRef-File-key.go-913"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object-walker.go-914"
+      "relatedSpdxElement": "SPDXRef-File-point.go-914"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-index.go-915"
+      "relatedSpdxElement": "SPDXRef-File-curve.go-915"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree.go-916"
+      "relatedSpdxElement": "SPDXRef-File-curve-generic.go-916"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dotgit-setref.go-917"
+      "relatedSpdxElement": "SPDXRef-File-signapi.go-917"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mocks.go-918"
+      "relatedSpdxElement": "SPDXRef-File-twistTables.go-918"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-919"
+      "relatedSpdxElement": "SPDXRef-File-table.go-919"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge-base.go-920"
+      "relatedSpdxElement": "SPDXRef-File-twist-basemult.go-920"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ulreq-encode.go-921"
+      "relatedSpdxElement": "SPDXRef-File-curve.go-921"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tree.go-922"
+      "relatedSpdxElement": "SPDXRef-File-scalar.go-922"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-storage.go-923"
+      "relatedSpdxElement": "SPDXRef-File-attr.go-923"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-924"
+      "relatedSpdxElement": "SPDXRef-File-term.go-924"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-925"
+      "relatedSpdxElement": "SPDXRef-File-nonblock-unix.go-925"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-926"
+      "relatedSpdxElement": "SPDXRef-File-direct.go-926"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-url.go-927"
+      "relatedSpdxElement": "SPDXRef-File-term.go-927"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reference.go-928"
+      "relatedSpdxElement": "SPDXRef-File-term.go-928"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-929"
+      "relatedSpdxElement": "SPDXRef-File-term.go-929"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-trace.go-930"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-930"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.go-931"
+      "relatedSpdxElement": "SPDXRef-File-term.go-931"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shallow.go-932"
+      "relatedSpdxElement": "SPDXRef-File-term.go-932"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bufio.go-933"
+      "relatedSpdxElement": "SPDXRef-File-term.go-933"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reader.go-934"
+      "relatedSpdxElement": "SPDXRef-File-tscreen-unix.go-934"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pattern.go-935"
+      "relatedSpdxElement": "SPDXRef-File-term.go-935"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-section.go-936"
+      "relatedSpdxElement": "SPDXRef-File-mouse.go-936"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uppackresp.go-937"
+      "relatedSpdxElement": "SPDXRef-File-terminfo.go-937"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-938"
+      "relatedSpdxElement": "SPDXRef-File-extended.go-938"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object-pack.go-939"
+      "relatedSpdxElement": "SPDXRef-File-term.go-939"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-format.go-940"
+      "relatedSpdxElement": "SPDXRef-File-term.go-940"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-path-util.go-941"
+      "relatedSpdxElement": "SPDXRef-File-term.go-941"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-942"
+      "relatedSpdxElement": "SPDXRef-File-eastasian.go-942"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-943"
+      "relatedSpdxElement": "SPDXRef-File-term.go-943"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reference.go-944"
+      "relatedSpdxElement": "SPDXRef-File-key.go-944"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-945"
+      "relatedSpdxElement": "SPDXRef-File-term.go-945"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-status.go-946"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-946"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch-delta.go-947"
+      "relatedSpdxElement": "SPDXRef-File-console-stub.go-947"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list.go-948"
+      "relatedSpdxElement": "SPDXRef-File-interrupt.go-948"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-remote.go-949"
+      "relatedSpdxElement": "SPDXRef-File-style.go-949"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-950"
+      "relatedSpdxElement": "SPDXRef-File-term.go-950"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-node.go-951"
+      "relatedSpdxElement": "SPDXRef-File-base.go-951"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-receive-pack.go-952"
+      "relatedSpdxElement": "SPDXRef-File-tscreen.go-952"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-muxer.go-953"
+      "relatedSpdxElement": "SPDXRef-File-direct.go-953"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-change.go-954"
+      "relatedSpdxElement": "SPDXRef-File-term.go-954"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-revision.go-955"
+      "relatedSpdxElement": "SPDXRef-File-term.go-955"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shallow.go-956"
+      "relatedSpdxElement": "SPDXRef-File-tty.go-956"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker.go-957"
+      "relatedSpdxElement": "SPDXRef-File-charset-unix.go-957"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-958"
+      "relatedSpdxElement": "SPDXRef-File-dynamic.go-958"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-storer.go-959"
+      "relatedSpdxElement": "SPDXRef-File-color.go-959"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fsobject.go-960"
+      "relatedSpdxElement": "SPDXRef-File-simulation.go-960"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.go-961"
+      "relatedSpdxElement": "SPDXRef-File-terms-dynamic.go-961"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deltaobject.go-962"
+      "relatedSpdxElement": "SPDXRef-File-term.go-962"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read.go-963"
+      "relatedSpdxElement": "SPDXRef-File-foot.go-963"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-ctime.go-964"
+      "relatedSpdxElement": "SPDXRef-File-event.go-964"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decoder.go-965"
+      "relatedSpdxElement": "SPDXRef-File-term.go-965"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-path.go-966"
+      "relatedSpdxElement": "SPDXRef-File-term.go-966"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-967"
+      "relatedSpdxElement": "SPDXRef-File-stdin-unix.go-967"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-memory.go-968"
+      "relatedSpdxElement": "SPDXRef-File-term.go-968"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noder.go-969"
+      "relatedSpdxElement": "SPDXRef-File-encoding.go-969"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-970"
+      "relatedSpdxElement": "SPDXRef-File-term.go-970"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tag.go-971"
+      "relatedSpdxElement": "SPDXRef-File-cell.go-971"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writers.go-972"
+      "relatedSpdxElement": "SPDXRef-File-term.go-972"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff.go-973"
+      "relatedSpdxElement": "SPDXRef-File-tty-unix.go-973"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-bfs-filtered.go-974"
+      "relatedSpdxElement": "SPDXRef-File-term.go-974"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ulreq.go-975"
+      "relatedSpdxElement": "SPDXRef-File-input.go-975"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-file.go-976"
+      "relatedSpdxElement": "SPDXRef-File-screen.go-976"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object-lru.go-977"
+      "relatedSpdxElement": "SPDXRef-File-term.go-977"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-module.go-978"
+      "relatedSpdxElement": "SPDXRef-File-term.go-978"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-979"
+      "relatedSpdxElement": "SPDXRef-File-focus.go-979"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-server.go-980"
+      "relatedSpdxElement": "SPDXRef-File-runes.go-980"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-981"
+      "relatedSpdxElement": "SPDXRef-File-resize.go-981"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-advrefs.go-982"
+      "relatedSpdxElement": "SPDXRef-File-paste.go-982"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-blob.go-983"
+      "relatedSpdxElement": "SPDXRef-File-colorfit.go-983"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-unified-encoder.go-984"
+      "relatedSpdxElement": "SPDXRef-File-term.go-984"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-985"
+      "relatedSpdxElement": "SPDXRef-File-terms-default.go-985"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-54",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash.go-986"
+      "relatedSpdxElement": "SPDXRef-File-orderedmap.go-986"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-54",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.go-987"
+      "relatedSpdxElement": "SPDXRef-File-yaml.go-987"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-54",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-modules.go-988"
+      "relatedSpdxElement": "SPDXRef-File-json.go-988"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-lazycore-31",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-989"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-989"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-lazycore-31",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-index.go-990"
+      "relatedSpdxElement": "SPDXRef-File-boxlayout.go-990"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-repository-filesystem.go-991"
+      "relatedSpdxElement": "SPDXRef-File-zsortanyfunc.go-991"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decoder.go-992"
+      "relatedSpdxElement": "SPDXRef-File-constraints.go-992"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-submodule.go-993"
+      "relatedSpdxElement": "SPDXRef-File-slices.go-993"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-994"
+      "relatedSpdxElement": "SPDXRef-File-zsortordered.go-994"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-repository.go-995"
+      "relatedSpdxElement": "SPDXRef-File-sort.go-995"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-golang.org-x-exp-58",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-996"
+      "relatedSpdxElement": "SPDXRef-File-cmp.go-996"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-997"
+      "relatedSpdxElement": "SPDXRef-File-ubc-amd64.go-997"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-998"
+      "relatedSpdxElement": "SPDXRef-File-sha1cd.go-998"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-upload-pack.go-999"
+      "relatedSpdxElement": "SPDXRef-File-const.go-999"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-revlist.go-1000"
+      "relatedSpdxElement": "SPDXRef-File-sha1cdblock-amd64.go-1000"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-idxfile.go-1001"
+      "relatedSpdxElement": "SPDXRef-File-detection.go-1001"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rename.go-1002"
+      "relatedSpdxElement": "SPDXRef-File-ubc.go-1002"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-advrefs-encode.go-1003"
+      "relatedSpdxElement": "SPDXRef-File-sha1cdblock-generic.go-1003"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-refspec.go-1004"
+      "relatedSpdxElement": "SPDXRef-File-const.go-1004"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-1005"
+      "relatedSpdxElement": "SPDXRef-File-ubc-generic.go-1005"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-kr-logfmt-35",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-difftree.go-1006"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-1006"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-kr-logfmt-35",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error.go-1007"
+      "relatedSpdxElement": "SPDXRef-File-decode.go-1007"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-kr-logfmt-35",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-delta-index.go-1008"
+      "relatedSpdxElement": "SPDXRef-File-unquote.go-1008"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-updreq-encode.go-1009"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-1009"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1010"
+      "relatedSpdxElement": "SPDXRef-File-intersect.go-1010"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-1011"
+      "relatedSpdxElement": "SPDXRef-File-condition.go-1011"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-1012"
+      "relatedSpdxElement": "SPDXRef-File-test.go-1012"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-demux.go-1013"
+      "relatedSpdxElement": "SPDXRef-File-concurrency.go-1013"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-report-status.go-1014"
+      "relatedSpdxElement": "SPDXRef-File-math.go-1014"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-node.go-1015"
+      "relatedSpdxElement": "SPDXRef-File-slice.go-1015"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-token.go-1016"
+      "relatedSpdxElement": "SPDXRef-File-types.go-1016"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-buffer-lru.go-1017"
+      "relatedSpdxElement": "SPDXRef-File-map.go-1017"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-treenoder.go-1018"
+      "relatedSpdxElement": "SPDXRef-File-func.go-1018"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dir.go-1019"
+      "relatedSpdxElement": "SPDXRef-File-string.go-1019"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shallowupd.go-1020"
+      "relatedSpdxElement": "SPDXRef-File-retry.go-1020"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-frame.go-1021"
+      "relatedSpdxElement": "SPDXRef-File-constraints.go-1021"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-capability.go-1022"
+      "relatedSpdxElement": "SPDXRef-File-channel.go-1022"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-path.go-1023"
+      "relatedSpdxElement": "SPDXRef-File-find.go-1023"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writer.go-1024"
+      "relatedSpdxElement": "SPDXRef-File-tuples.go-1024"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-samber-lo-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff-delta.go-1025"
+      "relatedSpdxElement": "SPDXRef-File-type-manipulation.go-1025"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-dario.cat-mergo-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-matcher.go-1026"
+      "relatedSpdxElement": "SPDXRef-File-mergo.go-1026"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-dario.cat-mergo-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-difftree.go-1027"
+      "relatedSpdxElement": "SPDXRef-File-map.go-1027"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-dario.cat-mergo-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-write.go-1028"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1028"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-dario.cat-mergo-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error.go-1029"
+      "relatedSpdxElement": "SPDXRef-File-merge.go-1029"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-change-adaptor.go-1030"
+      "relatedSpdxElement": "SPDXRef-File-keybinding.go-1030"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1031"
+      "relatedSpdxElement": "SPDXRef-File-gui-others.go-1031"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bytes.go-1032"
+      "relatedSpdxElement": "SPDXRef-File-loader.go-1032"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-storer.go-1033"
+      "relatedSpdxElement": "SPDXRef-File-scrollbar.go-1033"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transport.go-1034"
+      "relatedSpdxElement": "SPDXRef-File-tcell-driver.go-1034"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit-walker-bfs.go-1035"
+      "relatedSpdxElement": "SPDXRef-File-gui.go-1035"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-option.go-1036"
+      "relatedSpdxElement": "SPDXRef-File-view.go-1036"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gitproto.go-1037"
+      "relatedSpdxElement": "SPDXRef-File-text-area.go-1037"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-updreq.go-1038"
+      "relatedSpdxElement": "SPDXRef-File-edit.go-1038"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signer.go-1039"
+      "relatedSpdxElement": "SPDXRef-File-task.go-1039"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-updreq-decode.go-1040"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1040"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dotgit-rewrite-packed-refs.go-1041"
+      "relatedSpdxElement": "SPDXRef-File-attribute.go-1041"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decoder.go-1042"
+      "relatedSpdxElement": "SPDXRef-File-escape.go-1042"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-advrefs-decode.go-1043"
+      "relatedSpdxElement": "SPDXRef-File-task-manager.go-1043"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-1044"
+      "relatedSpdxElement": "SPDXRef-File-graphemeproperties.go-1044"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reference.go-1045"
+      "relatedSpdxElement": "SPDXRef-File-sentencerules.go-1045"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-object.go-1046"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1046"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-packfile.go-1047"
+      "relatedSpdxElement": "SPDXRef-File-wordproperties.go-1047"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-prune.go-1048"
+      "relatedSpdxElement": "SPDXRef-File-word.go-1048"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iter.go-1049"
+      "relatedSpdxElement": "SPDXRef-File-wordrules.go-1049"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-storage.go-1050"
+      "relatedSpdxElement": "SPDXRef-File-graphemerules.go-1050"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoder.go-1051"
+      "relatedSpdxElement": "SPDXRef-File-eastasianwidth.go-1051"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common.go-1052"
+      "relatedSpdxElement": "SPDXRef-File-properties.go-1052"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-loader.go-1053"
+      "relatedSpdxElement": "SPDXRef-File-sentenceproperties.go-1053"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-srvresp.go-1054"
+      "relatedSpdxElement": "SPDXRef-File-linerules.go-1054"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hash-sha1.go-1055"
+      "relatedSpdxElement": "SPDXRef-File-line.go-1055"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-filemode.go-1056"
+      "relatedSpdxElement": "SPDXRef-File-width.go-1056"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ulreq-decode.go-1057"
+      "relatedSpdxElement": "SPDXRef-File-emojipresentation.go-1057"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zlib.go-1058"
+      "relatedSpdxElement": "SPDXRef-File-step.go-1058"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-worktree-linux.go-1059"
+      "relatedSpdxElement": "SPDXRef-File-lineproperties.go-1059"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1060"
+      "relatedSpdxElement": "SPDXRef-File-sentence.go-1060"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-change.go-1061"
+      "relatedSpdxElement": "SPDXRef-File-grapheme.go-1061"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-commit.go-1062"
+      "relatedSpdxElement": "SPDXRef-File-bytes.go-1062"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-branch.go-1063"
+      "relatedSpdxElement": "SPDXRef-File-parser.go-1063"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signature.go-1064"
+      "relatedSpdxElement": "SPDXRef-File-escape.go-1064"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-config.go-1065"
+      "relatedSpdxElement": "SPDXRef-File-bytes-unsafe.go-1065"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-go-git-v5-31",
+      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-uppackreq.go-1066"
+      "relatedSpdxElement": "SPDXRef-File-fuzz.go-1066"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp-amd64.go-1067"
+      "relatedSpdxElement": "SPDXRef-File-happy-palettegen.go-1067"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-xor-unaligned.go-1068"
+      "relatedSpdxElement": "SPDXRef-File-colors.go-1068"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-modular.go-1069"
+      "relatedSpdxElement": "SPDXRef-File-soft-palettegen.go-1069"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-point.go-1070"
+      "relatedSpdxElement": "SPDXRef-File-colorgens.go-1070"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sign.go-1071"
+      "relatedSpdxElement": "SPDXRef-File-hexcolor.go-1071"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-primes.go-1072"
+      "relatedSpdxElement": "SPDXRef-File-sort.go-1072"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keccakf.go-1073"
+      "relatedSpdxElement": "SPDXRef-File-hsluv.go-1073"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve.go-1074"
+      "relatedSpdxElement": "SPDXRef-File-warm-palettegen.go-1074"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signapi.go-1075"
+      "relatedSpdxElement": "SPDXRef-File-rand.go-1075"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-table.go-1076"
+      "relatedSpdxElement": "SPDXRef-File-patch.go-1076"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed25519.go-1077"
+      "relatedSpdxElement": "SPDXRef-File-match.go-1077"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-key.go-1078"
+      "relatedSpdxElement": "SPDXRef-File-operation-string.go-1078"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mult.go-1079"
+      "relatedSpdxElement": "SPDXRef-File-diff.go-1079"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp-generic.go-1080"
+      "relatedSpdxElement": "SPDXRef-File-mathutil.go-1080"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1081"
+      "relatedSpdxElement": "SPDXRef-File-diffmatchpatch.go-1081"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-power.go-1082"
+      "relatedSpdxElement": "SPDXRef-File-stringutil.go-1082"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-9",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-conv.go-1083"
+      "relatedSpdxElement": "SPDXRef-File-logfmt-handler.go-1083"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-9",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp-generic.go-1084"
+      "relatedSpdxElement": "SPDXRef-File-docker-compose-handler.go-1084"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-9",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp.go-1085"
+      "relatedSpdxElement": "SPDXRef-File-handler.go-1085"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-9",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp-amd64.go-1086"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-1086"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-9",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rc.go-1087"
+      "relatedSpdxElement": "SPDXRef-File-json-handler.go-1087"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-9",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-shake.go-1088"
+      "relatedSpdxElement": "SPDXRef-File-time-parse.go-1088"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hashes.go-1089"
+      "relatedSpdxElement": "SPDXRef-File-walk.go-1089"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1090"
+      "relatedSpdxElement": "SPDXRef-File-polyfill.go-1090"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-twist.go-1091"
+      "relatedSpdxElement": "SPDXRef-File-util.go-1091"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tables.go-1092"
+      "relatedSpdxElement": "SPDXRef-File-os-options.go-1092"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-amd64.go-1093"
+      "relatedSpdxElement": "SPDXRef-File-os-posix.go-1093"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wnaf.go-1094"
+      "relatedSpdxElement": "SPDXRef-File-chroot.go-1094"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-integer.go-1095"
+      "relatedSpdxElement": "SPDXRef-File-os.go-1095"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-amd64.go-1096"
+      "relatedSpdxElement": "SPDXRef-File-os-bound.go-1096"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha3.go-1097"
+      "relatedSpdxElement": "SPDXRef-File-fs.go-1097"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mlsbset.go-1098"
+      "relatedSpdxElement": "SPDXRef-File-glob.go-1098"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fp.go-1099"
+      "relatedSpdxElement": "SPDXRef-File-os-chroot.go-1099"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-mattn-go-isatty-40",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-generic.go-1100"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1100"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-mattn-go-isatty-40",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-isogeny.go-1101"
+      "relatedSpdxElement": "SPDXRef-File-isatty-tcgets.go-1101"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-constants.go-1102"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1102"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1103"
+      "relatedSpdxElement": "SPDXRef-File-pty-linux.go-1103"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pubkey.go-1104"
+      "relatedSpdxElement": "SPDXRef-File-util.go-1104"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ed448.go-1105"
+      "relatedSpdxElement": "SPDXRef-File-run.go-1105"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-twistPoint.go-1106"
+      "relatedSpdxElement": "SPDXRef-File-ioctl.go-1106"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-creack-pty-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-key.go-1107"
+      "relatedSpdxElement": "SPDXRef-File-ztypes-amd64.go-1107"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-point.go-1108"
+      "relatedSpdxElement": "SPDXRef-File-enum.go-1108"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve.go-1109"
+      "relatedSpdxElement": "SPDXRef-File-serialize.go-1109"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve-generic.go-1110"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1110"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-signapi.go-1111"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-1111"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-twistTables.go-1112"
+      "relatedSpdxElement": "SPDXRef-File-bool.go-1112"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-table.go-1113"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1113"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-twist-basemult.go-1114"
+      "relatedSpdxElement": "SPDXRef-File-errors.go-1114"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-curve.go-1115"
+      "relatedSpdxElement": "SPDXRef-File-int.go-1115"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-cloudflare-circl-14",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scalar.go-1116"
+      "relatedSpdxElement": "SPDXRef-File-token.go-1116"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-attr.go-1117"
+      "relatedSpdxElement": "SPDXRef-File-scanner.go-1117"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1118"
+      "relatedSpdxElement": "SPDXRef-File-scan.go-1118"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-nonblock-unix.go-1119"
+      "relatedSpdxElement": "SPDXRef-File-set.go-1119"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-direct.go-1120"
+      "relatedSpdxElement": "SPDXRef-File-read.go-1120"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1121"
+      "relatedSpdxElement": "SPDXRef-File-position.go-1121"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-term-62",
       "relationshipType": "CONTAINS",
       "relatedSpdxElement": "SPDXRef-File-term.go-1122"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-term-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1123"
+      "relatedSpdxElement": "SPDXRef-File-term-unix.go-1123"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-term-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-1124"
+      "relatedSpdxElement": "SPDXRef-File-term-unix-other.go-1124"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-term-62",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1125"
+      "relatedSpdxElement": "SPDXRef-File-terminal.go-1125"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1126"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1126"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1127"
+      "relatedSpdxElement": "SPDXRef-File-open-linux.go-1127"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tscreen-unix.go-1128"
+      "relatedSpdxElement": "SPDXRef-File-vfs.go-1128"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1129"
+      "relatedSpdxElement": "SPDXRef-File-gocompat-errors-go120.go-1129"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mouse.go-1130"
+      "relatedSpdxElement": "SPDXRef-File-procfs-linux.go-1130"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminfo.go-1131"
+      "relatedSpdxElement": "SPDXRef-File-openat-linux.go-1131"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-extended.go-1132"
+      "relatedSpdxElement": "SPDXRef-File-mkdir-linux.go-1132"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1133"
+      "relatedSpdxElement": "SPDXRef-File-lookup-linux.go-1133"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1134"
+      "relatedSpdxElement": "SPDXRef-File-gocompat-generics-go121.go-1134"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1135"
+      "relatedSpdxElement": "SPDXRef-File-join.go-1135"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eastasian.go-1136"
+      "relatedSpdxElement": "SPDXRef-File-openat2-linux.go-1136"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-53",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1137"
+      "relatedSpdxElement": "SPDXRef-File-todo.go-1137"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-53",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-key.go-1138"
+      "relatedSpdxElement": "SPDXRef-File-write.go-1138"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-53",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1139"
+      "relatedSpdxElement": "SPDXRef-File-parse.go-1139"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1140"
+      "relatedSpdxElement": "SPDXRef-File-latin1.go-1140"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-console-stub.go-1141"
+      "relatedSpdxElement": "SPDXRef-File-utf8.go-1141"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-interrupt.go-1142"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1142"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-style.go-1143"
+      "relatedSpdxElement": "SPDXRef-File-ebcdic.go-1143"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1144"
+      "relatedSpdxElement": "SPDXRef-File-ascii.go-1144"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base.go-1145"
+      "relatedSpdxElement": "SPDXRef-File-latin5.go-1145"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tscreen.go-1146"
+      "relatedSpdxElement": "SPDXRef-File-charmap.go-1146"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-net-59",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-direct.go-1147"
+      "relatedSpdxElement": "SPDXRef-File-context.go-1147"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-net-59",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1148"
+      "relatedSpdxElement": "SPDXRef-File-per-host.go-1148"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-net-59",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1149"
+      "relatedSpdxElement": "SPDXRef-File-direct.go-1149"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-net-59",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tty.go-1150"
+      "relatedSpdxElement": "SPDXRef-File-client.go-1150"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-net-59",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-charset-unix.go-1151"
+      "relatedSpdxElement": "SPDXRef-File-dial.go-1151"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-net-59",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dynamic.go-1152"
+      "relatedSpdxElement": "SPDXRef-File-socks.go-1152"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-net-59",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-1153"
+      "relatedSpdxElement": "SPDXRef-File-proxy.go-1153"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-golang.org-x-net-59",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-simulation.go-1154"
+      "relatedSpdxElement": "SPDXRef-File-socks5.go-1154"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terms-dynamic.go-1155"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-1155"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1156"
+      "relatedSpdxElement": "SPDXRef-File-lists.go-1156"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-foot.go-1157"
+      "relatedSpdxElement": "SPDXRef-File-serialization.go-1157"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-event.go-1158"
+      "relatedSpdxElement": "SPDXRef-File-arraylist.go-1158"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1159"
+      "relatedSpdxElement": "SPDXRef-File-comparator.go-1159"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1160"
+      "relatedSpdxElement": "SPDXRef-File-enumerable.go-1160"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stdin-unix.go-1161"
+      "relatedSpdxElement": "SPDXRef-File-iterator.go-1161"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1162"
+      "relatedSpdxElement": "SPDXRef-File-sort.go-1162"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoding.go-1163"
+      "relatedSpdxElement": "SPDXRef-File-enumerable.go-1163"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1164"
+      "relatedSpdxElement": "SPDXRef-File-trees.go-1164"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cell.go-1165"
+      "relatedSpdxElement": "SPDXRef-File-containers.go-1165"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1166"
+      "relatedSpdxElement": "SPDXRef-File-serialization.go-1166"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tty-unix.go-1167"
+      "relatedSpdxElement": "SPDXRef-File-binaryheap.go-1167"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1168"
+      "relatedSpdxElement": "SPDXRef-File-iterator.go-1168"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-input.go-1169"
+      "relatedSpdxElement": "SPDXRef-File-iterator.go-1169"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-screen.go-1170"
+      "relatedSpdxElement": "SPDXRef-File-serialization.go-1170"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1171"
+      "relatedSpdxElement": "SPDXRef-File-maps.go-1171"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1172"
+      "relatedSpdxElement": "SPDXRef-File-set.go-1172"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-focus.go-1173"
+      "relatedSpdxElement": "SPDXRef-File-orderedset.go-1173"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-skeema-knownhosts-50",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-runes.go-1174"
+      "relatedSpdxElement": "SPDXRef-File-knownhosts.go-1174"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-mailru-easyjson-38",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-resize.go-1175"
+      "relatedSpdxElement": "SPDXRef-File-writer.go-1175"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-mailru-easyjson-38",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-paste.go-1176"
+      "relatedSpdxElement": "SPDXRef-File-pool.go-1176"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-spkg-bom-52",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colorfit.go-1177"
+      "relatedSpdxElement": "SPDXRef-File-discard-go15.go-1177"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-spkg-bom-52",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1178"
+      "relatedSpdxElement": "SPDXRef-File-bom.go-1178"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-gdamore-tcell-v2-21",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terms-default.go-1179"
+      "relatedSpdxElement": "SPDXRef-File-error-1-13.go-1179"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-56",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-orderedmap.go-1180"
+      "relatedSpdxElement": "SPDXRef-File-join-unwrap-1-20.go-1180"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-56",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-yaml.go-1181"
+      "relatedSpdxElement": "SPDXRef-File-parse-panic.go-1181"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-wk8-go-ordered-map-v2-56",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-json.go-1182"
+      "relatedSpdxElement": "SPDXRef-File-error.go-1182"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-lazycore-33",
+      "spdxElementId": "SPDXRef-github.com-go-errors-errors-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-1183"
+      "relatedSpdxElement": "SPDXRef-File-stackframe.go-1183"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-lazycore-33",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-boxlayout.go-1184"
+      "relatedSpdxElement": "SPDXRef-File-mib.go-1184"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-60",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsortanyfunc.go-1185"
+      "relatedSpdxElement": "SPDXRef-File-iter.go-1185"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-60",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-constraints.go-1186"
+      "relatedSpdxElement": "SPDXRef-File-normalize.go-1186"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-60",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slices.go-1187"
+      "relatedSpdxElement": "SPDXRef-File-input.go-1187"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-60",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zsortordered.go-1188"
+      "relatedSpdxElement": "SPDXRef-File-transform.go-1188"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-60",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sort.go-1189"
+      "relatedSpdxElement": "SPDXRef-File-identifier.go-1189"
     },
     {
-      "spdxElementId": "SPDXRef-golang.org-x-exp-60",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cmp.go-1190"
+      "relatedSpdxElement": "SPDXRef-File-runes.go-1190"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ubc-amd64.go-1191"
+      "relatedSpdxElement": "SPDXRef-File-encoding.go-1191"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1cd.go-1192"
+      "relatedSpdxElement": "SPDXRef-File-transform.go-1192"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-const.go-1193"
+      "relatedSpdxElement": "SPDXRef-File-readwriter.go-1193"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1cdblock-amd64.go-1194"
+      "relatedSpdxElement": "SPDXRef-File-tables15.0.0.go-1194"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-detection.go-1195"
+      "relatedSpdxElement": "SPDXRef-File-cond.go-1195"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ubc.go-1196"
+      "relatedSpdxElement": "SPDXRef-File-composition.go-1196"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sha1cdblock-generic.go-1197"
+      "relatedSpdxElement": "SPDXRef-File-trie.go-1197"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "spdxElementId": "SPDXRef-golang.org-x-text-63",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-const.go-1198"
+      "relatedSpdxElement": "SPDXRef-File-forminfo.go-1198"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-pjbgf-sha1cd-45",
+      "spdxElementId": "SPDXRef-github.com-cloudfoundry-jibber-jabber-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ubc-generic.go-1199"
+      "relatedSpdxElement": "SPDXRef-File-jibber-jabber-unix.go-1199"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kr-logfmt-37",
+      "spdxElementId": "SPDXRef-github.com-cloudfoundry-jibber-jabber-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-1200"
+      "relatedSpdxElement": "SPDXRef-File-jibber-jabber.go-1200"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kr-logfmt-37",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decode.go-1201"
+      "relatedSpdxElement": "SPDXRef-File-xdg.go-1201"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-kr-logfmt-37",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-unquote.go-1202"
+      "relatedSpdxElement": "SPDXRef-File-user-dirs.go-1202"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-1203"
+      "relatedSpdxElement": "SPDXRef-File-pathutil.go-1203"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-intersect.go-1204"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1204"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-condition.go-1205"
+      "relatedSpdxElement": "SPDXRef-File-pathutil-unix.go-1205"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-test.go-1206"
+      "relatedSpdxElement": "SPDXRef-File-base-dirs.go-1206"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-adrg-xdg-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-concurrency.go-1207"
+      "relatedSpdxElement": "SPDXRef-File-paths-unix.go-1207"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-mattn-go-colorable-39",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-math.go-1208"
+      "relatedSpdxElement": "SPDXRef-File-noncolorable.go-1208"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-mattn-go-colorable-39",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-slice.go-1209"
+      "relatedSpdxElement": "SPDXRef-File-colorable-others.go-1209"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-petermattis-goid-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-types.go-1210"
+      "relatedSpdxElement": "SPDXRef-File-goid.go-1210"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-petermattis-goid-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-map.go-1211"
+      "relatedSpdxElement": "SPDXRef-File-goid-go1.5.go-1211"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-petermattis-goid-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-func.go-1212"
+      "relatedSpdxElement": "SPDXRef-File-runtime-go1.25.go-1212"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-string.go-1213"
+      "relatedSpdxElement": "SPDXRef-File-color.go-1213"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-retry.go-1214"
+      "relatedSpdxElement": "SPDXRef-File-util.go-1214"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-constraints.go-1215"
+      "relatedSpdxElement": "SPDXRef-File-capvals.go-1215"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-channel.go-1216"
+      "relatedSpdxElement": "SPDXRef-File-terminfo.go-1216"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-find.go-1217"
+      "relatedSpdxElement": "SPDXRef-File-caps.go-1217"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tuples.go-1218"
+      "relatedSpdxElement": "SPDXRef-File-load.go-1218"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-samber-lo-48",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-type-manipulation.go-1219"
+      "relatedSpdxElement": "SPDXRef-File-stack.go-1219"
     },
     {
-      "spdxElementId": "SPDXRef-dario.cat-mergo-5",
+      "spdxElementId": "SPDXRef-github.com-xo-terminfo-56",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mergo.go-1220"
+      "relatedSpdxElement": "SPDXRef-File-param.go-1220"
     },
     {
-      "spdxElementId": "SPDXRef-dario.cat-mergo-5",
+      "spdxElementId": "SPDXRef-github.com-xanzy-ssh-agent-55",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-map.go-1221"
+      "relatedSpdxElement": "SPDXRef-File-sshagent.go-1221"
     },
     {
-      "spdxElementId": "SPDXRef-dario.cat-mergo-5",
+      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1222"
+      "relatedSpdxElement": "SPDXRef-File-reflect.go-1222"
     },
     {
-      "spdxElementId": "SPDXRef-dario.cat-mergo-5",
+      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-merge.go-1223"
+      "relatedSpdxElement": "SPDXRef-File-id.go-1223"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-keybinding.go-1224"
+      "relatedSpdxElement": "SPDXRef-File-comment-extractor.go-1224"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui-others.go-1225"
+      "relatedSpdxElement": "SPDXRef-File-utils.go-1225"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-kyokomi-emoji-v2-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-loader.go-1226"
+      "relatedSpdxElement": "SPDXRef-File-emoji.go-1226"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-kyokomi-emoji-v2-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scrollbar.go-1227"
+      "relatedSpdxElement": "SPDXRef-File-emoji-codemap.go-1227"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-64",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tcell-driver.go-1228"
+      "relatedSpdxElement": "SPDXRef-File-patricia.go-1228"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-64",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gui.go-1229"
+      "relatedSpdxElement": "SPDXRef-File-children.go-1229"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-fatih-color-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-view.go-1230"
+      "relatedSpdxElement": "SPDXRef-File-color.go-1230"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-fatih-color-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-text-area.go-1231"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1231"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-bahlo-generic-list-go-10",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-edit.go-1232"
+      "relatedSpdxElement": "SPDXRef-File-list.go-1232"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-task.go-1233"
+      "relatedSpdxElement": "SPDXRef-File-deadlock.go-1233"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1234"
+      "relatedSpdxElement": "SPDXRef-File-stacktraces.go-1234"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-attribute.go-1235"
+      "relatedSpdxElement": "SPDXRef-File-trylock.go-1235"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.go-1236"
+      "relatedSpdxElement": "SPDXRef-File-deadlock-map.go-1236"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-gocui-32",
+      "spdxElementId": "SPDXRef-github.com-jbenet-go-context-27",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-task-manager.go-1237"
+      "relatedSpdxElement": "SPDXRef-File-ctxio.go-1237"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
+      "spdxElementId": "SPDXRef-gopkg.in-warnings.v0-65",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-graphemeproperties.go-1238"
+      "relatedSpdxElement": "SPDXRef-File-warnings.go-1238"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
+      "spdxElementId": "SPDXRef-github.com-sahilm-fuzzy-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sentencerules.go-1239"
+      "relatedSpdxElement": "SPDXRef-File-fuzzy.go-1239"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
+      "spdxElementId": "SPDXRef-github.com-atotto-clipboard-8",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1240"
+      "relatedSpdxElement": "SPDXRef-File-clipboard.go-1240"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
+      "spdxElementId": "SPDXRef-github.com-atotto-clipboard-8",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wordproperties.go-1241"
+      "relatedSpdxElement": "SPDXRef-File-clipboard-unix.go-1241"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
+      "spdxElementId": "SPDXRef-github.com-mgutz-str-41",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-word.go-1242"
+      "relatedSpdxElement": "SPDXRef-File-funcsPZ.go-1242"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
+      "spdxElementId": "SPDXRef-github.com-mgutz-str-41",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-wordrules.go-1243"
+      "relatedSpdxElement": "SPDXRef-File-doc.go-1243"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
+      "spdxElementId": "SPDXRef-github.com-mgutz-str-41",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-graphemerules.go-1244"
+      "relatedSpdxElement": "SPDXRef-File-funcsAO.go-1244"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
+      "spdxElementId": "SPDXRef-github.com-golang-groupcache-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-eastasianwidth.go-1245"
+      "relatedSpdxElement": "SPDXRef-File-lru.go-1245"
     },
     {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
+      "spdxElementId": "SPDXRef-golang.org-x-sync-60",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-properties.go-1246"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sentenceproperties.go-1247"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-linerules.go-1248"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-line.go-1249"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-width.go-1250"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-emojipresentation.go-1251"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-step.go-1252"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lineproperties.go-1253"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sentence.go-1254"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-rivo-uniseg-46",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-grapheme.go-1255"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-13",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bytes.go-1256"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-13",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parser.go-1257"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-13",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-escape.go-1258"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-13",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bytes-unsafe.go-1259"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-buger-jsonparser-13",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fuzz.go-1260"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-happy-palettegen.go-1261"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colors.go-1262"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-soft-palettegen.go-1263"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colorgens.go-1264"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hexcolor.go-1265"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sort.go-1266"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hsluv.go-1267"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warm-palettegen.go-1268"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-lucasb-eyer-go-colorful-39",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-rand.go-1269"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-50",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patch.go-1270"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-50",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-match.go-1271"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-50",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-operation-string.go-1272"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-50",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diff.go-1273"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-50",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mathutil.go-1274"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-50",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-diffmatchpatch.go-1275"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sergi-go-diff-50",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stringutil.go-1276"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-11",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-logfmt-handler.go-1277"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-11",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-docker-compose-handler.go-1278"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-11",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-handler.go-1279"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-11",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-1280"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-11",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-json-handler.go-1281"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-aybabtme-humanlog-11",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-time-parse.go-1282"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lobject.h-1283"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lua.h-1284"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lauxlib.h-1285"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lstate.h-1286"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lualib.h-1287"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lzio.h-1288"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ltm.h-1289"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lmem.h-1290"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-llimits.h-1291"
-    },
-    {
-      "spdxElementId": "SPDXRef-lua-73",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-luaconf.h-1292"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-walk.go-1293"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-polyfill.go-1294"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.go-1295"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-options.go-1296"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-posix.go-1297"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-chroot.go-1298"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os.go-1299"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-bound.go-1300"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fs.go-1301"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-glob.go-1302"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-go-billy-v5-24",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-os-chroot.go-1303"
-    },
-    {
-      "spdxElementId": "SPDXRef-fast-float-6",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fast-float-strtod.h-1304"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mattn-go-isatty-42",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1305"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mattn-go-isatty-42",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-isatty-tcgets.go-1306"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1307"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pty-linux.go-1308"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.go-1309"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-run.go-1310"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ioctl.go-1311"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-creack-pty-16",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ztypes-amd64.go-1312"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-enum.go-1313"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-serialize.go-1314"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1315"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-1316"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bool.go-1317"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1318"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errors.go-1319"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-int.go-1320"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-token.go-1321"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scanner.go-1322"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-scan.go-1323"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-set.go-1324"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read.go-1325"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-git-gcfg-23",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-position.go-1326"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-term-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term.go-1327"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-term-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term-unix.go-1328"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-term-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-term-unix-other.go-1329"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-term-64",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminal.go-1330"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1331"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-open-linux.go-1332"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-vfs.go-1333"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gocompat-errors-go120.go-1334"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-procfs-linux.go-1335"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openat-linux.go-1336"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mkdir-linux.go-1337"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lookup-linux.go-1338"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gocompat-generics-go121.go-1339"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-join.go-1340"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cyphar-filepath-securejoin-17",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-openat2-linux.go-1341"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-55",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-todo.go-1342"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-55",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-write.go-1343"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-stefanhaller-git-todo-parser-55",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parse.go-1344"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-20",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-latin1.go-1345"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-20",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utf8.go-1346"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-20",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1347"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-20",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ebcdic.go-1348"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-20",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ascii.go-1349"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-20",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-latin5.go-1350"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-gdamore-encoding-20",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-charmap.go-1351"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-61",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-context.go-1352"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-61",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-per-host.go-1353"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-61",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-direct.go-1354"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-61",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-client.go-1355"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-61",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-dial.go-1356"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-61",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks.go-1357"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-61",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-proxy.go-1358"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-net-61",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-socks5.go-1359"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-1360"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lists.go-1361"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-serialization.go-1362"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-arraylist.go-1363"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-comparator.go-1364"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-enumerable.go-1365"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iterator.go-1366"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sort.go-1367"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-enumerable.go-1368"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-trees.go-1369"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-containers.go-1370"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-serialization.go-1371"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-binaryheap.go-1372"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iterator.go-1373"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iterator.go-1374"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-emirpasic-gods-18",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-serialization.go-1375"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-30",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-maps.go-1376"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-30",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-set.go-1377"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-jesseduffield-generics-30",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-orderedset.go-1378"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-skeema-knownhosts-52",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-knownhosts.go-1379"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mailru-easyjson-40",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-writer.go-1380"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mailru-easyjson-40",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pool.go-1381"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-spkg-bom-54",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-discard-go15.go-1382"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-spkg-bom-54",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bom.go-1383"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-70",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-read.h-1384"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-70",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-async.h-1385"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-70",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hiredis.h-1386"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-70",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-alloc.h-1387"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-70",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sds.h-1388"
-    },
-    {
-      "spdxElementId": "SPDXRef-hiredis-70",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sdscompat.h-1389"
-    },
-    {
-      "spdxElementId": "SPDXRef-fpconv-7",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fpconv-dtoa.h-1390"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error-1-13.go-1391"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-join-unwrap-1-20.go-1392"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-parse-panic.go-1393"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-error.go-1394"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-go-errors-errors-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stackframe.go-1395"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-mib.go-1396"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-iter.go-1397"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-normalize.go-1398"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-input.go-1399"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transform.go-1400"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-identifier.go-1401"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-runes.go-1402"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-encoding.go-1403"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-transform.go-1404"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-readwriter.go-1405"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-tables15.0.0.go-1406"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cond.go-1407"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-composition.go-1408"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-trie.go-1409"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-text-65",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-forminfo.go-1410"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cloudfoundry-jibber-jabber-15",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jibber-jabber-unix.go-1411"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-cloudfoundry-jibber-jabber-15",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jibber-jabber.go-1412"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-9",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-xdg.go-1413"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-9",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-user-dirs.go-1414"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-9",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pathutil.go-1415"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-9",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1416"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-9",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-pathutil-unix.go-1417"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-9",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-base-dirs.go-1418"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-adrg-xdg-9",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-paths-unix.go-1419"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mattn-go-colorable-41",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-noncolorable.go-1420"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mattn-go-colorable-41",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-colorable-others.go-1421"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-petermattis-goid-44",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-goid.go-1422"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-petermattis-goid-44",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-goid-go1.5.go-1423"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-petermattis-goid-44",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-runtime-go1.25.go-1424"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-58",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-1425"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-58",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-util.go-1426"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-58",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-capvals.go-1427"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-58",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-terminfo.go-1428"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-58",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-caps.go-1429"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-58",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-load.go-1430"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-58",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stack.go-1431"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xo-terminfo-58",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-param.go-1432"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-xanzy-ssh-agent-57",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-sshagent.go-1433"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-35",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-reflect.go-1434"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-35",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-id.go-1435"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-35",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-comment-extractor.go-1436"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-karimkhaleel-jsonschema-35",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.go-1437"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-kyokomi-emoji-v2-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-emoji.go-1438"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-kyokomi-emoji-v2-38",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-emoji-codemap.go-1439"
-    },
-    {
-      "spdxElementId": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-66",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-patricia.go-1440"
-    },
-    {
-      "spdxElementId": "SPDXRef-gopkg.in-ozeidan-fuzzy-patricia.v3-66",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-children.go-1441"
-    },
-    {
-      "spdxElementId": "SPDXRef-jemalloc-71",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-jemalloc.h-1442"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-fatih-color-19",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-color.go-1443"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-fatih-color-19",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1444"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-bahlo-generic-list-go-12",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-list.go-1445"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deadlock.go-1446"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-stacktraces.go-1447"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-trylock.go-1448"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sasha-s-go-deadlock-49",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deadlock-map.go-1449"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-jbenet-go-context-29",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ctxio.go-1450"
-    },
-    {
-      "spdxElementId": "SPDXRef-gopkg.in-warnings.v0-67",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-warnings.go-1451"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-sahilm-fuzzy-47",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-fuzzy.go-1452"
-    },
-    {
-      "spdxElementId": "SPDXRef-linenoise-72",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-linenoise.h-1453"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-atotto-clipboard-10",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-clipboard.go-1454"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-atotto-clipboard-10",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-clipboard-unix.go-1455"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mgutz-str-43",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-funcsPZ.go-1456"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mgutz-str-43",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-doc.go-1457"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-mgutz-str-43",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-funcsAO.go-1458"
-    },
-    {
-      "spdxElementId": "SPDXRef-github.com-golang-groupcache-26",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lru.go-1459"
-    },
-    {
-      "spdxElementId": "SPDXRef-golang.org-x-sync-62",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-errgroup.go-1460"
+      "relatedSpdxElement": "SPDXRef-File-errgroup.go-1246"
     }
   ]
 }

--- a/tests/golden/spdx/rust/oxipng/oxipng_analyzed.spdx.json
+++ b/tests/golden/spdx/rust/oxipng/oxipng_analyzed.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "oxipng",
-  "documentNamespace": "https://omnibor.io/omnibor-analysis/oxipng-f15af378-8e5c-46e8-9a88-c8b0a33da6b7",
+  "documentNamespace": "https://omnibor.io/omnibor-analysis/oxipng-1e7b9ce9-e317-4946-8ba9-8b0efeef613b",
   "creationInfo": {
-    "created": "2026-03-12T22:32:03Z",
+    "created": "2026-05-05T16:33:12Z",
     "creators": [
       "Tool: bomtrace3-unknown",
       "Tool: bomsh-unknown",
@@ -20,11 +20,11 @@
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": true,
       "primaryPackagePurpose": "APPLICATION",
-      "builtDate": "2026-03-12T22:32:03Z",
+      "builtDate": "2026-05-05T16:33:12Z",
       "externalRefs": [],
       "checksums": [],
       "comment": "Built on Ubuntu 22.04.5 LTS with gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
-      "versionInfo": "8.19.0-DEV"
+      "versionInfo": "10.1.0"
     },
     {
       "SPDXID": "SPDXRef-anstream-2",
@@ -189,12 +189,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/clap@4.5.60"
+          "referenceLocator": "pkg:cargo/clap@4.5.54"
         }
       ],
       "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
-      "versionInfo": "4.5.60"
+      "versionInfo": "4.5.54"
     },
     {
       "SPDXID": "SPDXRef-clap-builder-12",
@@ -206,12 +206,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/clap_builder@4.5.60"
+          "referenceLocator": "pkg:cargo/clap_builder@4.5.54"
         }
       ],
       "comment": "Rust crate (transitive, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Transitive dependency via Cargo. Downloaded from crates.io registry.",
-      "versionInfo": "4.5.60"
+      "versionInfo": "4.5.54"
     },
     {
       "SPDXID": "SPDXRef-clap-lex-13",
@@ -223,12 +223,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/clap_lex@1.0.0"
+          "referenceLocator": "pkg:cargo/clap_lex@0.7.5"
         }
       ],
       "comment": "Rust crate (transitive, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Transitive dependency via Cargo. Downloaded from crates.io registry.",
-      "versionInfo": "1.0.0"
+      "versionInfo": "0.7.5"
     },
     {
       "SPDXID": "SPDXRef-colorchoice-14",
@@ -248,7 +248,24 @@
       "versionInfo": "1.0.4"
     },
     {
-      "SPDXID": "SPDXRef-crossbeam-deque-15",
+      "SPDXID": "SPDXRef-crossbeam-channel-15",
+      "name": "crossbeam-channel",
+      "downloadLocation": "https://crates.io/crates/crossbeam-channel",
+      "filesAnalyzed": true,
+      "primaryPackagePurpose": "LIBRARY",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:cargo/crossbeam-channel@0.5.15"
+        }
+      ],
+      "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
+      "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
+      "versionInfo": "0.5.15"
+    },
+    {
+      "SPDXID": "SPDXRef-crossbeam-deque-16",
       "name": "crossbeam-deque",
       "downloadLocation": "https://crates.io/crates/crossbeam-deque",
       "filesAnalyzed": true,
@@ -265,7 +282,7 @@
       "versionInfo": "0.8.6"
     },
     {
-      "SPDXID": "SPDXRef-crossbeam-epoch-16",
+      "SPDXID": "SPDXRef-crossbeam-epoch-17",
       "name": "crossbeam-epoch",
       "downloadLocation": "https://crates.io/crates/crossbeam-epoch",
       "filesAnalyzed": true,
@@ -282,7 +299,7 @@
       "versionInfo": "0.9.18"
     },
     {
-      "SPDXID": "SPDXRef-crossbeam-utils-17",
+      "SPDXID": "SPDXRef-crossbeam-utils-18",
       "name": "crossbeam-utils",
       "downloadLocation": "https://crates.io/crates/crossbeam-utils",
       "filesAnalyzed": true,
@@ -299,7 +316,7 @@
       "versionInfo": "0.8.21"
     },
     {
-      "SPDXID": "SPDXRef-either-18",
+      "SPDXID": "SPDXRef-either-19",
       "name": "either",
       "downloadLocation": "https://crates.io/crates/either",
       "filesAnalyzed": true,
@@ -316,7 +333,7 @@
       "versionInfo": "1.15.0"
     },
     {
-      "SPDXID": "SPDXRef-env-filter-19",
+      "SPDXID": "SPDXRef-env-filter-20",
       "name": "env_filter",
       "downloadLocation": "https://crates.io/crates/env_filter",
       "filesAnalyzed": true,
@@ -325,15 +342,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/env_filter@1.0.0"
+          "referenceLocator": "pkg:cargo/env_filter@0.1.3"
         }
       ],
       "comment": "Rust crate (transitive, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Transitive dependency via Cargo. Downloaded from crates.io registry.",
-      "versionInfo": "1.0.0"
+      "versionInfo": "0.1.3"
     },
     {
-      "SPDXID": "SPDXRef-env-logger-20",
+      "SPDXID": "SPDXRef-env-logger-21",
       "name": "env_logger",
       "downloadLocation": "https://crates.io/crates/env_logger",
       "filesAnalyzed": true,
@@ -342,15 +359,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/env_logger@0.11.9"
+          "referenceLocator": "pkg:cargo/env_logger@0.11.8"
         }
       ],
       "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
-      "versionInfo": "0.11.9"
+      "versionInfo": "0.11.8"
     },
     {
-      "SPDXID": "SPDXRef-equivalent-21",
+      "SPDXID": "SPDXRef-equivalent-22",
       "name": "equivalent",
       "downloadLocation": "https://crates.io/crates/equivalent",
       "filesAnalyzed": true,
@@ -367,7 +384,7 @@
       "versionInfo": "1.0.2"
     },
     {
-      "SPDXID": "SPDXRef-find-msvc-tools-22",
+      "SPDXID": "SPDXRef-find-msvc-tools-23",
       "name": "find-msvc-tools",
       "downloadLocation": "https://crates.io/crates/find-msvc-tools",
       "filesAnalyzed": true,
@@ -384,7 +401,7 @@
       "versionInfo": "0.1.2"
     },
     {
-      "SPDXID": "SPDXRef-funty-23",
+      "SPDXID": "SPDXRef-funty-24",
       "name": "funty",
       "downloadLocation": "https://crates.io/crates/funty",
       "filesAnalyzed": true,
@@ -401,7 +418,7 @@
       "versionInfo": "2.0.0"
     },
     {
-      "SPDXID": "SPDXRef-hashbrown-24",
+      "SPDXID": "SPDXRef-hashbrown-25",
       "name": "hashbrown",
       "downloadLocation": "https://crates.io/crates/hashbrown",
       "filesAnalyzed": true,
@@ -418,7 +435,7 @@
       "versionInfo": "0.16.1"
     },
     {
-      "SPDXID": "SPDXRef-indexmap-25",
+      "SPDXID": "SPDXRef-indexmap-26",
       "name": "indexmap",
       "downloadLocation": "https://crates.io/crates/indexmap",
       "filesAnalyzed": true,
@@ -435,7 +452,7 @@
       "versionInfo": "2.13.0"
     },
     {
-      "SPDXID": "SPDXRef-is-terminal-polyfill-26",
+      "SPDXID": "SPDXRef-is-terminal-polyfill-27",
       "name": "is_terminal_polyfill",
       "downloadLocation": "https://crates.io/crates/is_terminal_polyfill",
       "filesAnalyzed": true,
@@ -452,167 +469,7 @@
       "versionInfo": "1.70.1"
     },
     {
-      "SPDXID": "SPDXRef-libanstream-af8c0c8b7745f81c.rlib-27",
-      "name": "libanstream-af8c0c8b7745f81c.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libanstream-af8c0c8b7745f81c.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libanstyle-a0a0ad7ff8b9c5a1.rlib-28",
-      "name": "libanstyle-a0a0ad7ff8b9c5a1.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libanstyle-a0a0ad7ff8b9c5a1.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libanstyle-parse-7aaeee641d2da150.rlib-29",
-      "name": "libanstyle_parse-7aaeee641d2da150.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libanstyle_parse-7aaeee641d2da150.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libanstyle-query-24c9d1b4892ed6c3.rlib-30",
-      "name": "libanstyle_query-24c9d1b4892ed6c3.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libanstyle_query-24c9d1b4892ed6c3.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libbitflags-1280f28be8e10639.rlib-31",
-      "name": "libbitflags-1280f28be8e10639.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libbitflags-1280f28be8e10639.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libbitvec-e8365d6a02442b17.rlib-32",
-      "name": "libbitvec-e8365d6a02442b17.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libbitvec-e8365d6a02442b17.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libbumpalo-b931f9f29ef28c54.rlib-33",
-      "name": "libbumpalo-b931f9f29ef28c54.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libbumpalo-b931f9f29ef28c54.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libbytemuck-554fa33dc3a4a114.rlib-34",
-      "name": "libbytemuck-554fa33dc3a4a114.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libbytemuck-554fa33dc3a4a114.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcc-6022fe8bec44565b.rlib-35",
-      "name": "libcc-6022fe8bec44565b.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcc-6022fe8bec44565b.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libclap-ba3cd817b4d126e9.rlib-36",
-      "name": "libclap-ba3cd817b4d126e9.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libclap-ba3cd817b4d126e9.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libclap-builder-b1a4cc9d08676f8c.rlib-37",
-      "name": "libclap_builder-b1a4cc9d08676f8c.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libclap_builder-b1a4cc9d08676f8c.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libclap-lex-da436b52c838ef3a.rlib-38",
-      "name": "libclap_lex-da436b52c838ef3a.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libclap_lex-da436b52c838ef3a.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcolorchoice-0db96e0fc98929ef.rlib-39",
-      "name": "libcolorchoice-0db96e0fc98929ef.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcolorchoice-0db96e0fc98929ef.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcrossbeam-deque-981e4e7399a46153.rlib-40",
-      "name": "libcrossbeam_deque-981e4e7399a46153.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcrossbeam_deque-981e4e7399a46153.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcrossbeam-epoch-2345908434fb69df.rlib-41",
-      "name": "libcrossbeam_epoch-2345908434fb69df.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcrossbeam_epoch-2345908434fb69df.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcrossbeam-utils-6aec20481488f580.rlib-42",
-      "name": "libcrossbeam_utils-6aec20481488f580.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcrossbeam_utils-6aec20481488f580.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libdeflate-sys-43",
+      "SPDXID": "SPDXRef-libdeflate-sys-28",
       "name": "libdeflate-sys",
       "downloadLocation": "https://crates.io/crates/libdeflate-sys",
       "filesAnalyzed": true,
@@ -621,15 +478,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/libdeflate-sys@1.25.2"
+          "referenceLocator": "pkg:cargo/libdeflate-sys@1.25.0"
         }
       ],
       "comment": "Rust crate (transitive, statically linked). 2 source files compiled into oxipng",
       "packageSourceInfo": "Transitive dependency via Cargo. Downloaded from crates.io registry.",
-      "versionInfo": "1.25.2"
+      "versionInfo": "1.25.0"
     },
     {
-      "SPDXID": "SPDXRef-libdeflater-44",
+      "SPDXID": "SPDXRef-libdeflater-29",
       "name": "libdeflater",
       "downloadLocation": "https://crates.io/crates/libdeflater",
       "filesAnalyzed": true,
@@ -638,305 +495,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/libdeflater@1.25.2"
+          "referenceLocator": "pkg:cargo/libdeflater@1.25.0"
         }
       ],
       "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
-      "versionInfo": "1.25.2"
+      "versionInfo": "1.25.0"
     },
     {
-      "SPDXID": "SPDXRef-libeither-293bc8bebd4fea10.rlib-45",
-      "name": "libeither-293bc8bebd4fea10.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libeither-293bc8bebd4fea10.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libenv-filter-6442a55f21f4f1e1.rlib-46",
-      "name": "libenv_filter-6442a55f21f4f1e1.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libenv_filter-6442a55f21f4f1e1.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libenv-logger-060457492833bd93.rlib-47",
-      "name": "libenv_logger-060457492833bd93.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libenv_logger-060457492833bd93.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libequivalent-de15a8ed2be8fbaa.rlib-48",
-      "name": "libequivalent-de15a8ed2be8fbaa.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libequivalent-de15a8ed2be8fbaa.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libfind-msvc-tools-c62d9445dcf587b3.rlib-49",
-      "name": "libfind_msvc_tools-c62d9445dcf587b3.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libfind_msvc_tools-c62d9445dcf587b3.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libfunty-bdb6172d22b9a442.rlib-50",
-      "name": "libfunty-bdb6172d22b9a442.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libfunty-bdb6172d22b9a442.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libhashbrown-f47a2216fbc1d1da.rlib-51",
-      "name": "libhashbrown-f47a2216fbc1d1da.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libhashbrown-f47a2216fbc1d1da.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libindexmap-e2aa6b12af0df1da.rlib-52",
-      "name": "libindexmap-e2aa6b12af0df1da.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libindexmap-e2aa6b12af0df1da.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libis-terminal-polyfill-2b547f002f59b182.rlib-53",
-      "name": "libis_terminal_polyfill-2b547f002f59b182.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libis_terminal_polyfill-2b547f002f59b182.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liblibdeflate-sys-8015b60baf6cbe73.rlib-54",
-      "name": "liblibdeflate_sys-8015b60baf6cbe73.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liblibdeflate_sys-8015b60baf6cbe73.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liblibdeflater-ee8c0839617ecdd2.rlib-55",
-      "name": "liblibdeflater-ee8c0839617ecdd2.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liblibdeflater-ee8c0839617ecdd2.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liblinux-raw-sys-f7fcb1738333da4b.rlib-56",
-      "name": "liblinux_raw_sys-f7fcb1738333da4b.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liblinux_raw_sys-f7fcb1738333da4b.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liblog-9ce69ee427be56af.rlib-57",
-      "name": "liblog-9ce69ee427be56af.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liblog-9ce69ee427be56af.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liboxipng-fdba2b3e9d33ac60.rlib-58",
-      "name": "liboxipng-fdba2b3e9d33ac60.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liboxipng-fdba2b3e9d33ac60.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libparse-size-deb3060eda4b6ee6.rlib-59",
-      "name": "libparse_size-deb3060eda4b6ee6.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libparse_size-deb3060eda4b6ee6.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libradium-48b1afdaab91e229.rlib-60",
-      "name": "libradium-48b1afdaab91e229.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libradium-48b1afdaab91e229.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librayon-bac265390ff2804d.rlib-61",
-      "name": "librayon-bac265390ff2804d.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librayon-bac265390ff2804d.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librayon-core-e84357bde9e25850.rlib-62",
-      "name": "librayon_core-e84357bde9e25850.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librayon_core-e84357bde9e25850.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librgb-eebcd6abc98a5aa6.rlib-63",
-      "name": "librgb-eebcd6abc98a5aa6.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librgb-eebcd6abc98a5aa6.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librustc-hash-d83abfe4c6f7957d.rlib-64",
-      "name": "librustc_hash-d83abfe4c6f7957d.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librustc_hash-d83abfe4c6f7957d.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librustix-14a819ab0f7085b5.rlib-65",
-      "name": "librustix-14a819ab0f7085b5.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librustix-14a819ab0f7085b5.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libshlex-83f5f3b3166a68cf.rlib-66",
-      "name": "libshlex-83f5f3b3166a68cf.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libshlex-83f5f3b3166a68cf.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libsimd-adler32-cc8fcc5583e774f1.rlib-67",
-      "name": "libsimd_adler32-cc8fcc5583e774f1.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libsimd_adler32-cc8fcc5583e774f1.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libstrsim-42bcc59cdc10da44.rlib-68",
-      "name": "libstrsim-42bcc59cdc10da44.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libstrsim-42bcc59cdc10da44.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libtap-195521f7f7a3d762.rlib-69",
-      "name": "libtap-195521f7f7a3d762.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libtap-195521f7f7a3d762.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libterminal-size-9ecd0743482c5010.rlib-70",
-      "name": "libterminal_size-9ecd0743482c5010.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libterminal_size-9ecd0743482c5010.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libutf8parse-6973cc3038d6458e.rlib-71",
-      "name": "libutf8parse-6973cc3038d6458e.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libutf8parse-6973cc3038d6458e.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libwyz-fa9d8f34112b5d93.rlib-72",
-      "name": "libwyz-fa9d8f34112b5d93.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libwyz-fa9d8f34112b5d93.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libzopfli-45a56469d617d29e.rlib-73",
-      "name": "libzopfli-45a56469d617d29e.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libzopfli-45a56469d617d29e.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-linux-raw-sys-74",
+      "SPDXID": "SPDXRef-linux-raw-sys-30",
       "name": "linux-raw-sys",
       "downloadLocation": "https://crates.io/crates/linux-raw-sys",
       "filesAnalyzed": true,
@@ -953,7 +520,7 @@
       "versionInfo": "0.11.0"
     },
     {
-      "SPDXID": "SPDXRef-log-75",
+      "SPDXID": "SPDXRef-log-31",
       "name": "log",
       "downloadLocation": "https://crates.io/crates/log",
       "filesAnalyzed": true,
@@ -970,17 +537,7 @@
       "versionInfo": "0.4.29"
     },
     {
-      "SPDXID": "SPDXRef-oxipng-0e7d4c98f7c577c1-76",
-      "name": "oxipng-0e7d4c98f7c577c1",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/oxipng-0e7d4c98f7c577c1/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-parse-size-77",
+      "SPDXID": "SPDXRef-parse-size-32",
       "name": "parse-size",
       "downloadLocation": "https://crates.io/crates/parse-size",
       "filesAnalyzed": true,
@@ -997,7 +554,7 @@
       "versionInfo": "1.1.0"
     },
     {
-      "SPDXID": "SPDXRef-radium-78",
+      "SPDXID": "SPDXRef-radium-33",
       "name": "radium",
       "downloadLocation": "https://crates.io/crates/radium",
       "filesAnalyzed": true,
@@ -1014,7 +571,7 @@
       "versionInfo": "0.7.0"
     },
     {
-      "SPDXID": "SPDXRef-rayon-79",
+      "SPDXID": "SPDXRef-rayon-34",
       "name": "rayon",
       "downloadLocation": "https://crates.io/crates/rayon",
       "filesAnalyzed": true,
@@ -1031,7 +588,7 @@
       "versionInfo": "1.11.0"
     },
     {
-      "SPDXID": "SPDXRef-rayon-core-80",
+      "SPDXID": "SPDXRef-rayon-core-35",
       "name": "rayon-core",
       "downloadLocation": "https://crates.io/crates/rayon-core",
       "filesAnalyzed": true,
@@ -1048,7 +605,7 @@
       "versionInfo": "1.13.0"
     },
     {
-      "SPDXID": "SPDXRef-rgb-81",
+      "SPDXID": "SPDXRef-rgb-36",
       "name": "rgb",
       "downloadLocation": "https://crates.io/crates/rgb",
       "filesAnalyzed": true,
@@ -1057,15 +614,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/rgb@0.8.53"
+          "referenceLocator": "pkg:cargo/rgb@0.8.52"
         }
       ],
       "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
-      "versionInfo": "0.8.53"
+      "versionInfo": "0.8.52"
     },
     {
-      "SPDXID": "SPDXRef-rustc-hash-82",
+      "SPDXID": "SPDXRef-rustc-hash-37",
       "name": "rustc-hash",
       "downloadLocation": "https://crates.io/crates/rustc-hash",
       "filesAnalyzed": true,
@@ -1082,7 +639,7 @@
       "versionInfo": "2.1.1"
     },
     {
-      "SPDXID": "SPDXRef-rustix-83",
+      "SPDXID": "SPDXRef-rustix-38",
       "name": "rustix",
       "downloadLocation": "https://crates.io/crates/rustix",
       "filesAnalyzed": true,
@@ -1099,7 +656,7 @@
       "versionInfo": "1.1.2"
     },
     {
-      "SPDXID": "SPDXRef-shlex-84",
+      "SPDXID": "SPDXRef-shlex-39",
       "name": "shlex",
       "downloadLocation": "https://crates.io/crates/shlex",
       "filesAnalyzed": true,
@@ -1116,7 +673,7 @@
       "versionInfo": "1.3.0"
     },
     {
-      "SPDXID": "SPDXRef-simd-adler32-85",
+      "SPDXID": "SPDXRef-simd-adler32-40",
       "name": "simd-adler32",
       "downloadLocation": "https://crates.io/crates/simd-adler32",
       "filesAnalyzed": true,
@@ -1133,7 +690,7 @@
       "versionInfo": "0.3.7"
     },
     {
-      "SPDXID": "SPDXRef-strsim-86",
+      "SPDXID": "SPDXRef-strsim-41",
       "name": "strsim",
       "downloadLocation": "https://crates.io/crates/strsim",
       "filesAnalyzed": true,
@@ -1150,7 +707,7 @@
       "versionInfo": "0.11.1"
     },
     {
-      "SPDXID": "SPDXRef-tap-87",
+      "SPDXID": "SPDXRef-tap-42",
       "name": "tap",
       "downloadLocation": "https://crates.io/crates/tap",
       "filesAnalyzed": true,
@@ -1167,7 +724,7 @@
       "versionInfo": "1.0.1"
     },
     {
-      "SPDXID": "SPDXRef-terminal-size-88",
+      "SPDXID": "SPDXRef-terminal-size-43",
       "name": "terminal_size",
       "downloadLocation": "https://crates.io/crates/terminal_size",
       "filesAnalyzed": true,
@@ -1184,7 +741,7 @@
       "versionInfo": "0.4.3"
     },
     {
-      "SPDXID": "SPDXRef-utf8parse-89",
+      "SPDXID": "SPDXRef-utf8parse-44",
       "name": "utf8parse",
       "downloadLocation": "https://crates.io/crates/utf8parse",
       "filesAnalyzed": true,
@@ -1201,7 +758,7 @@
       "versionInfo": "0.2.2"
     },
     {
-      "SPDXID": "SPDXRef-wyz-90",
+      "SPDXID": "SPDXRef-wyz-45",
       "name": "wyz",
       "downloadLocation": "https://crates.io/crates/wyz",
       "filesAnalyzed": true,
@@ -1218,7 +775,7 @@
       "versionInfo": "0.5.1"
     },
     {
-      "SPDXID": "SPDXRef-zopfli-91",
+      "SPDXID": "SPDXRef-zopfli-46",
       "name": "zopfli",
       "downloadLocation": "https://crates.io/crates/zopfli",
       "filesAnalyzed": true,
@@ -1237,7 +794,7 @@
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-File-main.rs-92",
+      "SPDXID": "SPDXRef-File-main.rs-47",
       "fileName": "repos/oxipng/src/main.rs",
       "checksums": [
         {
@@ -1247,7 +804,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-93",
+      "SPDXID": "SPDXRef-File-lib.rs-48",
       "fileName": "repos/oxipng/src/lib.rs",
       "checksums": [
         {
@@ -1257,7 +814,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-94",
+      "SPDXID": "SPDXRef-File-lib.rs-49",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/radium-0.7.0/src/lib.rs",
       "checksums": [
         {
@@ -1267,7 +824,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-95",
+      "SPDXID": "SPDXRef-File-build.rs-50",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/radium-0.7.0/build.rs",
       "checksums": [
         {
@@ -1277,7 +834,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-96",
+      "SPDXID": "SPDXRef-File-lib.rs-51",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustc-hash-2.1.1/src/lib.rs",
       "checksums": [
         {
@@ -1287,7 +844,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-97",
+      "SPDXID": "SPDXRef-File-lib.rs-52",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/utf8parse-0.2.2/src/lib.rs",
       "checksums": [
         {
@@ -1297,7 +854,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-98",
+      "SPDXID": "SPDXRef-File-lib.rs-53",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/equivalent-1.0.2/src/lib.rs",
       "checksums": [
         {
@@ -1307,7 +864,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-99",
+      "SPDXID": "SPDXRef-File-lib.rs-54",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/log-0.4.29/src/lib.rs",
       "checksums": [
         {
@@ -1317,17 +874,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-100",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/env_filter-1.0.0/src/lib.rs",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0b350882a7b9b47bf523a1911c5c9a05f81d8691"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lib.rs-101",
+      "SPDXID": "SPDXRef-File-lib.rs-55",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-deque-0.8.6/src/lib.rs",
       "checksums": [
         {
@@ -1337,8 +884,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zlib-compress.c-102",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/zlib_compress.c",
+      "SPDXID": "SPDXRef-File-zlib-compress.c-56",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/zlib_compress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1347,8 +894,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adler32-template.h-103",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/adler32_template.h",
+      "SPDXID": "SPDXRef-File-adler32-template.h-57",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/adler32_template.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1357,8 +904,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gzip-constants.h-104",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/gzip_constants.h",
+      "SPDXID": "SPDXRef-File-gzip-constants.h-58",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/gzip_constants.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1367,8 +914,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-matchfinder-impl.h-105",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/matchfinder_impl.h",
+      "SPDXID": "SPDXRef-File-matchfinder-impl.h-59",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/matchfinder_impl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1377,8 +924,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features.c-106",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/arm/cpu_features.c",
+      "SPDXID": "SPDXRef-File-cpu-features.c-60",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/arm/cpu_features.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1387,8 +934,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deflate-compress.c-107",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/deflate_compress.c",
+      "SPDXID": "SPDXRef-File-deflate-compress.c-61",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/deflate_compress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1397,8 +944,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32-impl.h-108",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/crc32_impl.h",
+      "SPDXID": "SPDXRef-File-crc32-impl.h-62",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/crc32_impl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1407,8 +954,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.c-109",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/utils.c",
+      "SPDXID": "SPDXRef-File-utils.c-63",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/utils.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1417,8 +964,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deflate-decompress.c-110",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/deflate_decompress.c",
+      "SPDXID": "SPDXRef-File-deflate-decompress.c-64",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/deflate_decompress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1427,8 +974,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ht-matchfinder.h-111",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/ht_matchfinder.h",
+      "SPDXID": "SPDXRef-File-ht-matchfinder.h-65",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/ht_matchfinder.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1437,8 +984,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adler32-impl.h-112",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/adler32_impl.h",
+      "SPDXID": "SPDXRef-File-adler32-impl.h-66",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/adler32_impl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1447,8 +994,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gzip-decompress.c-113",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/gzip_decompress.c",
+      "SPDXID": "SPDXRef-File-gzip-decompress.c-67",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/gzip_decompress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1457,8 +1004,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32-pclmul-template.h-114",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/crc32_pclmul_template.h",
+      "SPDXID": "SPDXRef-File-crc32-pclmul-template.h-68",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/crc32_pclmul_template.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1467,8 +1014,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decompress-template.h-115",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/decompress_template.h",
+      "SPDXID": "SPDXRef-File-decompress-template.h-69",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/decompress_template.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1477,8 +1024,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deflate-compress.h-116",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/deflate_compress.h",
+      "SPDXID": "SPDXRef-File-deflate-compress.h-70",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/deflate_compress.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1487,8 +1034,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deflate-constants.h-117",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/deflate_constants.h",
+      "SPDXID": "SPDXRef-File-deflate-constants.h-71",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/deflate_constants.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1497,8 +1044,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-matchfinder-common.h-118",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/matchfinder_common.h",
+      "SPDXID": "SPDXRef-File-matchfinder-common.h-72",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/matchfinder_common.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1507,8 +1054,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32-multipliers.h-119",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/crc32_multipliers.h",
+      "SPDXID": "SPDXRef-File-crc32-multipliers.h-73",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/crc32_multipliers.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1517,8 +1064,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common-defs.h-120",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/common_defs.h",
+      "SPDXID": "SPDXRef-File-common-defs.h-74",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/common_defs.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1527,8 +1074,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hc-matchfinder.h-121",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/hc_matchfinder.h",
+      "SPDXID": "SPDXRef-File-hc-matchfinder.h-75",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/hc_matchfinder.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1537,8 +1084,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32.c-122",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/crc32.c",
+      "SPDXID": "SPDXRef-File-crc32.c-76",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/crc32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1547,8 +1094,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features.c-123",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/cpu_features.c",
+      "SPDXID": "SPDXRef-File-cpu-features.c-77",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/cpu_features.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1557,8 +1104,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-124",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/build.rs",
+      "SPDXID": "SPDXRef-File-build.rs-78",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/build.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1567,8 +1114,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bt-matchfinder.h-125",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/bt_matchfinder.h",
+      "SPDXID": "SPDXRef-File-bt-matchfinder.h-79",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/bt_matchfinder.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1577,8 +1124,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gzip-compress.c-126",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/gzip_compress.c",
+      "SPDXID": "SPDXRef-File-gzip-compress.c-80",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/gzip_compress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1587,8 +1134,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-127",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/src/lib.rs",
+      "SPDXID": "SPDXRef-File-lib.rs-81",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/src/lib.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1597,8 +1144,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features.h-128",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/cpu_features.h",
+      "SPDXID": "SPDXRef-File-cpu-features.h-82",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/cpu_features.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1607,8 +1154,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features-common.h-129",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/cpu_features_common.h",
+      "SPDXID": "SPDXRef-File-cpu-features-common.h-83",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/cpu_features_common.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1617,8 +1164,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adler32.c-130",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/adler32.c",
+      "SPDXID": "SPDXRef-File-adler32.c-84",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/adler32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1627,8 +1174,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32-tables.h-131",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/crc32_tables.h",
+      "SPDXID": "SPDXRef-File-crc32-tables.h-85",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/crc32_tables.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1637,8 +1184,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libdeflate.h-132",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/libdeflate.h",
+      "SPDXID": "SPDXRef-File-libdeflate.h-86",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/libdeflate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1647,8 +1194,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decompress-impl.h-133",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/decompress_impl.h",
+      "SPDXID": "SPDXRef-File-decompress-impl.h-87",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/decompress_impl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1657,8 +1204,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features.h-134",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/arm/cpu_features.h",
+      "SPDXID": "SPDXRef-File-cpu-features.h-88",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/arm/cpu_features.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1667,8 +1214,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zlib-constants.h-135",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/zlib_constants.h",
+      "SPDXID": "SPDXRef-File-zlib-constants.h-89",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/zlib_constants.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1677,8 +1224,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zlib-decompress.c-136",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/zlib_decompress.c",
+      "SPDXID": "SPDXRef-File-zlib-decompress.c-90",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/zlib_decompress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1687,8 +1234,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib-common.h-137",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/lib_common.h",
+      "SPDXID": "SPDXRef-File-lib-common.h-91",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/lib_common.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1697,17 +1244,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-138",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rgb-0.8.53/src/lib.rs",
+      "SPDXID": "SPDXRef-File-lib.rs-92",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap-4.5.54/src/lib.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "139ace5698e594e1b14b0ebed28c7a5a5ca89629"
+          "checksumValue": "142b6759152f0f8d0d45d53c89ebda6a6a363f34"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-139",
+      "SPDXID": "SPDXRef-File-build.rs-93",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.2/build.rs",
       "checksums": [
         {
@@ -1717,7 +1264,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-140",
+      "SPDXID": "SPDXRef-File-lib.rs-94",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.2/src/lib.rs",
       "checksums": [
         {
@@ -1727,7 +1274,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-141",
+      "SPDXID": "SPDXRef-File-lib.rs-95",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/linux-raw-sys-0.11.0/src/lib.rs",
       "checksums": [
         {
@@ -1737,7 +1284,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-142",
+      "SPDXID": "SPDXRef-File-lib.rs-96",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bitflags-2.9.4/src/lib.rs",
       "checksums": [
         {
@@ -1747,17 +1294,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-143",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap-4.5.60/src/lib.rs",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1db8efd0e341e6a6f13dad67d350faeb4b32ad25"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lib.rs-144",
+      "SPDXID": "SPDXRef-File-lib.rs-97",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-parse-0.2.7/src/lib.rs",
       "checksums": [
         {
@@ -1767,7 +1304,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-145",
+      "SPDXID": "SPDXRef-File-lib.rs-98",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rayon-core-1.13.0/src/lib.rs",
       "checksums": [
         {
@@ -1777,7 +1314,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-146",
+      "SPDXID": "SPDXRef-File-build.rs-99",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rayon-core-1.13.0/build.rs",
       "checksums": [
         {
@@ -1787,7 +1324,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-147",
+      "SPDXID": "SPDXRef-File-lib.rs-100",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bitvec-1.0.1/src/lib.rs",
       "checksums": [
         {
@@ -1797,7 +1334,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-148",
+      "SPDXID": "SPDXRef-File-lib.rs-101",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rayon-1.11.0/src/lib.rs",
       "checksums": [
         {
@@ -1807,17 +1344,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-149",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflater-1.25.2/src/lib.rs",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5601ad31f360d2560528c2bd451d062a1cab44fe"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lib.rs-150",
+      "SPDXID": "SPDXRef-File-lib.rs-102",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zopfli-0.8.3/src/lib.rs",
       "checksums": [
         {
@@ -1827,7 +1354,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-151",
+      "SPDXID": "SPDXRef-File-lib.rs-103",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bytemuck-1.23.2/src/lib.rs",
       "checksums": [
         {
@@ -1837,7 +1364,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-152",
+      "SPDXID": "SPDXRef-File-lib.rs-104",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/strsim-0.11.1/src/lib.rs",
       "checksums": [
         {
@@ -1847,17 +1374,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-153",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_lex-1.0.0/src/lib.rs",
+      "SPDXID": "SPDXRef-File-lib.rs-105",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_lex-0.7.5/src/lib.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6ba028a6d7a665114059de6e71bbfa9b594940d6"
+          "checksumValue": "6b7621f51e47c1fc35ddba79573029f408ba9c4c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-154",
+      "SPDXID": "SPDXRef-File-lib.rs-106",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/indexmap-2.13.0/src/lib.rs",
       "checksums": [
         {
@@ -1867,7 +1394,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-155",
+      "SPDXID": "SPDXRef-File-lib.rs-107",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-utils-0.8.21/src/lib.rs",
       "checksums": [
         {
@@ -1877,7 +1404,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-156",
+      "SPDXID": "SPDXRef-File-build.rs-108",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-utils-0.8.21/build.rs",
       "checksums": [
         {
@@ -1887,17 +1414,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-157",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/env_logger-0.11.9/src/lib.rs",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7770bf1c4a3f02ccab0564c267d783acd381227d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lib.rs-158",
+      "SPDXID": "SPDXRef-File-lib.rs-109",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cc-1.2.38/src/lib.rs",
       "checksums": [
         {
@@ -1907,7 +1424,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-159",
+      "SPDXID": "SPDXRef-File-lib.rs-110",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstream-0.6.20/src/lib.rs",
       "checksums": [
         {
@@ -1917,7 +1434,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-160",
+      "SPDXID": "SPDXRef-File-lib.rs-111",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-channel-0.5.15/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "93e190b2eb62e41a46fb6ab31629f82cd95ba236"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-112",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/terminal_size-0.4.3/src/lib.rs",
       "checksums": [
         {
@@ -1927,8 +1454,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-161",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.60/src/lib.rs",
+      "SPDXID": "SPDXRef-File-lib.rs-113",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.54/src/lib.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1937,7 +1464,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-162",
+      "SPDXID": "SPDXRef-File-lib.rs-114",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-1.0.11/src/lib.rs",
       "checksums": [
         {
@@ -1947,7 +1474,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-163",
+      "SPDXID": "SPDXRef-File-lib.rs-115",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/shlex-1.3.0/src/lib.rs",
       "checksums": [
         {
@@ -1957,7 +1484,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-164",
+      "SPDXID": "SPDXRef-File-lib.rs-116",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflater-1.25.0/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "aec1dfa52ab1cdf56c20cc59564e972df96645f4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-117",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/colorchoice-1.0.4/src/lib.rs",
       "checksums": [
         {
@@ -1967,7 +1504,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-165",
+      "SPDXID": "SPDXRef-File-lib.rs-118",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashbrown-0.16.1/src/lib.rs",
       "checksums": [
         {
@@ -1977,7 +1514,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-166",
+      "SPDXID": "SPDXRef-File-lib.rs-119",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-query-1.1.4/src/lib.rs",
       "checksums": [
         {
@@ -1987,7 +1524,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-167",
+      "SPDXID": "SPDXRef-File-lib.rs-120",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parse-size-1.1.0/src/lib.rs",
       "checksums": [
         {
@@ -1997,7 +1534,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-168",
+      "SPDXID": "SPDXRef-File-lib.rs-121",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/funty-2.0.0/src/lib.rs",
       "checksums": [
         {
@@ -2007,7 +1544,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-169",
+      "SPDXID": "SPDXRef-File-lib.rs-122",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/is_terminal_polyfill-1.70.1/src/lib.rs",
       "checksums": [
         {
@@ -2017,7 +1554,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-170",
+      "SPDXID": "SPDXRef-File-lib.rs-123",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/env_logger-0.11.8/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e0afd1c2e397d9855b979f0e514e92965e532460"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-124",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/either-1.15.0/src/lib.rs",
       "checksums": [
         {
@@ -2027,7 +1574,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-171",
+      "SPDXID": "SPDXRef-File-lib.rs-125",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/simd-adler32-0.3.7/src/lib.rs",
       "checksums": [
         {
@@ -2037,7 +1584,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-172",
+      "SPDXID": "SPDXRef-File-lib.rs-126",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rgb-0.8.52/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e677762e26673cf93cebe04f9bedfa432577c03f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-127",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tap-1.0.1/src/lib.rs",
       "checksums": [
         {
@@ -2047,7 +1604,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-173",
+      "SPDXID": "SPDXRef-File-lib.rs-128",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/env_filter-0.1.3/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e9f42d1fabe245234ecc3e6ce2bc9491eef56a4a"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-129",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bumpalo-3.19.0/src/lib.rs",
       "checksums": [
         {
@@ -2057,7 +1624,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-174",
+      "SPDXID": "SPDXRef-File-lib.rs-130",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wyz-0.5.1/src/lib.rs",
       "checksums": [
         {
@@ -2067,7 +1634,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-175",
+      "SPDXID": "SPDXRef-File-lib.rs-131",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/find-msvc-tools-0.1.2/src/lib.rs",
       "checksums": [
         {
@@ -2077,7 +1644,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-176",
+      "SPDXID": "SPDXRef-File-lib.rs-132",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-epoch-0.9.18/src/lib.rs",
       "checksums": [
         {
@@ -2095,27 +1662,27 @@
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-anstream-2"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-anstyle-3"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-anstyle-parse-4"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-anstyle-query-5"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-bitflags-6"
     },
     {
@@ -2125,17 +1692,17 @@
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-bumpalo-8"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-bytemuck-9"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-cc-10"
     },
     {
@@ -2145,828 +1712,608 @@
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-clap-builder-12"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-clap-lex-13"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-colorchoice-14"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-crossbeam-deque-15"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-crossbeam-epoch-16"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-crossbeam-utils-17"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-either-18"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-env-filter-19"
+      "relationshipType": "STATIC_LINK",
+      "relatedSpdxElement": "SPDXRef-crossbeam-channel-15"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-env-logger-20"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-equivalent-21"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-find-msvc-tools-22"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-funty-23"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-hashbrown-24"
+      "relatedSpdxElement": "SPDXRef-crossbeam-deque-16"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-indexmap-25"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-is-terminal-polyfill-26"
+      "relatedSpdxElement": "SPDXRef-crossbeam-epoch-17"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libanstream-af8c0c8b7745f81c.rlib-27"
+      "relatedSpdxElement": "SPDXRef-crossbeam-utils-18"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libanstyle-a0a0ad7ff8b9c5a1.rlib-28"
+      "relatedSpdxElement": "SPDXRef-either-19"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libanstyle-parse-7aaeee641d2da150.rlib-29"
+      "relatedSpdxElement": "SPDXRef-env-filter-20"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libanstyle-query-24c9d1b4892ed6c3.rlib-30"
+      "relatedSpdxElement": "SPDXRef-env-logger-21"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libbitflags-1280f28be8e10639.rlib-31"
+      "relatedSpdxElement": "SPDXRef-equivalent-22"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libbitvec-e8365d6a02442b17.rlib-32"
+      "relatedSpdxElement": "SPDXRef-find-msvc-tools-23"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libbumpalo-b931f9f29ef28c54.rlib-33"
+      "relatedSpdxElement": "SPDXRef-funty-24"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libbytemuck-554fa33dc3a4a114.rlib-34"
+      "relatedSpdxElement": "SPDXRef-hashbrown-25"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcc-6022fe8bec44565b.rlib-35"
+      "relatedSpdxElement": "SPDXRef-indexmap-26"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libclap-ba3cd817b4d126e9.rlib-36"
+      "relatedSpdxElement": "SPDXRef-is-terminal-polyfill-27"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libclap-builder-b1a4cc9d08676f8c.rlib-37"
+      "relatedSpdxElement": "SPDXRef-libdeflate-sys-28"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libclap-lex-da436b52c838ef3a.rlib-38"
+      "relatedSpdxElement": "SPDXRef-libdeflater-29"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcolorchoice-0db96e0fc98929ef.rlib-39"
+      "relatedSpdxElement": "SPDXRef-linux-raw-sys-30"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcrossbeam-deque-981e4e7399a46153.rlib-40"
+      "relatedSpdxElement": "SPDXRef-log-31"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcrossbeam-epoch-2345908434fb69df.rlib-41"
+      "relatedSpdxElement": "SPDXRef-parse-size-32"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcrossbeam-utils-6aec20481488f580.rlib-42"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-libdeflate-sys-43"
+      "relatedSpdxElement": "SPDXRef-radium-33"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libdeflater-44"
+      "relatedSpdxElement": "SPDXRef-rayon-34"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libeither-293bc8bebd4fea10.rlib-45"
+      "relatedSpdxElement": "SPDXRef-rayon-core-35"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libenv-filter-6442a55f21f4f1e1.rlib-46"
+      "relatedSpdxElement": "SPDXRef-rgb-36"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libenv-logger-060457492833bd93.rlib-47"
+      "relatedSpdxElement": "SPDXRef-rustc-hash-37"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libequivalent-de15a8ed2be8fbaa.rlib-48"
+      "relatedSpdxElement": "SPDXRef-rustix-38"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libfind-msvc-tools-c62d9445dcf587b3.rlib-49"
+      "relatedSpdxElement": "SPDXRef-shlex-39"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libfunty-bdb6172d22b9a442.rlib-50"
+      "relatedSpdxElement": "SPDXRef-simd-adler32-40"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libhashbrown-f47a2216fbc1d1da.rlib-51"
+      "relatedSpdxElement": "SPDXRef-strsim-41"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libindexmap-e2aa6b12af0df1da.rlib-52"
+      "relatedSpdxElement": "SPDXRef-tap-42"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libis-terminal-polyfill-2b547f002f59b182.rlib-53"
+      "relatedSpdxElement": "SPDXRef-terminal-size-43"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liblibdeflate-sys-8015b60baf6cbe73.rlib-54"
+      "relatedSpdxElement": "SPDXRef-utf8parse-44"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liblibdeflater-ee8c0839617ecdd2.rlib-55"
+      "relatedSpdxElement": "SPDXRef-wyz-45"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liblinux-raw-sys-f7fcb1738333da4b.rlib-56"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liblog-9ce69ee427be56af.rlib-57"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liboxipng-fdba2b3e9d33ac60.rlib-58"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libparse-size-deb3060eda4b6ee6.rlib-59"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libradium-48b1afdaab91e229.rlib-60"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librayon-bac265390ff2804d.rlib-61"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librayon-core-e84357bde9e25850.rlib-62"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librgb-eebcd6abc98a5aa6.rlib-63"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librustc-hash-d83abfe4c6f7957d.rlib-64"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librustix-14a819ab0f7085b5.rlib-65"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libshlex-83f5f3b3166a68cf.rlib-66"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libsimd-adler32-cc8fcc5583e774f1.rlib-67"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libstrsim-42bcc59cdc10da44.rlib-68"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libtap-195521f7f7a3d762.rlib-69"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libterminal-size-9ecd0743482c5010.rlib-70"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libutf8parse-6973cc3038d6458e.rlib-71"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libwyz-fa9d8f34112b5d93.rlib-72"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libzopfli-45a56469d617d29e.rlib-73"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-linux-raw-sys-74"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-log-75"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-oxipng-0e7d4c98f7c577c1-76"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-parse-size-77"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-radium-78"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-rayon-79"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-rayon-core-80"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-rgb-81"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-rustc-hash-82"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-rustix-83"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-shlex-84"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-simd-adler32-85"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-strsim-86"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-tap-87"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-terminal-size-88"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-utf8parse-89"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-wyz-90"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-zopfli-91"
+      "relatedSpdxElement": "SPDXRef-zopfli-46"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main.rs-92"
+      "relatedSpdxElement": "SPDXRef-File-main.rs-47"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-93"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-48"
     },
     {
-      "spdxElementId": "SPDXRef-radium-78",
+      "spdxElementId": "SPDXRef-radium-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-94"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-49"
     },
     {
-      "spdxElementId": "SPDXRef-radium-78",
+      "spdxElementId": "SPDXRef-radium-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-95"
+      "relatedSpdxElement": "SPDXRef-File-build.rs-50"
     },
     {
-      "spdxElementId": "SPDXRef-rustc-hash-82",
+      "spdxElementId": "SPDXRef-rustc-hash-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-96"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-51"
     },
     {
-      "spdxElementId": "SPDXRef-utf8parse-89",
+      "spdxElementId": "SPDXRef-utf8parse-44",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-97"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-52"
     },
     {
-      "spdxElementId": "SPDXRef-equivalent-21",
+      "spdxElementId": "SPDXRef-equivalent-22",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-98"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-53"
     },
     {
-      "spdxElementId": "SPDXRef-log-75",
+      "spdxElementId": "SPDXRef-log-31",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-99"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-54"
     },
     {
-      "spdxElementId": "SPDXRef-env-filter-19",
+      "spdxElementId": "SPDXRef-crossbeam-deque-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-100"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-55"
     },
     {
-      "spdxElementId": "SPDXRef-crossbeam-deque-15",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-101"
+      "relatedSpdxElement": "SPDXRef-File-zlib-compress.c-56"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zlib-compress.c-102"
+      "relatedSpdxElement": "SPDXRef-File-adler32-template.h-57"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adler32-template.h-103"
+      "relatedSpdxElement": "SPDXRef-File-gzip-constants.h-58"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gzip-constants.h-104"
+      "relatedSpdxElement": "SPDXRef-File-matchfinder-impl.h-59"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-matchfinder-impl.h-105"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features.c-60"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features.c-106"
+      "relatedSpdxElement": "SPDXRef-File-deflate-compress.c-61"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deflate-compress.c-107"
+      "relatedSpdxElement": "SPDXRef-File-crc32-impl.h-62"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32-impl.h-108"
+      "relatedSpdxElement": "SPDXRef-File-utils.c-63"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.c-109"
+      "relatedSpdxElement": "SPDXRef-File-deflate-decompress.c-64"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deflate-decompress.c-110"
+      "relatedSpdxElement": "SPDXRef-File-ht-matchfinder.h-65"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ht-matchfinder.h-111"
+      "relatedSpdxElement": "SPDXRef-File-adler32-impl.h-66"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adler32-impl.h-112"
+      "relatedSpdxElement": "SPDXRef-File-gzip-decompress.c-67"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gzip-decompress.c-113"
+      "relatedSpdxElement": "SPDXRef-File-crc32-pclmul-template.h-68"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32-pclmul-template.h-114"
+      "relatedSpdxElement": "SPDXRef-File-decompress-template.h-69"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decompress-template.h-115"
+      "relatedSpdxElement": "SPDXRef-File-deflate-compress.h-70"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deflate-compress.h-116"
+      "relatedSpdxElement": "SPDXRef-File-deflate-constants.h-71"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deflate-constants.h-117"
+      "relatedSpdxElement": "SPDXRef-File-matchfinder-common.h-72"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-matchfinder-common.h-118"
+      "relatedSpdxElement": "SPDXRef-File-crc32-multipliers.h-73"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32-multipliers.h-119"
+      "relatedSpdxElement": "SPDXRef-File-common-defs.h-74"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common-defs.h-120"
+      "relatedSpdxElement": "SPDXRef-File-hc-matchfinder.h-75"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hc-matchfinder.h-121"
+      "relatedSpdxElement": "SPDXRef-File-crc32.c-76"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32.c-122"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features.c-77"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features.c-123"
+      "relatedSpdxElement": "SPDXRef-File-build.rs-78"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-124"
+      "relatedSpdxElement": "SPDXRef-File-bt-matchfinder.h-79"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bt-matchfinder.h-125"
+      "relatedSpdxElement": "SPDXRef-File-gzip-compress.c-80"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gzip-compress.c-126"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-81"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-127"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features.h-82"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features.h-128"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features-common.h-83"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features-common.h-129"
+      "relatedSpdxElement": "SPDXRef-File-adler32.c-84"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adler32.c-130"
+      "relatedSpdxElement": "SPDXRef-File-crc32-tables.h-85"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32-tables.h-131"
+      "relatedSpdxElement": "SPDXRef-File-libdeflate.h-86"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libdeflate.h-132"
+      "relatedSpdxElement": "SPDXRef-File-decompress-impl.h-87"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decompress-impl.h-133"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features.h-88"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features.h-134"
+      "relatedSpdxElement": "SPDXRef-File-zlib-constants.h-89"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zlib-constants.h-135"
+      "relatedSpdxElement": "SPDXRef-File-zlib-decompress.c-90"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
+      "spdxElementId": "SPDXRef-libdeflate-sys-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zlib-decompress.c-136"
-    },
-    {
-      "spdxElementId": "SPDXRef-libdeflate-sys-43",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib-common.h-137"
-    },
-    {
-      "spdxElementId": "SPDXRef-rgb-81",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-138"
-    },
-    {
-      "spdxElementId": "SPDXRef-rustix-83",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-139"
-    },
-    {
-      "spdxElementId": "SPDXRef-rustix-83",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-140"
-    },
-    {
-      "spdxElementId": "SPDXRef-linux-raw-sys-74",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-141"
-    },
-    {
-      "spdxElementId": "SPDXRef-bitflags-6",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-142"
+      "relatedSpdxElement": "SPDXRef-File-lib-common.h-91"
     },
     {
       "spdxElementId": "SPDXRef-clap-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-143"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-92"
+    },
+    {
+      "spdxElementId": "SPDXRef-rustix-38",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-build.rs-93"
+    },
+    {
+      "spdxElementId": "SPDXRef-rustix-38",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-94"
+    },
+    {
+      "spdxElementId": "SPDXRef-linux-raw-sys-30",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-95"
+    },
+    {
+      "spdxElementId": "SPDXRef-bitflags-6",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-96"
     },
     {
       "spdxElementId": "SPDXRef-anstyle-parse-4",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-144"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-97"
     },
     {
-      "spdxElementId": "SPDXRef-rayon-core-80",
+      "spdxElementId": "SPDXRef-rayon-core-35",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-145"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-98"
     },
     {
-      "spdxElementId": "SPDXRef-rayon-core-80",
+      "spdxElementId": "SPDXRef-rayon-core-35",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-146"
+      "relatedSpdxElement": "SPDXRef-File-build.rs-99"
     },
     {
       "spdxElementId": "SPDXRef-bitvec-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-147"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-100"
     },
     {
-      "spdxElementId": "SPDXRef-rayon-79",
+      "spdxElementId": "SPDXRef-rayon-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-148"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-101"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflater-44",
+      "spdxElementId": "SPDXRef-zopfli-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-149"
-    },
-    {
-      "spdxElementId": "SPDXRef-zopfli-91",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-150"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-102"
     },
     {
       "spdxElementId": "SPDXRef-bytemuck-9",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-151"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-103"
     },
     {
-      "spdxElementId": "SPDXRef-strsim-86",
+      "spdxElementId": "SPDXRef-strsim-41",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-152"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-104"
     },
     {
       "spdxElementId": "SPDXRef-clap-lex-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-153"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-105"
     },
     {
-      "spdxElementId": "SPDXRef-indexmap-25",
+      "spdxElementId": "SPDXRef-indexmap-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-154"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-106"
     },
     {
-      "spdxElementId": "SPDXRef-crossbeam-utils-17",
+      "spdxElementId": "SPDXRef-crossbeam-utils-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-155"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-107"
     },
     {
-      "spdxElementId": "SPDXRef-crossbeam-utils-17",
+      "spdxElementId": "SPDXRef-crossbeam-utils-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-156"
-    },
-    {
-      "spdxElementId": "SPDXRef-env-logger-20",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-157"
+      "relatedSpdxElement": "SPDXRef-File-build.rs-108"
     },
     {
       "spdxElementId": "SPDXRef-cc-10",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-158"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-109"
     },
     {
       "spdxElementId": "SPDXRef-anstream-2",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-159"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-110"
     },
     {
-      "spdxElementId": "SPDXRef-terminal-size-88",
+      "spdxElementId": "SPDXRef-crossbeam-channel-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-160"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-111"
+    },
+    {
+      "spdxElementId": "SPDXRef-terminal-size-43",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-112"
     },
     {
       "spdxElementId": "SPDXRef-clap-builder-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-161"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-113"
     },
     {
       "spdxElementId": "SPDXRef-anstyle-3",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-162"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-114"
     },
     {
-      "spdxElementId": "SPDXRef-shlex-84",
+      "spdxElementId": "SPDXRef-shlex-39",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-163"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-115"
+    },
+    {
+      "spdxElementId": "SPDXRef-libdeflater-29",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-116"
     },
     {
       "spdxElementId": "SPDXRef-colorchoice-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-164"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-117"
     },
     {
-      "spdxElementId": "SPDXRef-hashbrown-24",
+      "spdxElementId": "SPDXRef-hashbrown-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-165"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-118"
     },
     {
       "spdxElementId": "SPDXRef-anstyle-query-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-166"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-119"
     },
     {
-      "spdxElementId": "SPDXRef-parse-size-77",
+      "spdxElementId": "SPDXRef-parse-size-32",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-167"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-120"
     },
     {
-      "spdxElementId": "SPDXRef-funty-23",
+      "spdxElementId": "SPDXRef-funty-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-168"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-121"
     },
     {
-      "spdxElementId": "SPDXRef-is-terminal-polyfill-26",
+      "spdxElementId": "SPDXRef-is-terminal-polyfill-27",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-169"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-122"
     },
     {
-      "spdxElementId": "SPDXRef-either-18",
+      "spdxElementId": "SPDXRef-env-logger-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-170"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-123"
     },
     {
-      "spdxElementId": "SPDXRef-simd-adler32-85",
+      "spdxElementId": "SPDXRef-either-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-171"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-124"
     },
     {
-      "spdxElementId": "SPDXRef-tap-87",
+      "spdxElementId": "SPDXRef-simd-adler32-40",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-172"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-125"
+    },
+    {
+      "spdxElementId": "SPDXRef-rgb-36",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-126"
+    },
+    {
+      "spdxElementId": "SPDXRef-tap-42",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-127"
+    },
+    {
+      "spdxElementId": "SPDXRef-env-filter-20",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-128"
     },
     {
       "spdxElementId": "SPDXRef-bumpalo-8",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-173"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-129"
     },
     {
-      "spdxElementId": "SPDXRef-wyz-90",
+      "spdxElementId": "SPDXRef-wyz-45",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-174"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-130"
     },
     {
-      "spdxElementId": "SPDXRef-find-msvc-tools-22",
+      "spdxElementId": "SPDXRef-find-msvc-tools-23",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-175"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-131"
     },
     {
-      "spdxElementId": "SPDXRef-crossbeam-epoch-16",
+      "spdxElementId": "SPDXRef-crossbeam-epoch-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-176"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-132"
     }
   ]
 }

--- a/tests/golden/spdx/rust/oxipng/oxipng_build.spdx.json
+++ b/tests/golden/spdx/rust/oxipng/oxipng_build.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "oxipng",
-  "documentNamespace": "https://omnibor.io/omnibor-analysis/oxipng-d83256bb-b91b-42ce-9ad6-ecce47fa521a",
+  "documentNamespace": "https://omnibor.io/omnibor-analysis/oxipng-9cb0071b-5d57-4545-9b5f-6787ea229681",
   "creationInfo": {
-    "created": "2026-03-12T22:32:03Z",
+    "created": "2026-05-05T16:33:12Z",
     "creators": [
       "Tool: bomtrace3-unknown",
       "Tool: bomsh-unknown",
@@ -20,11 +20,11 @@
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": true,
       "primaryPackagePurpose": "APPLICATION",
-      "builtDate": "2026-03-12T22:32:03Z",
+      "builtDate": "2026-05-05T16:33:12Z",
       "externalRefs": [],
       "checksums": [],
       "comment": "Built on Ubuntu 22.04.5 LTS with gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
-      "versionInfo": "8.19.0-DEV"
+      "versionInfo": "10.1.0"
     },
     {
       "SPDXID": "SPDXRef-libgcc-s1-1",
@@ -255,12 +255,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/clap@4.5.60"
+          "referenceLocator": "pkg:cargo/clap@4.5.54"
         }
       ],
       "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
-      "versionInfo": "4.5.60"
+      "versionInfo": "4.5.54"
     },
     {
       "SPDXID": "SPDXRef-clap-builder-14",
@@ -272,12 +272,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/clap_builder@4.5.60"
+          "referenceLocator": "pkg:cargo/clap_builder@4.5.54"
         }
       ],
       "comment": "Rust crate (transitive, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Transitive dependency via Cargo. Downloaded from crates.io registry.",
-      "versionInfo": "4.5.60"
+      "versionInfo": "4.5.54"
     },
     {
       "SPDXID": "SPDXRef-clap-lex-15",
@@ -289,12 +289,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/clap_lex@1.0.0"
+          "referenceLocator": "pkg:cargo/clap_lex@0.7.5"
         }
       ],
       "comment": "Rust crate (transitive, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Transitive dependency via Cargo. Downloaded from crates.io registry.",
-      "versionInfo": "1.0.0"
+      "versionInfo": "0.7.5"
     },
     {
       "SPDXID": "SPDXRef-colorchoice-16",
@@ -314,7 +314,24 @@
       "versionInfo": "1.0.4"
     },
     {
-      "SPDXID": "SPDXRef-crossbeam-deque-17",
+      "SPDXID": "SPDXRef-crossbeam-channel-17",
+      "name": "crossbeam-channel",
+      "downloadLocation": "https://crates.io/crates/crossbeam-channel",
+      "filesAnalyzed": true,
+      "primaryPackagePurpose": "LIBRARY",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:cargo/crossbeam-channel@0.5.15"
+        }
+      ],
+      "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
+      "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
+      "versionInfo": "0.5.15"
+    },
+    {
+      "SPDXID": "SPDXRef-crossbeam-deque-18",
       "name": "crossbeam-deque",
       "downloadLocation": "https://crates.io/crates/crossbeam-deque",
       "filesAnalyzed": true,
@@ -331,7 +348,7 @@
       "versionInfo": "0.8.6"
     },
     {
-      "SPDXID": "SPDXRef-crossbeam-epoch-18",
+      "SPDXID": "SPDXRef-crossbeam-epoch-19",
       "name": "crossbeam-epoch",
       "downloadLocation": "https://crates.io/crates/crossbeam-epoch",
       "filesAnalyzed": true,
@@ -348,7 +365,7 @@
       "versionInfo": "0.9.18"
     },
     {
-      "SPDXID": "SPDXRef-crossbeam-utils-19",
+      "SPDXID": "SPDXRef-crossbeam-utils-20",
       "name": "crossbeam-utils",
       "downloadLocation": "https://crates.io/crates/crossbeam-utils",
       "filesAnalyzed": true,
@@ -365,7 +382,7 @@
       "versionInfo": "0.8.21"
     },
     {
-      "SPDXID": "SPDXRef-either-20",
+      "SPDXID": "SPDXRef-either-21",
       "name": "either",
       "downloadLocation": "https://crates.io/crates/either",
       "filesAnalyzed": true,
@@ -382,7 +399,7 @@
       "versionInfo": "1.15.0"
     },
     {
-      "SPDXID": "SPDXRef-env-filter-21",
+      "SPDXID": "SPDXRef-env-filter-22",
       "name": "env_filter",
       "downloadLocation": "https://crates.io/crates/env_filter",
       "filesAnalyzed": true,
@@ -391,15 +408,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/env_filter@1.0.0"
+          "referenceLocator": "pkg:cargo/env_filter@0.1.3"
         }
       ],
       "comment": "Rust crate (transitive, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Transitive dependency via Cargo. Downloaded from crates.io registry.",
-      "versionInfo": "1.0.0"
+      "versionInfo": "0.1.3"
     },
     {
-      "SPDXID": "SPDXRef-env-logger-22",
+      "SPDXID": "SPDXRef-env-logger-23",
       "name": "env_logger",
       "downloadLocation": "https://crates.io/crates/env_logger",
       "filesAnalyzed": true,
@@ -408,15 +425,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/env_logger@0.11.9"
+          "referenceLocator": "pkg:cargo/env_logger@0.11.8"
         }
       ],
       "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
-      "versionInfo": "0.11.9"
+      "versionInfo": "0.11.8"
     },
     {
-      "SPDXID": "SPDXRef-equivalent-23",
+      "SPDXID": "SPDXRef-equivalent-24",
       "name": "equivalent",
       "downloadLocation": "https://crates.io/crates/equivalent",
       "filesAnalyzed": true,
@@ -433,7 +450,7 @@
       "versionInfo": "1.0.2"
     },
     {
-      "SPDXID": "SPDXRef-find-msvc-tools-24",
+      "SPDXID": "SPDXRef-find-msvc-tools-25",
       "name": "find-msvc-tools",
       "downloadLocation": "https://crates.io/crates/find-msvc-tools",
       "filesAnalyzed": true,
@@ -450,7 +467,7 @@
       "versionInfo": "0.1.2"
     },
     {
-      "SPDXID": "SPDXRef-funty-25",
+      "SPDXID": "SPDXRef-funty-26",
       "name": "funty",
       "downloadLocation": "https://crates.io/crates/funty",
       "filesAnalyzed": true,
@@ -467,7 +484,7 @@
       "versionInfo": "2.0.0"
     },
     {
-      "SPDXID": "SPDXRef-hashbrown-26",
+      "SPDXID": "SPDXRef-hashbrown-27",
       "name": "hashbrown",
       "downloadLocation": "https://crates.io/crates/hashbrown",
       "filesAnalyzed": true,
@@ -484,7 +501,7 @@
       "versionInfo": "0.16.1"
     },
     {
-      "SPDXID": "SPDXRef-indexmap-27",
+      "SPDXID": "SPDXRef-indexmap-28",
       "name": "indexmap",
       "downloadLocation": "https://crates.io/crates/indexmap",
       "filesAnalyzed": true,
@@ -501,7 +518,7 @@
       "versionInfo": "2.13.0"
     },
     {
-      "SPDXID": "SPDXRef-is-terminal-polyfill-28",
+      "SPDXID": "SPDXRef-is-terminal-polyfill-29",
       "name": "is_terminal_polyfill",
       "downloadLocation": "https://crates.io/crates/is_terminal_polyfill",
       "filesAnalyzed": true,
@@ -518,167 +535,7 @@
       "versionInfo": "1.70.1"
     },
     {
-      "SPDXID": "SPDXRef-libanstream-af8c0c8b7745f81c.rlib-29",
-      "name": "libanstream-af8c0c8b7745f81c.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libanstream-af8c0c8b7745f81c.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libanstyle-a0a0ad7ff8b9c5a1.rlib-30",
-      "name": "libanstyle-a0a0ad7ff8b9c5a1.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libanstyle-a0a0ad7ff8b9c5a1.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libanstyle-parse-7aaeee641d2da150.rlib-31",
-      "name": "libanstyle_parse-7aaeee641d2da150.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libanstyle_parse-7aaeee641d2da150.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libanstyle-query-24c9d1b4892ed6c3.rlib-32",
-      "name": "libanstyle_query-24c9d1b4892ed6c3.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libanstyle_query-24c9d1b4892ed6c3.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libbitflags-1280f28be8e10639.rlib-33",
-      "name": "libbitflags-1280f28be8e10639.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libbitflags-1280f28be8e10639.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libbitvec-e8365d6a02442b17.rlib-34",
-      "name": "libbitvec-e8365d6a02442b17.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libbitvec-e8365d6a02442b17.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libbumpalo-b931f9f29ef28c54.rlib-35",
-      "name": "libbumpalo-b931f9f29ef28c54.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libbumpalo-b931f9f29ef28c54.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libbytemuck-554fa33dc3a4a114.rlib-36",
-      "name": "libbytemuck-554fa33dc3a4a114.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libbytemuck-554fa33dc3a4a114.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcc-6022fe8bec44565b.rlib-37",
-      "name": "libcc-6022fe8bec44565b.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcc-6022fe8bec44565b.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libclap-ba3cd817b4d126e9.rlib-38",
-      "name": "libclap-ba3cd817b4d126e9.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libclap-ba3cd817b4d126e9.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libclap-builder-b1a4cc9d08676f8c.rlib-39",
-      "name": "libclap_builder-b1a4cc9d08676f8c.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libclap_builder-b1a4cc9d08676f8c.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libclap-lex-da436b52c838ef3a.rlib-40",
-      "name": "libclap_lex-da436b52c838ef3a.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libclap_lex-da436b52c838ef3a.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcolorchoice-0db96e0fc98929ef.rlib-41",
-      "name": "libcolorchoice-0db96e0fc98929ef.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcolorchoice-0db96e0fc98929ef.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcrossbeam-deque-981e4e7399a46153.rlib-42",
-      "name": "libcrossbeam_deque-981e4e7399a46153.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcrossbeam_deque-981e4e7399a46153.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcrossbeam-epoch-2345908434fb69df.rlib-43",
-      "name": "libcrossbeam_epoch-2345908434fb69df.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcrossbeam_epoch-2345908434fb69df.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libcrossbeam-utils-6aec20481488f580.rlib-44",
-      "name": "libcrossbeam_utils-6aec20481488f580.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libcrossbeam_utils-6aec20481488f580.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libdeflate-sys-45",
+      "SPDXID": "SPDXRef-libdeflate-sys-30",
       "name": "libdeflate-sys",
       "downloadLocation": "https://crates.io/crates/libdeflate-sys",
       "filesAnalyzed": true,
@@ -687,15 +544,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/libdeflate-sys@1.25.2"
+          "referenceLocator": "pkg:cargo/libdeflate-sys@1.25.0"
         }
       ],
       "comment": "Rust crate (transitive, statically linked). 2 source files compiled into oxipng",
       "packageSourceInfo": "Transitive dependency via Cargo. Downloaded from crates.io registry.",
-      "versionInfo": "1.25.2"
+      "versionInfo": "1.25.0"
     },
     {
-      "SPDXID": "SPDXRef-libdeflater-46",
+      "SPDXID": "SPDXRef-libdeflater-31",
       "name": "libdeflater",
       "downloadLocation": "https://crates.io/crates/libdeflater",
       "filesAnalyzed": true,
@@ -704,305 +561,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/libdeflater@1.25.2"
+          "referenceLocator": "pkg:cargo/libdeflater@1.25.0"
         }
       ],
       "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
-      "versionInfo": "1.25.2"
+      "versionInfo": "1.25.0"
     },
     {
-      "SPDXID": "SPDXRef-libeither-293bc8bebd4fea10.rlib-47",
-      "name": "libeither-293bc8bebd4fea10.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libeither-293bc8bebd4fea10.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libenv-filter-6442a55f21f4f1e1.rlib-48",
-      "name": "libenv_filter-6442a55f21f4f1e1.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libenv_filter-6442a55f21f4f1e1.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libenv-logger-060457492833bd93.rlib-49",
-      "name": "libenv_logger-060457492833bd93.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libenv_logger-060457492833bd93.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libequivalent-de15a8ed2be8fbaa.rlib-50",
-      "name": "libequivalent-de15a8ed2be8fbaa.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libequivalent-de15a8ed2be8fbaa.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libfind-msvc-tools-c62d9445dcf587b3.rlib-51",
-      "name": "libfind_msvc_tools-c62d9445dcf587b3.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libfind_msvc_tools-c62d9445dcf587b3.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libfunty-bdb6172d22b9a442.rlib-52",
-      "name": "libfunty-bdb6172d22b9a442.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libfunty-bdb6172d22b9a442.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libhashbrown-f47a2216fbc1d1da.rlib-53",
-      "name": "libhashbrown-f47a2216fbc1d1da.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libhashbrown-f47a2216fbc1d1da.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libindexmap-e2aa6b12af0df1da.rlib-54",
-      "name": "libindexmap-e2aa6b12af0df1da.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libindexmap-e2aa6b12af0df1da.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libis-terminal-polyfill-2b547f002f59b182.rlib-55",
-      "name": "libis_terminal_polyfill-2b547f002f59b182.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libis_terminal_polyfill-2b547f002f59b182.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liblibdeflate-sys-8015b60baf6cbe73.rlib-56",
-      "name": "liblibdeflate_sys-8015b60baf6cbe73.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liblibdeflate_sys-8015b60baf6cbe73.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liblibdeflater-ee8c0839617ecdd2.rlib-57",
-      "name": "liblibdeflater-ee8c0839617ecdd2.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liblibdeflater-ee8c0839617ecdd2.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liblinux-raw-sys-f7fcb1738333da4b.rlib-58",
-      "name": "liblinux_raw_sys-f7fcb1738333da4b.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liblinux_raw_sys-f7fcb1738333da4b.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liblog-9ce69ee427be56af.rlib-59",
-      "name": "liblog-9ce69ee427be56af.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liblog-9ce69ee427be56af.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-liboxipng-fdba2b3e9d33ac60.rlib-60",
-      "name": "liboxipng-fdba2b3e9d33ac60.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/liboxipng-fdba2b3e9d33ac60.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libparse-size-deb3060eda4b6ee6.rlib-61",
-      "name": "libparse_size-deb3060eda4b6ee6.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libparse_size-deb3060eda4b6ee6.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libradium-48b1afdaab91e229.rlib-62",
-      "name": "libradium-48b1afdaab91e229.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libradium-48b1afdaab91e229.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librayon-bac265390ff2804d.rlib-63",
-      "name": "librayon-bac265390ff2804d.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librayon-bac265390ff2804d.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librayon-core-e84357bde9e25850.rlib-64",
-      "name": "librayon_core-e84357bde9e25850.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librayon_core-e84357bde9e25850.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librgb-eebcd6abc98a5aa6.rlib-65",
-      "name": "librgb-eebcd6abc98a5aa6.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librgb-eebcd6abc98a5aa6.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librustc-hash-d83abfe4c6f7957d.rlib-66",
-      "name": "librustc_hash-d83abfe4c6f7957d.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librustc_hash-d83abfe4c6f7957d.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-librustix-14a819ab0f7085b5.rlib-67",
-      "name": "librustix-14a819ab0f7085b5.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/librustix-14a819ab0f7085b5.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libshlex-83f5f3b3166a68cf.rlib-68",
-      "name": "libshlex-83f5f3b3166a68cf.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libshlex-83f5f3b3166a68cf.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libsimd-adler32-cc8fcc5583e774f1.rlib-69",
-      "name": "libsimd_adler32-cc8fcc5583e774f1.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libsimd_adler32-cc8fcc5583e774f1.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libstrsim-42bcc59cdc10da44.rlib-70",
-      "name": "libstrsim-42bcc59cdc10da44.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libstrsim-42bcc59cdc10da44.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libtap-195521f7f7a3d762.rlib-71",
-      "name": "libtap-195521f7f7a3d762.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libtap-195521f7f7a3d762.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libterminal-size-9ecd0743482c5010.rlib-72",
-      "name": "libterminal_size-9ecd0743482c5010.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libterminal_size-9ecd0743482c5010.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libutf8parse-6973cc3038d6458e.rlib-73",
-      "name": "libutf8parse-6973cc3038d6458e.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libutf8parse-6973cc3038d6458e.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libwyz-fa9d8f34112b5d93.rlib-74",
-      "name": "libwyz-fa9d8f34112b5d93.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libwyz-fa9d8f34112b5d93.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-libzopfli-45a56469d617d29e.rlib-75",
-      "name": "libzopfli-45a56469d617d29e.rlib",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/libzopfli-45a56469d617d29e.rlib/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-linux-raw-sys-76",
+      "SPDXID": "SPDXRef-linux-raw-sys-32",
       "name": "linux-raw-sys",
       "downloadLocation": "https://crates.io/crates/linux-raw-sys",
       "filesAnalyzed": true,
@@ -1019,7 +586,7 @@
       "versionInfo": "0.11.0"
     },
     {
-      "SPDXID": "SPDXRef-log-77",
+      "SPDXID": "SPDXRef-log-33",
       "name": "log",
       "downloadLocation": "https://crates.io/crates/log",
       "filesAnalyzed": true,
@@ -1036,17 +603,7 @@
       "versionInfo": "0.4.29"
     },
     {
-      "SPDXID": "SPDXRef-oxipng-0e7d4c98f7c577c1-78",
-      "name": "oxipng-0e7d4c98f7c577c1",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": true,
-      "primaryPackagePurpose": "LIBRARY",
-      "externalRefs": [],
-      "comment": "Vendored source compiled into oxipng. 0 source files.",
-      "packageSourceInfo": "Vendored from oxipng/deps/oxipng-0e7d4c98f7c577c1/. Source compiled into static archive and linked."
-    },
-    {
-      "SPDXID": "SPDXRef-parse-size-79",
+      "SPDXID": "SPDXRef-parse-size-34",
       "name": "parse-size",
       "downloadLocation": "https://crates.io/crates/parse-size",
       "filesAnalyzed": true,
@@ -1063,7 +620,7 @@
       "versionInfo": "1.1.0"
     },
     {
-      "SPDXID": "SPDXRef-radium-80",
+      "SPDXID": "SPDXRef-radium-35",
       "name": "radium",
       "downloadLocation": "https://crates.io/crates/radium",
       "filesAnalyzed": true,
@@ -1080,7 +637,7 @@
       "versionInfo": "0.7.0"
     },
     {
-      "SPDXID": "SPDXRef-rayon-81",
+      "SPDXID": "SPDXRef-rayon-36",
       "name": "rayon",
       "downloadLocation": "https://crates.io/crates/rayon",
       "filesAnalyzed": true,
@@ -1097,7 +654,7 @@
       "versionInfo": "1.11.0"
     },
     {
-      "SPDXID": "SPDXRef-rayon-core-82",
+      "SPDXID": "SPDXRef-rayon-core-37",
       "name": "rayon-core",
       "downloadLocation": "https://crates.io/crates/rayon-core",
       "filesAnalyzed": true,
@@ -1114,7 +671,7 @@
       "versionInfo": "1.13.0"
     },
     {
-      "SPDXID": "SPDXRef-rgb-83",
+      "SPDXID": "SPDXRef-rgb-38",
       "name": "rgb",
       "downloadLocation": "https://crates.io/crates/rgb",
       "filesAnalyzed": true,
@@ -1123,15 +680,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:cargo/rgb@0.8.53"
+          "referenceLocator": "pkg:cargo/rgb@0.8.52"
         }
       ],
       "comment": "Rust crate (direct, statically linked). 1 source files compiled into oxipng",
       "packageSourceInfo": "Downloaded from crates.io registry. Source at ~/.cargo/registry/src/.",
-      "versionInfo": "0.8.53"
+      "versionInfo": "0.8.52"
     },
     {
-      "SPDXID": "SPDXRef-rustc-hash-84",
+      "SPDXID": "SPDXRef-rustc-hash-39",
       "name": "rustc-hash",
       "downloadLocation": "https://crates.io/crates/rustc-hash",
       "filesAnalyzed": true,
@@ -1148,7 +705,7 @@
       "versionInfo": "2.1.1"
     },
     {
-      "SPDXID": "SPDXRef-rustix-85",
+      "SPDXID": "SPDXRef-rustix-40",
       "name": "rustix",
       "downloadLocation": "https://crates.io/crates/rustix",
       "filesAnalyzed": true,
@@ -1165,7 +722,7 @@
       "versionInfo": "1.1.2"
     },
     {
-      "SPDXID": "SPDXRef-shlex-86",
+      "SPDXID": "SPDXRef-shlex-41",
       "name": "shlex",
       "downloadLocation": "https://crates.io/crates/shlex",
       "filesAnalyzed": true,
@@ -1182,7 +739,7 @@
       "versionInfo": "1.3.0"
     },
     {
-      "SPDXID": "SPDXRef-simd-adler32-87",
+      "SPDXID": "SPDXRef-simd-adler32-42",
       "name": "simd-adler32",
       "downloadLocation": "https://crates.io/crates/simd-adler32",
       "filesAnalyzed": true,
@@ -1199,7 +756,7 @@
       "versionInfo": "0.3.7"
     },
     {
-      "SPDXID": "SPDXRef-strsim-88",
+      "SPDXID": "SPDXRef-strsim-43",
       "name": "strsim",
       "downloadLocation": "https://crates.io/crates/strsim",
       "filesAnalyzed": true,
@@ -1216,7 +773,7 @@
       "versionInfo": "0.11.1"
     },
     {
-      "SPDXID": "SPDXRef-tap-89",
+      "SPDXID": "SPDXRef-tap-44",
       "name": "tap",
       "downloadLocation": "https://crates.io/crates/tap",
       "filesAnalyzed": true,
@@ -1233,7 +790,7 @@
       "versionInfo": "1.0.1"
     },
     {
-      "SPDXID": "SPDXRef-terminal-size-90",
+      "SPDXID": "SPDXRef-terminal-size-45",
       "name": "terminal_size",
       "downloadLocation": "https://crates.io/crates/terminal_size",
       "filesAnalyzed": true,
@@ -1250,7 +807,7 @@
       "versionInfo": "0.4.3"
     },
     {
-      "SPDXID": "SPDXRef-utf8parse-91",
+      "SPDXID": "SPDXRef-utf8parse-46",
       "name": "utf8parse",
       "downloadLocation": "https://crates.io/crates/utf8parse",
       "filesAnalyzed": true,
@@ -1267,7 +824,7 @@
       "versionInfo": "0.2.2"
     },
     {
-      "SPDXID": "SPDXRef-wyz-92",
+      "SPDXID": "SPDXRef-wyz-47",
       "name": "wyz",
       "downloadLocation": "https://crates.io/crates/wyz",
       "filesAnalyzed": true,
@@ -1284,7 +841,7 @@
       "versionInfo": "0.5.1"
     },
     {
-      "SPDXID": "SPDXRef-zopfli-93",
+      "SPDXID": "SPDXRef-zopfli-48",
       "name": "zopfli",
       "downloadLocation": "https://crates.io/crates/zopfli",
       "filesAnalyzed": true,
@@ -1303,7 +860,7 @@
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-File-main.rs-94",
+      "SPDXID": "SPDXRef-File-main.rs-49",
       "fileName": "repos/oxipng/src/main.rs",
       "checksums": [
         {
@@ -1313,7 +870,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-95",
+      "SPDXID": "SPDXRef-File-lib.rs-50",
       "fileName": "repos/oxipng/src/lib.rs",
       "checksums": [
         {
@@ -1323,7 +880,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-96",
+      "SPDXID": "SPDXRef-File-lib.rs-51",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/radium-0.7.0/src/lib.rs",
       "checksums": [
         {
@@ -1333,7 +890,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-97",
+      "SPDXID": "SPDXRef-File-build.rs-52",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/radium-0.7.0/build.rs",
       "checksums": [
         {
@@ -1343,7 +900,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-98",
+      "SPDXID": "SPDXRef-File-lib.rs-53",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustc-hash-2.1.1/src/lib.rs",
       "checksums": [
         {
@@ -1353,7 +910,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-99",
+      "SPDXID": "SPDXRef-File-lib.rs-54",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/utf8parse-0.2.2/src/lib.rs",
       "checksums": [
         {
@@ -1363,7 +920,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-100",
+      "SPDXID": "SPDXRef-File-lib.rs-55",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/equivalent-1.0.2/src/lib.rs",
       "checksums": [
         {
@@ -1373,7 +930,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-101",
+      "SPDXID": "SPDXRef-File-lib.rs-56",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/log-0.4.29/src/lib.rs",
       "checksums": [
         {
@@ -1383,17 +940,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-102",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/env_filter-1.0.0/src/lib.rs",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "0b350882a7b9b47bf523a1911c5c9a05f81d8691"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lib.rs-103",
+      "SPDXID": "SPDXRef-File-lib.rs-57",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-deque-0.8.6/src/lib.rs",
       "checksums": [
         {
@@ -1403,8 +950,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zlib-compress.c-104",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/zlib_compress.c",
+      "SPDXID": "SPDXRef-File-zlib-compress.c-58",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/zlib_compress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1413,8 +960,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adler32-template.h-105",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/adler32_template.h",
+      "SPDXID": "SPDXRef-File-adler32-template.h-59",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/adler32_template.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1423,8 +970,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gzip-constants.h-106",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/gzip_constants.h",
+      "SPDXID": "SPDXRef-File-gzip-constants.h-60",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/gzip_constants.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1433,8 +980,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-matchfinder-impl.h-107",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/matchfinder_impl.h",
+      "SPDXID": "SPDXRef-File-matchfinder-impl.h-61",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/matchfinder_impl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1443,8 +990,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features.c-108",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/arm/cpu_features.c",
+      "SPDXID": "SPDXRef-File-cpu-features.c-62",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/arm/cpu_features.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1453,8 +1000,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deflate-compress.c-109",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/deflate_compress.c",
+      "SPDXID": "SPDXRef-File-deflate-compress.c-63",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/deflate_compress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1463,8 +1010,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32-impl.h-110",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/crc32_impl.h",
+      "SPDXID": "SPDXRef-File-crc32-impl.h-64",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/crc32_impl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1473,8 +1020,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-utils.c-111",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/utils.c",
+      "SPDXID": "SPDXRef-File-utils.c-65",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/utils.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1483,8 +1030,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deflate-decompress.c-112",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/deflate_decompress.c",
+      "SPDXID": "SPDXRef-File-deflate-decompress.c-66",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/deflate_decompress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1493,8 +1040,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-ht-matchfinder.h-113",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/ht_matchfinder.h",
+      "SPDXID": "SPDXRef-File-ht-matchfinder.h-67",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/ht_matchfinder.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1503,8 +1050,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adler32-impl.h-114",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/adler32_impl.h",
+      "SPDXID": "SPDXRef-File-adler32-impl.h-68",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/adler32_impl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1513,8 +1060,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gzip-decompress.c-115",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/gzip_decompress.c",
+      "SPDXID": "SPDXRef-File-gzip-decompress.c-69",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/gzip_decompress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1523,8 +1070,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32-pclmul-template.h-116",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/crc32_pclmul_template.h",
+      "SPDXID": "SPDXRef-File-crc32-pclmul-template.h-70",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/crc32_pclmul_template.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1533,8 +1080,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decompress-template.h-117",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/decompress_template.h",
+      "SPDXID": "SPDXRef-File-decompress-template.h-71",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/decompress_template.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1543,8 +1090,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deflate-compress.h-118",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/deflate_compress.h",
+      "SPDXID": "SPDXRef-File-deflate-compress.h-72",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/deflate_compress.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1553,8 +1100,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-deflate-constants.h-119",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/deflate_constants.h",
+      "SPDXID": "SPDXRef-File-deflate-constants.h-73",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/deflate_constants.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1563,8 +1110,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-matchfinder-common.h-120",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/matchfinder_common.h",
+      "SPDXID": "SPDXRef-File-matchfinder-common.h-74",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/matchfinder_common.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1573,8 +1120,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32-multipliers.h-121",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/crc32_multipliers.h",
+      "SPDXID": "SPDXRef-File-crc32-multipliers.h-75",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/crc32_multipliers.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1583,8 +1130,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-common-defs.h-122",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/common_defs.h",
+      "SPDXID": "SPDXRef-File-common-defs.h-76",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/common_defs.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1593,8 +1140,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-hc-matchfinder.h-123",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/hc_matchfinder.h",
+      "SPDXID": "SPDXRef-File-hc-matchfinder.h-77",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/hc_matchfinder.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1603,8 +1150,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32.c-124",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/crc32.c",
+      "SPDXID": "SPDXRef-File-crc32.c-78",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/crc32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1613,8 +1160,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features.c-125",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/cpu_features.c",
+      "SPDXID": "SPDXRef-File-cpu-features.c-79",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/cpu_features.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1623,8 +1170,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-126",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/build.rs",
+      "SPDXID": "SPDXRef-File-build.rs-80",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/build.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1633,8 +1180,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-bt-matchfinder.h-127",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/bt_matchfinder.h",
+      "SPDXID": "SPDXRef-File-bt-matchfinder.h-81",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/bt_matchfinder.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1643,8 +1190,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-gzip-compress.c-128",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/gzip_compress.c",
+      "SPDXID": "SPDXRef-File-gzip-compress.c-82",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/gzip_compress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1653,8 +1200,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-129",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/src/lib.rs",
+      "SPDXID": "SPDXRef-File-lib.rs-83",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/src/lib.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1663,8 +1210,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features.h-130",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/cpu_features.h",
+      "SPDXID": "SPDXRef-File-cpu-features.h-84",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/cpu_features.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1673,8 +1220,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features-common.h-131",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/cpu_features_common.h",
+      "SPDXID": "SPDXRef-File-cpu-features-common.h-85",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/cpu_features_common.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1683,8 +1230,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-adler32.c-132",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/adler32.c",
+      "SPDXID": "SPDXRef-File-adler32.c-86",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/adler32.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1693,8 +1240,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-crc32-tables.h-133",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/crc32_tables.h",
+      "SPDXID": "SPDXRef-File-crc32-tables.h-87",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/crc32_tables.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1703,8 +1250,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-libdeflate.h-134",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/libdeflate.h",
+      "SPDXID": "SPDXRef-File-libdeflate.h-88",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/libdeflate.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1713,8 +1260,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-decompress-impl.h-135",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/x86/decompress_impl.h",
+      "SPDXID": "SPDXRef-File-decompress-impl.h-89",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/x86/decompress_impl.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1723,8 +1270,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-cpu-features.h-136",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/arm/cpu_features.h",
+      "SPDXID": "SPDXRef-File-cpu-features.h-90",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/arm/cpu_features.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1733,8 +1280,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zlib-constants.h-137",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/zlib_constants.h",
+      "SPDXID": "SPDXRef-File-zlib-constants.h-91",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/zlib_constants.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1743,8 +1290,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-zlib-decompress.c-138",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/zlib_decompress.c",
+      "SPDXID": "SPDXRef-File-zlib-decompress.c-92",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/zlib_decompress.c",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1753,8 +1300,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib-common.h-139",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.2/libdeflate/lib/lib_common.h",
+      "SPDXID": "SPDXRef-File-lib-common.h-93",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflate-sys-1.25.0/libdeflate/lib/lib_common.h",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -1763,17 +1310,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-140",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rgb-0.8.53/src/lib.rs",
+      "SPDXID": "SPDXRef-File-lib.rs-94",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap-4.5.54/src/lib.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "139ace5698e594e1b14b0ebed28c7a5a5ca89629"
+          "checksumValue": "142b6759152f0f8d0d45d53c89ebda6a6a363f34"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-141",
+      "SPDXID": "SPDXRef-File-build.rs-95",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.2/build.rs",
       "checksums": [
         {
@@ -1783,7 +1330,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-142",
+      "SPDXID": "SPDXRef-File-lib.rs-96",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.2/src/lib.rs",
       "checksums": [
         {
@@ -1793,7 +1340,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-143",
+      "SPDXID": "SPDXRef-File-lib.rs-97",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/linux-raw-sys-0.11.0/src/lib.rs",
       "checksums": [
         {
@@ -1803,7 +1350,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-144",
+      "SPDXID": "SPDXRef-File-lib.rs-98",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bitflags-2.9.4/src/lib.rs",
       "checksums": [
         {
@@ -1813,17 +1360,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-145",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap-4.5.60/src/lib.rs",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1db8efd0e341e6a6f13dad67d350faeb4b32ad25"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lib.rs-146",
+      "SPDXID": "SPDXRef-File-lib.rs-99",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-parse-0.2.7/src/lib.rs",
       "checksums": [
         {
@@ -1833,7 +1370,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-147",
+      "SPDXID": "SPDXRef-File-lib.rs-100",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rayon-core-1.13.0/src/lib.rs",
       "checksums": [
         {
@@ -1843,7 +1380,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-148",
+      "SPDXID": "SPDXRef-File-build.rs-101",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rayon-core-1.13.0/build.rs",
       "checksums": [
         {
@@ -1853,7 +1390,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-149",
+      "SPDXID": "SPDXRef-File-lib.rs-102",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bitvec-1.0.1/src/lib.rs",
       "checksums": [
         {
@@ -1863,7 +1400,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-150",
+      "SPDXID": "SPDXRef-File-lib.rs-103",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rayon-1.11.0/src/lib.rs",
       "checksums": [
         {
@@ -1873,17 +1410,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-151",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflater-1.25.2/src/lib.rs",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "5601ad31f360d2560528c2bd451d062a1cab44fe"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lib.rs-152",
+      "SPDXID": "SPDXRef-File-lib.rs-104",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zopfli-0.8.3/src/lib.rs",
       "checksums": [
         {
@@ -1893,7 +1420,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-153",
+      "SPDXID": "SPDXRef-File-lib.rs-105",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bytemuck-1.23.2/src/lib.rs",
       "checksums": [
         {
@@ -1903,7 +1430,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-154",
+      "SPDXID": "SPDXRef-File-lib.rs-106",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/strsim-0.11.1/src/lib.rs",
       "checksums": [
         {
@@ -1913,17 +1440,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-155",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_lex-1.0.0/src/lib.rs",
+      "SPDXID": "SPDXRef-File-lib.rs-107",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_lex-0.7.5/src/lib.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6ba028a6d7a665114059de6e71bbfa9b594940d6"
+          "checksumValue": "6b7621f51e47c1fc35ddba79573029f408ba9c4c"
         }
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-156",
+      "SPDXID": "SPDXRef-File-lib.rs-108",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/indexmap-2.13.0/src/lib.rs",
       "checksums": [
         {
@@ -1933,7 +1460,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-157",
+      "SPDXID": "SPDXRef-File-lib.rs-109",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-utils-0.8.21/src/lib.rs",
       "checksums": [
         {
@@ -1943,7 +1470,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-build.rs-158",
+      "SPDXID": "SPDXRef-File-build.rs-110",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-utils-0.8.21/build.rs",
       "checksums": [
         {
@@ -1953,17 +1480,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-159",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/env_logger-0.11.9/src/lib.rs",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "7770bf1c4a3f02ccab0564c267d783acd381227d"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File-lib.rs-160",
+      "SPDXID": "SPDXRef-File-lib.rs-111",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cc-1.2.38/src/lib.rs",
       "checksums": [
         {
@@ -1973,7 +1490,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-161",
+      "SPDXID": "SPDXRef-File-lib.rs-112",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstream-0.6.20/src/lib.rs",
       "checksums": [
         {
@@ -1983,7 +1500,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-162",
+      "SPDXID": "SPDXRef-File-lib.rs-113",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-channel-0.5.15/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "93e190b2eb62e41a46fb6ab31629f82cd95ba236"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-114",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/terminal_size-0.4.3/src/lib.rs",
       "checksums": [
         {
@@ -1993,8 +1520,8 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-163",
-      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.60/src/lib.rs",
+      "SPDXID": "SPDXRef-File-lib.rs-115",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.54/src/lib.rs",
       "checksums": [
         {
           "algorithm": "SHA1",
@@ -2003,7 +1530,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-164",
+      "SPDXID": "SPDXRef-File-lib.rs-116",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-1.0.11/src/lib.rs",
       "checksums": [
         {
@@ -2013,7 +1540,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-165",
+      "SPDXID": "SPDXRef-File-lib.rs-117",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/shlex-1.3.0/src/lib.rs",
       "checksums": [
         {
@@ -2023,7 +1550,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-166",
+      "SPDXID": "SPDXRef-File-lib.rs-118",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libdeflater-1.25.0/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "aec1dfa52ab1cdf56c20cc59564e972df96645f4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-119",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/colorchoice-1.0.4/src/lib.rs",
       "checksums": [
         {
@@ -2033,7 +1570,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-167",
+      "SPDXID": "SPDXRef-File-lib.rs-120",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashbrown-0.16.1/src/lib.rs",
       "checksums": [
         {
@@ -2043,7 +1580,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-168",
+      "SPDXID": "SPDXRef-File-lib.rs-121",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-query-1.1.4/src/lib.rs",
       "checksums": [
         {
@@ -2053,7 +1590,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-169",
+      "SPDXID": "SPDXRef-File-lib.rs-122",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parse-size-1.1.0/src/lib.rs",
       "checksums": [
         {
@@ -2063,7 +1600,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-170",
+      "SPDXID": "SPDXRef-File-lib.rs-123",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/funty-2.0.0/src/lib.rs",
       "checksums": [
         {
@@ -2073,7 +1610,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-171",
+      "SPDXID": "SPDXRef-File-lib.rs-124",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/is_terminal_polyfill-1.70.1/src/lib.rs",
       "checksums": [
         {
@@ -2083,7 +1620,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-172",
+      "SPDXID": "SPDXRef-File-lib.rs-125",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/env_logger-0.11.8/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e0afd1c2e397d9855b979f0e514e92965e532460"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-126",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/either-1.15.0/src/lib.rs",
       "checksums": [
         {
@@ -2093,7 +1640,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-173",
+      "SPDXID": "SPDXRef-File-lib.rs-127",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/simd-adler32-0.3.7/src/lib.rs",
       "checksums": [
         {
@@ -2103,7 +1650,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-174",
+      "SPDXID": "SPDXRef-File-lib.rs-128",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rgb-0.8.52/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e677762e26673cf93cebe04f9bedfa432577c03f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-129",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tap-1.0.1/src/lib.rs",
       "checksums": [
         {
@@ -2113,7 +1670,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-175",
+      "SPDXID": "SPDXRef-File-lib.rs-130",
+      "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/env_filter-0.1.3/src/lib.rs",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e9f42d1fabe245234ecc3e6ce2bc9491eef56a4a"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-lib.rs-131",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bumpalo-3.19.0/src/lib.rs",
       "checksums": [
         {
@@ -2123,7 +1690,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-176",
+      "SPDXID": "SPDXRef-File-lib.rs-132",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wyz-0.5.1/src/lib.rs",
       "checksums": [
         {
@@ -2133,7 +1700,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-177",
+      "SPDXID": "SPDXRef-File-lib.rs-133",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/find-msvc-tools-0.1.2/src/lib.rs",
       "checksums": [
         {
@@ -2143,7 +1710,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-File-lib.rs-178",
+      "SPDXID": "SPDXRef-File-lib.rs-134",
       "fileName": ".cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-epoch-0.9.18/src/lib.rs",
       "checksums": [
         {
@@ -2176,27 +1743,27 @@
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-anstream-4"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-anstyle-5"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-anstyle-parse-6"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-anstyle-query-7"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-bitflags-8"
     },
     {
@@ -2206,17 +1773,17 @@
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-bumpalo-10"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-bytemuck-11"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-cc-12"
     },
     {
@@ -2226,828 +1793,608 @@
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-clap-builder-14"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-clap-lex-15"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
+      "relationshipType": "STATIC_LINK",
       "relatedSpdxElement": "SPDXRef-colorchoice-16"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-crossbeam-deque-17"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-crossbeam-epoch-18"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-crossbeam-utils-19"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-either-20"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-env-filter-21"
+      "relationshipType": "STATIC_LINK",
+      "relatedSpdxElement": "SPDXRef-crossbeam-channel-17"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-env-logger-22"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-equivalent-23"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-find-msvc-tools-24"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-funty-25"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-hashbrown-26"
+      "relatedSpdxElement": "SPDXRef-crossbeam-deque-18"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-indexmap-27"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-is-terminal-polyfill-28"
+      "relatedSpdxElement": "SPDXRef-crossbeam-epoch-19"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libanstream-af8c0c8b7745f81c.rlib-29"
+      "relatedSpdxElement": "SPDXRef-crossbeam-utils-20"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libanstyle-a0a0ad7ff8b9c5a1.rlib-30"
+      "relatedSpdxElement": "SPDXRef-either-21"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libanstyle-parse-7aaeee641d2da150.rlib-31"
+      "relatedSpdxElement": "SPDXRef-env-filter-22"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libanstyle-query-24c9d1b4892ed6c3.rlib-32"
+      "relatedSpdxElement": "SPDXRef-env-logger-23"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libbitflags-1280f28be8e10639.rlib-33"
+      "relatedSpdxElement": "SPDXRef-equivalent-24"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libbitvec-e8365d6a02442b17.rlib-34"
+      "relatedSpdxElement": "SPDXRef-find-msvc-tools-25"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libbumpalo-b931f9f29ef28c54.rlib-35"
+      "relatedSpdxElement": "SPDXRef-funty-26"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libbytemuck-554fa33dc3a4a114.rlib-36"
+      "relatedSpdxElement": "SPDXRef-hashbrown-27"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcc-6022fe8bec44565b.rlib-37"
+      "relatedSpdxElement": "SPDXRef-indexmap-28"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libclap-ba3cd817b4d126e9.rlib-38"
+      "relatedSpdxElement": "SPDXRef-is-terminal-polyfill-29"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libclap-builder-b1a4cc9d08676f8c.rlib-39"
+      "relatedSpdxElement": "SPDXRef-libdeflate-sys-30"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libclap-lex-da436b52c838ef3a.rlib-40"
+      "relatedSpdxElement": "SPDXRef-libdeflater-31"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcolorchoice-0db96e0fc98929ef.rlib-41"
+      "relatedSpdxElement": "SPDXRef-linux-raw-sys-32"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcrossbeam-deque-981e4e7399a46153.rlib-42"
+      "relatedSpdxElement": "SPDXRef-log-33"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcrossbeam-epoch-2345908434fb69df.rlib-43"
+      "relatedSpdxElement": "SPDXRef-parse-size-34"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libcrossbeam-utils-6aec20481488f580.rlib-44"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-libdeflate-sys-45"
+      "relatedSpdxElement": "SPDXRef-radium-35"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libdeflater-46"
+      "relatedSpdxElement": "SPDXRef-rayon-36"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libeither-293bc8bebd4fea10.rlib-47"
+      "relatedSpdxElement": "SPDXRef-rayon-core-37"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libenv-filter-6442a55f21f4f1e1.rlib-48"
+      "relatedSpdxElement": "SPDXRef-rgb-38"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libenv-logger-060457492833bd93.rlib-49"
+      "relatedSpdxElement": "SPDXRef-rustc-hash-39"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libequivalent-de15a8ed2be8fbaa.rlib-50"
+      "relatedSpdxElement": "SPDXRef-rustix-40"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libfind-msvc-tools-c62d9445dcf587b3.rlib-51"
+      "relatedSpdxElement": "SPDXRef-shlex-41"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libfunty-bdb6172d22b9a442.rlib-52"
+      "relatedSpdxElement": "SPDXRef-simd-adler32-42"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libhashbrown-f47a2216fbc1d1da.rlib-53"
+      "relatedSpdxElement": "SPDXRef-strsim-43"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libindexmap-e2aa6b12af0df1da.rlib-54"
+      "relatedSpdxElement": "SPDXRef-tap-44"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libis-terminal-polyfill-2b547f002f59b182.rlib-55"
+      "relatedSpdxElement": "SPDXRef-terminal-size-45"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liblibdeflate-sys-8015b60baf6cbe73.rlib-56"
+      "relatedSpdxElement": "SPDXRef-utf8parse-46"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liblibdeflater-ee8c0839617ecdd2.rlib-57"
+      "relatedSpdxElement": "SPDXRef-wyz-47"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liblinux-raw-sys-f7fcb1738333da4b.rlib-58"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liblog-9ce69ee427be56af.rlib-59"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-liboxipng-fdba2b3e9d33ac60.rlib-60"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libparse-size-deb3060eda4b6ee6.rlib-61"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libradium-48b1afdaab91e229.rlib-62"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librayon-bac265390ff2804d.rlib-63"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librayon-core-e84357bde9e25850.rlib-64"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librgb-eebcd6abc98a5aa6.rlib-65"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librustc-hash-d83abfe4c6f7957d.rlib-66"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-librustix-14a819ab0f7085b5.rlib-67"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libshlex-83f5f3b3166a68cf.rlib-68"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libsimd-adler32-cc8fcc5583e774f1.rlib-69"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libstrsim-42bcc59cdc10da44.rlib-70"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libtap-195521f7f7a3d762.rlib-71"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libterminal-size-9ecd0743482c5010.rlib-72"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libutf8parse-6973cc3038d6458e.rlib-73"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libwyz-fa9d8f34112b5d93.rlib-74"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-libzopfli-45a56469d617d29e.rlib-75"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-linux-raw-sys-76"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-log-77"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-oxipng-0e7d4c98f7c577c1-78"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-parse-size-79"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-radium-80"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-rayon-81"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-rayon-core-82"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-rgb-83"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-rustc-hash-84"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-rustix-85"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-shlex-86"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-simd-adler32-87"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-strsim-88"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-tap-89"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-terminal-size-90"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-utf8parse-91"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-wyz-92"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-root",
-      "relationshipType": "STATIC_LINK",
-      "relatedSpdxElement": "SPDXRef-zopfli-93"
+      "relatedSpdxElement": "SPDXRef-zopfli-48"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-main.rs-94"
+      "relatedSpdxElement": "SPDXRef-File-main.rs-49"
     },
     {
       "spdxElementId": "SPDXRef-Package-root",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-95"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-50"
     },
     {
-      "spdxElementId": "SPDXRef-radium-80",
+      "spdxElementId": "SPDXRef-radium-35",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-96"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-51"
     },
     {
-      "spdxElementId": "SPDXRef-radium-80",
+      "spdxElementId": "SPDXRef-radium-35",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-97"
+      "relatedSpdxElement": "SPDXRef-File-build.rs-52"
     },
     {
-      "spdxElementId": "SPDXRef-rustc-hash-84",
+      "spdxElementId": "SPDXRef-rustc-hash-39",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-98"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-53"
     },
     {
-      "spdxElementId": "SPDXRef-utf8parse-91",
+      "spdxElementId": "SPDXRef-utf8parse-46",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-99"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-54"
     },
     {
-      "spdxElementId": "SPDXRef-equivalent-23",
+      "spdxElementId": "SPDXRef-equivalent-24",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-100"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-55"
     },
     {
-      "spdxElementId": "SPDXRef-log-77",
+      "spdxElementId": "SPDXRef-log-33",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-101"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-56"
     },
     {
-      "spdxElementId": "SPDXRef-env-filter-21",
+      "spdxElementId": "SPDXRef-crossbeam-deque-18",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-102"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-57"
     },
     {
-      "spdxElementId": "SPDXRef-crossbeam-deque-17",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-103"
+      "relatedSpdxElement": "SPDXRef-File-zlib-compress.c-58"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zlib-compress.c-104"
+      "relatedSpdxElement": "SPDXRef-File-adler32-template.h-59"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adler32-template.h-105"
+      "relatedSpdxElement": "SPDXRef-File-gzip-constants.h-60"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gzip-constants.h-106"
+      "relatedSpdxElement": "SPDXRef-File-matchfinder-impl.h-61"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-matchfinder-impl.h-107"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features.c-62"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features.c-108"
+      "relatedSpdxElement": "SPDXRef-File-deflate-compress.c-63"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deflate-compress.c-109"
+      "relatedSpdxElement": "SPDXRef-File-crc32-impl.h-64"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32-impl.h-110"
+      "relatedSpdxElement": "SPDXRef-File-utils.c-65"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-utils.c-111"
+      "relatedSpdxElement": "SPDXRef-File-deflate-decompress.c-66"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deflate-decompress.c-112"
+      "relatedSpdxElement": "SPDXRef-File-ht-matchfinder.h-67"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-ht-matchfinder.h-113"
+      "relatedSpdxElement": "SPDXRef-File-adler32-impl.h-68"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adler32-impl.h-114"
+      "relatedSpdxElement": "SPDXRef-File-gzip-decompress.c-69"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gzip-decompress.c-115"
+      "relatedSpdxElement": "SPDXRef-File-crc32-pclmul-template.h-70"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32-pclmul-template.h-116"
+      "relatedSpdxElement": "SPDXRef-File-decompress-template.h-71"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decompress-template.h-117"
+      "relatedSpdxElement": "SPDXRef-File-deflate-compress.h-72"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deflate-compress.h-118"
+      "relatedSpdxElement": "SPDXRef-File-deflate-constants.h-73"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-deflate-constants.h-119"
+      "relatedSpdxElement": "SPDXRef-File-matchfinder-common.h-74"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-matchfinder-common.h-120"
+      "relatedSpdxElement": "SPDXRef-File-crc32-multipliers.h-75"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32-multipliers.h-121"
+      "relatedSpdxElement": "SPDXRef-File-common-defs.h-76"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-common-defs.h-122"
+      "relatedSpdxElement": "SPDXRef-File-hc-matchfinder.h-77"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-hc-matchfinder.h-123"
+      "relatedSpdxElement": "SPDXRef-File-crc32.c-78"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32.c-124"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features.c-79"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features.c-125"
+      "relatedSpdxElement": "SPDXRef-File-build.rs-80"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-126"
+      "relatedSpdxElement": "SPDXRef-File-bt-matchfinder.h-81"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-bt-matchfinder.h-127"
+      "relatedSpdxElement": "SPDXRef-File-gzip-compress.c-82"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-gzip-compress.c-128"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-83"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-129"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features.h-84"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features.h-130"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features-common.h-85"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features-common.h-131"
+      "relatedSpdxElement": "SPDXRef-File-adler32.c-86"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-adler32.c-132"
+      "relatedSpdxElement": "SPDXRef-File-crc32-tables.h-87"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-crc32-tables.h-133"
+      "relatedSpdxElement": "SPDXRef-File-libdeflate.h-88"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-libdeflate.h-134"
+      "relatedSpdxElement": "SPDXRef-File-decompress-impl.h-89"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-decompress-impl.h-135"
+      "relatedSpdxElement": "SPDXRef-File-cpu-features.h-90"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-cpu-features.h-136"
+      "relatedSpdxElement": "SPDXRef-File-zlib-constants.h-91"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zlib-constants.h-137"
+      "relatedSpdxElement": "SPDXRef-File-zlib-decompress.c-92"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
+      "spdxElementId": "SPDXRef-libdeflate-sys-30",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-zlib-decompress.c-138"
-    },
-    {
-      "spdxElementId": "SPDXRef-libdeflate-sys-45",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib-common.h-139"
-    },
-    {
-      "spdxElementId": "SPDXRef-rgb-83",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-140"
-    },
-    {
-      "spdxElementId": "SPDXRef-rustix-85",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-141"
-    },
-    {
-      "spdxElementId": "SPDXRef-rustix-85",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-142"
-    },
-    {
-      "spdxElementId": "SPDXRef-linux-raw-sys-76",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-143"
-    },
-    {
-      "spdxElementId": "SPDXRef-bitflags-8",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-144"
+      "relatedSpdxElement": "SPDXRef-File-lib-common.h-93"
     },
     {
       "spdxElementId": "SPDXRef-clap-13",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-145"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-94"
+    },
+    {
+      "spdxElementId": "SPDXRef-rustix-40",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-build.rs-95"
+    },
+    {
+      "spdxElementId": "SPDXRef-rustix-40",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-96"
+    },
+    {
+      "spdxElementId": "SPDXRef-linux-raw-sys-32",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-97"
+    },
+    {
+      "spdxElementId": "SPDXRef-bitflags-8",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-98"
     },
     {
       "spdxElementId": "SPDXRef-anstyle-parse-6",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-146"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-99"
     },
     {
-      "spdxElementId": "SPDXRef-rayon-core-82",
+      "spdxElementId": "SPDXRef-rayon-core-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-147"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-100"
     },
     {
-      "spdxElementId": "SPDXRef-rayon-core-82",
+      "spdxElementId": "SPDXRef-rayon-core-37",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-148"
+      "relatedSpdxElement": "SPDXRef-File-build.rs-101"
     },
     {
       "spdxElementId": "SPDXRef-bitvec-9",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-149"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-102"
     },
     {
-      "spdxElementId": "SPDXRef-rayon-81",
+      "spdxElementId": "SPDXRef-rayon-36",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-150"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-103"
     },
     {
-      "spdxElementId": "SPDXRef-libdeflater-46",
+      "spdxElementId": "SPDXRef-zopfli-48",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-151"
-    },
-    {
-      "spdxElementId": "SPDXRef-zopfli-93",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-152"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-104"
     },
     {
       "spdxElementId": "SPDXRef-bytemuck-11",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-153"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-105"
     },
     {
-      "spdxElementId": "SPDXRef-strsim-88",
+      "spdxElementId": "SPDXRef-strsim-43",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-154"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-106"
     },
     {
       "spdxElementId": "SPDXRef-clap-lex-15",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-155"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-107"
     },
     {
-      "spdxElementId": "SPDXRef-indexmap-27",
+      "spdxElementId": "SPDXRef-indexmap-28",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-156"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-108"
     },
     {
-      "spdxElementId": "SPDXRef-crossbeam-utils-19",
+      "spdxElementId": "SPDXRef-crossbeam-utils-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-157"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-109"
     },
     {
-      "spdxElementId": "SPDXRef-crossbeam-utils-19",
+      "spdxElementId": "SPDXRef-crossbeam-utils-20",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-build.rs-158"
-    },
-    {
-      "spdxElementId": "SPDXRef-env-logger-22",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-159"
+      "relatedSpdxElement": "SPDXRef-File-build.rs-110"
     },
     {
       "spdxElementId": "SPDXRef-cc-12",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-160"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-111"
     },
     {
       "spdxElementId": "SPDXRef-anstream-4",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-161"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-112"
     },
     {
-      "spdxElementId": "SPDXRef-terminal-size-90",
+      "spdxElementId": "SPDXRef-crossbeam-channel-17",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-162"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-113"
+    },
+    {
+      "spdxElementId": "SPDXRef-terminal-size-45",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-114"
     },
     {
       "spdxElementId": "SPDXRef-clap-builder-14",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-163"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-115"
     },
     {
       "spdxElementId": "SPDXRef-anstyle-5",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-164"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-116"
     },
     {
-      "spdxElementId": "SPDXRef-shlex-86",
+      "spdxElementId": "SPDXRef-shlex-41",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-165"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-117"
+    },
+    {
+      "spdxElementId": "SPDXRef-libdeflater-31",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-118"
     },
     {
       "spdxElementId": "SPDXRef-colorchoice-16",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-166"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-119"
     },
     {
-      "spdxElementId": "SPDXRef-hashbrown-26",
+      "spdxElementId": "SPDXRef-hashbrown-27",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-167"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-120"
     },
     {
       "spdxElementId": "SPDXRef-anstyle-query-7",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-168"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-121"
     },
     {
-      "spdxElementId": "SPDXRef-parse-size-79",
+      "spdxElementId": "SPDXRef-parse-size-34",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-169"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-122"
     },
     {
-      "spdxElementId": "SPDXRef-funty-25",
+      "spdxElementId": "SPDXRef-funty-26",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-170"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-123"
     },
     {
-      "spdxElementId": "SPDXRef-is-terminal-polyfill-28",
+      "spdxElementId": "SPDXRef-is-terminal-polyfill-29",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-171"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-124"
     },
     {
-      "spdxElementId": "SPDXRef-either-20",
+      "spdxElementId": "SPDXRef-env-logger-23",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-172"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-125"
     },
     {
-      "spdxElementId": "SPDXRef-simd-adler32-87",
+      "spdxElementId": "SPDXRef-either-21",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-173"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-126"
     },
     {
-      "spdxElementId": "SPDXRef-tap-89",
+      "spdxElementId": "SPDXRef-simd-adler32-42",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-174"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-127"
+    },
+    {
+      "spdxElementId": "SPDXRef-rgb-38",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-128"
+    },
+    {
+      "spdxElementId": "SPDXRef-tap-44",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-129"
+    },
+    {
+      "spdxElementId": "SPDXRef-env-filter-22",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-130"
     },
     {
       "spdxElementId": "SPDXRef-bumpalo-10",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-175"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-131"
     },
     {
-      "spdxElementId": "SPDXRef-wyz-92",
+      "spdxElementId": "SPDXRef-wyz-47",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-176"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-132"
     },
     {
-      "spdxElementId": "SPDXRef-find-msvc-tools-24",
+      "spdxElementId": "SPDXRef-find-msvc-tools-25",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-177"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-133"
     },
     {
-      "spdxElementId": "SPDXRef-crossbeam-epoch-18",
+      "spdxElementId": "SPDXRef-crossbeam-epoch-19",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File-lib.rs-178"
+      "relatedSpdxElement": "SPDXRef-File-lib.rs-134"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Replace lazygit and oxipng golden files with clean baselines built from pinned tags in a fresh container with treedb cleanup between runs.

### What was wrong

**lazygit** — Golden from PR #149 was contaminated by bomtrace3 treedb leakage. The redis build ran first, and its treedb artifacts leaked 7 C packages (`fast_float`, `fpconv`, `hdr_histogram`, `hiredis`, `jemalloc`, `linenoise`, `lua`) plus 214 redis `.c/.h` CONTAINS relationships into the lazygit SBOM.

**oxipng** — Golden was from a pre-pinned era (built from `master` at version `8.19.0-DEV`). Config now pins `v10.1.0`. Old golden also had 45 `.rlib` intermediate artifacts listed as separate packages.

### What changed

| Repo | Old Pkgs | New Pkgs | Old Rels | New Rels |
|------|----------|----------|----------|----------|
| lazygit (analyzed) | 71 | 64 | 1465 | 1244 |
| lazygit (build) | 74 | 67 | 1468 | 1247 |
| oxipng (analyzed) | 91 | 46 | 176 | 132 |
| oxipng (build) | 94 | 49 | 179 | 135 |

### Verification (May 5 clean runs)

| Repo | Pkgs | Rels | Result |
|------|------|------|--------|
| redis | identical | identical | PASS |
| lazygit | corrected | corrected | PASS (new baseline) |
| dura | identical | identical | PASS |
| oxipng | corrected | corrected | PASS (new baseline) |
| jsoup | identical | identical | PASS |
| checkstyle | identical | identical | PASS |

### Rule updates

- `CRITICAL.md` — Added treedb cleanup rule, strengthened golden file policy
- `golden-file-policy.md` — Rewritten: immutable baselines, pinned repos, treedb cleanup, no exceptions
