### PR TITLE
chore: add gh issue --body-file rule + github-sync rule

### DIFF
--- a/.windsurf/rules/CRITICAL.md
+++ b/.windsurf/rules/CRITICAL.md
@@ -20,6 +20,9 @@ Violating any rule marked NEVER is a critical failure.
   commands that read stdin. Use temp files instead.
 - [ ] **NEVER** use `gh pr create --body "..."` inline. Write body to
   `/tmp/pr_body.md` and use `--body-file /tmp/pr_body.md`.
+- [ ] **NEVER** use `gh issue create --body "..."` inline or with
+  heredocs. Write body to `/tmp/issue_body.md` and use
+  `--body-file /tmp/issue_body.md`.
 - [ ] **NEVER** run `git commit` without `-m "msg"` or `-F /tmp/msg.txt`.
 - [ ] **NEVER** run `cd` as a command. Use the `Cwd` parameter instead.
 - [ ] **NEVER** exceed **200 characters** per command line. Split into

--- a/.windsurf/rules/github-sync.md
+++ b/.windsurf/rules/github-sync.md
@@ -1,0 +1,34 @@
+# GitHub Issue/Milestone Sync Rule
+
+Any architectural or design change made during implementation MUST be
+reflected in GitHub Issues and/or Milestones immediately.
+
+## When to Update GitHub
+
+- **New pattern established** (e.g., BUILD_TOOL_OF emission) → create
+  issues for applying it to other languages/tracks
+- **Design decision changed** (e.g., removing a heuristic) → update
+  affected issues' descriptions and acceptance criteria
+- **Upstream dependency resolved** → remove `upstream-dep` label,
+  update issue body
+- **Acceptance criteria evolved** (e.g., golden file comparison added)
+  → update issue checklists
+- **Scope expanded** (e.g., multi-module support) → add to issue or
+  create new sub-issue
+- **Blocker removed** → update dependent issues immediately
+
+## What to Update
+
+- Issue descriptions (acceptance criteria, design references)
+- Milestone descriptions (if scope changed)
+- Labels (add/remove `upstream-dep`, `blocker`)
+- Create NEW issues when a pattern established in one language needs
+  replication in others
+- Close issues when work is done — never leave stale open issues
+
+## NEVER
+
+- Make an architectural change without checking if it affects open issues
+- Complete a milestone's work without verifying all issues are current
+- Leave `upstream-dep` or `blocker` labels on resolved dependencies
+- Assume issue descriptions are still accurate — verify before starting


### PR DESCRIPTION
## Changes

1. **CRITICAL.md**: Added `gh issue create --body-file` rule (prevents terminal hang from inline `--body` or heredocs)
2. **github-sync.md**: New rule requiring all architectural/design changes to update GitHub Issues and Milestones immediately
