### PR TITLE
feat: bake app/ into sidecar image for self-contained CI use

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -342,4 +342,12 @@ RUN python3 /tmp/apply_fast_javap.py && \
 
 ENV PATH="/opt/bomsh/bin:/opt/bomsh/scripts:${PATH}"
 
+# ── Bake app code into image for standalone CI use ──
+# When pulled from GHCR, the image must be self-contained.
+# Local dev can still override via volume mounts.
+COPY app/ /workspace/app/
+COPY requirements.txt /workspace/requirements.txt
+
+WORKDIR /workspace
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Problem

The sidecar image pulled from GHCR has no `app/` code — it was designed for volume-mounting in docker-compose. CI/CD pipelines pulling from `ghcr.io/tedg-dev/omnibor-sidecar` get `No such file: /workspace/app/analyze.py`.

## Fix

COPY `app/` and `requirements.txt` into the sidecar image. Local dev can still override via volume mounts (docker-compose volumes take precedence over baked-in files).

## Testing

1257 tests pass. Dockerfile change is additive (append to end of sidecar stage).
