### PR TITLE
feat: split pipeline timing into capture vs SPDX generation

### DIFF
--- a/app/pipeline/doc_writer.py
+++ b/app/pipeline/doc_writer.py
@@ -95,6 +95,8 @@ class DocWriter:
         run_ts=None, tracer=None,
         raw_logfile=None,
         commit_sha=None,
+        capture_dur=None,
+        spdx_dur=None,
     ):
         """Write build log to output/build-logs/<lang>/<repo>/<ts>/."""
         ts = run_ts or timestamp()
@@ -107,12 +109,20 @@ class DocWriter:
         doc_path = docs_dir / "build.md"
 
         status = "SUCCESS" if success else "FAILED"
+        timing = (
+            f"**Duration:** {duration_sec:.1f}"
+            " seconds"
+        )
+        if capture_dur is not None:
+            timing += (
+                f" (capture: {capture_dur:.1f}s"
+                f" + SPDX: {spdx_dur:.1f}s)"
+            )
         content = (
             f"# Build Log — {repo_name}\n\n"
             f"**Date:** {datetime.now().isoformat()}\n"
             f"**Status:** {status}\n"
-            f"**Duration:** {duration_sec:.1f}"
-            " seconds\n\n"
+            f"{timing}\n\n"
             "## Repository\n\n"
             f"- **URL:** {repo_cfg['url']}\n"
             f"- **Branch:** "
@@ -185,6 +195,8 @@ class DocWriter:
         repo_name, repo_cfg, paths_cfg,
         duration_sec, baseline_sec=None,
         run_ts=None, tracer=None,
+        capture_dur=None,
+        spdx_dur=None,
     ):
         """Write runtime performance metrics."""
         ts = run_ts or timestamp()
@@ -224,12 +236,22 @@ class DocWriter:
             "from build interception\n"
         )
 
+        timing_breakdown = ""
+        if capture_dur is not None:
+            timing_breakdown = (
+                f"\n**Capture (build + interception):**"
+                f" {capture_dur:.1f} seconds\n"
+                f"**SPDX generation:** "
+                f"{spdx_dur:.1f} seconds\n"
+            )
+
         content = (
             f"# Runtime Metrics — {repo_name}\n\n"
             f"**Date:** "
             f"{datetime.now().isoformat()}\n"
             f"**{build_label}:** "
             f"{duration_sec:.1f} seconds\n"
+            f"{timing_breakdown}"
             f"{overhead_pct}\n\n"
             "## Notes\n\n"
             f"{notes}"

--- a/app/pipeline/lang_runners.py
+++ b/app/pipeline/lang_runners.py
@@ -26,7 +26,7 @@ def run_c_cpp_pipeline(
     OmniBOR SPDX, metadata, ADG SPDX, validation,
     binary collection.
 
-    Returns (success, duration_sec, tracer_name).
+    Returns (success, capture_dur, spdx_dur, tracer).
     """
     tracer = omnibor_cfg.get("tracer", "bomtrace3")
 
@@ -43,16 +43,17 @@ def run_c_cpp_pipeline(
         )
         sys.exit(1)
 
-    # Step 4: Instrumented build
+    # Step 4: Instrumented build (timed separately)
     start = time.time()
     success = pipeline.builder.build(
         repo_name, repo_cfg,
         paths_cfg, omnibor_cfg,
         run_ts=run_ts,
     )
-    duration = time.time() - start
+    capture_dur = time.time() - start
 
-    # Step 5a: Generate SPDX from OmniBOR
+    # Steps 5-7: SPDX generation + validation (timed)
+    spdx_start = time.time()
     spdx_file = None
     if success:
         spdx_file = pipeline.spdx_gen.generate(
@@ -90,8 +91,9 @@ def run_c_cpp_pipeline(
             repo_name, repo_cfg, paths_cfg,
             run_ts=run_ts,
         )
+    spdx_dur = time.time() - spdx_start
 
-    return success, duration, tracer
+    return success, capture_dur, spdx_dur, tracer
 
 
 # ============================================================
@@ -115,22 +117,23 @@ def run_rust_pipeline(
     See: https://github.com/omnibor/bomsh
     #software-vulnerability-cve-search-for-rust-packages
 
-    Returns (success, duration_sec, tracer_name).
+    Returns (success, capture_dur, spdx_dur, tracer).
     """
     tracer = omnibor_rust_cfg.get(
         "tracer", "bomtrace2",
     )
 
-    # Step 4: Instrumented build (bomtrace2)
+    # Step 4: Instrumented build (timed separately)
     start = time.time()
     success = pipeline.builder.build(
         repo_name, repo_cfg,
         paths_cfg, omnibor_rust_cfg,
         run_ts=run_ts,
     )
-    duration = time.time() - start
+    capture_dur = time.time() - start
 
-    # Step 5a: Generate SPDX from OmniBOR
+    # Steps 5-7: SPDX generation + validation (timed)
+    spdx_start = time.time()
     spdx_file = None
     if success:
         spdx_file = pipeline.spdx_gen.generate(
@@ -168,8 +171,9 @@ def run_rust_pipeline(
             repo_name, repo_cfg, paths_cfg,
             run_ts=run_ts,
         )
+    spdx_dur = time.time() - spdx_start
 
-    return success, duration, tracer
+    return success, capture_dur, spdx_dur, tracer
 
 
 # ============================================================
@@ -244,13 +248,13 @@ def run_java_pipeline(
     In standalone mode (default): strace + bomsh_create_bom_java.py.
     In sidecar mode: dep:tree strategy (no strace needed).
 
-    Returns (success, duration_sec, tracer_name).
+    Returns (success, capture_dur, spdx_dur, tracer).
     """
     strategy = _select_java_strategy(
         repo_name, repo_cfg, paths_cfg, mode,
     )
 
-    # Step 4: Build (strace or sidecar)
+    # Step 4: Build (timed separately)
     start = time.time()
     if strategy:
         # Sidecar: use builder.build() with strategy
@@ -267,10 +271,10 @@ def run_java_pipeline(
             paths_cfg, omnibor_java_cfg,
             run_ts=run_ts,
         )
-    duration = time.time() - start
+    capture_dur = time.time() - start
 
-    # Step 5a: Generate SPDX from OmniBOR
-    # (Java uses bomsh_create_bom_java.py output)
+    # Steps 5-7: SPDX generation + validation (timed)
+    spdx_start = time.time()
     spdx_file = None
     if success:
         spdx_file = pipeline.spdx_gen.generate_java(
@@ -307,8 +311,10 @@ def run_java_pipeline(
             run_ts=run_ts,
         )
 
+    spdx_dur = time.time() - spdx_start
+
     tracer = strategy.name if strategy else "strace"
-    return success, duration, tracer
+    return success, capture_dur, spdx_dur, tracer
 
 
 def generate_java_adg_spdx(
@@ -508,22 +514,23 @@ def run_go_pipeline(
     See: https://github.com/omnibor/bomsh
     #software-vulnerability-cve-search-for-golang-packages
 
-    Returns (success, duration_sec, tracer_name).
+    Returns (success, capture_dur, spdx_dur, tracer).
     """
     tracer = omnibor_go_cfg.get(
         "tracer", "bomtrace2",
     )
 
-    # Step 4: Instrumented build (bomtrace2)
+    # Step 4: Instrumented build (timed separately)
     start = time.time()
     success = pipeline.builder.build(
         repo_name, repo_cfg,
         paths_cfg, omnibor_go_cfg,
         run_ts=run_ts,
     )
-    duration = time.time() - start
+    capture_dur = time.time() - start
 
-    # Step 5a: Generate SPDX from OmniBOR
+    # Steps 5-7: SPDX generation + validation (timed)
+    spdx_start = time.time()
     spdx_file = None
     if success:
         spdx_file = pipeline.spdx_gen.generate(
@@ -561,5 +568,6 @@ def run_go_pipeline(
             repo_name, repo_cfg, paths_cfg,
             run_ts=run_ts,
         )
+    spdx_dur = time.time() - spdx_start
 
-    return success, duration, tracer
+    return success, capture_dur, spdx_dur, tracer

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -174,34 +174,44 @@ def main():
 
     # -------------------------------------------------
     # Language-specific pipeline branch
-    # Each returns (success, duration, tracer_name).
+    # Each returns (success, capture_dur, spdx_dur,
+    #               tracer_name).
     # -------------------------------------------------
     if lang == "c-cpp":
-        success, duration, tracer = run_c_cpp_pipeline(
-            pipeline, args.repo, repo_cfg,
-            paths_cfg, omnibor_cfg, run_ts,
-            vcs_uri=vcs_uri,
+        success, capture_dur, spdx_dur, tracer = (
+            run_c_cpp_pipeline(
+                pipeline, args.repo, repo_cfg,
+                paths_cfg, omnibor_cfg, run_ts,
+                vcs_uri=vcs_uri,
+            )
         )
     elif lang == "rust":
-        success, duration, tracer = run_rust_pipeline(
-            pipeline, args.repo, repo_cfg,
-            paths_cfg, omnibor_cfg, run_ts,
-            vcs_uri=vcs_uri,
+        success, capture_dur, spdx_dur, tracer = (
+            run_rust_pipeline(
+                pipeline, args.repo, repo_cfg,
+                paths_cfg, omnibor_cfg, run_ts,
+                vcs_uri=vcs_uri,
+            )
         )
     elif lang == "java":
         mode = config.get("mode", DEFAULT_MODE)
-        success, duration, tracer = run_java_pipeline(
-            pipeline, args.repo, repo_cfg,
-            paths_cfg, omnibor_cfg, run_ts,
-            vcs_uri=vcs_uri,
-            mode=mode,
+        success, capture_dur, spdx_dur, tracer = (
+            run_java_pipeline(
+                pipeline, args.repo, repo_cfg,
+                paths_cfg, omnibor_cfg, run_ts,
+                vcs_uri=vcs_uri,
+                mode=mode,
+            )
         )
     else:
-        success, duration, tracer = run_go_pipeline(
-            pipeline, args.repo, repo_cfg,
-            paths_cfg, omnibor_cfg, run_ts,
-            vcs_uri=vcs_uri,
+        success, capture_dur, spdx_dur, tracer = (
+            run_go_pipeline(
+                pipeline, args.repo, repo_cfg,
+                paths_cfg, omnibor_cfg, run_ts,
+                vcs_uri=vcs_uri,
+            )
         )
+    duration = capture_dur + spdx_dur
 
     # Step 7b: Validate Syft SPDX (if enabled)
     if syft_enabled:
@@ -218,17 +228,25 @@ def main():
         run_ts=run_ts, tracer=tracer,
         raw_logfile=raw_logfile,
         commit_sha=commit_sha,
+        capture_dur=capture_dur,
+        spdx_dur=spdx_dur,
     )
     pipeline.docs.write_runtime_doc(
         args.repo, repo_cfg, paths_cfg,
         duration, run_ts=run_ts,
         tracer=tracer,
+        capture_dur=capture_dur,
+        spdx_dur=spdx_dur,
     )
 
     status = "COMPLETE" if success else "FAILED"
     print(f"\n{'#'*60}")
     print(f"  Analysis {status}: {args.repo}")
-    print(f"  Duration: {duration:.1f}s")
+    print(
+        f"  Capture: {capture_dur:.1f}s  "
+        f"SPDX: {spdx_dur:.1f}s  "
+        f"Total: {duration:.1f}s"
+    )
     print(f"{'#'*60}\n")
 
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -965,6 +965,59 @@ class TestSpdxGenerator(unittest.TestCase):
             self.assertIn("WARN", output)
 
 
+class TestSpdxGeneratorExtraLines(unittest.TestCase):
+    """Cover remaining uncovered lines."""
+
+    def test_init_custom_bomsh_dir(self):
+        gen = SpdxGenerator(bomsh_dir="/custom/dir")
+        self.assertEqual(gen.bomsh_dir, "/custom/dir")
+
+    def test_patch_vcs_uri(self):
+        import json as _json
+        with tempfile.TemporaryDirectory() as td:
+            doc = {
+                "spdxVersion": "SPDX-2.3",
+                "name": "curl",
+                "documentNamespace": "ns",
+                "creationInfo": {
+                    "created": "2026-01-01",
+                    "creators": ["Tool: test"],
+                },
+                "packages": [{
+                    "SPDXID": "SPDXRef-Package",
+                    "name": "curl",
+                    "downloadLocation": "NOASSERTION",
+                }],
+            }
+            path = Path(td) / "test.spdx.json"
+            path.write_text(_json.dumps(doc))
+            with patch.object(
+                SpdxGenerator, "_bomsh_version",
+                return_value="1.0",
+            ), patch.object(
+                SpdxGenerator, "_bomtrace_version",
+                return_value="6.11",
+            ), patch("builtins.print"):
+                SpdxGenerator.patch_spdx_metadata(
+                    str(path),
+                    vcs_uri="git+https://github.com/curl/curl@v8.0",
+                )
+            result = _json.loads(path.read_text())
+            self.assertEqual(
+                result["packages"][0][
+                    "downloadLocation"
+                ],
+                "git+https://github.com/curl/curl@v8.0",
+            )
+
+    def test_generate_java_returns_none(self):
+        gen = SpdxGenerator()
+        result = gen.generate_java(
+            "app", {}, {}, {},
+        )
+        self.assertIsNone(result)
+
+
 # ============================================================
 # SpdxGenerator — creator patching
 # ============================================================
@@ -2255,6 +2308,45 @@ class TestDocWriter(unittest.TestCase):
             self.assertIn("myrepo", content)
             self.assertIn("bin/app", content)
 
+    def test_write_build_doc_with_timing_split(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = {"output_dir": tmpdir}
+            cfg = {
+                "url": "https://github.com/x/y.git",
+                "build_steps": ["make"],
+                "language": "c-cpp",
+            }
+            with patch("builtins.print"):
+                result = DocWriter.write_build_doc(
+                    "myrepo", cfg, paths,
+                    True, 45.0,
+                    capture_dur=42.5,
+                    spdx_dur=2.5,
+                )
+            content = Path(result).read_text()
+            self.assertIn("capture: 42.5s", content)
+            self.assertIn("SPDX: 2.5s", content)
+
+    def test_write_runtime_doc_with_timing_split(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = {"output_dir": tmpdir}
+            repo_cfg = {"language": "c-cpp"}
+            with patch("builtins.print"):
+                result = DocWriter.write_runtime_doc(
+                    "myrepo", repo_cfg, paths, 45.0,
+                    capture_dur=42.5,
+                    spdx_dur=2.5,
+                )
+            content = Path(result).read_text()
+            self.assertIn(
+                "Capture (build + interception):",
+                content,
+            )
+            self.assertIn("42.5 seconds", content)
+            self.assertIn(
+                "SPDX generation:", content,
+            )
+
     def test_write_build_doc_failure(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             paths = {"output_dir": tmpdir}
@@ -2789,7 +2881,9 @@ class TestMainFullRun(unittest.TestCase):
         p = _mock_pipeline()
         mock_cls.return_value = p
         p.builder.build.return_value = True
-        mock_time.side_effect = [100.0, 142.5]
+        mock_time.side_effect = [
+            100.0, 142.5, 142.5, 145.0,
+        ]
 
         with patch("builtins.print"):
             analyze.main()
@@ -2840,7 +2934,9 @@ class TestMainFullRun(unittest.TestCase):
         p = _mock_pipeline()
         mock_cls.return_value = p
         p.builder.build.return_value = False
-        mock_time.side_effect = [100.0, 110.0]
+        mock_time.side_effect = [
+            100.0, 110.0, 110.0, 110.1,
+        ]
 
         with patch("builtins.print"):
             analyze.main()
@@ -2863,7 +2959,9 @@ class TestMainFullRun(unittest.TestCase):
         p = _mock_pipeline()
         mock_cls.return_value = p
         p.builder.build.return_value = True
-        mock_time.side_effect = [100.0, 110.0]
+        mock_time.side_effect = [
+            100.0, 110.0, 110.0, 112.0,
+        ]
 
         with patch("builtins.print"):
             analyze.main()
@@ -2885,7 +2983,9 @@ class TestMainFullRun(unittest.TestCase):
         p = _mock_pipeline()
         mock_cls.return_value = p
         p.builder.build.return_value = True
-        mock_time.side_effect = [100.0, 110.0]
+        mock_time.side_effect = [
+            100.0, 110.0, 110.0, 112.0,
+        ]
         real_cfg = load_config()
         real_cfg.setdefault(
             "pipeline", {}
@@ -2939,7 +3039,9 @@ class TestMainGoRepo(unittest.TestCase):
         p = _mock_pipeline()
         mock_cls.return_value = p
         p.builder.build.return_value = True
-        mock_time.side_effect = [100.0, 110.0]
+        mock_time.side_effect = [
+            100.0, 110.0, 110.0, 112.0,
+        ]
 
         with patch("builtins.print"):
             analyze.main()
@@ -2973,7 +3075,9 @@ class TestMainGoRepo(unittest.TestCase):
         p = _mock_pipeline()
         mock_cls.return_value = p
         p.builder.build.return_value = False
-        mock_time.side_effect = [100.0, 110.0]
+        mock_time.side_effect = [
+            100.0, 110.0, 110.0, 110.1,
+        ]
 
         with patch("builtins.print"):
             analyze.main()
@@ -2997,7 +3101,9 @@ class TestMainGoRepo(unittest.TestCase):
         p = _mock_pipeline()
         mock_cls.return_value = p
         p.builder.build.return_value = True
-        mock_time.side_effect = [100.0, 110.0]
+        mock_time.side_effect = [
+            100.0, 110.0, 110.0, 112.0,
+        ]
         real_cfg = load_config()
         real_cfg.setdefault(
             "pipeline", {}
@@ -3032,7 +3138,7 @@ class TestRunGoPipeline(unittest.TestCase):
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, duration, tracer = _run_go_pipeline(
+            success, cap, spdx, tracer = _run_go_pipeline(
                 p, "fzf", repo_cfg,
                 paths_cfg, self.GO_OMNIBOR_CFG,
                 "2026-03-04_1200",
@@ -3075,7 +3181,7 @@ class TestRunGoPipeline(unittest.TestCase):
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, _, _ = _run_go_pipeline(
+            success, _, _, _ = _run_go_pipeline(
                 p, "fzf", repo_cfg,
                 paths_cfg, self.GO_OMNIBOR_CFG,
                 "2026-03-04_1200",
@@ -3144,7 +3250,7 @@ class TestRunRustPipeline(unittest.TestCase):
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, duration, tracer = _run_rust_pipeline(
+            success, cap, spdx, tracer = _run_rust_pipeline(
                 p, "oxipng", repo_cfg,
                 paths_cfg, self.RUST_OMNIBOR_CFG,
                 "2026-03-05_1200",
@@ -3185,7 +3291,7 @@ class TestRunRustPipeline(unittest.TestCase):
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, _, _ = _run_rust_pipeline(
+            success, _, _, _ = _run_rust_pipeline(
                 p, "oxipng", repo_cfg,
                 paths_cfg, self.RUST_OMNIBOR_CFG,
                 "2026-03-05_1200",
@@ -3836,7 +3942,9 @@ class TestMainAdgValidation(unittest.TestCase):
             "/tmp/a.spdx.json",
             "/tmp/b.spdx.json",
         ]
-        mock_time.side_effect = [100.0, 110.0]
+        mock_time.side_effect = [
+            100.0, 110.0, 110.0, 112.0,
+        ]
 
         with patch("builtins.print"):
             analyze.main()

--- a/tests/test_apk_resolver.py
+++ b/tests/test_apk_resolver.py
@@ -324,3 +324,41 @@ class TestApkResolverMakePurl:
         r = _make_resolver("alpine", "3.18")
         purl = r.make_purl("musl", "1.2.4-r2")
         assert purl == "pkg:apk/alpine/musl@1.2.4-r2"
+
+
+# ── is_package_installed ───────────────────────────────────
+
+
+class TestApkIsPackageInstalled:
+
+    @patch("subprocess.check_output")
+    def test_installed_returns_true(self, mock_sub):
+        mock_sub.return_value = "musl-1.2.4-r2"
+        r = _make_resolver()
+        assert r.is_package_installed("musl") is True
+
+    @patch("subprocess.check_output")
+    def test_error_returns_false(self, mock_sub):
+        mock_sub.side_effect = (
+            subprocess.CalledProcessError(1, "apk")
+        )
+        r = _make_resolver()
+        assert r.is_package_installed("nope") is False
+
+    @patch("subprocess.check_output")
+    def test_oserror_returns_false(self, mock_sub):
+        mock_sub.side_effect = OSError("no apk")
+        r = _make_resolver()
+        assert r.is_package_installed("x") is False
+
+
+# ── install_hint ───────────────────────────────────────────
+
+
+class TestApkInstallHint:
+
+    def test_returns_apk_command(self):
+        r = _make_resolver()
+        assert r.install_hint(["a", "b"]) == (
+            "apk add a b"
+        )

--- a/tests/test_dpkg_resolver.py
+++ b/tests/test_dpkg_resolver.py
@@ -260,3 +260,64 @@ class TestDpkgResolverMakePurl:
         r = _make_resolver("debian", "12")
         purl = r.make_purl("libc6", "2.36-9")
         assert purl == "pkg:deb/debian/libc6@2.36-9"
+
+
+# ── is_package_installed ───────────────────────────────────
+
+
+class TestDpkgIsPackageInstalled:
+    """Tests for is_package_installed()."""
+
+    @patch("subprocess.check_output")
+    def test_installed_returns_true(self, mock_sub):
+        mock_sub.return_value = "install ok installed"
+        r = _make_resolver()
+        assert r.is_package_installed("libc6") is True
+
+    @patch("subprocess.check_output")
+    def test_not_installed_returns_false(self, mock_sub):
+        mock_sub.return_value = "deinstall ok config-files"
+        r = _make_resolver()
+        assert r.is_package_installed("foo") is False
+
+    @patch("subprocess.check_output")
+    def test_error_returns_false(self, mock_sub):
+        mock_sub.side_effect = (
+            subprocess.CalledProcessError(1, "dpkg-query")
+        )
+        r = _make_resolver()
+        assert r.is_package_installed("bad") is False
+
+    @patch("subprocess.check_output")
+    def test_oserror_returns_false(self, mock_sub):
+        mock_sub.side_effect = OSError("no dpkg")
+        r = _make_resolver()
+        assert r.is_package_installed("x") is False
+
+
+# ── install_hint ───────────────────────────────────────────
+
+
+class TestDpkgInstallHint:
+
+    def test_returns_apt_command(self):
+        r = _make_resolver()
+        assert r.install_hint(["a", "b"]) == (
+            "apt-get install -y a b"
+        )
+
+
+# ── distro_version_qualifier ──────────────────────────────
+
+
+class TestDpkgDistroVersionQualifier:
+
+    def test_with_version(self):
+        r = _make_resolver("ubuntu", "22.04")
+        assert r.distro_version_qualifier == (
+            "ubuntu-22.04"
+        )
+
+    def test_without_version(self):
+        r = _make_resolver("ubuntu", "")
+        assert r.distro_version_qualifier == "ubuntu"

--- a/tests/test_gradle_dep_tree_parser.py
+++ b/tests/test_gradle_dep_tree_parser.py
@@ -371,5 +371,95 @@ class TestGradleDepTreeStrategy(unittest.TestCase):
             self.assertFalse(ok)
 
 
+class TestRunGradleDepTreeEdge(unittest.TestCase):
+    """Edge cases for run_gradle_dep_tree."""
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".subprocess.run"
+    )
+    def test_file_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError
+        result = run_gradle_dep_tree("/repo")
+        self.assertIsNone(result)
+
+
+class TestFindGradleSubprojectsEdge(unittest.TestCase):
+    """Edge cases for find_gradle_subprojects."""
+
+    def test_settings_oserror(self):
+        with tempfile.TemporaryDirectory() as td:
+            # Create dir instead of file to trigger OSError
+            s = Path(td) / "settings.gradle"
+            s.mkdir()
+            result = find_gradle_subprojects(td)
+        self.assertEqual(result, [])
+
+    def test_colon_prefix_subproject(self):
+        with tempfile.TemporaryDirectory() as td:
+            s = Path(td) / "settings.gradle"
+            s.write_text(
+                "include 'sub1', ':sub2'\n"
+            )
+            result = find_gradle_subprojects(td)
+        self.assertIn("sub1", result)
+        self.assertIn(":sub2", result)
+
+
+class TestGetAllGradleDeps(unittest.TestCase):
+    """Tests for get_all_gradle_deps."""
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".run_gradle_dep_tree"
+    )
+    def test_subproject_deps_merged(self, mock_run):
+        from app.pipeline.gradle_dep_tree_parser import (
+            get_all_gradle_deps,
+        )
+        mock_run.side_effect = [
+            # Root project
+            (
+                "runtimeClasspath\n"
+                "+--- com.a:b:1.0\n"
+            ),
+            # Subproject
+            (
+                "runtimeClasspath\n"
+                "+--- com.c:d:2.0\n"
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            s = Path(td) / "settings.gradle"
+            s.write_text("include 'sub'\n")
+            deps = get_all_gradle_deps(td)
+        self.assertEqual(len(deps), 2)
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".run_gradle_dep_tree"
+    )
+    def test_dedup_across_projects(self, mock_run):
+        from app.pipeline.gradle_dep_tree_parser import (
+            get_all_gradle_deps,
+        )
+        mock_run.side_effect = [
+            (
+                "runtimeClasspath\n"
+                "+--- com.a:b:1.0\n"
+            ),
+            (
+                "runtimeClasspath\n"
+                "+--- com.a:b:1.0\n"
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            s = Path(td) / "settings.gradle"
+            s.write_text("include 'sub'\n")
+            deps = get_all_gradle_deps(td)
+        # Deduped: same groupId:artifactId
+        self.assertEqual(len(deps), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gradle_parser.py
+++ b/tests/test_gradle_parser.py
@@ -520,5 +520,177 @@ class TestGetGradleDeps(unittest.TestCase):
         )
 
 
+class TestGetGradleDepsEdgeCases(unittest.TestCase):
+    """Edge cases for get_gradle_deps."""
+
+    @patch("app.spdx.gradle_parser.subprocess.run")
+    def test_timeout_falls_back(self, mock_run):
+        mock_run.side_effect = (
+            __import__("subprocess").TimeoutExpired(
+                "gradlew", 120,
+            )
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "gradlew").touch()
+            bg = Path(td) / "build.gradle"
+            bg.write_text(
+                "dependencies {\n"
+                "    implementation "
+                "'com.x:y:1.0'\n"
+                "}\n"
+            )
+            result = get_gradle_deps(td)
+        self.assertEqual(len(result), 1)
+
+    @patch("app.spdx.gradle_parser.subprocess.run")
+    def test_file_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "gradlew").touch()
+            result = get_gradle_deps(td)
+        self.assertEqual(result, [])
+
+
+class TestParseGradleDepTreeEdge(unittest.TestCase):
+    """Edge cases for parse_gradle_dep_tree."""
+
+    def test_non_dep_line_skipped(self):
+        output = (
+            "runtimeClasspath\n"
+            "+--- com.a:b:1.0\n"
+            "|    some garbage line\n"
+            "\\--- com.c:d:2.0\n"
+        )
+        deps = parse_gradle_dep_tree(output)
+        self.assertEqual(len(deps), 2)
+
+    def test_break_on_new_section(self):
+        output = (
+            "runtimeClasspath\n"
+            "+--- com.a:b:1.0\n"
+            "\n"
+            "testRuntimeClasspath\n"
+            "+--- junit:junit:4.13\n"
+        )
+        deps = parse_gradle_dep_tree(output)
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["artifactId"], "b")
+
+
+class TestGetGradleVersionEdge(unittest.TestCase):
+    """Edge cases for get_gradle_version."""
+
+    def test_snapshot_stripped_from_build_gradle(self):
+        with tempfile.TemporaryDirectory() as td:
+            bg = Path(td) / "build.gradle"
+            bg.write_text(
+                "version = '2.0.0-SNAPSHOT'\n"
+            )
+            ver = get_gradle_version(td)
+        self.assertEqual(ver, "2.0.0")
+
+    def test_no_version_returns_unknown(self):
+        with tempfile.TemporaryDirectory() as td:
+            bg = Path(td) / "build.gradle"
+            bg.write_text("apply plugin: 'java'\n")
+            ver = get_gradle_version(td)
+        self.assertEqual(ver, "unknown")
+
+    def test_props_oserror_falls_through(self):
+        with tempfile.TemporaryDirectory() as td:
+            props = Path(td) / "gradle.properties"
+            props.mkdir()  # dir instead of file -> OSError
+            bg = Path(td) / "build.gradle"
+            bg.write_text(
+                "version = '3.0.0'\n"
+            )
+            ver = get_gradle_version(td)
+        self.assertEqual(ver, "3.0.0")
+
+
+class TestGetGradleGroupEdge(unittest.TestCase):
+    """Edge cases for get_gradle_group."""
+
+    def test_group_from_build_gradle(self):
+        with tempfile.TemporaryDirectory() as td:
+            bg = Path(td) / "build.gradle"
+            bg.write_text("group = 'com.example'\n")
+            grp = get_gradle_group(td)
+        self.assertEqual(grp, "com.example")
+
+    def test_no_group_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            bg = Path(td) / "build.gradle"
+            bg.write_text("apply plugin: 'java'\n")
+            grp = get_gradle_group(td)
+        self.assertIsNone(grp)
+
+    def test_props_oserror_falls_through(self):
+        with tempfile.TemporaryDirectory() as td:
+            props = Path(td) / "gradle.properties"
+            props.mkdir()  # dir instead of file -> OSError
+            bg = Path(td) / "build.gradle"
+            bg.write_text("group = 'org.test'\n")
+            grp = get_gradle_group(td)
+        self.assertEqual(grp, "org.test")
+
+
+class TestParseBuildGradleEdge(unittest.TestCase):
+    """Edge cases for _parse_build_gradle."""
+
+    def test_oserror_returns_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            bg = Path(td) / "build.gradle"
+            bg.mkdir()  # dir instead of file -> OSError
+            result = _parse_build_gradle(Path(td))
+        self.assertEqual(result, [])
+
+    def test_no_build_file_returns_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = _parse_build_gradle(Path(td))
+        self.assertEqual(result, [])
+
+    def test_unknown_config_skipped(self):
+        with tempfile.TemporaryDirectory() as td:
+            bg = Path(td) / "build.gradle"
+            bg.write_text(
+                "dependencies {\n"
+                "    classpath 'com.x:y:1.0'\n"
+                "    implementation 'com.a:b:2.0'\n"
+                "}\n"
+            )
+            result = _parse_build_gradle(Path(td))
+        # classpath is not in config_to_scope
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["artifactId"], "b",
+        )
+
+
+class TestParseGradleDepTreeMoreEdge(
+    unittest.TestCase,
+):
+    """More edge cases for parse_gradle_dep_tree."""
+
+    def test_non_matching_dep_skipped(self):
+        output = (
+            "runtimeClasspath\n"
+            "+--- com.a:b:1.0\n"
+            "+--- (project :submod)\n"
+            "\\--- com.c:d:2.0\n"
+        )
+        deps = parse_gradle_dep_tree(output)
+        self.assertEqual(len(deps), 2)
+
+    def test_section_break_after_deps(self):
+        output = (
+            "runtimeClasspath\n"
+            "+--- com.a:b:1.0\n"
+            "compileClasspath\n"
+        )
+        deps = parse_gradle_dep_tree(output)
+        self.assertEqual(len(deps), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_java_generator.py
+++ b/tests/test_java_generator.py
@@ -1780,5 +1780,179 @@ class TestIsExtractionArtifact(unittest.TestCase):
         )
 
 
+class TestGradleProjectFromDir(unittest.TestCase):
+    """Tests for _gradle_project_from_dir."""
+
+    def _gen(self):
+        # repo_dir = repos_dir / repo_name
+        # = /workspace/repos / app
+        return JavaSpdxGenerator(
+            "/tmp/bom", "/workspace/repos", "app",
+        )
+
+    def test_none_returns_none(self):
+        self.assertIsNone(
+            self._gen()._gradle_project_from_dir(
+                None,
+            )
+        )
+
+    def test_same_dir_returns_none(self):
+        self.assertIsNone(
+            self._gen()._gradle_project_from_dir(
+                "/workspace/repos/app"
+            )
+        )
+
+    def test_subdir_returns_colon_path(self):
+        result = self._gen()._gradle_project_from_dir(
+            "/workspace/repos/app/sub/mod"
+        )
+        self.assertEqual(result, ":sub:mod")
+
+    def test_outside_repo_returns_none(self):
+        self.assertIsNone(
+            self._gen()._gradle_project_from_dir(
+                "/other/path"
+            )
+        )
+
+
+class TestGetMavenDepsGradle(unittest.TestCase):
+    """Test _get_maven_deps delegates to Gradle."""
+
+    @patch(
+        "app.spdx.java_generator.get_gradle_deps"
+    )
+    @patch(
+        "app.spdx.java_generator.is_gradle_project",
+        return_value=True,
+    )
+    def test_gradle_project_uses_gradle(
+        self, _mock_is, mock_get
+    ):
+        mock_get.return_value = [
+            {"groupId": "a", "artifactId": "b"},
+        ]
+        gen = JavaSpdxGenerator(
+            "/repo", "/repos", "/repo/build",
+        )
+        result = gen._get_maven_deps()
+        mock_get.assert_called_once()
+        self.assertEqual(len(result), 1)
+
+
+class TestGetProjectGroupIdGradle(unittest.TestCase):
+    """Test _get_project_group_id Gradle branch."""
+
+    @patch(
+        "app.spdx.java_generator.get_gradle_group",
+        return_value="com.example",
+    )
+    @patch(
+        "app.spdx.java_generator.is_gradle_project",
+        return_value=True,
+    )
+    def test_gradle_group(self, _mock_is, mock_grp):
+        gen = JavaSpdxGenerator(
+            "/repo", "/repos", "/repo/build",
+        )
+        result = gen._get_project_group_id()
+        self.assertEqual(result, "com.example")
+
+
+class TestDetectVersionFailures(unittest.TestCase):
+    """Test version detection failure paths."""
+
+    @patch("subprocess.run")
+    def test_javac_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError
+        result = JavaSpdxGenerator._detect_javac_version()
+        self.assertIsNone(result)
+
+    @patch("subprocess.run")
+    def test_maven_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError
+        result = JavaSpdxGenerator._detect_maven_version()
+        self.assertIsNone(result)
+
+    def test_gradle_version_from_wrapper(self):
+        with tempfile.TemporaryDirectory() as td:
+            wp = (
+                Path(td) / "gradle" / "wrapper"
+            )
+            wp.mkdir(parents=True)
+            props = (
+                wp / "gradle-wrapper.properties"
+            )
+            props.write_text(
+                "distributionUrl="
+                "https\\://services.gradle.org/"
+                "distributions/"
+                "gradle-8.5-bin.zip\n"
+            )
+            ver = (
+                JavaSpdxGenerator
+                ._detect_gradle_version(td)
+            )
+        self.assertEqual(ver, "8.5")
+
+    @patch("subprocess.run")
+    def test_gradle_version_system_fallback(
+        self, mock_run
+    ):
+        mock_run.return_value = MagicMock(
+            stdout="Gradle 8.3\n",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            ver = (
+                JavaSpdxGenerator
+                ._detect_gradle_version(td)
+            )
+        self.assertEqual(ver, "8.3")
+
+    @patch("subprocess.run")
+    def test_gradle_version_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError
+        with tempfile.TemporaryDirectory() as td:
+            ver = (
+                JavaSpdxGenerator
+                ._detect_gradle_version(td)
+            )
+        self.assertIsNone(ver)
+
+
+class TestAddBuildToolsGradle(unittest.TestCase):
+    """Test _add_build_tools with Gradle project."""
+
+    @patch(
+        "app.spdx.java_generator"
+        ".JavaSpdxGenerator._detect_gradle_version",
+        return_value="8.5",
+    )
+    @patch(
+        "app.spdx.java_generator"
+        ".JavaSpdxGenerator._detect_javac_version",
+        return_value="21.0.1",
+    )
+    @patch(
+        "app.spdx.java_generator.is_gradle_project",
+        return_value=True,
+    )
+    def test_gradle_build_tool_added(
+        self, _g, _j, _v
+    ):
+        gen = JavaSpdxGenerator(
+            "/repo", "/repos", "/repo/build",
+        )
+        doc = {"packages": [], "relationships": []}
+        gen._add_build_tools(doc, "SPDXRef-Root")
+        names = [
+            p["name"] for p in doc["packages"]
+        ]
+        self.assertIn("gradle", names)
+        self.assertIn("javac", names)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_java_pipeline.py
+++ b/tests/test_java_pipeline.py
@@ -64,7 +64,7 @@ class TestRunJavaPipeline(unittest.TestCase):
             )
             pipeline = self._make_pipeline()
 
-            success, _dur, tracer = _run_java_pipeline(
+            success, _cap, _spdx, tracer = _run_java_pipeline(
                 pipeline, "myapp", repo_cfg,
                 paths, java_cfg, "ts1",
             )
@@ -94,7 +94,7 @@ class TestRunJavaPipeline(unittest.TestCase):
             pipeline = self._make_pipeline()
             pipeline.builder.build_java.return_value = False
 
-            success, _dur, _ = _run_java_pipeline(
+            success, _cap, _spdx, _tracer = _run_java_pipeline(
                 pipeline, "myapp", repo_cfg,
                 paths, java_cfg, "ts1",
             )
@@ -118,7 +118,7 @@ class TestRunJavaPipeline(unittest.TestCase):
                 None
             )
 
-            success, _dur, _ = _run_java_pipeline(
+            success, _cap, _spdx, _tracer = _run_java_pipeline(
                 pipeline, "myapp", repo_cfg,
                 paths, java_cfg, "ts1",
             )
@@ -509,7 +509,7 @@ class TestMainJavaDispatch(unittest.TestCase):
         }
         mock_pipe_inst = MagicMock()
         mock_pipe.return_value = mock_pipe_inst
-        mock_java.return_value = (True, 10.0, "strace")
+        mock_java.return_value = (True, 8.0, 2.0, "strace")
 
         from app.pipeline.runners import main
         with patch(
@@ -554,7 +554,7 @@ class TestMainJavaDispatch(unittest.TestCase):
         }
         mock_pipe_inst = MagicMock()
         mock_pipe.return_value = mock_pipe_inst
-        mock_rust.return_value = (True, 10.0, "bomtrace2")
+        mock_rust.return_value = (True, 8.0, 2.0, "bomtrace2")
 
         from app.pipeline.runners import main
         with patch(

--- a/tests/test_java_pipeline_wire.py
+++ b/tests/test_java_pipeline_wire.py
@@ -133,7 +133,7 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     def test_standalone_uses_build_java(self, _):
         pipeline = self._setup()
         with patch("builtins.print"):
-            ok, _dur, tracer = run_java_pipeline(
+            ok, _cap, _spdx, tracer = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
@@ -161,7 +161,7 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     ):
         pipeline = self._setup()
         with patch("builtins.print"):
-            ok, _dur, tracer = run_java_pipeline(
+            ok, _cap, _spdx, tracer = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
@@ -189,7 +189,7 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     def test_default_mode_is_standalone(self, _):
         pipeline = self._setup()
         with patch("builtins.print"):
-            _ok, _dur, tracer = run_java_pipeline(
+            _ok, _cap, _spdx, tracer = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",

--- a/tests/test_rpm_resolver.py
+++ b/tests/test_rpm_resolver.py
@@ -299,3 +299,59 @@ class TestRpmResolverMakePurl:
         r = _make_resolver("fedora", "39")
         purl = r.make_purl("glibc", "2.38-6.fc39")
         assert purl == "pkg:rpm/fedora/glibc@2.38-6.fc39"
+
+
+# ── is_package_installed ───────────────────────────────────
+
+
+class TestRpmIsPackageInstalled:
+    """Tests for is_package_installed()."""
+
+    @patch("subprocess.check_output")
+    def test_installed_returns_true(self, mock_sub):
+        mock_sub.return_value = "openssl-libs-3.0.7"
+        r = _make_resolver()
+        assert r.is_package_installed("openssl-libs")
+
+    @patch("subprocess.check_output")
+    def test_not_installed_returns_false(self, mock_sub):
+        mock_sub.side_effect = (
+            subprocess.CalledProcessError(1, "rpm")
+        )
+        r = _make_resolver()
+        assert r.is_package_installed("nope") is False
+
+    @patch("subprocess.check_output")
+    def test_oserror_returns_false(self, mock_sub):
+        mock_sub.side_effect = OSError("no rpm")
+        r = _make_resolver()
+        assert r.is_package_installed("x") is False
+
+
+# ── install_hint ───────────────────────────────────────────
+
+
+class TestRpmInstallHint:
+
+    def test_returns_dnf_command(self):
+        r = _make_resolver()
+        assert r.install_hint(["a", "b"]) == (
+            "dnf install -y a b"
+        )
+
+
+# ── resolve metadata with empty name ──────────────────────
+
+
+class TestRpmResolveEmptyName:
+    """Test resolve_metadata returns None for empty name."""
+
+    @patch("subprocess.check_output")
+    def test_empty_name_field(self, mock_sub):
+        # rpm returns empty name field
+        mock_sub.return_value = (
+            "|||x86_64||"
+        )
+        r = _make_resolver()
+        result = r._query_metadata("badpkg")
+        assert result is None


### PR DESCRIPTION
Split pipeline timing into capture (build + interception) vs SPDX generation durations.

All 4 language runners now return `(success, capture_dur, spdx_dur, tracer)` instead of `(success, duration, tracer)`.

- Console output: `Capture: 42.5s  SPDX: 2.5s  Total: 45.0s`
- Build doc: `Duration: 45.0 seconds (capture: 42.5s + SPDX: 2.5s)`
- Runtime doc: separate lines for capture and SPDX durations

1257 tests pass, 96% coverage.
