### PR TITLE
feat(rhel): Java sidecar pipeline on RHEL with golden file comparison

### DIFF
--- a/.windsurf/rules/CRITICAL.md
+++ b/.windsurf/rules/CRITICAL.md
@@ -59,6 +59,16 @@ Violating any rule marked NEVER is a critical failure.
 
 ## Before Every Golden File Comparison
 
+- [ ] **Golden files are PROJECT-WIDE** — one baseline for ALL variants.
+  Every OS (Ubuntu, RHEL, Alpine), every mode (standalone, sidecar),
+  every environment (EC2, local, CI) must be compared against the
+  **same** golden files. There are NO per-OS or per-mode golden files.
+- [ ] **Standalone mode is the AUTHORITATIVE baseline.** Golden files
+  MUST be generated from standalone mode (strace/ptrace on Ubuntu).
+  All other variants (sidecar, RHEL, Alpine) are compared against
+  standalone-generated golden files to verify structural equivalence.
+- [ ] **ALWAYS** compare SPDX output against golden files after every
+  successful run, regardless of OS or mode.
 - [ ] **NEVER** update golden files without explicit user approval.
 - [ ] **NEVER** suggest updating golden files — no reason is valid.
   The user reviews diffs and decides. Period.

--- a/.windsurf/rules/cascade/golden-file-policy.md
+++ b/.windsurf/rules/cascade/golden-file-policy.md
@@ -9,6 +9,29 @@ priority: critical
 Golden SPDX files are **immutable baselines**. They exist solely to detect
 changes caused by our code. They are NOT tracking upstream repos.
 
+## Golden Files Are Project-Wide — One Baseline for ALL Variants
+
+Golden files are the **single source of truth for the entire project**.
+Every execution variant must produce structurally equivalent SPDX output
+when compared against the same golden files:
+
+- **Every OS**: Ubuntu, RHEL (Rocky Linux 9), Alpine 3.19
+- **Every mode**: standalone (strace/ptrace), sidecar (dep:tree)
+- **Every environment**: EC2, local Docker, CI
+
+If a run on any OS or mode produces SPDX that differs from the golden
+file, that is a **regression** that must be investigated and reported.
+There are NO per-OS or per-mode golden files — the golden files are
+OS-agnostic and mode-agnostic.
+
+## Standalone Mode Is the Authoritative Baseline
+
+Golden files MUST be generated from **standalone mode** (strace/ptrace
+on Ubuntu). Standalone is the original, most thorough analysis mode —
+it produces the ground-truth SPDX via build interception. All other
+variants (sidecar, RHEL, Alpine) are then compared against the
+standalone-generated golden files to verify structural equivalence.
+
 ## Absolute Rule: Cascade NEVER Updates Golden Files
 
 No code change, upstream change, bomsh update, or any other reason

--- a/app/pipeline/interception.py
+++ b/app/pipeline/interception.py
@@ -263,9 +263,10 @@ class MavenDepTreeStrategy(InterceptionStrategy):
     pipeline as standalone mode.
     """
 
-    def __init__(self, runner=None):
+    def __init__(self, runner=None, maven_modules=None):
         from app.runner import CommandRunner
         self._runner = runner or CommandRunner()
+        self._maven_modules = maven_modules
 
     @property
     def name(self):
@@ -341,6 +342,7 @@ class MavenDepTreeStrategy(InterceptionStrategy):
         # Step 2: Capture Maven dependency graph
         dot_output = run_maven_dep_tree(
             repo_dir, runner=self._runner,
+            maven_modules=self._maven_modules,
         )
         if dot_output is None:
             return False

--- a/app/pipeline/lang_runners.py
+++ b/app/pipeline/lang_runners.py
@@ -176,6 +176,27 @@ def run_rust_pipeline(
 # Java pipeline
 # ============================================================
 
+def _extract_maven_modules(build_steps):
+    """Extract ``-pl`` value from Maven build steps.
+
+    Scans the build command strings for ``-pl <modules>``
+    to support multi-module projects where dep:tree must
+    target the same module(s) as the build.
+
+    Returns:
+        The modules string (e.g. ``"crawler4j"``) or None.
+    """
+    import shlex
+    for step in (build_steps or []):
+        if not step.startswith("mvn"):
+            continue
+        tokens = shlex.split(step)
+        for i, tok in enumerate(tokens):
+            if tok == "-pl" and i + 1 < len(tokens):
+                return tokens[i + 1]
+    return None
+
+
 def _select_java_strategy(
     repo_name, repo_cfg, paths_cfg, mode,
 ):
@@ -204,7 +225,12 @@ def _select_java_strategy(
     from app.pipeline.interception import (
         MavenDepTreeStrategy,
     )
-    return MavenDepTreeStrategy()
+    maven_modules = _extract_maven_modules(
+        repo_cfg.get("build_steps"),
+    )
+    return MavenDepTreeStrategy(
+        maven_modules=maven_modules,
+    )
 
 
 def run_java_pipeline(

--- a/app/pipeline/maven_dep_tree_parser.py
+++ b/app/pipeline/maven_dep_tree_parser.py
@@ -211,7 +211,9 @@ def classify_scopes(deps):
     return result
 
 
-def run_maven_dep_tree(repo_dir, runner=None):
+def run_maven_dep_tree(
+    repo_dir, runner=None, maven_modules=None,
+):
     """Run ``mvn dependency:tree -DoutputType=dot``.
 
     Args:
@@ -219,6 +221,10 @@ def run_maven_dep_tree(repo_dir, runner=None):
             contain ``pom.xml``).
         runner: Optional ``CommandRunner`` for logging.
             If None, uses subprocess directly.
+        maven_modules: Optional ``-pl`` value for
+            multi-module projects (e.g. ``"crawler4j"``).
+            When set, dep:tree targets only the specified
+            module(s) instead of the entire reactor.
 
     Returns:
         The raw stdout string, or None on failure.
@@ -231,16 +237,26 @@ def run_maven_dep_tree(repo_dir, runner=None):
         )
         return None
 
+    cmd = [
+        "mvn", "dependency:tree",
+        "-DoutputType=dot",
+    ]
+    if maven_modules:
+        cmd.extend(["-pl", maven_modules])
+
+    # runner is accepted for interface consistency
+    # with other pipeline functions but not yet used
+    # for dep:tree (subprocess.run is sufficient).
+    _ = runner
+
     try:
         result = subprocess.run(
-            [
-                "mvn", "dependency:tree",
-                "-DoutputType=dot",
-            ],
+            cmd,
             cwd=str(repo_path),
             capture_output=True,
             text=True,
             timeout=120,
+            check=False,
         )
         if result.returncode != 0:
             print(

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -41,6 +41,12 @@ RUN wget -q "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/ap
        /usr/local/bin/mvn \
     && rm /tmp/maven.tar.gz
 
+# Unblock HTTP Maven repositories (Maven 3.8.1+ blocks HTTP by default).
+# Some repos (e.g. Oracle BerkeleyDB for crawler4j) only serve HTTP.
+# Remove the maven-default-http-blocker mirror entry (same as main Dockerfile).
+RUN sed -i '/<mirror>/,/<\/mirror>/{/maven-default-http-blocker/,/<\/mirror>/d; /<mirror>/d}' \
+    /opt/apache-maven-${MAVEN_VERSION}/conf/settings.xml
+
 # Use python3.11 as default python3
 RUN ln -sf /usr/bin/python3.11 /usr/bin/python3
 

--- a/tests/test_java_pipeline_wire.py
+++ b/tests/test_java_pipeline_wire.py
@@ -9,6 +9,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from app.pipeline.lang_runners import (
+    _extract_maven_modules,
     _select_java_strategy,
     run_java_pipeline,
 )
@@ -67,7 +68,7 @@ class TestSelectJavaStrategy(unittest.TestCase):
         ".is_gradle_project",
         return_value=True,
     )
-    def test_sidecar_gradle(self, mock_is_gradle):
+    def test_sidecar_gradle(self, _mock_is_gradle):
         result = _select_java_strategy(
             "checkstyle", self._repo_cfg(),
             self._paths(), "sidecar",
@@ -132,13 +133,13 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     def test_standalone_uses_build_java(self, _):
         pipeline = self._setup()
         with patch("builtins.print"):
-            success, dur, tracer = run_java_pipeline(
+            ok, _dur, tracer = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
                 mode="standalone",
             )
-        self.assertTrue(success)
+        self.assertTrue(ok)
         self.assertEqual(tracer, "strace")
         pipeline.builder.build_java\
             .assert_called_once()
@@ -160,13 +161,13 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     ):
         pipeline = self._setup()
         with patch("builtins.print"):
-            success, dur, tracer = run_java_pipeline(
+            ok, _dur, tracer = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
                 mode="sidecar",
             )
-        self.assertTrue(success)
+        self.assertTrue(ok)
         self.assertEqual(tracer, "maven-dep-tree")
         pipeline.builder.build\
             .assert_called_once()
@@ -188,7 +189,7 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     def test_default_mode_is_standalone(self, _):
         pipeline = self._setup()
         with patch("builtins.print"):
-            success, dur, tracer = run_java_pipeline(
+            _ok, _dur, tracer = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
@@ -197,6 +198,93 @@ class TestRunJavaPipelineMode(unittest.TestCase):
         # Default mode=standalone -> build_java
         pipeline.builder.build_java\
             .assert_called_once()
+
+
+class TestExtractMavenModules(unittest.TestCase):
+    """Tests for _extract_maven_modules()."""
+
+    def test_no_pl_flag(self):
+        steps = ["mvn package -DskipTests"]
+        self.assertIsNone(
+            _extract_maven_modules(steps),
+        )
+
+    def test_pl_flag(self):
+        steps = [
+            "mvn package -DskipTests -q -pl crawler4j",
+        ]
+        self.assertEqual(
+            _extract_maven_modules(steps),
+            "crawler4j",
+        )
+
+    def test_pl_with_also_make(self):
+        steps = ["mvn package -pl cli -am"]
+        self.assertEqual(
+            _extract_maven_modules(steps),
+            "cli",
+        )
+
+    def test_non_maven_step_ignored(self):
+        steps = [
+            "gradle build",
+            "mvn package -pl core",
+        ]
+        self.assertEqual(
+            _extract_maven_modules(steps),
+            "core",
+        )
+
+    def test_none_build_steps(self):
+        self.assertIsNone(
+            _extract_maven_modules(None),
+        )
+
+    def test_empty_build_steps(self):
+        self.assertIsNone(
+            _extract_maven_modules([]),
+        )
+
+
+class TestSidecarPassesMavenModules(unittest.TestCase):
+    """Verify -pl flows from config to strategy."""
+
+    @patch(
+        "app.spdx.gradle_parser"
+        ".is_gradle_project",
+        return_value=False,
+    )
+    def test_modules_set_on_strategy(self, _):
+        cfg = {
+            "build_steps": [
+                "mvn package -pl crawler4j",
+            ],
+        }
+        paths = {"repos_dir": "/workspace/repos"}
+        strategy = _select_java_strategy(
+            "crawler4j", cfg, paths, "sidecar",
+        )
+        self.assertIsInstance(
+            strategy, MavenDepTreeStrategy,
+        )
+        self.assertEqual(
+            strategy._maven_modules, "crawler4j",
+        )
+
+    @patch(
+        "app.spdx.gradle_parser"
+        ".is_gradle_project",
+        return_value=False,
+    )
+    def test_no_modules_when_absent(self, _):
+        cfg = {"build_steps": ["mvn package"]}
+        paths = {"repos_dir": "/workspace/repos"}
+        strategy = _select_java_strategy(
+            "jsoup", cfg, paths, "sidecar",
+        )
+        self.assertIsNone(
+            strategy._maven_modules,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_java_rhel_integration.py
+++ b/tests/test_java_rhel_integration.py
@@ -24,6 +24,7 @@ Skip in normal test runs::
 import json
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -43,6 +44,7 @@ def _image_exists(tag="omnibor-env:rhel9"):
         result = subprocess.run(
             ["docker", "image", "inspect", tag],
             capture_output=True, timeout=10,
+            check=False,
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, OSError):
@@ -74,13 +76,17 @@ PROJECT_ROOT = Path(__file__).parent.parent
 class TestJavaOnRhel(unittest.TestCase):
     """Integration test: Java sidecar pipeline on RHEL.
 
-    Builds jsoup 1.22.1 using dep:tree strategy inside
+    Builds crawler4j 4.4.0 using dep:tree strategy inside
     the RHEL container (sidecar mode, no SYS_PTRACE).
+    Uses a complex multi-module Maven project with
+    BUILD_TOOL_OF dependencies.
 
     Acceptance criteria (from issue #112):
     - Valid SPDX on RHEL
     - No strace, no SYS_PTRACE, no dpkg in logs
     - PURLs use pkg:rpm/
+    - BUILD_TOOL_OF relationships present
+    - Structurally equivalent to standalone golden files
     """
 
     _output_dir = None
@@ -108,7 +114,7 @@ class TestJavaOnRhel(unittest.TestCase):
             "-w", "/workspace",
             "omnibor-env:rhel9",
             "python3", "/workspace/app/analyze.py",
-            "--repo", "jsoup",
+            "--repo", "crawler4j",
             "--mode", "sidecar",
         ]
         cls._run_result = subprocess.run(
@@ -116,24 +122,33 @@ class TestJavaOnRhel(unittest.TestCase):
             capture_output=True,
             text=True,
             timeout=600,
+            check=False,
         )
 
         # Find the generated SPDX files
         spdx_java_dir = (
             Path(cls._output_dir) / "spdx" / "java"
-            / "jsoup"
+            / "crawler4j"
         )
         cls._build_spdx = None
+        cls._analyzed_spdx = None
         if spdx_java_dir.exists():
             ts_dirs = sorted(spdx_java_dir.iterdir())
             if ts_dirs:
                 ts_dir = ts_dirs[-1]
                 build = (
                     ts_dir
-                    / "jsoup-1.22.1_build.spdx.json"
+                    / "crawler4j-4.4.0_build.spdx.json"
+                )
+                analyzed = (
+                    ts_dir
+                    / "crawler4j-4.4.0_analyzed"
+                    ".spdx.json"
                 )
                 if build.exists():
                     cls._build_spdx = build
+                if analyzed.exists():
+                    cls._analyzed_spdx = analyzed
 
     @classmethod
     def tearDownClass(cls):
@@ -183,8 +198,8 @@ class TestJavaOnRhel(unittest.TestCase):
         """Build SPDX file should be created on RHEL."""
         self.assertIsNotNone(
             self._build_spdx,
-            "jsoup-1.22.1_build.spdx.json not found "
-            f"in output. Pipeline output:\n"
+            "crawler4j-4.4.0_build.spdx.json not "
+            "found in output. Pipeline output:\n"
             f"{self._run_result.stdout[-1000:]}",
         )
 
@@ -193,7 +208,7 @@ class TestJavaOnRhel(unittest.TestCase):
         if not self._build_spdx:
             self.skipTest("Build SPDX not generated")
 
-        with open(self._build_spdx) as f:
+        with open(self._build_spdx, encoding="utf-8") as f:
             doc = json.load(f)
 
         self.assertEqual(
@@ -207,7 +222,7 @@ class TestJavaOnRhel(unittest.TestCase):
         if not self._build_spdx:
             self.skipTest("Build SPDX not generated")
 
-        with open(self._build_spdx) as f:
+        with open(self._build_spdx, encoding="utf-8") as f:
             doc = json.load(f)
 
         pkgs = doc.get("packages", [])
@@ -231,7 +246,7 @@ class TestJavaOnRhel(unittest.TestCase):
         if not self._build_spdx:
             self.skipTest("Build SPDX not generated")
 
-        with open(self._build_spdx) as f:
+        with open(self._build_spdx, encoding="utf-8") as f:
             doc = json.load(f)
 
         for pkg in doc.get("packages", []):
@@ -255,6 +270,95 @@ class TestJavaOnRhel(unittest.TestCase):
             or "MavenDepTreeStrategy" in stdout,
             "Expected dep:tree strategy in pipeline "
             f"output:\n{stdout[-1000:]}",
+        )
+
+    # ── BUILD_TOOL_OF ────────────────────────────────
+
+    def test_build_tool_of_present(self):
+        """Build SPDX should have BUILD_TOOL_OF rels."""
+        if not self._build_spdx:
+            self.skipTest("Build SPDX not generated")
+
+        with open(self._build_spdx, encoding="utf-8") as f:
+            doc = json.load(f)
+
+        bt_rels = [
+            r for r in doc.get("relationships", [])
+            if r["relationshipType"] == "BUILD_TOOL_OF"
+        ]
+        self.assertGreaterEqual(
+            len(bt_rels), 1,
+            "Expected BUILD_TOOL_OF relationships "
+            "in crawler4j build SPDX",
+        )
+
+    # ── Golden file comparison ───────────────────────
+
+    def test_build_spdx_matches_golden(self):
+        """Build SPDX must be structurally equivalent
+        to the standalone-generated golden file."""
+        if not self._build_spdx:
+            self.skipTest("Build SPDX not generated")
+
+        golden = (
+            PROJECT_ROOT / "tests" / "golden"
+            / "spdx" / "java" / "crawler4j"
+            / "crawler4j-4.4.0_build.spdx.json"
+        )
+        if not golden.exists():
+            self.skipTest(
+                f"Golden file not found: {golden}"
+            )
+
+        sys.path.insert(0, str(PROJECT_ROOT))
+        from app.spdx.structural_comparator import (
+            SpdxStructuralComparator,
+        )
+        comparator = SpdxStructuralComparator(
+            tolerance_pct=0,
+        )
+        result = comparator.compare(
+            str(golden), str(self._build_spdx),
+        )
+        self.assertTrue(
+            result.is_equivalent,
+            f"RHEL build SPDX differs from golden:\n"
+            f"{result.summary()}",
+        )
+
+    def test_analyzed_spdx_matches_golden(self):
+        """Analyzed SPDX must be structurally equivalent
+        to the standalone-generated golden file."""
+        if not self._analyzed_spdx:
+            self.skipTest(
+                "Analyzed SPDX not generated"
+            )
+
+        golden = (
+            PROJECT_ROOT / "tests" / "golden"
+            / "spdx" / "java" / "crawler4j"
+            / "crawler4j-4.4.0_analyzed.spdx.json"
+        )
+        if not golden.exists():
+            self.skipTest(
+                f"Golden file not found: {golden}"
+            )
+
+        sys.path.insert(0, str(PROJECT_ROOT))
+        from app.spdx.structural_comparator import (
+            SpdxStructuralComparator,
+        )
+        comparator = SpdxStructuralComparator(
+            tolerance_pct=0,
+        )
+        result = comparator.compare(
+            str(golden),
+            str(self._analyzed_spdx),
+        )
+        self.assertTrue(
+            result.is_equivalent,
+            "RHEL analyzed SPDX differs from "
+            f"golden:\n{result.summary()}",
         )
 
 


### PR DESCRIPTION
## Summary

Complete RHEL Java sidecar integration: run crawler4j on RHEL, compare against standalone Ubuntu golden files, confirm structural equivalence.

## Changes

### Pipeline
- **`maven_dep_tree_parser.py`**: support `-pl` flag for multi-module Maven projects
- **`lang_runners.py`**: `_extract_maven_modules()` extracts `-pl` from build_steps config
- **`interception.py`**: pass `maven_modules` to `MavenDepTreeStrategy`

### Docker
- **`Dockerfile.rhel`**: remove `maven-default-http-blocker` (Maven 3.8.1+ blocks HTTP repos; crawler4j needs Oracle BerkeleyDB via HTTP)

### Tests
- **`test_java_rhel_integration.py`**: switch jsoup→crawler4j, add BUILD_TOOL_OF assertions, add golden file structural comparison (build + analyzed)
- **`test_java_pipeline_wire.py`**: expand coverage for maven_modules flow

### Rules
- **`CRITICAL.md`**: add project-wide golden file and standalone-authoritative baseline rules
- **`golden-file-policy.md`**: add standalone-authoritative and project-wide sections

## EC2 Verification

| Metric | Golden (Ubuntu standalone) | RHEL (sidecar) |
|---|---|---|
| Packages | 25 | 25 |
| BUILD_TOOL_OF | 2 | 2 |
| DEPENDS_ON | 22 | 22 |
| CONTAINED_BY | 110 | 110 |
| Files | 110 | 110 |
| javac version | 21.0.10 | 17.0.19 (expected: RHEL java-17) |

**Structurally identical** — only expected version difference in javac.
