### PR TITLE
feat: add testapp config + GHCR sidecar publish workflow

### DIFF
--- a/.github/workflows/publish-sidecar.yml
+++ b/.github/workflows/publish-sidecar.yml
@@ -1,0 +1,65 @@
+# Publish OmniBOR sidecar Docker image to GitHub Container Registry
+#
+# Triggered manually or on pushes to main that change the sidecar image.
+# The sidecar image is used by external CI/CD pipelines (e.g.,
+# tedg-dev/omnibor-java-testapp) to generate SPDX SBOMs without
+# SYS_PTRACE.
+
+name: Publish Sidecar Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/Dockerfile"
+      - "app/**"
+      - "requirements.txt"
+      - ".github/workflows/publish-sidecar.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/omnibor-sidecar
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build sidecar image
+        run: |
+          docker build \
+            --target sidecar \
+            -f docker/Dockerfile \
+            -t "$IMAGE_NAME:latest" \
+            -t "$IMAGE_NAME:${{ github.sha }}" \
+            .
+
+      - name: Push to GHCR
+        run: |
+          docker push "$IMAGE_NAME:latest"
+          docker push "$IMAGE_NAME:${{ github.sha }}"
+
+      - name: Summary
+        run: |
+          echo "## Sidecar Image Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`$IMAGE_NAME:latest\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`$IMAGE_NAME:${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -307,6 +307,16 @@ repos:
     description: Bouncy Castle crypto library (Gradle multi-module, building bcprov provider, JDK 21, Java25 MR classes excluded)
     output_binaries:
     - '**/build/libs/*.jar'
+  omnibor-java-testapp:
+    url: https://github.com/tedg-dev/omnibor-java-testapp.git
+    branch: main
+    language: java
+    build_steps:
+    - mvn package -DskipTests -q
+    clean_cmd: mvn clean -q
+    description: CI/CD sidecar integration test app (jsoup + log4j2 + bouncy-castle, Maven, tested on Amazon Linux 2023 / Corretto 21)
+    output_binaries:
+    - '**/target/*.jar'
 paths:
   repos_dir: /workspace/repos
   output_dir: /workspace/output


### PR DESCRIPTION
## Changes

1. **config.yaml**: Added `omnibor-java-testapp` entry for sidecar CI/CD integration testing
2. **publish-sidecar.yml**: New GitHub Actions workflow to build and push `omnibor-env:sidecar` to `ghcr.io/tedg-dev/omnibor-sidecar`

## Context

The test app repo (`tedg-dev/omnibor-java-testapp`) exercises the Java sidecar pipeline in a completely different environment:

| Aspect | EC2 Standalone | CI Sidecar |
|--------|---------------|-----------|
| OS | Ubuntu 22.04 | Amazon Linux 2023 |
| JDK | OpenJDK 21 | Amazon Corretto 21 |
| Interception | strace/bomtrace3 | dep:tree only |
| SYS_PTRACE | Required | Not used |

## Testing

- 1257 tests pass, 75 skipped (docker_integration markers)
- Config change is additive only
