### PR TITLE
chore: fix coverage thresholds in testing-standards.md

### DIFF
--- a/.windsurf/rules/quality/testing-standards.md
+++ b/.windsurf/rules/quality/testing-standards.md
@@ -18,8 +18,8 @@ and are never deferred to "later."
 
 ## Coverage Requirements
 
-- **Overall project**: ≥95% line coverage (configurable per project)
-- **Individual source files**: ≥90% line coverage
+- **Overall project**: ≥97% line coverage
+- **Individual source files**: ≥95% line coverage
 - **New code**: 100% of new public functions must have at least one test
 - Report coverage to the user after every test run
 


### PR DESCRIPTION
Fix stale coverage thresholds in testing-standards.md.

Was: 95%% overall / 90%% per file
Now: 97%% overall / 95%% per file

Matches CRITICAL.md and pre-commit.md.
