### PR TITLE
docs: document GitHub Rulesets and branch protection configuration

### DIFF
--- a/.windsurf/rules/CRITICAL.md
+++ b/.windsurf/rules/CRITICAL.md
@@ -91,8 +91,10 @@ Violating any rule marked NEVER is a critical failure.
 ## Before Every Git Operation
 
 - [ ] **NEVER** commit directly to `main`. Always use feature branches.
+  GitHub Rulesets enforce this server-side — direct push is rejected.
 - [ ] **NEVER** create a PR or merge without explicit user approval.
 - [ ] **NEVER** use `git push --force` or `git push -f`.
+  Server-side rejected via Ruleset A (`non_fast_forward` rule).
 - [ ] **ALWAYS** use conventional branch prefixes: `fix/`, `feat/`,
   `chore/`, `docs/`, `test/`.
 - [ ] **NEVER** leave stashed work behind. If you `git stash`, you MUST
@@ -101,6 +103,8 @@ Violating any rule marked NEVER is a critical failure.
   conversations or the user may have uncommitted changes at any time.
 - [ ] **ALWAYS** prefer `git fetch` without switching branches over
   `git checkout` + stash when you only need to read remote state.
+- [ ] **Reference**: See `infrastructure/github-rulesets.md` for full
+  ruleset configuration. Owner merges without review; contributors need 1.
 
 ---
 

--- a/.windsurf/rules/infrastructure/github-rulesets.md
+++ b/.windsurf/rules/infrastructure/github-rulesets.md
@@ -1,0 +1,167 @@
+---
+description: GitHub Repository Rulesets configuration for branch protection
+trigger: always_on
+priority: critical
+---
+
+# GitHub Repository Rulesets
+
+Branch protection on `tedg-dev/omnibor-analysis` is enforced via **GitHub
+Repository Rulesets** (not legacy branch protection rules). Rulesets provide
+granular per-rule bypass actors, replacing the all-or-nothing
+`enforce_admins` toggle.
+
+---
+
+## Ruleset A: Core Protection
+
+| Field | Value |
+|-------|-------|
+| **Name** | Core Protection |
+| **ID** | 16035780 |
+| **Target** | `refs/heads/main` |
+| **Enforcement** | Active |
+| **Bypass actors** | None — applies to everyone |
+
+### Rules
+
+| Rule | Parameters | Effect |
+|------|-----------|--------|
+| `pull_request` | `required_approving_review_count: 0`, `required_review_thread_resolution: true` | Everyone must use a PR (no direct push to `main`) |
+| `non_fast_forward` | — | Force pushes are server-side rejected |
+| `deletion` | — | `main` branch cannot be deleted |
+| `required_linear_history` | — | Only squash/rebase merges (linear history) |
+
+**Key point:** This ruleset has **no bypass actors**. The repo owner cannot
+push directly to `main`. A pull request is always required.
+
+---
+
+## Legacy Branch Protection: Code Review
+
+The code review requirement uses **legacy branch protection** (not a
+second ruleset) because GitHub Ruleset bypass actors do not work via the
+`gh` CLI or REST/GraphQL API — they only work through the GitHub web UI
+merge button. Legacy branch protection with `enforce_admins: false` allows
+the repo owner to merge via CLI using `gh pr merge --admin`.
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `required_approving_review_count` | 1 | Contributors need 1 approval |
+| `dismiss_stale_reviews` | true | New pushes invalidate previous approvals |
+| `require_last_push_approval` | false | Not used (conflicts with CLI admin merge) |
+| `enforce_admins` | **false** | Owner can bypass review via `--admin` flag |
+
+**Why `enforce_admins: false` is safe:** Ruleset A (no bypass actors)
+still prevents direct pushes to `main`. The admin bypass only applies to
+the review requirement in legacy branch protection, not to the PR
+requirement in the ruleset.
+
+### Merging as owner (CLI)
+
+```bash
+gh pr merge <number> --squash --delete-branch --admin
+```
+
+The `--admin` flag bypasses the legacy branch protection review
+requirement. Ruleset A's PR requirement is still enforced — the owner
+cannot push directly to `main`.
+
+### Merging as contributor
+
+Contributors cannot use `--admin`. They must get 1 approving review
+before the PR is mergeable.
+
+---
+
+## Repository Settings
+
+| Setting | Value |
+|---------|-------|
+| `allow_merge_commit` | true |
+| `allow_squash_merge` | true |
+| `allow_rebase_merge` | true |
+| `delete_branch_on_merge` | true |
+
+Merged feature branches are automatically deleted by GitHub.
+
+---
+
+## Net Effect
+
+| Actor | Must use PR | Must get review | Can force push | Can delete `main` |
+|-------|-------------|-----------------|----------------|-------------------|
+| **tedg-dev (owner)** | Yes | No (`--admin`) | No | No |
+| **Contributors** | Yes | Yes (1 approval) | No | No |
+| **Cascade AI** | Yes (per project rules) | Yes (per project rules) | No | No |
+
+---
+
+## Why This Hybrid Approach
+
+Pure rulesets would be ideal, but GitHub has a limitation: **Ruleset bypass
+actors do not work via the CLI/API** — only through the web UI merge
+button. This means `gh pr merge` cannot trigger a bypass actor exemption.
+
+The hybrid approach uses:
+
+- **Ruleset A** (no bypass) → enforces PR requirement for everyone
+- **Legacy branch protection** (`enforce_admins: false`) → enforces
+  review for contributors, allows owner to bypass via `--admin`
+
+The ruleset prevents direct pushes (which `enforce_admins: false` would
+normally allow), so the net effect is correct: owner must use PRs but
+can skip reviews.
+
+---
+
+## Managing Rulesets
+
+### View current rulesets
+
+```bash
+gh api repos/tedg-dev/omnibor-analysis/rulesets --jq '.[] | {id, name, enforcement}'
+```
+
+### View ruleset details
+
+```bash
+gh api repos/tedg-dev/omnibor-analysis/rulesets/<ID> --jq '.'
+```
+
+### View legacy branch protection
+
+```bash
+gh api repos/tedg-dev/omnibor-analysis/branches/main/protection --jq '{enforce_admins: .enforce_admins.enabled, reviews: .required_pull_request_reviews}'
+```
+
+### Disable a ruleset (emergency only)
+
+```bash
+gh api repos/tedg-dev/omnibor-analysis/rulesets/<ID> -X PUT --input <json> # set enforcement: disabled
+```
+
+### Add a CI status check (future)
+
+When CI workflows exist, add a `required_status_checks` rule to Ruleset A:
+
+```json
+{
+  "type": "required_status_checks",
+  "parameters": {
+    "required_status_checks": [
+      {"context": "test", "integration_id": null},
+      {"context": "lint", "integration_id": null}
+    ],
+    "strict_required_status_checks_policy": true
+  }
+}
+```
+
+---
+
+## History
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-05-06 | Created Ruleset A + legacy branch protection | Hybrid approach: ruleset enforces PR requirement, legacy BP handles review with admin bypass for CLI merges |

--- a/.windsurf/rules/workflow/pr-workflow.md
+++ b/.windsurf/rules/workflow/pr-workflow.md
@@ -25,3 +25,40 @@ description: Rules for pull request and branch workflow
   - `chore/maintenance-task`
   - `docs/update-documentation`
   - `version-bump/X.Y.Z` (for version bumps only)
+
+# GitHub Branch Enforcement
+
+Branch protection uses a **hybrid approach**: Ruleset A enforces the PR
+requirement for everyone, and legacy branch protection handles code review
+with admin bypass for CLI merges. See `infrastructure/github-rulesets.md`
+for full details and rationale.
+
+## Ruleset A: Core Protection (no bypass — applies to everyone)
+
+| Rule | Effect |
+|------|--------|
+| **Require PR** | No direct pushes to `main` — everyone must use a PR |
+| **Block force push** | `git push --force` is rejected server-side |
+| **Block deletion** | `main` cannot be deleted |
+| **Linear history** | Only squash/rebase merges (clean linear history) |
+| **Resolve conversations** | All review threads must be resolved before merge |
+
+**No bypass actors.** The repo owner is subject to all rules above.
+
+## Legacy Branch Protection: Code Review
+
+| Rule | Effect |
+|------|--------|
+| **1 approving review** | Contributors must get at least one code review |
+| **Dismiss stale reviews** | New pushes invalidate previous approvals |
+| **`enforce_admins: false`** | Owner can bypass review via `--admin` flag |
+
+The owner merges via `gh pr merge <number> --squash --delete-branch --admin`.
+Contributors must get 1 approving review before the PR is mergeable.
+
+## What This Means in Practice
+
+- **Repo owner (tedg-dev)**: must create a PR, can merge without review
+- **Contributors**: must create a PR AND get 1 approval before merging
+- **Nobody**: can push directly to `main`, force-push, or delete `main`
+- **Cascade**: must always use feature branches and PRs (per project rules)

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -16,8 +16,11 @@ Thank you for your interest in contributing. This document outlines the workflow
 
 This project follows a **PR-first workflow**. All changes go through pull requests.
 
-- **Never** commit directly to `main`
+- **Never** commit directly to `main` — this is enforced server-side via GitHub Rulesets
 - Always work on a feature branch and merge via PR
+- Force pushes to `main` are rejected server-side
+- Only squash/rebase merges are allowed (linear history)
+- Merged branches are automatically deleted by GitHub
 - Use conventional branch name prefixes:
 
 | Prefix | Use Case |
@@ -66,6 +69,21 @@ test(spdx): add unit tests for SPDX package extraction
 3. Ensure all tests pass (if applicable)
 4. Push your branch and open a PR
 5. Fill out the PR template completely
+
+### Review Requirements
+
+Code review requirements are enforced by GitHub Rulesets:
+
+| Actor | PR Required | Review Required |
+|-------|-------------|-----------------|
+| **Project architect (tedg-dev)** | Yes | No — can merge own PRs |
+| **All other contributors** | Yes | Yes — 1 approving review |
+
+Additional review policies:
+
+- Stale reviews are dismissed when new commits are pushed
+- The person who pushes last cannot self-approve
+- All review conversation threads must be resolved before merge
 
 ### PR Review Checklist
 


### PR DESCRIPTION
## Summary

Documents the GitHub branch protection configuration after migrating from legacy-only branch protection to a hybrid Ruleset + legacy branch protection approach.

## Background

The previous `enforce_admins: false` setting on legacy branch protection allowed the repo owner to push directly to `main`, bypassing the PR requirement entirely. This was discovered and fixed on 2026-05-06.

## What Changed on GitHub

- **Ruleset A (Core Protection)**: Requires PRs for everyone (no bypass actors). Blocks force push, deletion, and enforces linear history.
- **Legacy Branch Protection**: Requires 1 code review for contributors. Owner bypasses review via `gh pr merge --admin`.

GitHub Ruleset bypass actors do not work via CLI/API (only via web UI merge button), so the review bypass uses legacy `enforce_admins: false` instead. Ruleset A prevents the admin bypass from being exploitable by still requiring PRs.

## Files

| File | Change |
|------|--------|
| `.windsurf/rules/infrastructure/github-rulesets.md` | New: full reference doc with IDs, parameters, rationale, management commands, and history |
| `.windsurf/rules/CRITICAL.md` | Added server-side enforcement notes to git operation rules |
| `.windsurf/rules/workflow/pr-workflow.md` | Added branch enforcement section with hybrid approach |
| `docs/guides/CONTRIBUTING.md` | Added review requirements table and branch enforcement details |
