### PR TITLE
fix: resolve tracer unknown in docs and module-info.class leak

### DIFF
--- a/app/pipeline/interception.py
+++ b/app/pipeline/interception.py
@@ -28,6 +28,15 @@ class InterceptionStrategy(ABC):
     selects a strategy based on ``config.yaml`` settings.
     """
 
+    @property
+    @abstractmethod
+    def name(self):
+        """Human-readable instrumentation method name.
+
+        Used in build docs and runtime reports to
+        identify the interception technique.
+        """
+
     @abstractmethod
     def instrument_command(self, build_cmd, repo_dir):
         """Modify a build command for OmniBOR tracing.
@@ -71,6 +80,11 @@ class PtraceStrategy(InterceptionStrategy):
 
     def __init__(self, tracer="bomtrace3"):
         self._tracer = tracer
+
+    @property
+    def name(self):
+        """Return the tracer binary name."""
+        return self._tracer
 
     def instrument_command(self, build_cmd, repo_dir):
         """Prepend the tracer to the build command.
@@ -122,6 +136,11 @@ class CcWrapperStrategy(InterceptionStrategy):
     def __init__(self, wrapper_dir="/opt/bomsh/bin"):
         self._wrapper_dir = wrapper_dir
 
+    @property
+    def name(self):
+        """Return the instrumentation method."""
+        return "cc-wrapper"
+
     def instrument_command(self, build_cmd, repo_dir):
         """Return the build command with CC/CXX wrappers.
 
@@ -161,6 +180,11 @@ class GoToolexecStrategy(InterceptionStrategy):
     ):
         self._wrapper = wrapper
 
+    @property
+    def name(self):
+        """Return the instrumentation method."""
+        return "go-toolexec"
+
     def instrument_command(self, build_cmd, repo_dir):
         """Insert ``-toolexec`` into the go build command.
 
@@ -196,6 +220,11 @@ class RustcWrapperStrategy(InterceptionStrategy):
         self, wrapper="/opt/bomsh/bin/bomsh_hook.sh",
     ):
         self._wrapper = wrapper
+
+    @property
+    def name(self):
+        """Return the instrumentation method."""
+        return "rustc-wrapper"
 
     def instrument_command(self, build_cmd, repo_dir):
         """Set ``RUSTC_WRAPPER`` for cargo build.
@@ -237,6 +266,11 @@ class MavenDepTreeStrategy(InterceptionStrategy):
     def __init__(self, runner=None):
         from app.runner import CommandRunner
         self._runner = runner or CommandRunner()
+
+    @property
+    def name(self):
+        """Return the instrumentation method."""
+        return "maven-dep-tree"
 
     def instrument_command(self, build_cmd, repo_dir):
         """Return the build command unmodified — no strace.
@@ -348,6 +382,11 @@ class GradleDepTreeStrategy(InterceptionStrategy):
     def __init__(self, runner=None):
         from app.runner import CommandRunner
         self._runner = runner or CommandRunner()
+
+    @property
+    def name(self):
+        """Return the instrumentation method."""
+        return "gradle-dep-tree"
 
     def instrument_command(self, build_cmd, repo_dir):
         """Return the build command unmodified — no strace.

--- a/app/pipeline/lang_runners.py
+++ b/app/pipeline/lang_runners.py
@@ -26,8 +26,10 @@ def run_c_cpp_pipeline(
     OmniBOR SPDX, metadata, ADG SPDX, validation,
     binary collection.
 
-    Returns (success, duration_sec).
+    Returns (success, duration_sec, tracer_name).
     """
+    tracer = omnibor_cfg.get("tracer", "bomtrace3")
+
     # Step 3: Validate apt dependencies
     deps_ok, missing = (
         pipeline.validator.validate(repo_cfg)
@@ -89,7 +91,7 @@ def run_c_cpp_pipeline(
             run_ts=run_ts,
         )
 
-    return success, duration
+    return success, duration, tracer
 
 
 # ============================================================
@@ -113,8 +115,12 @@ def run_rust_pipeline(
     See: https://github.com/omnibor/bomsh
     #software-vulnerability-cve-search-for-rust-packages
 
-    Returns (success, duration_sec).
+    Returns (success, duration_sec, tracer_name).
     """
+    tracer = omnibor_rust_cfg.get(
+        "tracer", "bomtrace2",
+    )
+
     # Step 4: Instrumented build (bomtrace2)
     start = time.time()
     success = pipeline.builder.build(
@@ -163,7 +169,7 @@ def run_rust_pipeline(
             run_ts=run_ts,
         )
 
-    return success, duration
+    return success, duration, tracer
 
 
 # ============================================================
@@ -212,7 +218,7 @@ def run_java_pipeline(
     In standalone mode (default): strace + bomsh_create_bom_java.py.
     In sidecar mode: dep:tree strategy (no strace needed).
 
-    Returns (success, duration_sec).
+    Returns (success, duration_sec, tracer_name).
     """
     strategy = _select_java_strategy(
         repo_name, repo_cfg, paths_cfg, mode,
@@ -275,7 +281,8 @@ def run_java_pipeline(
             run_ts=run_ts,
         )
 
-    return success, duration
+    tracer = strategy.name if strategy else "strace"
+    return success, duration, tracer
 
 
 def generate_java_adg_spdx(
@@ -475,8 +482,12 @@ def run_go_pipeline(
     See: https://github.com/omnibor/bomsh
     #software-vulnerability-cve-search-for-golang-packages
 
-    Returns (success, duration_sec).
+    Returns (success, duration_sec, tracer_name).
     """
+    tracer = omnibor_go_cfg.get(
+        "tracer", "bomtrace2",
+    )
+
     # Step 4: Instrumented build (bomtrace2)
     start = time.time()
     success = pipeline.builder.build(
@@ -525,4 +536,4 @@ def run_go_pipeline(
             run_ts=run_ts,
         )
 
-    return success, duration
+    return success, duration, tracer

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -174,29 +174,30 @@ def main():
 
     # -------------------------------------------------
     # Language-specific pipeline branch
+    # Each returns (success, duration, tracer_name).
     # -------------------------------------------------
     if lang == "c-cpp":
-        success, duration = run_c_cpp_pipeline(
+        success, duration, tracer = run_c_cpp_pipeline(
             pipeline, args.repo, repo_cfg,
             paths_cfg, omnibor_cfg, run_ts,
             vcs_uri=vcs_uri,
         )
     elif lang == "rust":
-        success, duration = run_rust_pipeline(
+        success, duration, tracer = run_rust_pipeline(
             pipeline, args.repo, repo_cfg,
             paths_cfg, omnibor_cfg, run_ts,
             vcs_uri=vcs_uri,
         )
     elif lang == "java":
         mode = config.get("mode", DEFAULT_MODE)
-        success, duration = run_java_pipeline(
+        success, duration, tracer = run_java_pipeline(
             pipeline, args.repo, repo_cfg,
             paths_cfg, omnibor_cfg, run_ts,
             vcs_uri=vcs_uri,
             mode=mode,
         )
     else:
-        success, duration = run_go_pipeline(
+        success, duration, tracer = run_go_pipeline(
             pipeline, args.repo, repo_cfg,
             paths_cfg, omnibor_cfg, run_ts,
             vcs_uri=vcs_uri,
@@ -210,7 +211,6 @@ def main():
         )
 
     # Step 8: Write docs (all languages)
-    tracer = omnibor_cfg.get("tracer")
     raw_logfile = omnibor_cfg.get("raw_logfile")
     pipeline.docs.write_build_doc(
         args.repo, repo_cfg, paths_cfg,

--- a/app/spdx/java_generator.py
+++ b/app/spdx/java_generator.py
@@ -30,6 +30,7 @@ from app.spdx.gradle_parser import (
     is_gradle_project,
 )
 from app.spdx.relationships import (
+    BUILD_TOOL_OF,
     CONTAINED_BY,
     DESCRIBES,
     java_dep_relationship,
@@ -561,21 +562,33 @@ class JavaSpdxGenerator:
                 else:
                     target = root_pkg_id
 
-            # SPDX 2.3 Table 68: compile, runtime,
-            # and provided scopes all map to DEPENDS_ON.
-            # BUILD_TOOL_OF is reserved for the build
-            # system itself (javac, maven, gradle).
+            # Classify relationship type based on scope
+            # and groupId.  Known build tools (ant, maven
+            # plugins, etc.) get BUILD_TOOL_OF; others
+            # get scope-based type (DEPENDS_ON, etc.).
             # Scope metadata is in the package comment.
             rel_type = java_dep_relationship(
                 dep.get("scope", "compile"),
+                group_id=dep.get("groupId"),
             )
             if rel_type is None:
                 continue
-            doc["relationships"].append({
-                "spdxElementId": target,
-                "relatedSpdxElement": dep_id,
-                "relationshipType": rel_type,
-            })
+
+            # Relationship direction differs by type:
+            #   BUILD_TOOL_OF: tool → target
+            #   DEPENDS_ON:    parent → child
+            if rel_type == BUILD_TOOL_OF:
+                doc["relationships"].append({
+                    "spdxElementId": dep_id,
+                    "relatedSpdxElement": target,
+                    "relationshipType": rel_type,
+                })
+            else:
+                doc["relationships"].append({
+                    "spdxElementId": target,
+                    "relatedSpdxElement": dep_id,
+                    "relationshipType": rel_type,
+                })
 
         return doc
 

--- a/app/spdx/java_generator.py
+++ b/app/spdx/java_generator.py
@@ -224,6 +224,9 @@ class JavaSpdxGenerator:
             if not self._is_test_file(
                 f.get("file_path", "")
             )
+            and not self._is_extraction_artifact(
+                f.get("file_path", "")
+            )
         ]
         test_files_excluded = (
             len(all_files) - len(source_files)
@@ -599,6 +602,22 @@ class JavaSpdxGenerator:
         name = version_pattern.sub("", name)
 
         return name
+
+    @staticmethod
+    def _is_extraction_artifact(file_path):
+        """Return True if path is a bomsh extraction artifact.
+
+        ``bomsh_create_bom_java.py`` extracts JARs into
+        ``/tmp/bomjdir/`` for introspection.  These paths
+        appear in the treedb but are not project source
+        files — they are intermediate extraction artifacts
+        (e.g. ``.class`` files from multi-release JARs).
+
+        In standalone mode the strace ``openat`` filter
+        already excludes them.  This filter ensures
+        sidecar mode is consistent.
+        """
+        return "/tmp/bomjdir/" in file_path
 
     @staticmethod
     def _is_test_file(file_path):

--- a/app/spdx/parser.py
+++ b/app/spdx/parser.py
@@ -110,7 +110,11 @@ class AdgParser:
                     "project_source"
                 ].append(item)
             else:
-                # Other system files (incl. /tmp/go-build)
+                # Catch-all: anything not positively matched
+                # above (e.g. /tmp/ build intermediates,
+                # /opt/ tool files).  Allowlist above is the
+                # security boundary — nothing reaches
+                # project_source without a prefix match.
                 classified["system_header"].append(
                     item
                 )
@@ -179,10 +183,15 @@ class AdgParser:
                             ),
                         })
 
-                # Also include the class file itself
+                # Also include the class file itself,
+                # but skip bomsh extraction artifacts
+                # (/tmp/bomjdir/) — these are intermediate
+                # paths from JAR introspection, not
+                # project source files.
                 if (
                     cls_path
                     and class_sha not in seen
+                    and "/tmp/bomjdir/" not in cls_path
                 ):
                     seen.add(class_sha)
                     sources.append({

--- a/app/spdx/relationships.py
+++ b/app/spdx/relationships.py
@@ -9,23 +9,26 @@ https://spdx.github.io/spdx-spec/v2.3/relationships-between-SPDX-elements/
 Key spec guidance (Table 68 examples):
   - compile scope      → DEPENDS_ON
   - runtime scope      → DEPENDS_ON
-  - provided scope     → DEPENDS_ON  (NOT BUILD_TOOL_OF)
+  - provided scope     → DEPENDS_ON (unless build tool)
   - test scope         → TEST_DEPENDENCY_OF
   - devDependencies    → DEV_DEPENDENCY_OF
   - optional           → OPTIONAL_DEPENDENCY_OF
   - compiler / linker  → BUILD_TOOL_OF
   - makefile           → BUILD_TOOL_OF
+  - build tool dep     → BUILD_TOOL_OF
 
-BUILD_TOOL_OF is reserved for the *build system itself*
-(gcc, go, javac, maven, gradle, make) — packages that
-compile/link the software. It is NOT for library
-dependencies in Maven ``provided`` scope.
+BUILD_TOOL_OF applies to packages that compile, link, or
+package the software — gcc, go, javac, maven, gradle,
+make, ant, etc.  When a Maven/Gradle dependency has a
+groupId in ``BUILD_TOOL_GROUP_IDS``, it gets
+BUILD_TOOL_OF regardless of its declared scope.
 
 Maven ``provided`` means "the dependency is required at
 compile time but supplied by the deployment environment
-at runtime".  In SPDX terms this is still DEPENDS_ON;
-the scope is recorded in the package comment field.
-SPDX 3.0 formalises this as ``hasProvidedDependency``.
+at runtime".  For regular libraries this maps to
+DEPENDS_ON; for recognized build tools (e.g. ant) it
+maps to BUILD_TOOL_OF.  Scope is always recorded in the
+package comment field.
 """
 
 # -----------------------------------------------------------
@@ -67,11 +70,14 @@ _JAVA_SCOPE_MAP = {
 _JAVA_EXCLUDED_SCOPES = frozenset({"test"})
 
 
-def java_dep_relationship(scope):
+def java_dep_relationship(scope, group_id=None):
     """Return the SPDX relationship type for a Java dependency.
 
     Args:
         scope: Maven or Gradle dependency scope string.
+        group_id: Maven groupId (optional).  When the
+            groupId matches a known build tool, returns
+            BUILD_TOOL_OF instead of the scope default.
 
     Returns:
         The SPDX 2.3 relationship type string, or *None*
@@ -79,6 +85,8 @@ def java_dep_relationship(scope):
     """
     if scope in _JAVA_EXCLUDED_SCOPES:
         return None
+    if is_build_tool(group_id=group_id):
+        return BUILD_TOOL_OF
     return _JAVA_SCOPE_MAP.get(scope, DEPENDS_ON)
 
 
@@ -86,9 +94,9 @@ def java_dep_relationship(scope):
 # Build-tool classification
 # -----------------------------------------------------------
 # These groupIds identify *build tools* — software used to
-# compile, link, or package the project.  If we ever extract
-# Maven/Gradle plugins as SPDX packages, they should use
-# BUILD_TOOL_OF rather than DEPENDS_ON.
+# compile, link, or package the project.  Dependencies
+# with these groupIds get BUILD_TOOL_OF regardless of
+# their declared Maven/Gradle scope.
 BUILD_TOOL_GROUP_IDS = frozenset({
     # Java build systems
     "org.apache.maven",
@@ -97,6 +105,8 @@ BUILD_TOOL_GROUP_IDS = frozenset({
     "org.gradle",
     # Compilers / code generators
     "org.apache.maven.plugin-tools",
+    # Apache Ant
+    "org.apache.ant",
 })
 
 # Binary names that are build tools (C/C++/Go)

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -3032,13 +3032,14 @@ class TestRunGoPipeline(unittest.TestCase):
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, duration = _run_go_pipeline(
+            success, duration, tracer = _run_go_pipeline(
                 p, "fzf", repo_cfg,
                 paths_cfg, self.GO_OMNIBOR_CFG,
                 "2026-03-04_1200",
             )
 
         self.assertTrue(success)
+        self.assertIn("bomtrace2", tracer)
         p.builder.build.assert_called_once_with(
             "fzf", repo_cfg,
             paths_cfg, self.GO_OMNIBOR_CFG,
@@ -3074,7 +3075,7 @@ class TestRunGoPipeline(unittest.TestCase):
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, _ = _run_go_pipeline(
+            success, _, _ = _run_go_pipeline(
                 p, "fzf", repo_cfg,
                 paths_cfg, self.GO_OMNIBOR_CFG,
                 "2026-03-04_1200",
@@ -3143,13 +3144,14 @@ class TestRunRustPipeline(unittest.TestCase):
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, duration = _run_rust_pipeline(
+            success, duration, tracer = _run_rust_pipeline(
                 p, "oxipng", repo_cfg,
                 paths_cfg, self.RUST_OMNIBOR_CFG,
                 "2026-03-05_1200",
             )
 
         self.assertTrue(success)
+        self.assertEqual(tracer, "bomtrace2")
         p.builder.build.assert_called_once_with(
             "oxipng", repo_cfg,
             paths_cfg, self.RUST_OMNIBOR_CFG,
@@ -3183,7 +3185,7 @@ class TestRunRustPipeline(unittest.TestCase):
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, _ = _run_rust_pipeline(
+            success, _, _ = _run_rust_pipeline(
                 p, "oxipng", repo_cfg,
                 paths_cfg, self.RUST_OMNIBOR_CFG,
                 "2026-03-05_1200",

--- a/tests/test_interception.py
+++ b/tests/test_interception.py
@@ -16,6 +16,8 @@ from app.pipeline.interception import (
     CcWrapperStrategy,
     GoToolexecStrategy,
     RustcWrapperStrategy,
+    MavenDepTreeStrategy,
+    GradleDepTreeStrategy,
 )
 
 
@@ -25,6 +27,14 @@ from app.pipeline.interception import (
 
 class TestPtraceStrategy(unittest.TestCase):
     """Tests for PtraceStrategy."""
+
+    def test_name_default(self):
+        s = PtraceStrategy()
+        self.assertEqual(s.name, "bomtrace3")
+
+    def test_name_custom_tracer(self):
+        s = PtraceStrategy(tracer="bomtrace2")
+        self.assertEqual(s.name, "bomtrace2")
 
     def test_default_tracer(self):
         s = PtraceStrategy()
@@ -120,6 +130,10 @@ class TestPtraceStrategy(unittest.TestCase):
 class TestCcWrapperStrategy(unittest.TestCase):
     """Tests for CcWrapperStrategy."""
 
+    def test_name(self):
+        s = CcWrapperStrategy()
+        self.assertEqual(s.name, "cc-wrapper")
+
     def test_default_wrappers(self):
         s = CcWrapperStrategy()
         cmd, env = s.instrument_command(
@@ -154,6 +168,10 @@ class TestCcWrapperStrategy(unittest.TestCase):
 
 class TestGoToolexecStrategy(unittest.TestCase):
     """Tests for GoToolexecStrategy."""
+
+    def test_name(self):
+        s = GoToolexecStrategy()
+        self.assertEqual(s.name, "go-toolexec")
 
     def test_default_wrapper(self):
         s = GoToolexecStrategy()
@@ -199,6 +217,10 @@ class TestGoToolexecStrategy(unittest.TestCase):
 class TestRustcWrapperStrategy(unittest.TestCase):
     """Tests for RustcWrapperStrategy."""
 
+    def test_name(self):
+        s = RustcWrapperStrategy()
+        self.assertEqual(s.name, "rustc-wrapper")
+
     def test_default_wrapper(self):
         s = RustcWrapperStrategy()
         cmd, env = s.instrument_command(
@@ -230,6 +252,48 @@ class TestRustcWrapperStrategy(unittest.TestCase):
         self.assertEqual(
             cmd, "cargo build --release",
         )
+
+
+# ============================================================
+# MavenDepTreeStrategy
+# ============================================================
+
+class TestMavenDepTreeStrategy(unittest.TestCase):
+    """Tests for MavenDepTreeStrategy."""
+
+    def test_name(self):
+        s = MavenDepTreeStrategy(runner=MagicMock())
+        self.assertEqual(s.name, "maven-dep-tree")
+
+    def test_command_passthrough(self):
+        s = MavenDepTreeStrategy(runner=MagicMock())
+        cmd, env = s.instrument_command(
+            "mvn package -DskipTests", "/repo",
+        )
+        self.assertEqual(
+            cmd, "mvn package -DskipTests",
+        )
+        self.assertEqual(env, {})
+
+
+# ============================================================
+# GradleDepTreeStrategy
+# ============================================================
+
+class TestGradleDepTreeStrategy(unittest.TestCase):
+    """Tests for GradleDepTreeStrategy."""
+
+    def test_name(self):
+        s = GradleDepTreeStrategy(runner=MagicMock())
+        self.assertEqual(s.name, "gradle-dep-tree")
+
+    def test_command_passthrough(self):
+        s = GradleDepTreeStrategy(runner=MagicMock())
+        cmd, env = s.instrument_command(
+            "./gradlew build", "/repo",
+        )
+        self.assertEqual(cmd, "./gradlew build")
+        self.assertEqual(env, {})
 
 
 # ============================================================

--- a/tests/test_java_generator.py
+++ b/tests/test_java_generator.py
@@ -1533,5 +1533,40 @@ class TestStraceFiltering(unittest.TestCase):
             self.assertEqual(len(doc["files"]), 2)
 
 
+class TestIsExtractionArtifact(unittest.TestCase):
+    """Tests for _is_extraction_artifact filter."""
+
+    def test_bomjdir_path_is_artifact(self):
+        self.assertTrue(
+            JavaSpdxGenerator._is_extraction_artifact(
+                "/tmp/bomjdir/jsoup-1.22.1.jar/"
+                "META-INF/versions/11/"
+                "module-info.class"
+            )
+        )
+
+    def test_bomjdir_nested_path(self):
+        self.assertTrue(
+            JavaSpdxGenerator._is_extraction_artifact(
+                "/tmp/bomjdir/foo.jar/Bar.class"
+            )
+        )
+
+    def test_repo_source_not_artifact(self):
+        self.assertFalse(
+            JavaSpdxGenerator._is_extraction_artifact(
+                "/workspace/repos/jsoup/"
+                "src/main/java/org/jsoup/Jsoup.java"
+            )
+        )
+
+    def test_empty_string(self):
+        self.assertFalse(
+            JavaSpdxGenerator._is_extraction_artifact(
+                ""
+            )
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_java_pipeline.py
+++ b/tests/test_java_pipeline.py
@@ -64,12 +64,13 @@ class TestRunJavaPipeline(unittest.TestCase):
             )
             pipeline = self._make_pipeline()
 
-            success, _dur = _run_java_pipeline(
+            success, _dur, tracer = _run_java_pipeline(
                 pipeline, "myapp", repo_cfg,
                 paths, java_cfg, "ts1",
             )
 
             self.assertTrue(success)
+            self.assertEqual(tracer, "strace")
             pipeline.builder.build_java.assert_called_once()
             pipeline.spdx_gen.generate_java.assert_called_once()
             pipeline.metadata_collector.collect.assert_called_once()
@@ -93,7 +94,7 @@ class TestRunJavaPipeline(unittest.TestCase):
             pipeline = self._make_pipeline()
             pipeline.builder.build_java.return_value = False
 
-            success, _dur = _run_java_pipeline(
+            success, _dur, _ = _run_java_pipeline(
                 pipeline, "myapp", repo_cfg,
                 paths, java_cfg, "ts1",
             )
@@ -117,7 +118,7 @@ class TestRunJavaPipeline(unittest.TestCase):
                 None
             )
 
-            success, _dur = _run_java_pipeline(
+            success, _dur, _ = _run_java_pipeline(
                 pipeline, "myapp", repo_cfg,
                 paths, java_cfg, "ts1",
             )
@@ -508,7 +509,7 @@ class TestMainJavaDispatch(unittest.TestCase):
         }
         mock_pipe_inst = MagicMock()
         mock_pipe.return_value = mock_pipe_inst
-        mock_java.return_value = (True, 10.0)
+        mock_java.return_value = (True, 10.0, "strace")
 
         from app.pipeline.runners import main
         with patch(
@@ -553,7 +554,7 @@ class TestMainJavaDispatch(unittest.TestCase):
         }
         mock_pipe_inst = MagicMock()
         mock_pipe.return_value = mock_pipe_inst
-        mock_rust.return_value = (True, 10.0)
+        mock_rust.return_value = (True, 10.0, "bomtrace2")
 
         from app.pipeline.runners import main
         with patch(

--- a/tests/test_java_pipeline_wire.py
+++ b/tests/test_java_pipeline_wire.py
@@ -132,13 +132,14 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     def test_standalone_uses_build_java(self, _):
         pipeline = self._setup()
         with patch("builtins.print"):
-            success, dur = run_java_pipeline(
+            success, dur, tracer = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
                 mode="standalone",
             )
         self.assertTrue(success)
+        self.assertEqual(tracer, "strace")
         pipeline.builder.build_java\
             .assert_called_once()
         pipeline.builder.build\
@@ -159,13 +160,14 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     ):
         pipeline = self._setup()
         with patch("builtins.print"):
-            success, dur = run_java_pipeline(
+            success, dur, tracer = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
                 mode="sidecar",
             )
         self.assertTrue(success)
+        self.assertEqual(tracer, "maven-dep-tree")
         pipeline.builder.build\
             .assert_called_once()
         # Verify strategy was passed
@@ -186,11 +188,12 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     def test_default_mode_is_standalone(self, _):
         pipeline = self._setup()
         with patch("builtins.print"):
-            success, dur = run_java_pipeline(
+            success, dur, tracer = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
             )
+        self.assertEqual(tracer, "strace")
         # Default mode=standalone -> build_java
         pipeline.builder.build_java\
             .assert_called_once()

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -47,15 +47,34 @@ class TestJavaDepRelationship:
         """Unknown scopes default to DEPENDS_ON."""
         assert java_dep_relationship("custom") == DEPENDS_ON
 
-    def test_provided_is_not_build_tool_of(self):
-        """Maven 'provided' scope is DEPENDS_ON, not
-        BUILD_TOOL_OF.  'provided' means the dependency
-        is needed at compile/runtime but supplied by the
-        deployment environment — it is still a dependency,
-        not a build tool."""
+    def test_provided_library_is_depends_on(self):
+        """Maven 'provided' for a regular library is
+        DEPENDS_ON — the dependency is needed at compile
+        time but supplied by the deployment environment."""
         result = java_dep_relationship("provided")
         assert result == DEPENDS_ON
-        assert result != BUILD_TOOL_OF
+
+    def test_provided_build_tool_is_build_tool_of(self):
+        """Maven 'provided' for a known build tool gets
+        BUILD_TOOL_OF — scope does not override identity."""
+        result = java_dep_relationship(
+            "provided", group_id="org.apache.ant",
+        )
+        assert result == BUILD_TOOL_OF
+
+    def test_compile_build_tool_is_build_tool_of(self):
+        """Even compile-scope build tools get BUILD_TOOL_OF."""
+        result = java_dep_relationship(
+            "compile", group_id="org.apache.maven",
+        )
+        assert result == BUILD_TOOL_OF
+
+    def test_test_scope_build_tool_excluded(self):
+        """Test-scope deps excluded even if build tool."""
+        result = java_dep_relationship(
+            "test", group_id="org.apache.ant",
+        )
+        assert result is None
 
 
 class TestIsBuildTool:
@@ -71,8 +90,13 @@ class TestIsBuildTool:
         """Known build system groupIds are build tools."""
         assert is_build_tool(group_id=group_id) is True
 
+    def test_ant_is_build_tool(self):
+        """Apache Ant is a build tool."""
+        assert is_build_tool(
+            group_id="org.apache.ant",
+        ) is True
+
     @pytest.mark.parametrize("group_id", [
-        "org.apache.ant",
         "com.google.guava",
         "org.checkerframework",
         "info.picocli",
@@ -80,9 +104,7 @@ class TestIsBuildTool:
     def test_library_group_ids_not_build_tools(
         self, group_id,
     ):
-        """Library dependencies are NOT build tools, even
-        if they are build systems in other contexts (e.g.
-        ant as a provided dep of checkstyle)."""
+        """Library dependencies are NOT build tools."""
         assert is_build_tool(group_id=group_id) is False
 
     @pytest.mark.parametrize("binary", [

--- a/tests/test_spdx_from_adg.py
+++ b/tests/test_spdx_from_adg.py
@@ -451,6 +451,69 @@ class TestAdgParser(unittest.TestCase):
                 sources[0]["file_path"],
             )
 
+    def test_get_jar_source_files_excludes_bomjdir(self):
+        """Extraction artifacts in /tmp/bomjdir/ excluded."""
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "jar_sha": {
+                    "file_path": (
+                        "/repos/myapp/target/app.jar"
+                    ),
+                    "hash_tree": [
+                        "cls_sha", "mi_sha",
+                    ],
+                },
+                "cls_sha": {
+                    "file_path": (
+                        "/repos/myapp/target/"
+                        "classes/App.class"
+                    ),
+                    "hash_tree": ["src_sha"],
+                },
+                "src_sha": {
+                    "file_path": (
+                        "/repos/myapp/src/main/"
+                        "java/App.java"
+                    ),
+                },
+                "mi_sha": {
+                    "file_path": (
+                        "/tmp/bomjdir/app.jar/"
+                        "META-INF/versions/11/"
+                        "module-info.class"
+                    ),
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.get_jar_source_files()
+            sources = result["myapp/target/app.jar"]
+            paths = [
+                s["file_path"] for s in sources
+            ]
+            # Source and class included
+            self.assertTrue(
+                any("App.java" in p for p in paths)
+            )
+            self.assertTrue(
+                any("App.class" in p for p in paths)
+            )
+            # bomjdir artifact excluded
+            self.assertFalse(
+                any("bomjdir" in p for p in paths)
+            )
+            self.assertFalse(
+                any(
+                    "module-info" in p
+                    for p in paths
+                )
+            )
+
     def test_classify_empty_filepath(self):
         """Entries with empty file_path are skipped."""
         with tempfile.TemporaryDirectory() as td:
@@ -511,6 +574,57 @@ class TestAdgParser(unittest.TestCase):
             result = parser.parse()
             self.assertEqual(
                 len(result["system_header"]), 1
+            )
+
+    def test_classify_tmp_never_reaches_project_source(self):
+        """/tmp/ paths land in catch-all, not project_source."""
+        with tempfile.TemporaryDirectory() as td:
+            meta = self._setup_bom_dir(td)
+            treedb = {
+                "lto": {
+                    "file_path": (
+                        "/tmp/cc3RYFEm.ltrans0.o"
+                    ),
+                },
+                "gobuild": {
+                    "file_path": (
+                        "/tmp/go-build123/main.go"
+                    ),
+                },
+                "bomjdir": {
+                    "file_path": (
+                        "/tmp/bomjdir/app.jar/"
+                        "module-info.class"
+                    ),
+                },
+                "real": {
+                    "file_path": "/repos/myapp/main.c",
+                },
+            }
+            (meta / "bomsh_omnibor_treedb").write_text(
+                json.dumps(treedb)
+            )
+            parser = AdgParser(
+                str(Path(td) / "bom"), "/repos"
+            )
+            result = parser.parse()
+            # Only real file in project_source
+            self.assertEqual(
+                len(result["project_source"]), 1
+            )
+            self.assertEqual(
+                result["project_source"][0][
+                    "file_path"
+                ],
+                "/repos/myapp/main.c",
+            )
+            # /tmp/ paths are in catch-all bucket
+            self.assertEqual(
+                len(result["system_header"]), 3
+            )
+            # Zero in build_intermediate
+            self.assertEqual(
+                len(result["build_intermediate"]), 0
             )
 
 


### PR DESCRIPTION
## Summary

Three fixes:

### Bug 1 — Tracer shows "unknown" in build/runtime docs

**Root cause:** Language pipelines returned `(success, duration)` but the generic
runner hardcoded tracer name lookup from config, which failed for sidecar strategies.

**Fix:**
- Add abstract `name` property to `InterceptionStrategy` ABC
- Implement `name` in all 6 concrete strategies
- Update all 4 language pipelines to return `(success, duration, tracer_name)`
- Unpack tracer in `runners.py` and pass to `DocWriter`

### Bug 2 — module-info.class (+1 file) in Java sidecar SPDX

**Root cause:** `bomsh_create_bom_java.py` extracts JARs into `/tmp/bomjdir/` for
introspection. In sidecar mode (no strace), extraction artifacts leaked into SPDX
via `AdgParser.get_jar_source_files()` hash_tree traversal.

**Fix (2 layers):**
- `AdgParser.get_jar_source_files()` — skip `/tmp/bomjdir/` class files at the source
- `JavaSpdxGenerator._is_extraction_artifact()` — defense-in-depth downstream filter

**Other languages not affected:** `AdgParser.parse()` uses an allowlist pattern —
only `repos_dir/`, `/usr/lib`, `/usr/include`, Go stdlib, and Cargo registry paths
positively match. `/tmp/` artifacts fall to catch-all `system_header` bucket.

### Bug 3 — BUILD_TOOL_OF dropped for Java build tools

**Root cause:** PR #74 refactored scope→relationship mapping into `relationships.py`
and changed all scopes (including `provided`) to `DEPENDS_ON`. This silently removed
`BUILD_TOOL_OF` for actual build tools like Apache Ant in checkstyle.

**Fix:**
- `java_dep_relationship()` now accepts `group_id` parameter
- Known build tool groupIds (`org.apache.ant`, `org.apache.maven`, etc.) get
  `BUILD_TOOL_OF` regardless of declared scope
- Added `org.apache.ant` to `BUILD_TOOL_GROUP_IDS`
- Correct relationship direction: `tool --BUILD_TOOL_OF--> target`

**Pending:** Full re-run needed to validate BUILD_TOOL_OF restoration across all
Java repos and update golden files.

## Regression Test Results (Bugs 1 & 2)

All repos rebuilt on EC2, compared against golden files:

| Lang | Repo | Result | Notes |
|------|------|--------|-------|
| Java | **jsoup** | **IDENTICAL** | module-info.class fix confirmed |
| Java | **checkstyle** | **IDENTICAL** | (pre-BUILD_TOOL_OF fix) |
| Go | **lazygit** | **IDENTICAL** | |
| Rust | **dura** | **IDENTICAL** | |
| Rust | **oxipng** | **IDENTICAL** | |
| C/C++ | **curl** | Version drift | apt updates (libssl3, libnghttp2) |
| C/C++ | **redis** | Gitoid only | Binary rebuild hash change |
| C/C++ | **nmap** | Version drift | Unpinned branch: master |
| C/C++ | **ffmpeg** | Version drift | Stale clone on EC2 |

## Tests

- 1207 passed, 15 skipped, 97% coverage
