### PR TITLE
feat: baseline builds, contention analysis, infer_parallelism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ output/binaries/*/**
 output/binary-scan/*/**
 output/build-logs/*/**
 output/runtime/*/**
+!output/runtime/**/baseline.json
 !output/**/.gitkeep
 
 # ============================================================

--- a/.windsurf/rules/project/runtime-timing.md
+++ b/.windsurf/rules/project/runtime-timing.md
@@ -1,0 +1,81 @@
+# Runtime Timing Policy
+
+All analysis runs MUST capture granular per-step timing with CPU
+monitoring. Baseline (non-instrumented) builds are run once per repo
+and stored for comparison.
+
+## Baseline (Non-Instrumented Build Time)
+
+- Run ONCE per repo per language: clean + configure + build WITHOUT
+  bomtrace/strace
+- Each step (clean, prebuild, build) is timed **separately** —
+  exactly mirroring the instrumented path — so the build step can
+  be compared apples-to-apples
+- Store in `output/runtime/<lang>/<repo>/baseline.json` as a
+  ``{"steps": [...], "run_ts": "..."}`` structure
+- Repos are pinned to specific versions (for golden file accuracy),
+  so baseline is stable
+- Re-run baseline only when repo version changes in `config.yaml`
+- Each step records CPU metrics (same as instrumented runs)
+
+## CPU Monitoring (Every Timed Step)
+
+- **Primary:** `resource.getrusage(RUSAGE_CHILDREN)` — user+sys CPU
+  time (stdlib, always available)
+- **Secondary:** `/usr/bin/time -v` wrapper on Linux — captures all
+  descendant CPU, max RSS, context switches
+- **Load average:** `os.getloadavg()` sampled at start and end of
+  each step
+- **CPU count:** `os.cpu_count()`
+- **Contention threshold:** `cpu_efficiency < expected * 0.70`
+  (70% of expected efficiency = flag as contention)
+- **Expected efficiency:** `min(parallel_jobs, cpu_count)`
+
+## Per-Step Timing (Every Analysis Run)
+
+### Phase 1 — Build Interception
+
+| Timer | What it measures |
+|-------|-----------------|
+| `clean_dur` | `clean_cmd` (e.g. `make clean`) |
+| `configure_dur` | Pre-build steps (e.g. `./configure`) |
+| `build_dur` | Instrumented compilation only (bomtrace/strace + build command) |
+
+### Phase 2 — Post-Build Analysis (no baseline equivalent)
+
+| Timer | What it measures |
+|-------|-----------------|
+| `adg_dur` | `bomsh_create_bom.py` / `bomsh_create_bom_java.py` (+ dep:tree for Java sidecar) |
+| `omnibor_sbom_dur` | `bomsh_sbom.py` → `_omnibor.spdx.json` + metadata patch + HTML viz |
+| `metadata_dur` | `collect_metadata.py` + `collect_dynamic_libs.py` |
+| `spdx_gen_dur` | `AdgSpdxGenerator` / `JavaSpdxGenerator` → `_analyzed` + `_build` `.spdx.json` + HTML |
+| `validate_dur` | JSON schema + semantic validation |
+| `collect_dur` | Binary collection to `output/binaries/` |
+
+## Storage
+
+- Per-run: `output/runtime/<lang>/<repo>/<ts>/runtime.json`
+- Baseline: `output/runtime/<lang>/<repo>/baseline.json`
+- Both use the same datetime-stamp folder convention as SPDX output
+
+## Run Report (runtime.md)
+
+Every run MUST produce a report showing:
+
+1. All per-step durations with CPU efficiency per step
+2. Phase 1 total and Phase 2 total
+3. Non-instrumented baseline build time (from `baseline.json`)
+4. Build overhead (build step only):
+   `(instrumented_build - baseline_build) / baseline_build × 100`
+   — compares ONLY the build step (the sole difference between
+   baseline and instrumented). Pre-build and clean are captured
+   but NOT included in overhead calculation.
+   Phase 2 has NO baseline comparison (entirely new work).
+5. Contention flag per step if CPU efficiency < 70% of expected
+
+## When Running Any Repo
+
+- If `baseline.json` does not exist for the repo, run baseline FIRST
+- Always store per-run timing data in `runtime.json`
+- Always include baseline comparison in the report
+- Always include CPU contention flags

--- a/app/pipeline/builder.py
+++ b/app/pipeline/builder.py
@@ -3,13 +3,34 @@ Instrumented build with bomtrace for OmniBOR Analysis.
 
 Runs pre-build steps, the instrumented build via bomtrace3/bomtrace2,
 and generates OmniBOR ADG documents.
+
+Each phase is timed separately via ``StepTimer`` so
+callers can report Phase 1 (build interception) vs
+Phase 2 (post-build analysis) accurately.
 """
 
 import shutil
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import List
 
 from app.config import lang_subdir, timestamp
+from app.pipeline.timing import StepMetrics, StepTimer
 from app.runner import CommandRunner
+
+
+@dataclass
+class BuildResult:
+    """Result from ``build()`` or ``build_java()``.
+
+    Carries success flag plus per-phase ``StepMetrics``
+    so callers can assign Phase 1 vs Phase 2 timing.
+    """
+
+    success: bool = False
+    steps: List[StepMetrics] = field(
+        default_factory=list,
+    )
 
 
 class BomtraceBuilder:
@@ -37,8 +58,10 @@ class BomtraceBuilder:
                 the strategy.  When ``None``, uses
                 legacy hardcoded bomtrace behavior.
 
-        Returns True on success, False on failure.
+        Returns:
+            ``BuildResult`` with per-phase metrics.
         """
+        result = BuildResult()
         ts = run_ts or timestamp()
         repo_dir = (
             Path(paths_cfg["repos_dir"]) / repo_name
@@ -48,41 +71,47 @@ class BomtraceBuilder:
             Path(paths_cfg["output_dir"])
             / "omnibor" / lang / repo_name / ts
         )
-        # Clean stale build artifacts so bomtrace3
-        # intercepts a full recompilation.
-        # Without this, a prior build leaves object
-        # files in place and make becomes a no-op —
-        # bomtrace3 intercepts zero compiler calls
-        # and bomsh_create_bom.py has no data.
+
+        # --- Phase 1a: Clean ---
         clean_cmd = repo_cfg.get("clean_cmd")
         if clean_cmd:
-            self.runner.run(
-                clean_cmd, cwd=str(repo_dir),
-                description=(
-                    f"Clean: {clean_cmd}"
-                ),
-            )
-            # Ignore clean_cmd exit code — it may
-            # fail on a fresh clone (nothing to clean)
-
-        # Pre-build steps (configure, etc.)
-        build_steps = repo_cfg["build_steps"]
-        for step in build_steps[:-1]:
-            rc = self.runner.run(
-                step, cwd=str(repo_dir),
-                description=(
-                    f"Pre-build: {step[:60]}"
-                ),
-            )
-            if rc != 0:
-                print(
-                    "[ERROR] Pre-build step "
-                    f"failed: {step}"
+            timer = StepTimer("clean", "phase1")
+            with timer:
+                self.runner.run(
+                    clean_cmd, cwd=str(repo_dir),
+                    description=(
+                        f"Clean: {clean_cmd}"
+                    ),
                 )
-                return False
+                # Ignore clean_cmd exit code — it may
+                # fail on a fresh clone
+            result.steps.append(timer.metrics)
 
-        # Final build step — delegate to strategy
-        # or fall back to legacy bomtrace prefix.
+        # --- Phase 1b: Configure (pre-build steps) ---
+        build_steps = repo_cfg["build_steps"]
+        pre_steps = build_steps[:-1]
+        if pre_steps:
+            timer = StepTimer("configure", "phase1")
+            with timer:
+                for step in pre_steps:
+                    rc = self.runner.run(
+                        step, cwd=str(repo_dir),
+                        description=(
+                            f"Pre-build: {step[:60]}"
+                        ),
+                    )
+                    if rc != 0:
+                        print(
+                            "[ERROR] Pre-build step "
+                            f"failed: {step}"
+                        )
+                        result.steps.append(
+                            timer.metrics
+                        )
+                        return result
+            result.steps.append(timer.metrics)
+
+        # --- Phase 1c: Instrumented build ---
         make_cmd = build_steps[-1]
         if strategy:
             instrumented, env = (
@@ -95,54 +124,63 @@ class BomtraceBuilder:
             instrumented = f"{tracer} {make_cmd}"
             env = None
 
-        rc = self.runner.run(
-            instrumented, cwd=str(repo_dir),
-            env=env,
-            description=(
-                f"Instrumented build: "
-                f"{instrumented[:60]}"
-            ),
-        )
-        if rc != 0:
-            print("[ERROR] Instrumented build failed")
-            return False
-
-        # Generate OmniBOR ADG documents — delegate
-        # to strategy or fall back to legacy.
-        if strategy:
-            ok = strategy.generate_adg(
-                str(repo_dir), str(bom_dir),
-                omnibor_cfg,
-            )
-            if not ok:
-                print(
-                    "[ERROR] ADG generation failed"
-                )
-                return False
-        else:
-            create_bom = (
-                omnibor_cfg["create_bom_script"]
-            )
-            raw_logfile = omnibor_cfg["raw_logfile"]
+        timer = StepTimer("build", "phase1")
+        with timer:
             rc = self.runner.run(
-                f"{create_bom} -r {raw_logfile} "
-                f"-b {bom_dir}",
-                cwd=str(repo_dir),
+                instrumented, cwd=str(repo_dir),
+                env=env,
                 description=(
-                    "Generating OmniBOR ADG documents"
+                    f"Instrumented build: "
+                    f"{instrumented[:60]}"
                 ),
             )
-            if rc != 0:
-                print(
-                    "[ERROR] ADG generation failed"
+        result.steps.append(timer.metrics)
+        if rc != 0:
+            print("[ERROR] Instrumented build failed")
+            return result
+
+        # --- Phase 2a: ADG generation ---
+        timer = StepTimer("adg", "phase2")
+        with timer:
+            if strategy:
+                ok = strategy.generate_adg(
+                    str(repo_dir), str(bom_dir),
+                    omnibor_cfg,
                 )
-                return False
+                if not ok:
+                    print(
+                        "[ERROR] ADG generation failed"
+                    )
+                    result.steps.append(timer.metrics)
+                    return result
+            else:
+                create_bom = (
+                    omnibor_cfg["create_bom_script"]
+                )
+                raw_logfile = omnibor_cfg["raw_logfile"]
+                rc = self.runner.run(
+                    f"{create_bom} -r {raw_logfile} "
+                    f"-b {bom_dir}",
+                    cwd=str(repo_dir),
+                    description=(
+                        "Generating OmniBOR ADG "
+                        "documents"
+                    ),
+                )
+                if rc != 0:
+                    print(
+                        "[ERROR] ADG generation failed"
+                    )
+                    result.steps.append(timer.metrics)
+                    return result
+        result.steps.append(timer.metrics)
 
         print(
             "[OK] OmniBOR ADG documents "
             f"written to {bom_dir}"
         )
-        return True
+        result.success = True
+        return result
 
     def build_java(
         self, repo_name, repo_cfg,
@@ -155,8 +193,10 @@ class BomtraceBuilder:
         1. Build with strace to capture file I/O (openat syscalls)
         2. Run bomsh_create_bom_java.py with strace log to create treedb
 
-        Returns True on success, False on failure.
+        Returns:
+            ``BuildResult`` with per-phase metrics.
         """
+        result = BuildResult()
         ts = run_ts or timestamp()
         repo_dir = (
             Path(paths_cfg["repos_dir"]) / repo_name
@@ -174,81 +214,110 @@ class BomtraceBuilder:
         strace_log = omnibor_java_cfg["strace_logfile"]
         create_bom = omnibor_java_cfg["create_bom_script"]
 
-        # Clean stale build artifacts
+        # --- Phase 1a: Clean ---
         clean_cmd = repo_cfg.get("clean_cmd")
         if clean_cmd:
-            self.runner.run(
-                clean_cmd, cwd=str(repo_dir),
-                description=f"Clean: {clean_cmd}",
-            )
+            timer = StepTimer("clean", "phase1")
+            with timer:
+                self.runner.run(
+                    clean_cmd, cwd=str(repo_dir),
+                    description=(
+                        f"Clean: {clean_cmd}"
+                    ),
+                )
+            result.steps.append(timer.metrics)
 
-        # Pre-build steps (if any before final build)
+        # --- Phase 1b: Configure (pre-build steps) ---
         build_steps = repo_cfg["build_steps"]
-        for step in build_steps[:-1]:
-            rc = self.runner.run(
-                step, cwd=str(repo_dir),
-                description=f"Pre-build: {step[:60]}",
-            )
-            if rc != 0:
-                print(f"[ERROR] Pre-build step failed: {step}")
-                return False
+        pre_steps = build_steps[:-1]
+        if pre_steps:
+            timer = StepTimer("configure", "phase1")
+            with timer:
+                for step in pre_steps:
+                    rc = self.runner.run(
+                        step, cwd=str(repo_dir),
+                        description=(
+                            f"Pre-build: {step[:60]}"
+                        ),
+                    )
+                    if rc != 0:
+                        print(
+                            "[ERROR] Pre-build step "
+                            f"failed: {step}"
+                        )
+                        result.steps.append(
+                            timer.metrics
+                        )
+                        return result
+            result.steps.append(timer.metrics)
 
-        # Final build step with strace
+        # --- Phase 1c: Instrumented build ---
         build_cmd = build_steps[-1]
         instrumented = (
-            f"strace {strace_opts} -o {strace_log} {build_cmd}"
+            f"strace {strace_opts} -o {strace_log} "
+            f"{build_cmd}"
         )
-        rc = self.runner.run(
-            instrumented, cwd=str(repo_dir),
-            description=(
-                f"Instrumented build: strace {build_cmd[:40]}"
-            ),
-        )
+        timer = StepTimer("build", "phase1")
+        with timer:
+            rc = self.runner.run(
+                instrumented, cwd=str(repo_dir),
+                description=(
+                    f"Instrumented build: "
+                    f"strace {build_cmd[:40]}"
+                ),
+            )
+        result.steps.append(timer.metrics)
         if rc != 0:
             print("[ERROR] Instrumented build failed")
-            return False
+            return result
 
-        # Generate OmniBOR treedb by scanning entire workspace
-        # The script automatically finds all .java, .class, and .jar files
-        # and builds the complete dependency graph
-        # See: bomsh docs/Quickstart.md - "For Java" section
-        treedb_file = meta_dir / "bomsh_omnibor_treedb"
-        rc = self.runner.run(
-            f"{create_bom} -r {repo_dir} "
-            f"-j {treedb_file}",
-            cwd=str(repo_dir),
-            description=(
-                "Generating OmniBOR treedb for Java workspace"
-            ),
-        )
-        if rc != 0:
-            print("[ERROR] bomsh_create_bom_java.py failed")
-            return False
+        # --- Phase 2a: ADG generation ---
+        timer = StepTimer("adg", "phase2")
+        with timer:
+            treedb_file = (
+                meta_dir / "bomsh_omnibor_treedb"
+            )
+            rc = self.runner.run(
+                f"{create_bom} -r {repo_dir} "
+                f"-j {treedb_file}",
+                cwd=str(repo_dir),
+                description=(
+                    "Generating OmniBOR treedb "
+                    "for Java workspace"
+                ),
+            )
+            if rc != 0:
+                print(
+                    "[ERROR] "
+                    "bomsh_create_bom_java.py failed"
+                )
+                result.steps.append(timer.metrics)
+                return result
 
-        # Archive strace log to metadata dir so
-        # AdgParser.parse_strace_openat_log() can
-        # consume it — mirrors how C/C++ archives
-        # the raw logfile via bomsh_create_bom.py.
-        strace_archive = (
-            meta_dir / "strace_java_logfile"
-        )
-        strace_src = Path(strace_log)
-        if strace_src.exists():
-            shutil.copy2(
-                str(strace_src), str(strace_archive)
+            # Archive strace log to metadata dir
+            strace_archive = (
+                meta_dir / "strace_java_logfile"
             )
-            print(
-                "[OK] strace log archived to "
-                f"{strace_archive}"
-            )
-        else:
-            print(
-                f"[WARN] strace log not found: "
-                f"{strace_log}"
-            )
+            strace_src = Path(strace_log)
+            if strace_src.exists():
+                shutil.copy2(
+                    str(strace_src),
+                    str(strace_archive),
+                )
+                print(
+                    "[OK] strace log archived to "
+                    f"{strace_archive}"
+                )
+            else:
+                print(
+                    f"[WARN] strace log not found: "
+                    f"{strace_log}"
+                )
+        result.steps.append(timer.metrics)
 
         print(
             "[OK] OmniBOR treedb written to "
             f"{treedb_file}"
         )
-        return True
+        result.success = True
+        return result

--- a/app/pipeline/builder.py
+++ b/app/pipeline/builder.py
@@ -23,7 +23,8 @@ from app.runner import CommandRunner
 
 @dataclass
 class BuildResult:
-    """Result from ``build()`` or ``build_java()``.
+    """Result from ``build()``, ``build_java()``, or
+    ``build_baseline()``.
 
     Carries success flag plus per-phase ``StepMetrics``
     so callers can assign Phase 1 vs Phase 2 timing.
@@ -193,15 +194,16 @@ class BomtraceBuilder:
         """Run non-instrumented build for baseline timing.
 
         Executes clean + prebuild + build WITHOUT any
-        tracer (no bomtrace/strace).  The entire Phase 1
-        is timed as one aggregate measurement so the
-        result can be compared against instrumented Phase 1
-        to compute overhead.
+        tracer (no bomtrace/strace).  Each step is timed
+        separately — exactly mirroring the instrumented
+        path — so the build step can be compared
+        apples-to-apples against the instrumented build.
 
         Returns:
-            ``StepMetrics`` for the full Phase 1, or
+            ``BuildResult`` with per-step metrics, or
             ``None`` if the build failed.
         """
+        result = BuildResult()
         repo_dir = (
             Path(paths_cfg["repos_dir"]) / repo_name
         )
@@ -210,49 +212,61 @@ class BomtraceBuilder:
         pre_steps = build_steps[:-1]
         make_cmd = build_steps[-1]
 
-        parallelism = infer_parallelism(make_cmd)
-        timer = StepTimer(
-            "baseline", "phase1", parallelism,
-        )
-        with timer:
-            # Clean (ignore exit code)
-            if clean_cmd:
+        # --- Clean (ignore exit code) ---
+        if clean_cmd:
+            timer = StepTimer("clean", "phase1")
+            with timer:
                 self.runner.run(
                     clean_cmd, cwd=str(repo_dir),
                     description=(
                         f"Clean: {clean_cmd}"
                     ),
                 )
+            result.steps.append(timer.metrics)
 
-            # Pre-build steps
-            for step in pre_steps:
-                rc = self.runner.run(
-                    step, cwd=str(repo_dir),
-                    description=(
-                        f"Pre-build: {step[:60]}"
-                    ),
-                )
-                if rc != 0:
-                    print(
-                        "[ERROR] Baseline pre-build "
-                        f"failed: {step}"
+        # --- Pre-build steps ---
+        if pre_steps:
+            timer = StepTimer("prebuild", "phase1")
+            with timer:
+                for step in pre_steps:
+                    rc = self.runner.run(
+                        step, cwd=str(repo_dir),
+                        description=(
+                            f"Pre-build: {step[:60]}"
+                        ),
                     )
-                    return None
+                    if rc != 0:
+                        print(
+                            "[ERROR] Baseline pre-build "
+                            f"failed: {step}"
+                        )
+                        result.steps.append(
+                            timer.metrics
+                        )
+                        return result
+            result.steps.append(timer.metrics)
 
-            # Build (NO tracer)
+        # --- Build (NO tracer) ---
+        parallelism = infer_parallelism(make_cmd)
+        timer = StepTimer(
+            "build", "phase1", parallelism,
+        )
+        with timer:
             rc = self.runner.run(
                 make_cmd, cwd=str(repo_dir),
                 description=(
                     f"Baseline: {make_cmd[:60]}"
                 ),
             )
-            if rc != 0:
-                print(
-                    "[ERROR] Baseline build failed"
-                )
-                return None
+        result.steps.append(timer.metrics)
+        if rc != 0:
+            print(
+                "[ERROR] Baseline build failed"
+            )
+            return result
 
-        return timer.metrics
+        result.success = True
+        return result
 
     def build_java(
         self, repo_name, repo_cfg,

--- a/app/pipeline/builder.py
+++ b/app/pipeline/builder.py
@@ -15,7 +15,9 @@ from pathlib import Path
 from typing import List
 
 from app.config import lang_subdir, timestamp
-from app.pipeline.timing import StepMetrics, StepTimer
+from app.pipeline.timing import (
+    StepMetrics, StepTimer, infer_parallelism,
+)
 from app.runner import CommandRunner
 
 
@@ -87,11 +89,11 @@ class BomtraceBuilder:
                 # fail on a fresh clone
             result.steps.append(timer.metrics)
 
-        # --- Phase 1b: Configure (pre-build steps) ---
+        # --- Phase 1b: Pre-build steps ---
         build_steps = repo_cfg["build_steps"]
         pre_steps = build_steps[:-1]
         if pre_steps:
-            timer = StepTimer("configure", "phase1")
+            timer = StepTimer("prebuild", "phase1")
             with timer:
                 for step in pre_steps:
                     rc = self.runner.run(
@@ -124,7 +126,10 @@ class BomtraceBuilder:
             instrumented = f"{tracer} {make_cmd}"
             env = None
 
-        timer = StepTimer("build", "phase1")
+        parallelism = infer_parallelism(make_cmd)
+        timer = StepTimer(
+            "build", "phase1", parallelism,
+        )
         with timer:
             rc = self.runner.run(
                 instrumented, cwd=str(repo_dir),
@@ -182,6 +187,73 @@ class BomtraceBuilder:
         result.success = True
         return result
 
+    def build_baseline(
+        self, repo_name, repo_cfg, paths_cfg,
+    ):
+        """Run non-instrumented build for baseline timing.
+
+        Executes clean + prebuild + build WITHOUT any
+        tracer (no bomtrace/strace).  The entire Phase 1
+        is timed as one aggregate measurement so the
+        result can be compared against instrumented Phase 1
+        to compute overhead.
+
+        Returns:
+            ``StepMetrics`` for the full Phase 1, or
+            ``None`` if the build failed.
+        """
+        repo_dir = (
+            Path(paths_cfg["repos_dir"]) / repo_name
+        )
+        build_steps = repo_cfg["build_steps"]
+        clean_cmd = repo_cfg.get("clean_cmd")
+        pre_steps = build_steps[:-1]
+        make_cmd = build_steps[-1]
+
+        parallelism = infer_parallelism(make_cmd)
+        timer = StepTimer(
+            "baseline", "phase1", parallelism,
+        )
+        with timer:
+            # Clean (ignore exit code)
+            if clean_cmd:
+                self.runner.run(
+                    clean_cmd, cwd=str(repo_dir),
+                    description=(
+                        f"Clean: {clean_cmd}"
+                    ),
+                )
+
+            # Pre-build steps
+            for step in pre_steps:
+                rc = self.runner.run(
+                    step, cwd=str(repo_dir),
+                    description=(
+                        f"Pre-build: {step[:60]}"
+                    ),
+                )
+                if rc != 0:
+                    print(
+                        "[ERROR] Baseline pre-build "
+                        f"failed: {step}"
+                    )
+                    return None
+
+            # Build (NO tracer)
+            rc = self.runner.run(
+                make_cmd, cwd=str(repo_dir),
+                description=(
+                    f"Baseline: {make_cmd[:60]}"
+                ),
+            )
+            if rc != 0:
+                print(
+                    "[ERROR] Baseline build failed"
+                )
+                return None
+
+        return timer.metrics
+
     def build_java(
         self, repo_name, repo_cfg,
         paths_cfg, omnibor_java_cfg,
@@ -227,11 +299,11 @@ class BomtraceBuilder:
                 )
             result.steps.append(timer.metrics)
 
-        # --- Phase 1b: Configure (pre-build steps) ---
+        # --- Phase 1b: Pre-build steps ---
         build_steps = repo_cfg["build_steps"]
         pre_steps = build_steps[:-1]
         if pre_steps:
-            timer = StepTimer("configure", "phase1")
+            timer = StepTimer("prebuild", "phase1")
             with timer:
                 for step in pre_steps:
                     rc = self.runner.run(
@@ -257,7 +329,10 @@ class BomtraceBuilder:
             f"strace {strace_opts} -o {strace_log} "
             f"{build_cmd}"
         )
-        timer = StepTimer("build", "phase1")
+        parallelism = infer_parallelism(build_cmd)
+        timer = StepTimer(
+            "build", "phase1", parallelism,
+        )
         with timer:
             rc = self.runner.run(
                 instrumented, cwd=str(repo_dir),

--- a/app/pipeline/doc_writer.py
+++ b/app/pipeline/doc_writer.py
@@ -95,8 +95,7 @@ class DocWriter:
         run_ts=None, tracer=None,
         raw_logfile=None,
         commit_sha=None,
-        capture_dur=None,
-        spdx_dur=None,
+        timing=None,
     ):
         """Write build log to output/build-logs/<lang>/<repo>/<ts>/."""
         ts = run_ts or timestamp()
@@ -109,20 +108,21 @@ class DocWriter:
         doc_path = docs_dir / "build.md"
 
         status = "SUCCESS" if success else "FAILED"
-        timing = (
+        timing_str = (
             f"**Duration:** {duration_sec:.1f}"
             " seconds"
         )
-        if capture_dur is not None:
-            timing += (
-                f" (capture: {capture_dur:.1f}s"
-                f" + SPDX: {spdx_dur:.1f}s)"
+        if timing:
+            timing_str += (
+                f" (build: {timing.phase1_total:.1f}s"
+                f" + analysis: "
+                f"{timing.phase2_total:.1f}s)"
             )
         content = (
-            f"# Build Log — {repo_name}\n\n"
+            f"# Build Log \u2014 {repo_name}\n\n"
             f"**Date:** {datetime.now().isoformat()}\n"
             f"**Status:** {status}\n"
-            f"{timing}\n\n"
+            f"{timing_str}\n\n"
             "## Repository\n\n"
             f"- **URL:** {repo_cfg['url']}\n"
             f"- **Branch:** "
@@ -182,6 +182,12 @@ class DocWriter:
                 "production/release binaries.\n"
             )
 
+        if timing:
+            content += _format_timing_table(timing)
+            content += _format_phase_summary(
+                timing, None,
+            )
+
         with open(
             doc_path, "w", encoding="utf-8"
         ) as f:
@@ -193,10 +199,10 @@ class DocWriter:
     @staticmethod
     def write_runtime_doc(
         repo_name, repo_cfg, paths_cfg,
-        duration_sec, baseline_sec=None,
+        duration_sec,
         run_ts=None, tracer=None,
-        capture_dur=None,
-        spdx_dur=None,
+        timing=None,
+        baseline=None,
     ):
         """Write runtime performance metrics."""
         ts = run_ts or timestamp()
@@ -212,49 +218,31 @@ class DocWriter:
             runtime_dir / "runtime.md"
         )
 
-        overhead_pct = ""
-        if baseline_sec and baseline_sec > 0:
-            pct = (
-                (duration_sec - baseline_sec)
-                / baseline_sec * 100
-            )
-            overhead_pct = (
-                f"\n**Bomtrace3 overhead:** "
-                f"{pct:.1f}%"
+        tracer_name = tracer or "unknown"
+        content = (
+            f"# Runtime Metrics \u2014 {repo_name}\n\n"
+            f"**Date:** "
+            f"{datetime.now().isoformat()}\n"
+            f"**Tracer:** {tracer_name}\n"
+            f"**Total:** {duration_sec:.1f} seconds\n"
+        )
+
+        if timing:
+            content += _format_timing_table(timing)
+            content += _format_phase_summary(
+                timing, baseline,
             )
 
         build_cmd = repo_cfg.get(
             "build_steps", ["unknown"]
         )[-1]
-        tracer_name = tracer or "unknown"
-        build_label = "Instrumented build time"
-        notes = (
+        content += (
+            "\n## Notes\n\n"
             f"- Measured wall-clock time for "
             f"{tracer_name}-instrumented "
             f"`{build_cmd}`\n"
             "- OmniBOR ADG + SPDX generated "
             "from build interception\n"
-        )
-
-        timing_breakdown = ""
-        if capture_dur is not None:
-            timing_breakdown = (
-                f"\n**Capture (build + interception):**"
-                f" {capture_dur:.1f} seconds\n"
-                f"**SPDX generation:** "
-                f"{spdx_dur:.1f} seconds\n"
-            )
-
-        content = (
-            f"# Runtime Metrics — {repo_name}\n\n"
-            f"**Date:** "
-            f"{datetime.now().isoformat()}\n"
-            f"**{build_label}:** "
-            f"{duration_sec:.1f} seconds\n"
-            f"{timing_breakdown}"
-            f"{overhead_pct}\n\n"
-            "## Notes\n\n"
-            f"{notes}"
         )
 
         with open(
@@ -266,3 +254,93 @@ class DocWriter:
             f"[OK] Runtime doc written to {doc_path}"
         )
         return str(doc_path)
+
+
+# ============================================================
+# Formatting helpers (module-level, used by both doc methods)
+# ============================================================
+
+_STEP_LABELS = {
+    "clean": "Clean",
+    "configure": "Configure",
+    "build": "Build",
+    "adg": "ADG Generation",
+    "omnibor_sbom": "OmniBOR SBOM",
+    "metadata": "Metadata",
+    "spdx_gen": "SPDX Generation",
+    "validate": "Validation",
+    "collect": "Binary Collection",
+}
+
+_PHASE_LABELS = {
+    "phase1": "Phase 1: Build Interception",
+    "phase2": "Phase 2: Post-Build Analysis",
+}
+
+
+def _format_timing_table(timing):
+    """Format per-step timing as a markdown table.
+
+    Each row shows step name, phase, wall time,
+    CPU efficiency, and contention flag.
+    """
+    lines = [
+        "\n## Per-Step Timing\n",
+        "| Step | Phase | Wall (s) "
+        "| CPU Eff | Flag |",
+        "|------|-------|----------"
+        "|---------|------|",
+    ]
+    for step in timing.steps:
+        label = _STEP_LABELS.get(
+            step.name, step.name,
+        )
+        phase = _PHASE_LABELS.get(
+            step.phase, step.phase,
+        )
+        flag = "CONTENTION" if step.contention else ""
+        eff = f"{step.cpu_efficiency:.2f}x"
+        lines.append(
+            f"| {label} | {phase} "
+            f"| {step.wall_sec:.1f} "
+            f"| {eff} | {flag} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _format_phase_summary(timing, baseline=None):
+    """Format phase totals and baseline comparison."""
+    p1 = timing.phase1_total
+    p2 = timing.phase2_total
+    total = p1 + p2
+
+    lines = [
+        "\n## Phase Summary\n",
+        f"- **Phase 1 (Build Interception):** "
+        f"{p1:.1f}s",
+        f"- **Phase 2 (Post-Build Analysis):** "
+        f"{p2:.1f}s",
+        f"- **Total:** {total:.1f}s",
+    ]
+
+    if baseline:
+        bl = baseline.get("wall_sec", 0)
+        if bl > 0:
+            overhead = (p1 - bl) / bl * 100
+            lines.append(
+                "\n### Baseline Comparison\n"
+            )
+            lines.append(
+                f"- **Non-instrumented build:** "
+                f"{bl:.1f}s"
+            )
+            lines.append(
+                f"- **Instrumented build "
+                f"(Phase 1):** {p1:.1f}s"
+            )
+            lines.append(
+                f"- **Overhead:** {overhead:+.1f}%"
+            )
+    lines.append("")
+    return "\n".join(lines)

--- a/app/pipeline/doc_writer.py
+++ b/app/pipeline/doc_writer.py
@@ -334,23 +334,39 @@ def _format_phase_summary(timing, baseline=None):
     ]
 
     if baseline:
-        bl = baseline.get("wall_sec", 0)
-        if bl > 0:
-            overhead = (p1 - bl) / bl * 100
-            lines.append(
-                "\n### Baseline Comparison\n"
+        from app.pipeline.timing import (
+            baseline_build_step,
+        )
+        bl_build = baseline_build_step(baseline)
+        if bl_build:
+            bl_wall = bl_build.get("wall_sec", 0)
+            # Find instrumented build step
+            inst_build = next(
+                (s for s in timing.steps
+                 if s.name == "build"),
+                None,
             )
-            lines.append(
-                f"- **Non-instrumented build:** "
-                f"{bl:.1f}s"
-            )
-            lines.append(
-                f"- **Instrumented build "
-                f"(Phase 1):** {p1:.1f}s"
-            )
-            lines.append(
-                f"- **Overhead:** {overhead:+.1f}%"
-            )
+            if bl_wall > 0 and inst_build:
+                overhead = (
+                    (inst_build.wall_sec - bl_wall)
+                    / bl_wall * 100
+                )
+                lines.append(
+                    "\n### Baseline Comparison "
+                    "(Build Step Only)\n"
+                )
+                lines.append(
+                    "- **Baseline build:** "
+                    f"{bl_wall:.1f}s"
+                )
+                lines.append(
+                    "- **Instrumented build:** "
+                    f"{inst_build.wall_sec:.1f}s"
+                )
+                lines.append(
+                    f"- **Overhead:** "
+                    f"{overhead:+.1f}%"
+                )
     lines.append("")
     return "\n".join(lines)
 

--- a/app/pipeline/doc_writer.py
+++ b/app/pipeline/doc_writer.py
@@ -232,6 +232,9 @@ class DocWriter:
             content += _format_phase_summary(
                 timing, baseline,
             )
+            content += _format_contention_summary(
+                timing,
+            )
 
         build_cmd = repo_cfg.get(
             "build_steps", ["unknown"]
@@ -262,7 +265,7 @@ class DocWriter:
 
 _STEP_LABELS = {
     "clean": "Clean",
-    "configure": "Configure",
+    "prebuild": "Pre-Build",
     "build": "Build",
     "adg": "ADG Generation",
     "omnibor_sbom": "OmniBOR SBOM",
@@ -282,14 +285,15 @@ def _format_timing_table(timing):
     """Format per-step timing as a markdown table.
 
     Each row shows step name, phase, wall time,
-    CPU efficiency, and contention flag.
+    expected parallelism, actual CPU efficiency,
+    and contention severity.
     """
     lines = [
         "\n## Per-Step Timing\n",
         "| Step | Phase | Wall (s) "
-        "| CPU Eff | Flag |",
+        "| Expected | CPU Eff | Contention |",
         "|------|-------|----------"
-        "|---------|------|",
+        "|----------|---------|------------|",
     ]
     for step in timing.steps:
         label = _STEP_LABELS.get(
@@ -298,12 +302,17 @@ def _format_timing_table(timing):
         phase = _PHASE_LABELS.get(
             step.phase, step.phase,
         )
-        flag = "CONTENTION" if step.contention else ""
+        exp = f"{step.expected_parallelism}x"
         eff = f"{step.cpu_efficiency:.2f}x"
+        if step.contention:
+            sev = step.contention_severity
+            flag = f"\u26a0 {sev:.0f}% below"
+        else:
+            flag = "\u2014"
         lines.append(
             f"| {label} | {phase} "
             f"| {step.wall_sec:.1f} "
-            f"| {eff} | {flag} |"
+            f"| {exp} | {eff} | {flag} |"
         )
     lines.append("")
     return "\n".join(lines)
@@ -342,5 +351,50 @@ def _format_phase_summary(timing, baseline=None):
             lines.append(
                 f"- **Overhead:** {overhead:+.1f}%"
             )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _format_contention_summary(timing):
+    """Format aggregate contention analysis section.
+
+    Reports how many steps had contention, total time
+    under contention, percentage of pipeline time, and
+    the most severe step.
+    """
+    flagged = timing.contention_steps
+    total_steps = len(timing.steps)
+    if not flagged:
+        return (
+            "\n## Contention Analysis\n\n"
+            f"No contention detected across "
+            f"{total_steps} steps.\n"
+        )
+
+    dur = timing.contention_total_sec
+    pct = timing.contention_pct
+    lines = [
+        "\n## Contention Analysis\n",
+        f"- **Steps with contention:** "
+        f"{len(flagged)} of {total_steps}",
+        f"- **Total contention duration:** "
+        f"{dur:.1f}s of {timing.total:.1f}s "
+        f"({pct:.1f}%)",
+    ]
+
+    # Most severe step
+    worst = max(
+        flagged, key=lambda s: s.contention_severity,
+    )
+    worst_label = _STEP_LABELS.get(
+        worst.name, worst.name,
+    )
+    lines.append(
+        f"- **Most severe:** {worst_label} "
+        f"\u2014 {worst.cpu_efficiency:.2f}x actual "
+        f"vs {worst.expected_parallelism}x expected "
+        f"({worst.contention_severity:.0f}% below "
+        f"threshold)"
+    )
     lines.append("")
     return "\n".join(lines)

--- a/app/pipeline/lang_runners.py
+++ b/app/pipeline/lang_runners.py
@@ -4,13 +4,17 @@ Language-specific pipeline runners.
 Contains the per-language orchestration functions that run
 the build→SPDX→validate→collect workflow for C/C++, Rust,
 Go, and Java repositories.
+
+Each runner returns a ``TimingResult`` with per-step
+metrics for Phase 1 (build interception) and Phase 2
+(post-build analysis).
 """
 
 import sys
-import time
 from pathlib import Path
 
 from app.config import lang_subdir
+from app.pipeline.timing import StepTimer, TimingResult
 
 
 # ============================================================
@@ -26,74 +30,56 @@ def run_c_cpp_pipeline(
     OmniBOR SPDX, metadata, ADG SPDX, validation,
     binary collection.
 
-    Returns (success, capture_dur, spdx_dur, tracer).
+    Returns ``TimingResult`` with per-step metrics.
     """
     tracer = omnibor_cfg.get("tracer", "bomtrace3")
+    timing = TimingResult(tracer=tracer)
 
-    # Step 3: Validate apt dependencies
+    # Validate apt dependencies
     deps_ok, missing = (
         pipeline.validator.validate(repo_cfg)
     )
     if not deps_ok:
         print(
-            "[ERROR] Cannot proceed — "
+            "[ERROR] Cannot proceed \u2014 "
             f"{len(missing)} missing package(s). "
             "Add them to the Dockerfile and "
             "rebuild the image."
         )
         sys.exit(1)
 
-    # Step 4: Instrumented build (timed separately)
-    start = time.time()
-    success = pipeline.builder.build(
+    # Phase 1: Build (clean + configure + build + ADG)
+    build_result = pipeline.builder.build(
         repo_name, repo_cfg,
         paths_cfg, omnibor_cfg,
         run_ts=run_ts,
     )
-    capture_dur = time.time() - start
+    timing.steps.extend(build_result.steps)
+    timing.success = build_result.success
+    if not build_result.success:
+        return timing
 
-    # Steps 5-7: SPDX generation + validation (timed)
-    spdx_start = time.time()
-    spdx_file = None
-    if success:
-        spdx_file = pipeline.spdx_gen.generate(
-            repo_name, repo_cfg,
-            paths_cfg, omnibor_cfg,
-            run_ts=run_ts,
-            vcs_uri=vcs_uri,
+    # Phase 2: Post-build analysis
+    timing.steps.extend(
+        _run_post_build(
+            pipeline, repo_name, repo_cfg,
+            paths_cfg, run_ts,
+            sbom_fn=lambda: pipeline.spdx_gen.generate(
+                repo_name, repo_cfg,
+                paths_cfg, omnibor_cfg,
+                run_ts=run_ts,
+                vcs_uri=vcs_uri,
+            ),
+            spdx_gen_fn=lambda: (
+                pipeline.adg_spdx.generate(
+                    repo_name, repo_cfg, paths_cfg,
+                    run_ts=run_ts,
+                    vcs_uri=vcs_uri,
+                )
+            ),
         )
-
-    # Step 5b: Collect component metadata + dynamic libs
-    if success:
-        pipeline.metadata_collector.collect(
-            repo_name, repo_cfg, paths_cfg,
-            run_ts=run_ts,
-        )
-
-    # Step 5c: Generate per-binary ADG SPDX
-    adg_files = []
-    if success:
-        adg_files = pipeline.adg_spdx.generate(
-            repo_name, repo_cfg, paths_cfg,
-            run_ts=run_ts,
-            vcs_uri=vcs_uri,
-        )
-
-    # Step 6: Validate SPDX documents
-    if spdx_file:
-        pipeline.spdx_validator.validate(spdx_file)
-    for adg_file in adg_files:
-        pipeline.spdx_validator.validate(adg_file)
-
-    # Step 7: Collect output binaries
-    if success:
-        pipeline.binary_collector.collect(
-            repo_name, repo_cfg, paths_cfg,
-            run_ts=run_ts,
-        )
-    spdx_dur = time.time() - spdx_start
-
-    return success, capture_dur, spdx_dur, tracer
+    )
+    return timing
 
 
 # ============================================================
@@ -117,63 +103,45 @@ def run_rust_pipeline(
     See: https://github.com/omnibor/bomsh
     #software-vulnerability-cve-search-for-rust-packages
 
-    Returns (success, capture_dur, spdx_dur, tracer).
+    Returns ``TimingResult`` with per-step metrics.
     """
     tracer = omnibor_rust_cfg.get(
         "tracer", "bomtrace2",
     )
+    timing = TimingResult(tracer=tracer)
 
-    # Step 4: Instrumented build (timed separately)
-    start = time.time()
-    success = pipeline.builder.build(
+    # Phase 1: Build
+    build_result = pipeline.builder.build(
         repo_name, repo_cfg,
         paths_cfg, omnibor_rust_cfg,
         run_ts=run_ts,
     )
-    capture_dur = time.time() - start
+    timing.steps.extend(build_result.steps)
+    timing.success = build_result.success
+    if not build_result.success:
+        return timing
 
-    # Steps 5-7: SPDX generation + validation (timed)
-    spdx_start = time.time()
-    spdx_file = None
-    if success:
-        spdx_file = pipeline.spdx_gen.generate(
-            repo_name, repo_cfg,
-            paths_cfg, omnibor_rust_cfg,
-            run_ts=run_ts,
-            vcs_uri=vcs_uri,
+    # Phase 2: Post-build analysis
+    timing.steps.extend(
+        _run_post_build(
+            pipeline, repo_name, repo_cfg,
+            paths_cfg, run_ts,
+            sbom_fn=lambda: pipeline.spdx_gen.generate(
+                repo_name, repo_cfg,
+                paths_cfg, omnibor_rust_cfg,
+                run_ts=run_ts,
+                vcs_uri=vcs_uri,
+            ),
+            spdx_gen_fn=lambda: (
+                pipeline.adg_spdx.generate(
+                    repo_name, repo_cfg, paths_cfg,
+                    run_ts=run_ts,
+                    vcs_uri=vcs_uri,
+                )
+            ),
         )
-
-    # Step 5b: Collect component metadata
-    if success:
-        pipeline.metadata_collector.collect(
-            repo_name, repo_cfg, paths_cfg,
-            run_ts=run_ts,
-        )
-
-    # Step 5c: Generate per-binary ADG SPDX
-    adg_files = []
-    if success:
-        adg_files = pipeline.adg_spdx.generate(
-            repo_name, repo_cfg, paths_cfg,
-            run_ts=run_ts,
-            vcs_uri=vcs_uri,
-        )
-
-    # Step 6: Validate SPDX documents
-    if spdx_file:
-        pipeline.spdx_validator.validate(spdx_file)
-    for adg_file in adg_files:
-        pipeline.spdx_validator.validate(adg_file)
-
-    # Step 7: Collect output binaries
-    if success:
-        pipeline.binary_collector.collect(
-            repo_name, repo_cfg, paths_cfg,
-            run_ts=run_ts,
-        )
-    spdx_dur = time.time() - spdx_start
-
-    return success, capture_dur, spdx_dur, tracer
+    )
+    return timing
 
 
 # ============================================================
@@ -248,73 +216,55 @@ def run_java_pipeline(
     In standalone mode (default): strace + bomsh_create_bom_java.py.
     In sidecar mode: dep:tree strategy (no strace needed).
 
-    Returns (success, capture_dur, spdx_dur, tracer).
+    Returns ``TimingResult`` with per-step metrics.
     """
     strategy = _select_java_strategy(
         repo_name, repo_cfg, paths_cfg, mode,
     )
+    tracer = strategy.name if strategy else "strace"
+    timing = TimingResult(tracer=tracer)
 
-    # Step 4: Build (timed separately)
-    start = time.time()
+    # Phase 1: Build
     if strategy:
-        # Sidecar: use builder.build() with strategy
-        success = pipeline.builder.build(
+        build_result = pipeline.builder.build(
             repo_name, repo_cfg,
             paths_cfg, omnibor_java_cfg,
             run_ts=run_ts,
             strategy=strategy,
         )
     else:
-        # Standalone: legacy strace path
-        success = pipeline.builder.build_java(
+        build_result = pipeline.builder.build_java(
             repo_name, repo_cfg,
             paths_cfg, omnibor_java_cfg,
             run_ts=run_ts,
         )
-    capture_dur = time.time() - start
+    timing.steps.extend(build_result.steps)
+    timing.success = build_result.success
+    if not build_result.success:
+        return timing
 
-    # Steps 5-7: SPDX generation + validation (timed)
-    spdx_start = time.time()
-    spdx_file = None
-    if success:
-        spdx_file = pipeline.spdx_gen.generate_java(
-            repo_name, repo_cfg,
-            paths_cfg, omnibor_java_cfg,
-            run_ts=run_ts,
+    # Phase 2: Post-build analysis
+    timing.steps.extend(
+        _run_post_build(
+            pipeline, repo_name, repo_cfg,
+            paths_cfg, run_ts,
+            sbom_fn=lambda: (
+                pipeline.spdx_gen.generate_java(
+                    repo_name, repo_cfg,
+                    paths_cfg, omnibor_java_cfg,
+                    run_ts=run_ts,
+                )
+            ),
+            spdx_gen_fn=lambda: (
+                generate_java_adg_spdx(
+                    repo_name, repo_cfg,
+                    paths_cfg, run_ts,
+                    vcs_uri=vcs_uri,
+                )
+            ),
         )
-
-    # Step 5b: Collect component metadata
-    if success:
-        pipeline.metadata_collector.collect(
-            repo_name, repo_cfg, paths_cfg,
-            run_ts=run_ts,
-        )
-
-    # Step 5c: Generate per-binary ADG SPDX (Java-specific)
-    adg_files = []
-    if success:
-        adg_files = generate_java_adg_spdx(
-            repo_name, repo_cfg, paths_cfg, run_ts,
-            vcs_uri=vcs_uri,
-        )
-
-    # Step 6: Validate SPDX documents
-    if spdx_file:
-        pipeline.spdx_validator.validate(spdx_file)
-    for adg_file in adg_files:
-        pipeline.spdx_validator.validate(adg_file)
-
-    # Step 7: Collect output JARs
-    if success:
-        pipeline.binary_collector.collect(
-            repo_name, repo_cfg, paths_cfg,
-            run_ts=run_ts,
-        )
-
-    spdx_dur = time.time() - spdx_start
-
-    tracer = strategy.name if strategy else "strace"
-    return success, capture_dur, spdx_dur, tracer
+    )
+    return timing
 
 
 def generate_java_adg_spdx(
@@ -514,60 +464,116 @@ def run_go_pipeline(
     See: https://github.com/omnibor/bomsh
     #software-vulnerability-cve-search-for-golang-packages
 
-    Returns (success, capture_dur, spdx_dur, tracer).
+    Returns ``TimingResult`` with per-step metrics.
     """
     tracer = omnibor_go_cfg.get(
         "tracer", "bomtrace2",
     )
+    timing = TimingResult(tracer=tracer)
 
-    # Step 4: Instrumented build (timed separately)
-    start = time.time()
-    success = pipeline.builder.build(
+    # Phase 1: Build
+    build_result = pipeline.builder.build(
         repo_name, repo_cfg,
         paths_cfg, omnibor_go_cfg,
         run_ts=run_ts,
     )
-    capture_dur = time.time() - start
+    timing.steps.extend(build_result.steps)
+    timing.success = build_result.success
+    if not build_result.success:
+        return timing
 
-    # Steps 5-7: SPDX generation + validation (timed)
-    spdx_start = time.time()
-    spdx_file = None
-    if success:
-        spdx_file = pipeline.spdx_gen.generate(
-            repo_name, repo_cfg,
-            paths_cfg, omnibor_go_cfg,
-            run_ts=run_ts,
-            vcs_uri=vcs_uri,
+    # Phase 2: Post-build analysis
+    timing.steps.extend(
+        _run_post_build(
+            pipeline, repo_name, repo_cfg,
+            paths_cfg, run_ts,
+            sbom_fn=lambda: pipeline.spdx_gen.generate(
+                repo_name, repo_cfg,
+                paths_cfg, omnibor_go_cfg,
+                run_ts=run_ts,
+                vcs_uri=vcs_uri,
+            ),
+            spdx_gen_fn=lambda: (
+                pipeline.adg_spdx.generate(
+                    repo_name, repo_cfg, paths_cfg,
+                    run_ts=run_ts,
+                    vcs_uri=vcs_uri,
+                )
+            ),
         )
+    )
+    return timing
 
-    # Step 5b: Collect component metadata
-    if success:
+
+# ============================================================
+# Shared post-build helper (Phase 2 steps)
+# ============================================================
+
+def _run_post_build(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, run_ts,
+    sbom_fn=None,
+    spdx_gen_fn=None,
+):
+    """Run Phase 2 post-build steps (generic, all languages).
+
+    Callers inject two callbacks to vary behavior:
+
+    - ``sbom_fn``: generates the OmniBOR SBOM
+      (``bomsh_sbom.py`` for C/Rust/Go, no-op for Java).
+    - ``spdx_gen_fn``: generates per-binary SPDX
+      (``AdgSpdxGenerator`` for C/Rust/Go,
+      ``JavaSpdxGenerator`` for Java).
+
+    Returns list of ``StepMetrics`` for each step.
+    """
+    steps = []
+
+    # OmniBOR SBOM
+    spdx_file = None
+    timer = StepTimer("omnibor_sbom", "phase2")
+    with timer:
+        if sbom_fn:
+            spdx_file = sbom_fn()
+    steps.append(timer.metrics)
+
+    # Metadata collection
+    timer = StepTimer("metadata", "phase2")
+    with timer:
         pipeline.metadata_collector.collect(
             repo_name, repo_cfg, paths_cfg,
             run_ts=run_ts,
         )
+    steps.append(timer.metrics)
 
-    # Step 5c: Generate per-binary ADG SPDX
+    # SPDX generation
     adg_files = []
-    if success:
-        adg_files = pipeline.adg_spdx.generate(
-            repo_name, repo_cfg, paths_cfg,
-            run_ts=run_ts,
-            vcs_uri=vcs_uri,
-        )
+    timer = StepTimer("spdx_gen", "phase2")
+    with timer:
+        if spdx_gen_fn:
+            adg_files = spdx_gen_fn()
+    steps.append(timer.metrics)
 
-    # Step 6: Validate SPDX documents
-    if spdx_file:
-        pipeline.spdx_validator.validate(spdx_file)
-    for adg_file in adg_files:
-        pipeline.spdx_validator.validate(adg_file)
+    # Validation
+    timer = StepTimer("validate", "phase2")
+    with timer:
+        if spdx_file:
+            pipeline.spdx_validator.validate(
+                spdx_file,
+            )
+        for adg_file in adg_files:
+            pipeline.spdx_validator.validate(
+                adg_file,
+            )
+    steps.append(timer.metrics)
 
-    # Step 7: Collect output binaries
-    if success:
+    # Binary collection
+    timer = StepTimer("collect", "phase2")
+    with timer:
         pipeline.binary_collector.collect(
             repo_name, repo_cfg, paths_cfg,
             run_ts=run_ts,
         )
-    spdx_dur = time.time() - spdx_start
+    steps.append(timer.metrics)
 
-    return success, capture_dur, spdx_dur, tracer
+    return steps

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -174,44 +174,36 @@ def main():
 
     # -------------------------------------------------
     # Language-specific pipeline branch
-    # Each returns (success, capture_dur, spdx_dur,
-    #               tracer_name).
+    # Each returns a TimingResult with per-step metrics.
     # -------------------------------------------------
     if lang == "c-cpp":
-        success, capture_dur, spdx_dur, tracer = (
-            run_c_cpp_pipeline(
-                pipeline, args.repo, repo_cfg,
-                paths_cfg, omnibor_cfg, run_ts,
-                vcs_uri=vcs_uri,
-            )
+        timing = run_c_cpp_pipeline(
+            pipeline, args.repo, repo_cfg,
+            paths_cfg, omnibor_cfg, run_ts,
+            vcs_uri=vcs_uri,
         )
     elif lang == "rust":
-        success, capture_dur, spdx_dur, tracer = (
-            run_rust_pipeline(
-                pipeline, args.repo, repo_cfg,
-                paths_cfg, omnibor_cfg, run_ts,
-                vcs_uri=vcs_uri,
-            )
+        timing = run_rust_pipeline(
+            pipeline, args.repo, repo_cfg,
+            paths_cfg, omnibor_cfg, run_ts,
+            vcs_uri=vcs_uri,
         )
     elif lang == "java":
         mode = config.get("mode", DEFAULT_MODE)
-        success, capture_dur, spdx_dur, tracer = (
-            run_java_pipeline(
-                pipeline, args.repo, repo_cfg,
-                paths_cfg, omnibor_cfg, run_ts,
-                vcs_uri=vcs_uri,
-                mode=mode,
-            )
+        timing = run_java_pipeline(
+            pipeline, args.repo, repo_cfg,
+            paths_cfg, omnibor_cfg, run_ts,
+            vcs_uri=vcs_uri,
+            mode=mode,
         )
     else:
-        success, capture_dur, spdx_dur, tracer = (
-            run_go_pipeline(
-                pipeline, args.repo, repo_cfg,
-                paths_cfg, omnibor_cfg, run_ts,
-                vcs_uri=vcs_uri,
-            )
+        timing = run_go_pipeline(
+            pipeline, args.repo, repo_cfg,
+            paths_cfg, omnibor_cfg, run_ts,
+            vcs_uri=vcs_uri,
         )
-    duration = capture_dur + spdx_dur
+    success = timing.success
+    duration = timing.total
 
     # Step 7b: Validate Syft SPDX (if enabled)
     if syft_enabled:
@@ -225,28 +217,50 @@ def main():
     pipeline.docs.write_build_doc(
         args.repo, repo_cfg, paths_cfg,
         success, duration,
-        run_ts=run_ts, tracer=tracer,
+        run_ts=run_ts, tracer=timing.tracer,
         raw_logfile=raw_logfile,
         commit_sha=commit_sha,
-        capture_dur=capture_dur,
-        spdx_dur=spdx_dur,
+        timing=timing,
     )
     pipeline.docs.write_runtime_doc(
         args.repo, repo_cfg, paths_cfg,
         duration, run_ts=run_ts,
-        tracer=tracer,
-        capture_dur=capture_dur,
-        spdx_dur=spdx_dur,
+        tracer=timing.tracer,
+        timing=timing,
     )
 
+    # Save runtime.json
+    from app.pipeline.timing import (
+        load_baseline, save_runtime_json,
+    )
+    baseline = load_baseline(
+        paths_cfg, args.repo, repo_cfg,
+    )
+    save_runtime_json(
+        timing, paths_cfg, args.repo,
+        repo_cfg, run_ts,
+        baseline=baseline,
+    )
+
+    # Console summary
+    p1 = timing.phase1_total
+    p2 = timing.phase2_total
     status = "COMPLETE" if success else "FAILED"
     print(f"\n{'#'*60}")
     print(f"  Analysis {status}: {args.repo}")
     print(
-        f"  Capture: {capture_dur:.1f}s  "
-        f"SPDX: {spdx_dur:.1f}s  "
+        f"  Build: {p1:.1f}s  "
+        f"Analysis: {p2:.1f}s  "
         f"Total: {duration:.1f}s"
     )
+    if baseline:
+        bl = baseline.get("wall_sec", 0)
+        if bl > 0:
+            overhead = (p1 - bl) / bl * 100
+            print(
+                f"  Baseline: {bl:.1f}s  "
+                f"Overhead: {overhead:+.1f}%"
+            )
     print(f"{'#'*60}\n")
 
 

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -65,6 +65,13 @@ def main():
             f"Default: {DEFAULT_MODE}"
         ),
     )
+    parser.add_argument(
+        "--baseline", action="store_true",
+        help=(
+            "Run non-instrumented build to capture "
+            "baseline timing. No Phase 2 analysis."
+        ),
+    )
     args = parser.parse_args()
 
     config = load_config()
@@ -153,6 +160,14 @@ def main():
             "[WARN] Could not resolve commit SHA"
         )
 
+    # Baseline mode: non-instrumented build only
+    if args.baseline:
+        _run_baseline(
+            args.repo, repo_cfg, paths_cfg,
+            run_ts, pipeline,
+        )
+        return
+
     # Step 2: Syft SBOM (manifest-based — optional,
     # disabled by default in config.yaml).
     # --syft-only CLI flag overrides config.
@@ -212,6 +227,14 @@ def main():
             paths_cfg, run_ts,
         )
 
+    # Load baseline (golden reference) for overhead calc
+    from app.pipeline.timing import (
+        load_baseline, save_runtime_json,
+    )
+    baseline = load_baseline(
+        paths_cfg, args.repo, repo_cfg,
+    )
+
     # Step 8: Write docs (all languages)
     raw_logfile = omnibor_cfg.get("raw_logfile")
     pipeline.docs.write_build_doc(
@@ -227,15 +250,10 @@ def main():
         duration, run_ts=run_ts,
         tracer=timing.tracer,
         timing=timing,
+        baseline=baseline,
     )
 
     # Save runtime.json
-    from app.pipeline.timing import (
-        load_baseline, save_runtime_json,
-    )
-    baseline = load_baseline(
-        paths_cfg, args.repo, repo_cfg,
-    )
     save_runtime_json(
         timing, paths_cfg, args.repo,
         repo_cfg, run_ts,
@@ -261,6 +279,42 @@ def main():
                 f"  Baseline: {bl:.1f}s  "
                 f"Overhead: {overhead:+.1f}%"
             )
+    print(f"{'#'*60}\n")
+
+
+def _run_baseline(
+    repo_name, repo_cfg, paths_cfg,
+    run_ts, pipeline,
+):
+    """Run non-instrumented build and save baseline.
+
+    Delegates to ``BomtraceBuilder.build_baseline()``
+    which runs clean + prebuild + build WITHOUT tracer.
+    The entire Phase 1 is timed as one aggregate
+    ``StepMetrics`` and saved as ``baseline.json``.
+    """
+    from app.pipeline.timing import save_baseline
+
+    print(f"\n[BASELINE] {repo_name}: "
+          "non-instrumented build")
+
+    metrics = pipeline.builder.build_baseline(
+        repo_name, repo_cfg, paths_cfg,
+    )
+    if metrics is None:
+        print(f"[ERROR] Baseline failed: {repo_name}")
+        return
+
+    save_baseline(
+        metrics, paths_cfg, repo_name,
+        repo_cfg, run_ts=run_ts,
+    )
+
+    print(
+        f"[BASELINE] {repo_name}: "
+        f"{metrics.wall_sec:.1f}s "
+        f"(CPU eff: {metrics.cpu_efficiency:.2f}x)"
+    )
     print(f"{'#'*60}\n")
 
 

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -272,13 +272,29 @@ def main():
         f"Total: {duration:.1f}s"
     )
     if baseline:
-        bl = baseline.get("wall_sec", 0)
-        if bl > 0:
-            overhead = (p1 - bl) / bl * 100
-            print(
-                f"  Baseline: {bl:.1f}s  "
-                f"Overhead: {overhead:+.1f}%"
+        from app.pipeline.timing import (
+            baseline_build_step,
+        )
+        bl_build = baseline_build_step(baseline)
+        if bl_build:
+            bl_wall = bl_build.get("wall_sec", 0)
+            # Find instrumented build step
+            inst_build = next(
+                (s for s in timing.steps
+                 if s.name == "build"),
+                None,
             )
+            if bl_wall > 0 and inst_build:
+                overhead = (
+                    (inst_build.wall_sec - bl_wall)
+                    / bl_wall * 100
+                )
+                print(
+                    f"  Build overhead: "
+                    f"{bl_wall:.1f}s → "
+                    f"{inst_build.wall_sec:.1f}s "
+                    f"({overhead:+.1f}%)"
+                )
     print(f"{'#'*60}\n")
 
 
@@ -290,30 +306,46 @@ def _run_baseline(
 
     Delegates to ``BomtraceBuilder.build_baseline()``
     which runs clean + prebuild + build WITHOUT tracer.
-    The entire Phase 1 is timed as one aggregate
-    ``StepMetrics`` and saved as ``baseline.json``.
+    Each step is timed separately so the build step
+    can be compared apples-to-apples against the
+    instrumented build.
     """
     from app.pipeline.timing import save_baseline
 
     print(f"\n[BASELINE] {repo_name}: "
           "non-instrumented build")
 
-    metrics = pipeline.builder.build_baseline(
+    build_result = pipeline.builder.build_baseline(
         repo_name, repo_cfg, paths_cfg,
     )
-    if metrics is None:
+    if build_result is None or not build_result.success:
         print(f"[ERROR] Baseline failed: {repo_name}")
         return
 
     save_baseline(
-        metrics, paths_cfg, repo_name,
+        build_result, paths_cfg, repo_name,
         repo_cfg, run_ts=run_ts,
     )
 
+    # Report the build step specifically
+    build_step = next(
+        (s for s in build_result.steps
+         if s.name == "build"),
+        None,
+    )
+    if build_step:
+        print(
+            f"[BASELINE] {repo_name}: build "
+            f"{build_step.wall_sec:.1f}s "
+            f"(CPU eff: "
+            f"{build_step.cpu_efficiency:.2f}x)"
+        )
+    total = sum(
+        s.wall_sec for s in build_result.steps
+    )
     print(
-        f"[BASELINE] {repo_name}: "
-        f"{metrics.wall_sec:.1f}s "
-        f"(CPU eff: {metrics.cpu_efficiency:.2f}x)"
+        f"[BASELINE] {repo_name}: total "
+        f"{total:.1f}s"
     )
     print(f"{'#'*60}\n")
 

--- a/app/pipeline/timing.py
+++ b/app/pipeline/timing.py
@@ -430,13 +430,14 @@ def load_baseline(paths_cfg, repo_name, repo_cfg):
 
 
 def save_baseline(
-    metrics, paths_cfg, repo_name, repo_cfg,
+    build_result, paths_cfg, repo_name, repo_cfg,
     run_ts=None,
 ):
     """Write baseline.json from a non-instrumented build.
 
     Args:
-        metrics: ``StepMetrics`` from the plain build.
+        build_result: ``BuildResult`` from
+            ``build_baseline()`` with per-step metrics.
         paths_cfg: Paths config section.
         repo_name: Repository name.
         repo_cfg: Repository config section.
@@ -453,7 +454,11 @@ def save_baseline(
     baseline_dir.mkdir(parents=True, exist_ok=True)
     out_path = baseline_dir / "baseline.json"
 
-    data = metrics.to_dict()
+    data = {
+        "steps": [
+            s.to_dict() for s in build_result.steps
+        ],
+    }
     if run_ts:
         data["run_ts"] = run_ts
     with open(out_path, "w", encoding="utf-8") as f:
@@ -461,3 +466,31 @@ def save_baseline(
 
     print(f"[OK] Baseline written to {out_path}")
     return str(out_path)
+
+
+def baseline_build_step(baseline):
+    """Extract the build step from a baseline dict.
+
+    Finds the step named ``build`` in the baseline's
+    ``steps`` array for apples-to-apples comparison
+    against the instrumented build step.
+
+    Supports both the current format (steps array) and
+    legacy format (single flat dict with ``wall_sec``).
+
+    Returns:
+        Step dict with ``wall_sec``, ``cpu_total_sec``,
+        etc., or ``None`` if not found.
+    """
+    if not baseline:
+        return None
+    # Current format: {"steps": [...]}
+    if "steps" in baseline:
+        for step in baseline["steps"]:
+            if step.get("name") == "build":
+                return step
+        return None
+    # Legacy format: single flat dict (aggregate)
+    if "wall_sec" in baseline:
+        return baseline
+    return None

--- a/app/pipeline/timing.py
+++ b/app/pipeline/timing.py
@@ -19,6 +19,7 @@ and end of each step to detect contention.
 
 import json
 import os
+import re
 import resource
 import time
 from dataclasses import dataclass, field, asdict
@@ -29,6 +30,69 @@ from typing import List
 # Contention threshold: if actual CPU efficiency is below
 # 70% of expected, flag as contention.
 CONTENTION_THRESHOLD = 0.70
+
+# Regex for make -j<N> patterns
+_MAKE_J_RE = re.compile(
+    r"-j\s*(\d+|\$\(nproc\))"
+)
+
+
+def infer_parallelism(build_cmd, cpu_count=None):
+    """Infer expected CPU parallelism from a build command.
+
+    Uses build-tool conventions to determine how many cores
+    a command is expected to utilize.  This is generic —
+    no repo-specific logic.
+
+    Build tool defaults:
+      - ``make -j<N>``       → N (or cpu_count for nproc)
+      - ``make`` (bare)      → 1
+      - ``go build``         → cpu_count (GOMAXPROCS)
+      - ``cargo build``      → cpu_count (num_cpus)
+      - ``mvn``              → 1 (sequential lifecycle)
+      - ``gradlew``/``gradle`` → cpu_count (worker pool)
+      - Other                → 1 (conservative default)
+
+    Args:
+        build_cmd: The build command string.
+        cpu_count: Available CPU cores (defaults to
+            ``os.cpu_count()``).
+
+    Returns:
+        Expected parallelism as an integer ≥ 1.
+    """
+    cpus = cpu_count or os.cpu_count() or 1
+    cmd = build_cmd.strip()
+
+    # make with -j flag
+    if "make" in cmd:
+        m = _MAKE_J_RE.search(cmd)
+        if m:
+            val = m.group(1)
+            if val == "$(nproc)":
+                return cpus
+            return max(1, int(val))
+        # bare make → single-threaded
+        return 1
+
+    # Go: inherently parallel (GOMAXPROCS = cpu_count)
+    if cmd.startswith("go "):
+        return cpus
+
+    # Rust/Cargo: parallel by default (num_cpus)
+    if "cargo " in cmd:
+        return cpus
+
+    # Gradle: worker pool = cpu_count by default
+    if "gradlew" in cmd or "gradle " in cmd:
+        return cpus
+
+    # Maven: sequential lifecycle by default
+    if "mvn " in cmd:
+        return 1
+
+    # Conservative default for unknown tools
+    return 1
 
 
 @dataclass
@@ -41,6 +105,7 @@ class StepMetrics:
     cpu_user_sec: float = 0.0
     cpu_sys_sec: float = 0.0
     cpu_count: int = 1
+    expected_parallelism: int = 1
     load_avg_start: tuple = (0.0, 0.0, 0.0)
     load_avg_end: tuple = (0.0, 0.0, 0.0)
     contention: bool = False
@@ -61,12 +126,36 @@ class StepMetrics:
             return 0.0
         return self.cpu_total_sec / self.wall_sec
 
+    @property
+    def contention_severity(self):
+        """How far below threshold, as a percentage.
+
+        Returns 0.0 if no contention.  Otherwise returns
+        the deficit — e.g. 45.0 means actual efficiency
+        was 45% below the contention threshold.
+        """
+        if not self.contention or self.wall_sec <= 0:
+            return 0.0
+        threshold = (
+            min(self.expected_parallelism, self.cpu_count)
+            * CONTENTION_THRESHOLD
+        )
+        if threshold <= 0:
+            return 0.0
+        actual = self.cpu_efficiency
+        return max(
+            0.0, (1.0 - actual / threshold) * 100
+        )
+
     def to_dict(self):
         """Serialize to dict for JSON storage."""
         d = asdict(self)
         d["cpu_total_sec"] = round(self.cpu_total_sec, 2)
         d["cpu_efficiency"] = round(
             self.cpu_efficiency, 2
+        )
+        d["contention_severity"] = round(
+            self.contention_severity, 1
         )
         # Round floats for readability
         for k in (
@@ -125,6 +214,28 @@ class TimingResult:
         """Total wall-clock time for all steps."""
         return self.phase1_total + self.phase2_total
 
+    @property
+    def contention_steps(self):
+        """Steps flagged with contention."""
+        return [
+            s for s in self.steps if s.contention
+        ]
+
+    @property
+    def contention_total_sec(self):
+        """Wall-clock seconds spent in contended steps."""
+        return sum(
+            s.wall_sec for s in self.contention_steps
+        )
+
+    @property
+    def contention_pct(self):
+        """Percentage of total time under contention."""
+        t = self.total
+        if t <= 0:
+            return 0.0
+        return self.contention_total_sec / t * 100
+
     def to_dict(self):
         """Serialize to dict for JSON storage."""
         return {
@@ -137,6 +248,18 @@ class TimingResult:
                 self.phase2_total, 2
             ),
             "total_sec": round(self.total, 2),
+            "contention_summary": {
+                "steps_flagged": len(
+                    self.contention_steps
+                ),
+                "total_steps": len(self.steps),
+                "duration_sec": round(
+                    self.contention_total_sec, 2
+                ),
+                "pct_of_total": round(
+                    self.contention_pct, 1
+                ),
+            },
             "steps": [
                 s.to_dict() for s in self.steps
             ],
@@ -145,6 +268,11 @@ class TimingResult:
 
 class StepTimer:
     """Context manager that measures a pipeline step.
+
+    Measures both ``RUSAGE_SELF`` (Python in-process work)
+    and ``RUSAGE_CHILDREN`` (subprocesses) so that CPU
+    efficiency is accurate for all step types — subprocess-
+    heavy build steps and Python-internal analysis steps.
 
     Usage::
 
@@ -161,7 +289,8 @@ class StepTimer:
         self._phase = phase
         self._expected = expected_parallelism
         self._start_wall = 0.0
-        self._start_usage = None
+        self._start_self = None
+        self._start_children = None
         self._start_load = (0.0, 0.0, 0.0)
         self._metrics = None
 
@@ -173,7 +302,10 @@ class StepTimer:
     def __enter__(self):
         """Record start timestamps."""
         self._start_load = _safe_loadavg()
-        self._start_usage = resource.getrusage(
+        self._start_self = resource.getrusage(
+            resource.RUSAGE_SELF,
+        )
+        self._start_children = resource.getrusage(
             resource.RUSAGE_CHILDREN,
         )
         self._start_wall = time.monotonic()
@@ -182,19 +314,31 @@ class StepTimer:
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Compute metrics from start/end deltas."""
         wall = time.monotonic() - self._start_wall
-        end_usage = resource.getrusage(
+        end_self = resource.getrusage(
+            resource.RUSAGE_SELF,
+        )
+        end_children = resource.getrusage(
             resource.RUSAGE_CHILDREN,
         )
         end_load = _safe_loadavg()
         cpu_count = os.cpu_count() or 1
 
+        # Sum RUSAGE_SELF (Python) + RUSAGE_CHILDREN
+        # (subprocesses) for total CPU consumed by
+        # this step.  This ensures Python-internal
+        # steps (spdx_gen, validate) report real CPU
+        # instead of zero.
         user = (
-            end_usage.ru_utime
-            - self._start_usage.ru_utime
+            (end_self.ru_utime
+             - self._start_self.ru_utime)
+            + (end_children.ru_utime
+               - self._start_children.ru_utime)
         )
         sys_ = (
-            end_usage.ru_stime
-            - self._start_usage.ru_stime
+            (end_self.ru_stime
+             - self._start_self.ru_stime)
+            + (end_children.ru_stime
+               - self._start_children.ru_stime)
         )
 
         # Contention detection
@@ -217,6 +361,7 @@ class StepTimer:
             cpu_user_sec=user,
             cpu_sys_sec=sys_,
             cpu_count=cpu_count,
+            expected_parallelism=self._expected,
             load_avg_start=self._start_load,
             load_avg_end=end_load,
             contention=contention,
@@ -286,6 +431,7 @@ def load_baseline(paths_cfg, repo_name, repo_cfg):
 
 def save_baseline(
     metrics, paths_cfg, repo_name, repo_cfg,
+    run_ts=None,
 ):
     """Write baseline.json from a non-instrumented build.
 
@@ -294,6 +440,8 @@ def save_baseline(
         paths_cfg: Paths config section.
         repo_name: Repository name.
         repo_cfg: Repository config section.
+        run_ts: Timestamp string for when baseline was
+            captured.
     """
     from app.config import lang_subdir
 
@@ -306,6 +454,8 @@ def save_baseline(
     out_path = baseline_dir / "baseline.json"
 
     data = metrics.to_dict()
+    if run_ts:
+        data["run_ts"] = run_ts
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 

--- a/app/pipeline/timing.py
+++ b/app/pipeline/timing.py
@@ -1,0 +1,313 @@
+"""
+Per-step timing and CPU monitoring for OmniBOR Analysis.
+
+Provides ``StepTimer`` for measuring wall-clock time, CPU
+usage, and load average for each pipeline step.  Results
+are collected into ``StepMetrics`` and ``TimingResult``
+for structured reporting.
+
+CPU monitoring uses two complementary approaches:
+  1. ``resource.getrusage(RUSAGE_CHILDREN)`` — stdlib,
+     always available, measures waited-on child processes.
+  2. ``/usr/bin/time -v`` — Linux GNU time, captures all
+     descendant CPU, max RSS, context switches.  Used as
+     secondary cross-validation when available.
+
+Load average (``os.getloadavg()``) is sampled at start
+and end of each step to detect contention.
+"""
+
+import json
+import os
+import resource
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import List
+
+
+# Contention threshold: if actual CPU efficiency is below
+# 70% of expected, flag as contention.
+CONTENTION_THRESHOLD = 0.70
+
+
+@dataclass
+class StepMetrics:
+    """Metrics for a single timed pipeline step."""
+
+    name: str
+    phase: str
+    wall_sec: float = 0.0
+    cpu_user_sec: float = 0.0
+    cpu_sys_sec: float = 0.0
+    cpu_count: int = 1
+    load_avg_start: tuple = (0.0, 0.0, 0.0)
+    load_avg_end: tuple = (0.0, 0.0, 0.0)
+    contention: bool = False
+
+    @property
+    def cpu_total_sec(self):
+        """Total CPU time (user + system)."""
+        return self.cpu_user_sec + self.cpu_sys_sec
+
+    @property
+    def cpu_efficiency(self):
+        """CPU utilization ratio: cpu_time / wall_time.
+
+        For a single-threaded build this should be ~1.0.
+        For ``make -j4`` on 4 cores it should be ~4.0.
+        """
+        if self.wall_sec <= 0:
+            return 0.0
+        return self.cpu_total_sec / self.wall_sec
+
+    def to_dict(self):
+        """Serialize to dict for JSON storage."""
+        d = asdict(self)
+        d["cpu_total_sec"] = round(self.cpu_total_sec, 2)
+        d["cpu_efficiency"] = round(
+            self.cpu_efficiency, 2
+        )
+        # Round floats for readability
+        for k in (
+            "wall_sec", "cpu_user_sec", "cpu_sys_sec",
+        ):
+            d[k] = round(d[k], 2)
+        d["load_avg_start"] = [
+            round(v, 2) for v in d["load_avg_start"]
+        ]
+        d["load_avg_end"] = [
+            round(v, 2) for v in d["load_avg_end"]
+        ]
+        return d
+
+
+@dataclass
+class TimingResult:
+    """Aggregated timing for a full pipeline run."""
+
+    tracer: str = ""
+    success: bool = False
+    steps: List[StepMetrics] = field(
+        default_factory=list,
+    )
+
+    @property
+    def phase1_steps(self):
+        """Steps in Phase 1 (Build Interception)."""
+        return [
+            s for s in self.steps if s.phase == "phase1"
+        ]
+
+    @property
+    def phase2_steps(self):
+        """Steps in Phase 2 (Post-Build Analysis)."""
+        return [
+            s for s in self.steps if s.phase == "phase2"
+        ]
+
+    @property
+    def phase1_total(self):
+        """Total wall-clock time for Phase 1."""
+        return sum(
+            s.wall_sec for s in self.phase1_steps
+        )
+
+    @property
+    def phase2_total(self):
+        """Total wall-clock time for Phase 2."""
+        return sum(
+            s.wall_sec for s in self.phase2_steps
+        )
+
+    @property
+    def total(self):
+        """Total wall-clock time for all steps."""
+        return self.phase1_total + self.phase2_total
+
+    def to_dict(self):
+        """Serialize to dict for JSON storage."""
+        return {
+            "tracer": self.tracer,
+            "success": self.success,
+            "phase1_total_sec": round(
+                self.phase1_total, 2
+            ),
+            "phase2_total_sec": round(
+                self.phase2_total, 2
+            ),
+            "total_sec": round(self.total, 2),
+            "steps": [
+                s.to_dict() for s in self.steps
+            ],
+        }
+
+
+class StepTimer:
+    """Context manager that measures a pipeline step.
+
+    Usage::
+
+        timer = StepTimer("build", "phase1")
+        with timer:
+            run_the_build()
+        metrics = timer.metrics
+    """
+
+    def __init__(
+        self, name, phase, expected_parallelism=1,
+    ):
+        self._name = name
+        self._phase = phase
+        self._expected = expected_parallelism
+        self._start_wall = 0.0
+        self._start_usage = None
+        self._start_load = (0.0, 0.0, 0.0)
+        self._metrics = None
+
+    @property
+    def metrics(self):
+        """Return ``StepMetrics`` after exiting."""
+        return self._metrics
+
+    def __enter__(self):
+        """Record start timestamps."""
+        self._start_load = _safe_loadavg()
+        self._start_usage = resource.getrusage(
+            resource.RUSAGE_CHILDREN,
+        )
+        self._start_wall = time.monotonic()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Compute metrics from start/end deltas."""
+        wall = time.monotonic() - self._start_wall
+        end_usage = resource.getrusage(
+            resource.RUSAGE_CHILDREN,
+        )
+        end_load = _safe_loadavg()
+        cpu_count = os.cpu_count() or 1
+
+        user = (
+            end_usage.ru_utime
+            - self._start_usage.ru_utime
+        )
+        sys_ = (
+            end_usage.ru_stime
+            - self._start_usage.ru_stime
+        )
+
+        # Contention detection
+        cpu_total = user + sys_
+        expected_eff = min(
+            self._expected, cpu_count,
+        )
+        actual_eff = (
+            cpu_total / wall if wall > 0 else 0.0
+        )
+        contention = (
+            actual_eff
+            < expected_eff * CONTENTION_THRESHOLD
+        )
+
+        self._metrics = StepMetrics(
+            name=self._name,
+            phase=self._phase,
+            wall_sec=wall,
+            cpu_user_sec=user,
+            cpu_sys_sec=sys_,
+            cpu_count=cpu_count,
+            load_avg_start=self._start_load,
+            load_avg_end=end_load,
+            contention=contention,
+        )
+        return False
+
+
+def _safe_loadavg():
+    """Return load averages, or zeros on platforms
+    where ``os.getloadavg()`` is unavailable (Windows).
+    """
+    try:
+        return os.getloadavg()
+    except (OSError, AttributeError):
+        return (0.0, 0.0, 0.0)
+
+
+def save_runtime_json(
+    timing, paths_cfg, repo_name, repo_cfg, run_ts,
+    baseline=None,
+):
+    """Write ``runtime.json`` for a completed run.
+
+    Args:
+        timing: ``TimingResult`` from the pipeline.
+        paths_cfg: Paths config section.
+        repo_name: Repository name.
+        repo_cfg: Repository config section.
+        run_ts: Timestamp string for the run folder.
+        baseline: Optional baseline dict to include.
+    """
+    from app.config import lang_subdir
+
+    lang = lang_subdir(repo_cfg)
+    runtime_dir = (
+        Path(paths_cfg["output_dir"])
+        / "runtime" / lang / repo_name / run_ts
+    )
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    out_path = runtime_dir / "runtime.json"
+
+    data = timing.to_dict()
+    if baseline:
+        data["baseline"] = baseline
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+    print(f"[OK] Runtime JSON written to {out_path}")
+    return str(out_path)
+
+
+def load_baseline(paths_cfg, repo_name, repo_cfg):
+    """Load baseline.json for a repo, or None."""
+    from app.config import lang_subdir
+
+    lang = lang_subdir(repo_cfg)
+    path = (
+        Path(paths_cfg["output_dir"])
+        / "runtime" / lang / repo_name / "baseline.json"
+    )
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_baseline(
+    metrics, paths_cfg, repo_name, repo_cfg,
+):
+    """Write baseline.json from a non-instrumented build.
+
+    Args:
+        metrics: ``StepMetrics`` from the plain build.
+        paths_cfg: Paths config section.
+        repo_name: Repository name.
+        repo_cfg: Repository config section.
+    """
+    from app.config import lang_subdir
+
+    lang = lang_subdir(repo_cfg)
+    baseline_dir = (
+        Path(paths_cfg["output_dir"])
+        / "runtime" / lang / repo_name
+    )
+    baseline_dir.mkdir(parents=True, exist_ok=True)
+    out_path = baseline_dir / "baseline.json"
+
+    data = metrics.to_dict()
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+    print(f"[OK] Baseline written to {out_path}")
+    return str(out_path)

--- a/output/runtime/c-cpp/curl/baseline.json
+++ b/output/runtime/c-cpp/curl/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 62.2,
+  "cpu_user_sec": 159.97,
+  "cpu_sys_sec": 28.76,
+  "cpu_count": 4,
+  "load_avg_start": [
+    0.03,
+    0.84,
+    1.05
+  ],
+  "load_avg_end": [
+    2.18,
+    1.28,
+    1.18
+  ],
+  "contention": false,
+  "cpu_total_sec": 188.73,
+  "cpu_efficiency": 3.03,
+  "run_ts": "2026-05-11_1956"
+}

--- a/output/runtime/c-cpp/ffmpeg/baseline.json
+++ b/output/runtime/c-cpp/ffmpeg/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 646.23,
+  "cpu_user_sec": 600.21,
+  "cpu_sys_sec": 41.68,
+  "cpu_count": 4,
+  "load_avg_start": [
+    2.18,
+    1.28,
+    1.18
+  ],
+  "load_avg_end": [
+    1.06,
+    1.06,
+    1.09
+  ],
+  "contention": false,
+  "cpu_total_sec": 641.88,
+  "cpu_efficiency": 0.99,
+  "run_ts": "2026-05-11_1957"
+}

--- a/output/runtime/c-cpp/nmap/baseline.json
+++ b/output/runtime/c-cpp/nmap/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 47.14,
+  "cpu_user_sec": 125.0,
+  "cpu_sys_sec": 17.58,
+  "cpu_count": 4,
+  "load_avg_start": [
+    1.06,
+    1.06,
+    1.09
+  ],
+  "load_avg_end": [
+    2.47,
+    1.41,
+    1.21
+  ],
+  "contention": false,
+  "cpu_total_sec": 142.58,
+  "cpu_efficiency": 3.02,
+  "run_ts": "2026-05-11_2008"
+}

--- a/output/runtime/c-cpp/node/baseline.json
+++ b/output/runtime/c-cpp/node/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 5344.56,
+  "cpu_user_sec": 20184.1,
+  "cpu_sys_sec": 967.7,
+  "cpu_count": 4,
+  "load_avg_start": [
+    3.18,
+    1.7,
+    1.31
+  ],
+  "load_avg_end": [
+    3.18,
+    3.71,
+    3.89
+  ],
+  "contention": false,
+  "cpu_total_sec": 21151.79,
+  "cpu_efficiency": 3.96,
+  "run_ts": "2026-05-11_2009"
+}

--- a/output/runtime/c-cpp/openosc/baseline.json
+++ b/output/runtime/c-cpp/openosc/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 5.49,
+  "cpu_user_sec": 3.78,
+  "cpu_sys_sec": 1.42,
+  "cpu_count": 4,
+  "load_avg_start": [
+    3.37,
+    1.72,
+    1.31
+  ],
+  "load_avg_end": [
+    3.18,
+    1.7,
+    1.31
+  ],
+  "contention": false,
+  "cpu_total_sec": 5.2,
+  "cpu_efficiency": 0.95,
+  "run_ts": "2026-05-11_2009"
+}

--- a/output/runtime/c-cpp/redis/baseline.json
+++ b/output/runtime/c-cpp/redis/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 26.43,
+  "cpu_user_sec": 89.0,
+  "cpu_sys_sec": 6.26,
+  "cpu_count": 4,
+  "load_avg_start": [
+    2.47,
+    1.41,
+    1.21
+  ],
+  "load_avg_end": [
+    3.37,
+    1.72,
+    1.31
+  ],
+  "contention": false,
+  "cpu_total_sec": 95.25,
+  "cpu_efficiency": 3.6,
+  "run_ts": "2026-05-11_2009"
+}

--- a/output/runtime/go/croc/baseline.json
+++ b/output/runtime/go/croc/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 16.12,
+  "cpu_user_sec": 43.31,
+  "cpu_sys_sec": 5.61,
+  "cpu_count": 4,
+  "load_avg_start": [
+    4.57,
+    3.99,
+    3.98
+  ],
+  "load_avg_end": [
+    4.26,
+    3.96,
+    3.97
+  ],
+  "contention": false,
+  "cpu_total_sec": 48.93,
+  "cpu_efficiency": 3.04,
+  "run_ts": "2026-05-11_2139"
+}

--- a/output/runtime/go/dive/baseline.json
+++ b/output/runtime/go/dive/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 21.34,
+  "cpu_user_sec": 61.99,
+  "cpu_sys_sec": 8.44,
+  "cpu_count": 4,
+  "load_avg_start": [
+    4.26,
+    3.96,
+    3.97
+  ],
+  "load_avg_end": [
+    5.47,
+    4.24,
+    4.06
+  ],
+  "contention": false,
+  "cpu_total_sec": 70.43,
+  "cpu_efficiency": 3.3,
+  "run_ts": "2026-05-11_2139"
+}

--- a/output/runtime/go/fzf/baseline.json
+++ b/output/runtime/go/fzf/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 9.3,
+  "cpu_user_sec": 24.21,
+  "cpu_sys_sec": 3.02,
+  "cpu_count": 4,
+  "load_avg_start": [
+    3.18,
+    3.71,
+    3.89
+  ],
+  "load_avg_end": [
+    3.09,
+    3.67,
+    3.88
+  ],
+  "contention": false,
+  "cpu_total_sec": 27.23,
+  "cpu_efficiency": 2.93,
+  "run_ts": "2026-05-11_2138"
+}

--- a/output/runtime/go/gdu/baseline.json
+++ b/output/runtime/go/gdu/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 35.4,
+  "cpu_user_sec": 97.93,
+  "cpu_sys_sec": 10.42,
+  "cpu_count": 4,
+  "load_avg_start": [
+    5.47,
+    4.24,
+    4.06
+  ],
+  "load_avg_end": [
+    5.43,
+    4.37,
+    4.11
+  ],
+  "contention": false,
+  "cpu_total_sec": 108.34,
+  "cpu_efficiency": 3.06,
+  "run_ts": "2026-05-11_2140"
+}

--- a/output/runtime/go/lazygit/baseline.json
+++ b/output/runtime/go/lazygit/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 28.45,
+  "cpu_user_sec": 86.05,
+  "cpu_sys_sec": 10.43,
+  "cpu_count": 4,
+  "load_avg_start": [
+    3.09,
+    3.67,
+    3.88
+  ],
+  "load_avg_end": [
+    4.57,
+    3.99,
+    3.98
+  ],
+  "contention": false,
+  "cpu_total_sec": 96.48,
+  "cpu_efficiency": 3.39,
+  "run_ts": "2026-05-11_2138"
+}

--- a/output/runtime/go/pocketbase/baseline.json
+++ b/output/runtime/go/pocketbase/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 51.35,
+  "cpu_user_sec": 151.75,
+  "cpu_sys_sec": 15.82,
+  "cpu_count": 4,
+  "load_avg_start": [
+    5.43,
+    4.37,
+    4.11
+  ],
+  "load_avg_end": [
+    7.37,
+    5.03,
+    4.35
+  ],
+  "contention": false,
+  "cpu_total_sec": 167.57,
+  "cpu_efficiency": 3.26,
+  "run_ts": "2026-05-11_2140"
+}

--- a/output/runtime/java/bc-java/baseline.json
+++ b/output/runtime/java/bc-java/baseline.json
@@ -1,22 +1,51 @@
 {
-  "name": "baseline",
-  "phase": "phase1",
-  "wall_sec": 165.15,
-  "cpu_user_sec": 422.38,
-  "cpu_sys_sec": 11.85,
-  "cpu_count": 4,
-  "load_avg_start": [
-    2.8,
-    2.79,
-    3.42
+  "steps": [
+    {
+      "name": "clean",
+      "phase": "phase1",
+      "wall_sec": 23.29,
+      "cpu_user_sec": 60.65,
+      "cpu_sys_sec": 2.52,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        3.5,
+        2.09,
+        1.12
+      ],
+      "load_avg_end": [
+        3.8,
+        2.27,
+        1.21
+      ],
+      "contention": false,
+      "cpu_total_sec": 63.18,
+      "cpu_efficiency": 2.71,
+      "contention_severity": 0.0
+    },
+    {
+      "name": "build",
+      "phase": "phase1",
+      "wall_sec": 140.7,
+      "cpu_user_sec": 363.38,
+      "cpu_sys_sec": 9.27,
+      "cpu_count": 4,
+      "expected_parallelism": 4,
+      "load_avg_start": [
+        3.8,
+        2.27,
+        1.21
+      ],
+      "load_avg_end": [
+        2.51,
+        2.34,
+        1.39
+      ],
+      "contention": true,
+      "cpu_total_sec": 372.65,
+      "cpu_efficiency": 2.65,
+      "contention_severity": 5.4
+    }
   ],
-  "load_avg_end": [
-    2.62,
-    2.77,
-    3.31
-  ],
-  "contention": false,
-  "cpu_total_sec": 434.23,
-  "cpu_efficiency": 2.63,
-  "run_ts": "2026-05-11_2149"
+  "run_ts": "2026-05-12_1543"
 }

--- a/output/runtime/java/bc-java/baseline.json
+++ b/output/runtime/java/bc-java/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 165.15,
+  "cpu_user_sec": 422.38,
+  "cpu_sys_sec": 11.85,
+  "cpu_count": 4,
+  "load_avg_start": [
+    2.8,
+    2.79,
+    3.42
+  ],
+  "load_avg_end": [
+    2.62,
+    2.77,
+    3.31
+  ],
+  "contention": false,
+  "cpu_total_sec": 434.23,
+  "cpu_efficiency": 2.63,
+  "run_ts": "2026-05-11_2149"
+}

--- a/output/runtime/java/checkstyle/baseline.json
+++ b/output/runtime/java/checkstyle/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 39.6,
+  "cpu_user_sec": 62.52,
+  "cpu_sys_sec": 2.83,
+  "cpu_count": 4,
+  "load_avg_start": [
+    3.12,
+    4.29,
+    4.16
+  ],
+  "load_avg_end": [
+    2.79,
+    4.05,
+    4.08
+  ],
+  "contention": false,
+  "cpu_total_sec": 65.35,
+  "cpu_efficiency": 1.65,
+  "run_ts": "2026-05-11_2143"
+}

--- a/output/runtime/java/checkstyle/baseline.json
+++ b/output/runtime/java/checkstyle/baseline.json
@@ -1,22 +1,51 @@
 {
-  "name": "baseline",
-  "phase": "phase1",
-  "wall_sec": 39.6,
-  "cpu_user_sec": 62.52,
-  "cpu_sys_sec": 2.83,
-  "cpu_count": 4,
-  "load_avg_start": [
-    3.12,
-    4.29,
-    4.16
+  "steps": [
+    {
+      "name": "clean",
+      "phase": "phase1",
+      "wall_sec": 10.53,
+      "cpu_user_sec": 7.59,
+      "cpu_sys_sec": 0.51,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        1.06,
+        0.31,
+        0.38
+      ],
+      "load_avg_end": [
+        1.05,
+        0.34,
+        0.39
+      ],
+      "contention": false,
+      "cpu_total_sec": 8.1,
+      "cpu_efficiency": 0.77,
+      "contention_severity": 0.0
+    },
+    {
+      "name": "build",
+      "phase": "phase1",
+      "wall_sec": 41.84,
+      "cpu_user_sec": 76.19,
+      "cpu_sys_sec": 2.58,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        1.05,
+        0.34,
+        0.39
+      ],
+      "load_avg_end": [
+        1.21,
+        0.47,
+        0.43
+      ],
+      "contention": false,
+      "cpu_total_sec": 78.77,
+      "cpu_efficiency": 1.88,
+      "contention_severity": 0.0
+    }
   ],
-  "load_avg_end": [
-    2.79,
-    4.05,
-    4.08
-  ],
-  "contention": false,
-  "cpu_total_sec": 65.35,
-  "cpu_efficiency": 1.65,
-  "run_ts": "2026-05-11_2143"
+  "run_ts": "2026-05-12_1535"
 }

--- a/output/runtime/java/crawler4j/baseline.json
+++ b/output/runtime/java/crawler4j/baseline.json
@@ -1,22 +1,51 @@
 {
-  "name": "baseline",
-  "phase": "phase1",
-  "wall_sec": 97.26,
-  "cpu_user_sec": 34.02,
-  "cpu_sys_sec": 1.28,
-  "cpu_count": 4,
-  "load_avg_start": [
-    2.79,
-    4.05,
-    4.08
+  "steps": [
+    {
+      "name": "clean",
+      "phase": "phase1",
+      "wall_sec": 2.32,
+      "cpu_user_sec": 5.43,
+      "cpu_sys_sec": 0.24,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        1.21,
+        0.47,
+        0.43
+      ],
+      "load_avg_end": [
+        1.52,
+        0.54,
+        0.45
+      ],
+      "contention": false,
+      "cpu_total_sec": 5.68,
+      "cpu_efficiency": 2.45,
+      "contention_severity": 0.0
+    },
+    {
+      "name": "build",
+      "phase": "phase1",
+      "wall_sec": 98.92,
+      "cpu_user_sec": 27.77,
+      "cpu_sys_sec": 1.15,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        1.52,
+        0.54,
+        0.45
+      ],
+      "load_avg_end": [
+        0.4,
+        0.43,
+        0.42
+      ],
+      "contention": true,
+      "cpu_total_sec": 28.92,
+      "cpu_efficiency": 0.29,
+      "contention_severity": 58.2
+    }
   ],
-  "load_avg_end": [
-    1.21,
-    3.1,
-    3.73
-  ],
-  "contention": true,
-  "cpu_total_sec": 35.3,
-  "cpu_efficiency": 0.36,
-  "run_ts": "2026-05-11_2143"
+  "run_ts": "2026-05-12_1536"
 }

--- a/output/runtime/java/crawler4j/baseline.json
+++ b/output/runtime/java/crawler4j/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 97.26,
+  "cpu_user_sec": 34.02,
+  "cpu_sys_sec": 1.28,
+  "cpu_count": 4,
+  "load_avg_start": [
+    2.79,
+    4.05,
+    4.08
+  ],
+  "load_avg_end": [
+    1.21,
+    3.1,
+    3.73
+  ],
+  "contention": true,
+  "cpu_total_sec": 35.3,
+  "cpu_efficiency": 0.36,
+  "run_ts": "2026-05-11_2143"
+}

--- a/output/runtime/java/dependency-check/baseline.json
+++ b/output/runtime/java/dependency-check/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 44.19,
+  "cpu_user_sec": 72.16,
+  "cpu_sys_sec": 3.53,
+  "cpu_count": 4,
+  "load_avg_start": [
+    1.21,
+    3.1,
+    3.73
+  ],
+  "load_avg_end": [
+    1.41,
+    2.9,
+    3.64
+  ],
+  "contention": false,
+  "cpu_total_sec": 75.69,
+  "cpu_efficiency": 1.71,
+  "run_ts": "2026-05-11_2145"
+}

--- a/output/runtime/java/dependency-check/baseline.json
+++ b/output/runtime/java/dependency-check/baseline.json
@@ -1,22 +1,51 @@
 {
-  "name": "baseline",
-  "phase": "phase1",
-  "wall_sec": 44.19,
-  "cpu_user_sec": 72.16,
-  "cpu_sys_sec": 3.53,
-  "cpu_count": 4,
-  "load_avg_start": [
-    1.21,
-    3.1,
-    3.73
+  "steps": [
+    {
+      "name": "clean",
+      "phase": "phase1",
+      "wall_sec": 23.24,
+      "cpu_user_sec": 20.48,
+      "cpu_sys_sec": 1.32,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        0.45,
+        0.44,
+        0.43
+      ],
+      "load_avg_end": [
+        0.53,
+        0.46,
+        0.43
+      ],
+      "contention": false,
+      "cpu_total_sec": 21.8,
+      "cpu_efficiency": 0.94,
+      "contention_severity": 0.0
+    },
+    {
+      "name": "build",
+      "phase": "phase1",
+      "wall_sec": 29.97,
+      "cpu_user_sec": 61.63,
+      "cpu_sys_sec": 2.25,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        0.53,
+        0.46,
+        0.43
+      ],
+      "load_avg_end": [
+        1.02,
+        0.59,
+        0.48
+      ],
+      "contention": false,
+      "cpu_total_sec": 63.88,
+      "cpu_efficiency": 2.13,
+      "contention_severity": 0.0
+    }
   ],
-  "load_avg_end": [
-    1.41,
-    2.9,
-    3.64
-  ],
-  "contention": false,
-  "cpu_total_sec": 75.69,
-  "cpu_efficiency": 1.71,
-  "run_ts": "2026-05-11_2145"
+  "run_ts": "2026-05-12_1538"
 }

--- a/output/runtime/java/jsoup/baseline.json
+++ b/output/runtime/java/jsoup/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 31.86,
+  "cpu_user_sec": 57.11,
+  "cpu_sys_sec": 1.91,
+  "cpu_count": 4,
+  "load_avg_start": [
+    4.51,
+    4.64,
+    4.26
+  ],
+  "load_avg_end": [
+    3.12,
+    4.29,
+    4.16
+  ],
+  "contention": false,
+  "cpu_total_sec": 59.02,
+  "cpu_efficiency": 1.85,
+  "run_ts": "2026-05-11_2142"
+}

--- a/output/runtime/java/jsoup/baseline.json
+++ b/output/runtime/java/jsoup/baseline.json
@@ -1,22 +1,51 @@
 {
-  "name": "baseline",
-  "phase": "phase1",
-  "wall_sec": 31.86,
-  "cpu_user_sec": 57.11,
-  "cpu_sys_sec": 1.91,
-  "cpu_count": 4,
-  "load_avg_start": [
-    4.51,
-    4.64,
-    4.26
+  "steps": [
+    {
+      "name": "clean",
+      "phase": "phase1",
+      "wall_sec": 3.61,
+      "cpu_user_sec": 7.17,
+      "cpu_sys_sec": 0.33,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        0.0,
+        0.06,
+        0.3
+      ],
+      "load_avg_end": [
+        0.0,
+        0.06,
+        0.3
+      ],
+      "contention": false,
+      "cpu_total_sec": 7.49,
+      "cpu_efficiency": 2.07,
+      "contention_severity": 0.0
+    },
+    {
+      "name": "build",
+      "phase": "phase1",
+      "wall_sec": 25.1,
+      "cpu_user_sec": 54.68,
+      "cpu_sys_sec": 1.57,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        0.0,
+        0.06,
+        0.3
+      ],
+      "load_avg_end": [
+        0.71,
+        0.23,
+        0.36
+      ],
+      "contention": false,
+      "cpu_total_sec": 56.24,
+      "cpu_efficiency": 2.24,
+      "contention_severity": 0.0
+    }
   ],
-  "load_avg_end": [
-    3.12,
-    4.29,
-    4.16
-  ],
-  "contention": false,
-  "cpu_total_sec": 59.02,
-  "cpu_efficiency": 1.85,
-  "run_ts": "2026-05-11_2142"
+  "run_ts": "2026-05-12_1535"
 }

--- a/output/runtime/java/logging-log4j2/baseline.json
+++ b/output/runtime/java/logging-log4j2/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 106.73,
+  "cpu_user_sec": 249.79,
+  "cpu_sys_sec": 5.61,
+  "cpu_count": 4,
+  "load_avg_start": [
+    1.41,
+    2.9,
+    3.64
+  ],
+  "load_avg_end": [
+    2.24,
+    2.72,
+    3.48
+  ],
+  "contention": false,
+  "cpu_total_sec": 255.4,
+  "cpu_efficiency": 2.39,
+  "run_ts": "2026-05-11_2146"
+}

--- a/output/runtime/java/logging-log4j2/baseline.json
+++ b/output/runtime/java/logging-log4j2/baseline.json
@@ -1,22 +1,51 @@
 {
-  "name": "baseline",
-  "phase": "phase1",
-  "wall_sec": 106.73,
-  "cpu_user_sec": 249.79,
-  "cpu_sys_sec": 5.61,
-  "cpu_count": 4,
-  "load_avg_start": [
-    1.41,
-    2.9,
-    3.64
+  "steps": [
+    {
+      "name": "clean",
+      "phase": "phase1",
+      "wall_sec": 3.8,
+      "cpu_user_sec": 7.54,
+      "cpu_sys_sec": 0.36,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        1.1,
+        0.62,
+        0.49
+      ],
+      "load_avg_end": [
+        1.1,
+        0.62,
+        0.49
+      ],
+      "contention": false,
+      "cpu_total_sec": 7.9,
+      "cpu_efficiency": 2.08,
+      "contention_severity": 0.0
+    },
+    {
+      "name": "build",
+      "phase": "phase1",
+      "wall_sec": 120.89,
+      "cpu_user_sec": 311.49,
+      "cpu_sys_sec": 6.04,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        1.1,
+        0.62,
+        0.49
+      ],
+      "load_avg_end": [
+        2.89,
+        1.42,
+        0.8
+      ],
+      "contention": false,
+      "cpu_total_sec": 317.53,
+      "cpu_efficiency": 2.63,
+      "contention_severity": 0.0
+    }
   ],
-  "load_avg_end": [
-    2.24,
-    2.72,
-    3.48
-  ],
-  "contention": false,
-  "cpu_total_sec": 255.4,
-  "cpu_efficiency": 2.39,
-  "run_ts": "2026-05-11_2146"
+  "run_ts": "2026-05-12_1539"
 }

--- a/output/runtime/java/omnibor-java-testapp/baseline.json
+++ b/output/runtime/java/omnibor-java-testapp/baseline.json
@@ -1,22 +1,51 @@
 {
-  "name": "baseline",
-  "phase": "phase1",
-  "wall_sec": 4.91,
-  "cpu_user_sec": 12.85,
-  "cpu_sys_sec": 0.53,
-  "cpu_count": 4,
-  "load_avg_start": [
-    2.62,
-    2.77,
-    3.31
+  "steps": [
+    {
+      "name": "clean",
+      "phase": "phase1",
+      "wall_sec": 2.03,
+      "cpu_user_sec": 4.69,
+      "cpu_sys_sec": 0.23,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        2.51,
+        2.34,
+        1.39
+      ],
+      "load_avg_end": [
+        2.51,
+        2.34,
+        1.39
+      ],
+      "contention": false,
+      "cpu_total_sec": 4.92,
+      "cpu_efficiency": 2.42,
+      "contention_severity": 0.0
+    },
+    {
+      "name": "build",
+      "phase": "phase1",
+      "wall_sec": 6.41,
+      "cpu_user_sec": 11.56,
+      "cpu_sys_sec": 0.5,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        2.51,
+        2.34,
+        1.39
+      ],
+      "load_avg_end": [
+        2.43,
+        2.33,
+        1.4
+      ],
+      "contention": false,
+      "cpu_total_sec": 12.05,
+      "cpu_efficiency": 1.88,
+      "contention_severity": 0.0
+    }
   ],
-  "load_avg_end": [
-    2.57,
-    2.76,
-    3.3
-  ],
-  "contention": false,
-  "cpu_total_sec": 13.38,
-  "cpu_efficiency": 2.72,
-  "run_ts": "2026-05-11_2152"
+  "run_ts": "2026-05-12_1545"
 }

--- a/output/runtime/java/omnibor-java-testapp/baseline.json
+++ b/output/runtime/java/omnibor-java-testapp/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 4.91,
+  "cpu_user_sec": 12.85,
+  "cpu_sys_sec": 0.53,
+  "cpu_count": 4,
+  "load_avg_start": [
+    2.62,
+    2.77,
+    3.31
+  ],
+  "load_avg_end": [
+    2.57,
+    2.76,
+    3.3
+  ],
+  "contention": false,
+  "cpu_total_sec": 13.38,
+  "cpu_efficiency": 2.72,
+  "run_ts": "2026-05-11_2152"
+}

--- a/output/runtime/java/spring-boot/baseline.json
+++ b/output/runtime/java/spring-boot/baseline.json
@@ -1,22 +1,51 @@
 {
-  "name": "baseline",
-  "phase": "phase1",
-  "wall_sec": 116.19,
-  "cpu_user_sec": 154.26,
-  "cpu_sys_sec": 6.98,
-  "cpu_count": 4,
-  "load_avg_start": [
-    2.24,
-    2.72,
-    3.48
+  "steps": [
+    {
+      "name": "clean",
+      "phase": "phase1",
+      "wall_sec": 64.66,
+      "cpu_user_sec": 160.72,
+      "cpu_sys_sec": 6.9,
+      "cpu_count": 4,
+      "expected_parallelism": 1,
+      "load_avg_start": [
+        2.74,
+        1.42,
+        0.8
+      ],
+      "load_avg_end": [
+        2.74,
+        1.69,
+        0.94
+      ],
+      "contention": false,
+      "cpu_total_sec": 167.62,
+      "cpu_efficiency": 2.59,
+      "contention_severity": 0.0
+    },
+    {
+      "name": "build",
+      "phase": "phase1",
+      "wall_sec": 56.67,
+      "cpu_user_sec": 2.18,
+      "cpu_sys_sec": 0.19,
+      "cpu_count": 4,
+      "expected_parallelism": 4,
+      "load_avg_start": [
+        2.74,
+        1.69,
+        0.94
+      ],
+      "load_avg_end": [
+        3.5,
+        2.09,
+        1.12
+      ],
+      "contention": true,
+      "cpu_total_sec": 2.38,
+      "cpu_efficiency": 0.04,
+      "contention_severity": 98.5
+    }
   ],
-  "load_avg_end": [
-    2.8,
-    2.79,
-    3.42
-  ],
-  "contention": false,
-  "cpu_total_sec": 161.25,
-  "cpu_efficiency": 1.39,
-  "run_ts": "2026-05-11_2147"
+  "run_ts": "2026-05-12_1541"
 }

--- a/output/runtime/java/spring-boot/baseline.json
+++ b/output/runtime/java/spring-boot/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 116.19,
+  "cpu_user_sec": 154.26,
+  "cpu_sys_sec": 6.98,
+  "cpu_count": 4,
+  "load_avg_start": [
+    2.24,
+    2.72,
+    3.48
+  ],
+  "load_avg_end": [
+    2.8,
+    2.79,
+    3.42
+  ],
+  "contention": false,
+  "cpu_total_sec": 161.25,
+  "cpu_efficiency": 1.39,
+  "run_ts": "2026-05-11_2147"
+}

--- a/output/runtime/rust/dura/baseline.json
+++ b/output/runtime/rust/dura/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 45.76,
+  "cpu_user_sec": 157.85,
+  "cpu_sys_sec": 12.62,
+  "cpu_count": 4,
+  "load_avg_start": [
+    5.55,
+    4.8,
+    4.29
+  ],
+  "load_avg_end": [
+    4.51,
+    4.64,
+    4.26
+  ],
+  "contention": false,
+  "cpu_total_sec": 170.47,
+  "cpu_efficiency": 3.73,
+  "run_ts": "2026-05-11_2141"
+}

--- a/output/runtime/rust/oxipng/baseline.json
+++ b/output/runtime/rust/oxipng/baseline.json
@@ -1,0 +1,22 @@
+{
+  "name": "baseline",
+  "phase": "phase1",
+  "wall_sec": 21.94,
+  "cpu_user_sec": 41.56,
+  "cpu_sys_sec": 3.25,
+  "cpu_count": 4,
+  "load_avg_start": [
+    7.37,
+    5.03,
+    4.35
+  ],
+  "load_avg_end": [
+    5.55,
+    4.8,
+    4.29
+  ],
+  "contention": false,
+  "cpu_total_sec": 44.81,
+  "cpu_efficiency": 2.04,
+  "run_ts": "2026-05-11_2141"
+}

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -612,6 +612,106 @@ class TestBomtraceBuilder(unittest.TestCase):
         )
 
 
+class TestBomtraceBuilderBaseline(unittest.TestCase):
+    """Tests for BomtraceBuilder.build_baseline()."""
+
+    def _cfg(self):
+        return (
+            {
+                "build_steps": [
+                    "autoreconf -fi",
+                    "./configure",
+                    "make -j4",
+                ],
+                "clean_cmd": "make clean",
+                "language": "c-cpp",
+            },
+            {
+                "repos_dir": "/repos",
+                "output_dir": "/out",
+            },
+        )
+
+    def test_success(self):
+        runner = MagicMock()
+        runner.run.return_value = 0
+        builder = BomtraceBuilder(runner)
+        repo_cfg, paths = self._cfg()
+
+        with patch("builtins.print"):
+            result = builder.build_baseline(
+                "curl", repo_cfg, paths,
+            )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, "baseline")
+        self.assertEqual(result.phase, "phase1")
+        self.assertGreaterEqual(result.wall_sec, 0)
+        # clean + 2 prebuild + build = 4 calls
+        self.assertEqual(runner.run.call_count, 4)
+        # NO tracer prefix on build cmd
+        build_call = runner.run.call_args_list[3]
+        self.assertEqual(
+            build_call[0][0], "make -j4",
+        )
+
+    def test_no_clean_cmd(self):
+        runner = MagicMock()
+        runner.run.return_value = 0
+        builder = BomtraceBuilder(runner)
+        repo_cfg, paths = self._cfg()
+        del repo_cfg["clean_cmd"]
+
+        with patch("builtins.print"):
+            result = builder.build_baseline(
+                "curl", repo_cfg, paths,
+            )
+        self.assertIsNotNone(result)
+        # 2 prebuild + build = 3 calls (no clean)
+        self.assertEqual(runner.run.call_count, 3)
+
+    def test_no_prebuild_steps(self):
+        runner = MagicMock()
+        runner.run.return_value = 0
+        builder = BomtraceBuilder(runner)
+        repo_cfg, paths = self._cfg()
+        repo_cfg["build_steps"] = ["make -j4"]
+        del repo_cfg["clean_cmd"]
+
+        with patch("builtins.print"):
+            result = builder.build_baseline(
+                "curl", repo_cfg, paths,
+            )
+        self.assertIsNotNone(result)
+        # Only build = 1 call
+        self.assertEqual(runner.run.call_count, 1)
+
+    def test_prebuild_failure(self):
+        runner = MagicMock()
+        # clean ok, first prebuild fails
+        runner.run.side_effect = [0, 1]
+        builder = BomtraceBuilder(runner)
+        repo_cfg, paths = self._cfg()
+
+        with patch("builtins.print"):
+            result = builder.build_baseline(
+                "curl", repo_cfg, paths,
+            )
+        self.assertIsNone(result)
+
+    def test_build_failure(self):
+        runner = MagicMock()
+        # clean ok, 2 prebuild ok, build fails
+        runner.run.side_effect = [0, 0, 0, 1]
+        builder = BomtraceBuilder(runner)
+        repo_cfg, paths = self._cfg()
+
+        with patch("builtins.print"):
+            result = builder.build_baseline(
+                "curl", repo_cfg, paths,
+            )
+        self.assertIsNone(result)
+
+
 class TestBomtraceBuilderJava(unittest.TestCase):
     """Tests for BomtraceBuilder.build_java()."""
 
@@ -3278,6 +3378,65 @@ class TestMainGoRepo(unittest.TestCase):
             analyze.main()
 
         p.syft_gen.generate.assert_called_once()
+
+
+class TestBaseline(unittest.TestCase):
+    """Tests for --baseline mode."""
+
+    @patch(
+        "app.pipeline.timing.save_baseline",
+    )
+    @patch("app.pipeline.runners.AnalysisPipeline")
+    @patch(
+        "sys.argv",
+        ["analyze.py", "--repo", "curl",
+         "--baseline", "--skip-clone"],
+    )
+    def test_baseline_success(
+        self, mock_cls, mock_save,
+    ):
+        p = _mock_pipeline()
+        mock_cls.return_value = p
+        p.builder.build_baseline.return_value = (
+            StepMetrics(
+                name="baseline", phase="phase1",
+                wall_sec=8.0,
+                cpu_user_sec=6.0, cpu_sys_sec=1.5,
+            )
+        )
+
+        with patch("builtins.print"):
+            analyze.main()
+
+        p.builder.build_baseline\
+            .assert_called_once()
+        # No Phase 2 in baseline mode
+        p.spdx_gen.generate.assert_not_called()
+        p.binary_collector.collect\
+            .assert_not_called()
+        mock_save.assert_called_once()
+
+    @patch(
+        "app.pipeline.timing.save_baseline",
+    )
+    @patch("app.pipeline.runners.AnalysisPipeline")
+    @patch(
+        "sys.argv",
+        ["analyze.py", "--repo", "curl",
+         "--baseline", "--skip-clone"],
+    )
+    def test_baseline_build_failure(
+        self, mock_cls, mock_save,
+    ):
+        p = _mock_pipeline()
+        mock_cls.return_value = p
+        # build_baseline returns None on failure
+        p.builder.build_baseline.return_value = None
+
+        with patch("builtins.print"):
+            analyze.main()
+
+        mock_save.assert_not_called()
 
 
 class TestRunGoPipeline(unittest.TestCase):

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -643,9 +643,18 @@ class TestBomtraceBuilderBaseline(unittest.TestCase):
                 "curl", repo_cfg, paths,
             )
         self.assertIsNotNone(result)
-        self.assertEqual(result.name, "baseline")
-        self.assertEqual(result.phase, "phase1")
-        self.assertGreaterEqual(result.wall_sec, 0)
+        self.assertTrue(result.success)
+        # Separate steps: clean, prebuild, build
+        names = [s.name for s in result.steps]
+        self.assertEqual(
+            names, ["clean", "prebuild", "build"],
+        )
+        # Build step has correct phase
+        build_step = result.steps[2]
+        self.assertEqual(build_step.phase, "phase1")
+        self.assertGreaterEqual(
+            build_step.wall_sec, 0,
+        )
         # clean + 2 prebuild + build = 4 calls
         self.assertEqual(runner.run.call_count, 4)
         # NO tracer prefix on build cmd
@@ -666,6 +675,11 @@ class TestBomtraceBuilderBaseline(unittest.TestCase):
                 "curl", repo_cfg, paths,
             )
         self.assertIsNotNone(result)
+        self.assertTrue(result.success)
+        names = [s.name for s in result.steps]
+        self.assertEqual(
+            names, ["prebuild", "build"],
+        )
         # 2 prebuild + build = 3 calls (no clean)
         self.assertEqual(runner.run.call_count, 3)
 
@@ -682,6 +696,9 @@ class TestBomtraceBuilderBaseline(unittest.TestCase):
                 "curl", repo_cfg, paths,
             )
         self.assertIsNotNone(result)
+        self.assertTrue(result.success)
+        names = [s.name for s in result.steps]
+        self.assertEqual(names, ["build"])
         # Only build = 1 call
         self.assertEqual(runner.run.call_count, 1)
 
@@ -696,7 +713,8 @@ class TestBomtraceBuilderBaseline(unittest.TestCase):
             result = builder.build_baseline(
                 "curl", repo_cfg, paths,
             )
-        self.assertIsNone(result)
+        self.assertIsNotNone(result)
+        self.assertFalse(result.success)
 
     def test_build_failure(self):
         runner = MagicMock()
@@ -709,7 +727,8 @@ class TestBomtraceBuilderBaseline(unittest.TestCase):
             result = builder.build_baseline(
                 "curl", repo_cfg, paths,
             )
-        self.assertIsNone(result)
+        self.assertIsNotNone(result)
+        self.assertFalse(result.success)
 
 
 class TestBomtraceBuilderJava(unittest.TestCase):
@@ -3100,7 +3119,11 @@ class TestMainFullRun(unittest.TestCase):
     )
     @patch(
         "app.pipeline.timing.load_baseline",
-        return_value={"wall_sec": 5.0},
+        return_value={
+            "steps": [
+                {"name": "build", "wall_sec": 5.0},
+            ],
+        },
     )
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
@@ -3114,6 +3137,14 @@ class TestMainFullRun(unittest.TestCase):
         mock_cls.return_value = p
         p.builder.build.return_value = BuildResult(
             success=True,
+            steps=[
+                StepMetrics(
+                    name="build", phase="phase1",
+                    wall_sec=6.0,
+                    cpu_user_sec=5.0,
+                    cpu_sys_sec=0.5,
+                ),
+            ],
         )
         printed = []
         with patch(
@@ -3127,7 +3158,7 @@ class TestMainFullRun(unittest.TestCase):
             analyze.main()
         overhead_lines = [
             line for line in printed
-            if "Overhead" in line
+            if "overhead" in line.lower()
         ]
         self.assertTrue(len(overhead_lines) > 0)
 
@@ -3398,10 +3429,22 @@ class TestBaseline(unittest.TestCase):
         p = _mock_pipeline()
         mock_cls.return_value = p
         p.builder.build_baseline.return_value = (
-            StepMetrics(
-                name="baseline", phase="phase1",
-                wall_sec=8.0,
-                cpu_user_sec=6.0, cpu_sys_sec=1.5,
+            BuildResult(
+                success=True,
+                steps=[
+                    StepMetrics(
+                        name="clean",
+                        phase="phase1",
+                        wall_sec=1.0,
+                    ),
+                    StepMetrics(
+                        name="build",
+                        phase="phase1",
+                        wall_sec=8.0,
+                        cpu_user_sec=6.0,
+                        cpu_sys_sec=1.5,
+                    ),
+                ],
             )
         )
 
@@ -3430,8 +3473,10 @@ class TestBaseline(unittest.TestCase):
     ):
         p = _mock_pipeline()
         mock_cls.return_value = p
-        # build_baseline returns None on failure
-        p.builder.build_baseline.return_value = None
+        # build_baseline returns failed BuildResult
+        p.builder.build_baseline.return_value = (
+            BuildResult(success=False, steps=[])
+        )
 
         with patch("builtins.print"):
             analyze.main()

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -26,6 +26,8 @@ from analyze import (
     _run_rust_pipeline,
     _validate_syft_spdx,
 )
+from app.pipeline.builder import BuildResult
+from app.pipeline.timing import TimingResult, StepMetrics
 from app.spdx.package_resolver import PackageResolver
 
 
@@ -443,7 +445,7 @@ class TestBomtraceBuilder(unittest.TestCase):
             result = builder.build(
                 "curl", repo_cfg, paths, omnibor
             )
-        self.assertTrue(result)
+        self.assertTrue(result.success)
         # clean + 2 pre-build + instrumented + ADG = 5
         self.assertEqual(runner.run.call_count, 5)
 
@@ -458,7 +460,7 @@ class TestBomtraceBuilder(unittest.TestCase):
             result = builder.build(
                 "curl", repo_cfg, paths, omnibor
             )
-        self.assertTrue(result)
+        self.assertTrue(result.success)
         # no clean + 2 pre-build + instrumented + ADG = 4
         self.assertEqual(runner.run.call_count, 4)
 
@@ -473,7 +475,7 @@ class TestBomtraceBuilder(unittest.TestCase):
             result = builder.build(
                 "curl", repo_cfg, paths, omnibor
             )
-        self.assertFalse(result)
+        self.assertFalse(result.success)
 
     def test_make_failure(self):
         runner = MagicMock()
@@ -486,7 +488,7 @@ class TestBomtraceBuilder(unittest.TestCase):
             result = builder.build(
                 "curl", repo_cfg, paths, omnibor
             )
-        self.assertFalse(result)
+        self.assertFalse(result.success)
 
     def test_adg_failure(self):
         runner = MagicMock()
@@ -499,7 +501,7 @@ class TestBomtraceBuilder(unittest.TestCase):
             result = builder.build(
                 "curl", repo_cfg, paths, omnibor
             )
-        self.assertFalse(result)
+        self.assertFalse(result.success)
 
     def test_clean_failure_ignored(self):
         runner = MagicMock()
@@ -512,7 +514,7 @@ class TestBomtraceBuilder(unittest.TestCase):
             result = builder.build(
                 "curl", repo_cfg, paths, omnibor
             )
-        self.assertTrue(result)
+        self.assertTrue(result.success)
 
     def test_instrumented_cmd_uses_tracer(self):
         runner = MagicMock()
@@ -546,7 +548,7 @@ class TestBomtraceBuilder(unittest.TestCase):
                 "curl", repo_cfg, paths, omnibor,
                 strategy=strategy,
             )
-        self.assertTrue(result)
+        self.assertTrue(result.success)
         strategy.instrument_command.assert_called_once()
         # Verify env was passed to runner.run
         build_call = runner.run.call_args_list[3]
@@ -589,7 +591,7 @@ class TestBomtraceBuilder(unittest.TestCase):
                 "curl", repo_cfg, paths, omnibor,
                 strategy=strategy,
             )
-        self.assertFalse(result)
+        self.assertFalse(result.success)
 
     def test_no_strategy_uses_legacy(self):
         runner = MagicMock()
@@ -651,7 +653,7 @@ class TestBomtraceBuilderJava(unittest.TestCase):
                 result = builder.build_java(
                     "myapp", repo_cfg, paths, java_cfg
                 )
-            self.assertTrue(result)
+            self.assertTrue(result.success)
             # clean + instrumented build + treedb gen = 3
             self.assertEqual(runner.run.call_count, 3)
             # Verify strace log was archived
@@ -684,7 +686,7 @@ class TestBomtraceBuilderJava(unittest.TestCase):
                 result = builder.build_java(
                     "myapp", repo_cfg, paths, java_cfg
                 )
-            self.assertTrue(result)
+            self.assertTrue(result.success)
             self.assertTrue(
                 any("WARN" in p for p in printed)
             )
@@ -700,7 +702,7 @@ class TestBomtraceBuilderJava(unittest.TestCase):
                 result = builder.build_java(
                     "myapp", repo_cfg, paths, java_cfg
                 )
-            self.assertTrue(result)
+            self.assertTrue(result.success)
             # no clean + instrumented + treedb = 2
             self.assertEqual(runner.run.call_count, 2)
 
@@ -717,7 +719,7 @@ class TestBomtraceBuilderJava(unittest.TestCase):
                 result = builder.build_java(
                     "myapp", repo_cfg, paths, java_cfg
                 )
-            self.assertFalse(result)
+            self.assertFalse(result.success)
 
     def test_instrumented_build_failure(self):
         runner = MagicMock()
@@ -730,7 +732,7 @@ class TestBomtraceBuilderJava(unittest.TestCase):
                 result = builder.build_java(
                     "myapp", repo_cfg, paths, java_cfg
                 )
-            self.assertFalse(result)
+            self.assertFalse(result.success)
 
     def test_create_bom_failure(self):
         runner = MagicMock()
@@ -743,7 +745,7 @@ class TestBomtraceBuilderJava(unittest.TestCase):
                 result = builder.build_java(
                     "myapp", repo_cfg, paths, java_cfg
                 )
-            self.assertFalse(result)
+            self.assertFalse(result.success)
 
 
 # ============================================================
@@ -2316,35 +2318,71 @@ class TestDocWriter(unittest.TestCase):
                 "build_steps": ["make"],
                 "language": "c-cpp",
             }
+            t = TimingResult(
+                tracer="bomtrace3",
+                success=True,
+                steps=[
+                    StepMetrics(
+                        name="build",
+                        phase="phase1",
+                        wall_sec=42.5,
+                    ),
+                    StepMetrics(
+                        name="spdx_gen",
+                        phase="phase2",
+                        wall_sec=2.5,
+                    ),
+                ],
+            )
             with patch("builtins.print"):
                 result = DocWriter.write_build_doc(
                     "myrepo", cfg, paths,
                     True, 45.0,
-                    capture_dur=42.5,
-                    spdx_dur=2.5,
+                    timing=t,
                 )
             content = Path(result).read_text()
-            self.assertIn("capture: 42.5s", content)
-            self.assertIn("SPDX: 2.5s", content)
+            self.assertIn(
+                "build: 42.5s", content,
+            )
+            self.assertIn(
+                "analysis: 2.5s", content,
+            )
 
     def test_write_runtime_doc_with_timing_split(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             paths = {"output_dir": tmpdir}
             repo_cfg = {"language": "c-cpp"}
+            t = TimingResult(
+                tracer="bomtrace3",
+                success=True,
+                steps=[
+                    StepMetrics(
+                        name="build",
+                        phase="phase1",
+                        wall_sec=42.5,
+                    ),
+                    StepMetrics(
+                        name="spdx_gen",
+                        phase="phase2",
+                        wall_sec=2.5,
+                    ),
+                ],
+            )
             with patch("builtins.print"):
                 result = DocWriter.write_runtime_doc(
-                    "myrepo", repo_cfg, paths, 45.0,
-                    capture_dur=42.5,
-                    spdx_dur=2.5,
+                    "myrepo", repo_cfg, paths,
+                    45.0,
+                    timing=t,
                 )
             content = Path(result).read_text()
             self.assertIn(
-                "Capture (build + interception):",
+                "Phase 1 (Build Interception):",
                 content,
             )
-            self.assertIn("42.5 seconds", content)
+            self.assertIn("42.5s", content)
             self.assertIn(
-                "SPDX generation:", content,
+                "Phase 2 (Post-Build Analysis):",
+                content,
             )
 
     def test_write_build_doc_failure(self):
@@ -2380,13 +2418,25 @@ class TestDocWriter(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             paths = {"output_dir": tmpdir}
             repo_cfg = {"language": "c-cpp"}
+            t = TimingResult(
+                tracer="bomtrace3",
+                success=True,
+                steps=[
+                    StepMetrics(
+                        name="build",
+                        phase="phase1",
+                        wall_sec=60.0,
+                    ),
+                ],
+            )
             with patch("builtins.print"):
                 result = DocWriter.write_runtime_doc(
                     "repo", repo_cfg, paths, 60.0,
-                    baseline_sec=30.0,
+                    timing=t,
+                    baseline={"wall_sec": 30.0},
                 )
             content = Path(result).read_text()
-            self.assertIn("100.0%", content)
+            self.assertIn("+100.0%", content)
 
     def test_write_runtime_doc_no_baseline(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2395,10 +2445,9 @@ class TestDocWriter(unittest.TestCase):
             with patch("builtins.print"):
                 result = DocWriter.write_runtime_doc(
                     "repo", repo_cfg, paths, 60.0,
-                    baseline_sec=None,
                 )
             content = Path(result).read_text()
-            self.assertNotIn("overhead", content)
+            self.assertNotIn("Overhead", content)
 
     def test_write_build_doc_go(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2440,7 +2489,7 @@ class TestDocWriter(unittest.TestCase):
                 )
             content = Path(result).read_text()
             self.assertIn(
-                "Instrumented build time", content
+                "Total:", content,
             )
             self.assertIn("go build -a", content)
             self.assertIn("bomtrace2", content)
@@ -2486,7 +2535,7 @@ class TestDocWriter(unittest.TestCase):
                 )
             content = Path(result).read_text()
             self.assertIn(
-                "Instrumented build time", content
+                "Total:", content,
             )
             self.assertIn(
                 "cargo build --release", content
@@ -2869,21 +2918,26 @@ class TestMainModeFlag(unittest.TestCase):
 class TestMainFullRun(unittest.TestCase):
     """Tests for main() full analysis run."""
 
-    @patch("app.pipeline.lang_runners.time.time")
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
         "sys.argv",
         ["analyze.py", "--repo", "curl"],
     )
     def test_full_run_success(
-        self, mock_cls, mock_time
+        self, mock_cls, _bl, _save,
     ):
         p = _mock_pipeline()
         mock_cls.return_value = p
-        p.builder.build.return_value = True
-        mock_time.side_effect = [
-            100.0, 142.5, 142.5, 145.0,
-        ]
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
 
         with patch("builtins.print"):
             analyze.main()
@@ -2898,6 +2952,84 @@ class TestMainFullRun(unittest.TestCase):
         p.binary_collector.collect.assert_called_once()
         p.docs.write_build_doc.assert_called_once()
         p.docs.write_runtime_doc.assert_called_once()
+
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
+    @patch(
+        "app.pipeline.cloner.RepoCloner"
+        ".get_commit_sha",
+        return_value="abc123def456789",
+    )
+    @patch("app.pipeline.runners.AnalysisPipeline")
+    @patch(
+        "sys.argv",
+        ["analyze.py", "--repo", "curl"],
+    )
+    def test_commit_sha_printed(
+        self, mock_cls, _sha, _bl, _save,
+    ):
+        p = _mock_pipeline()
+        mock_cls.return_value = p
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
+        printed = []
+        with patch(
+            "builtins.print",
+            side_effect=lambda *a, **kw: (
+                printed.append(
+                    " ".join(str(x) for x in a)
+                )
+            ),
+        ):
+            analyze.main()
+        sha_lines = [
+            line for line in printed
+            if "Commit SHA" in line
+        ]
+        self.assertTrue(len(sha_lines) > 0)
+        self.assertIn("abc123def456", sha_lines[0])
+
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value={"wall_sec": 5.0},
+    )
+    @patch("app.pipeline.runners.AnalysisPipeline")
+    @patch(
+        "sys.argv",
+        ["analyze.py", "--repo", "curl"],
+    )
+    def test_baseline_overhead_printed(
+        self, mock_cls, _bl, _save,
+    ):
+        p = _mock_pipeline()
+        mock_cls.return_value = p
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
+        printed = []
+        with patch(
+            "builtins.print",
+            side_effect=lambda *a, **kw: (
+                printed.append(
+                    " ".join(str(x) for x in a)
+                )
+            ),
+        ):
+            analyze.main()
+        overhead_lines = [
+            line for line in printed
+            if "Overhead" in line
+        ]
+        self.assertTrue(len(overhead_lines) > 0)
 
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
@@ -2922,21 +3054,26 @@ class TestMainFullRun(unittest.TestCase):
 
         p.builder.build.assert_not_called()
 
-    @patch("app.pipeline.lang_runners.time.time")
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
         "sys.argv",
         ["analyze.py", "--repo", "curl"],
     )
     def test_full_run_build_failure(
-        self, mock_cls, mock_time
+        self, mock_cls, _bl, _save,
     ):
         p = _mock_pipeline()
         mock_cls.return_value = p
-        p.builder.build.return_value = False
-        mock_time.side_effect = [
-            100.0, 110.0, 110.0, 110.1,
-        ]
+        p.builder.build.return_value = BuildResult(
+            success=False,
+        )
 
         with patch("builtins.print"):
             analyze.main()
@@ -2946,7 +3083,13 @@ class TestMainFullRun(unittest.TestCase):
         p.binary_collector.collect.assert_not_called()
         p.docs.write_build_doc.assert_called_once()
 
-    @patch("app.pipeline.lang_runners.time.time")
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
         "sys.argv",
@@ -2955,13 +3098,14 @@ class TestMainFullRun(unittest.TestCase):
             "--skip-clone",
         ],
     )
-    def test_skip_clone(self, mock_cls, mock_time):
+    def test_skip_clone(
+        self, mock_cls, _bl, _save,
+    ):
         p = _mock_pipeline()
         mock_cls.return_value = p
-        p.builder.build.return_value = True
-        mock_time.side_effect = [
-            100.0, 110.0, 110.0, 112.0,
-        ]
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
 
         with patch("builtins.print"):
             analyze.main()
@@ -2969,23 +3113,28 @@ class TestMainFullRun(unittest.TestCase):
         p.cloner.clone.assert_not_called()
 
     @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
+    @patch(
         "app.pipeline.runners.load_config",
     )
-    @patch("app.pipeline.lang_runners.time.time")
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
         "sys.argv",
         ["analyze.py", "--repo", "curl"],
     )
     def test_syft_enabled_via_config(
-        self, mock_cls, mock_time, mock_cfg
+        self, mock_cls, mock_cfg, _bl, _save,
     ):
         p = _mock_pipeline()
         mock_cls.return_value = p
-        p.builder.build.return_value = True
-        mock_time.side_effect = [
-            100.0, 110.0, 110.0, 112.0,
-        ]
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
         real_cfg = load_config()
         real_cfg.setdefault(
             "pipeline", {}
@@ -3027,21 +3176,26 @@ class TestMainFullRun(unittest.TestCase):
 class TestMainGoRepo(unittest.TestCase):
     """Tests for main() with Go repos."""
 
-    @patch("app.pipeline.lang_runners.time.time")
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
         "sys.argv",
         ["analyze.py", "--repo", "fzf"],
     )
     def test_go_uses_bomtrace2(
-        self, mock_cls, mock_time
+        self, mock_cls, _bl, _save,
     ):
         p = _mock_pipeline()
         mock_cls.return_value = p
-        p.builder.build.return_value = True
-        mock_time.side_effect = [
-            100.0, 110.0, 110.0, 112.0,
-        ]
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
 
         with patch("builtins.print"):
             analyze.main()
@@ -3063,21 +3217,26 @@ class TestMainGoRepo(unittest.TestCase):
         p.docs.write_runtime_doc\
             .assert_called_once()
 
-    @patch("app.pipeline.lang_runners.time.time")
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
         "sys.argv",
         ["analyze.py", "--repo", "fzf"],
     )
     def test_go_build_failure(
-        self, mock_cls, mock_time
+        self, mock_cls, _bl, _save,
     ):
         p = _mock_pipeline()
         mock_cls.return_value = p
-        p.builder.build.return_value = False
-        mock_time.side_effect = [
-            100.0, 110.0, 110.0, 110.1,
-        ]
+        p.builder.build.return_value = BuildResult(
+            success=False,
+        )
 
         with patch("builtins.print"):
             analyze.main()
@@ -3087,23 +3246,28 @@ class TestMainGoRepo(unittest.TestCase):
         p.docs.write_build_doc.assert_called_once()
 
     @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
+    @patch(
         "app.pipeline.runners.load_config",
     )
-    @patch("app.pipeline.lang_runners.time.time")
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
         "sys.argv",
         ["analyze.py", "--repo", "fzf"],
     )
     def test_go_syft_enabled(
-        self, mock_cls, mock_time, mock_cfg
+        self, mock_cls, mock_cfg, _bl, _save,
     ):
         p = _mock_pipeline()
         mock_cls.return_value = p
-        p.builder.build.return_value = True
-        mock_time.side_effect = [
-            100.0, 110.0, 110.0, 112.0,
-        ]
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
         real_cfg = load_config()
         real_cfg.setdefault(
             "pipeline", {}
@@ -3133,19 +3297,21 @@ class TestRunGoPipeline(unittest.TestCase):
 
     def test_instrumented_build_called(self):
         p = _mock_pipeline()
-        p.builder.build.return_value = True
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
         repo_cfg = {"language": "go"}
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, cap, spdx, tracer = _run_go_pipeline(
+            timing = _run_go_pipeline(
                 p, "fzf", repo_cfg,
                 paths_cfg, self.GO_OMNIBOR_CFG,
                 "2026-03-04_1200",
             )
 
-        self.assertTrue(success)
-        self.assertIn("bomtrace2", tracer)
+        self.assertTrue(timing.success)
+        self.assertIn("bomtrace2", timing.tracer)
         p.builder.build.assert_called_once_with(
             "fzf", repo_cfg,
             paths_cfg, self.GO_OMNIBOR_CFG,
@@ -3154,7 +3320,9 @@ class TestRunGoPipeline(unittest.TestCase):
 
     def test_full_pipeline_on_success(self):
         p = _mock_pipeline()
-        p.builder.build.return_value = True
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
         repo_cfg = {"language": "go"}
         paths_cfg = {"output_dir": "/tmp/out"}
 
@@ -3176,18 +3344,20 @@ class TestRunGoPipeline(unittest.TestCase):
 
     def test_skips_steps_on_failure(self):
         p = _mock_pipeline()
-        p.builder.build.return_value = False
+        p.builder.build.return_value = BuildResult(
+            success=False,
+        )
         repo_cfg = {"language": "go"}
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, _, _, _ = _run_go_pipeline(
+            timing = _run_go_pipeline(
                 p, "fzf", repo_cfg,
                 paths_cfg, self.GO_OMNIBOR_CFG,
                 "2026-03-04_1200",
             )
 
-        self.assertFalse(success)
+        self.assertFalse(timing.success)
         p.spdx_gen.generate.assert_not_called()
         p.metadata_collector.collect\
             .assert_not_called()
@@ -3245,19 +3415,21 @@ class TestRunRustPipeline(unittest.TestCase):
 
     def test_instrumented_build_called(self):
         p = _mock_pipeline()
-        p.builder.build.return_value = True
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
         repo_cfg = {"language": "rust"}
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, cap, spdx, tracer = _run_rust_pipeline(
+            timing = _run_rust_pipeline(
                 p, "oxipng", repo_cfg,
                 paths_cfg, self.RUST_OMNIBOR_CFG,
                 "2026-03-05_1200",
             )
 
-        self.assertTrue(success)
-        self.assertEqual(tracer, "bomtrace2")
+        self.assertTrue(timing.success)
+        self.assertEqual(timing.tracer, "bomtrace2")
         p.builder.build.assert_called_once_with(
             "oxipng", repo_cfg,
             paths_cfg, self.RUST_OMNIBOR_CFG,
@@ -3266,7 +3438,9 @@ class TestRunRustPipeline(unittest.TestCase):
 
     def test_full_pipeline_on_success(self):
         p = _mock_pipeline()
-        p.builder.build.return_value = True
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
         repo_cfg = {"language": "rust"}
         paths_cfg = {"output_dir": "/tmp/out"}
 
@@ -3286,18 +3460,20 @@ class TestRunRustPipeline(unittest.TestCase):
 
     def test_skips_steps_on_failure(self):
         p = _mock_pipeline()
-        p.builder.build.return_value = False
+        p.builder.build.return_value = BuildResult(
+            success=False,
+        )
         repo_cfg = {"language": "rust"}
         paths_cfg = {"output_dir": "/tmp/out"}
 
         with patch("builtins.print"):
-            success, _, _, _ = _run_rust_pipeline(
+            timing = _run_rust_pipeline(
                 p, "oxipng", repo_cfg,
                 paths_cfg, self.RUST_OMNIBOR_CFG,
                 "2026-03-05_1200",
             )
 
-        self.assertFalse(success)
+        self.assertFalse(timing.success)
         p.spdx_gen.generate.assert_not_called()
         p.metadata_collector.collect\
             .assert_not_called()
@@ -3923,27 +4099,32 @@ class TestMetadataCollector(unittest.TestCase):
 class TestMainAdgValidation(unittest.TestCase):
     """Cover line 1400: adg_files validation loop."""
 
-    @patch("app.pipeline.lang_runners.time.time")
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch(
         "sys.argv",
         ["analyze.py", "--repo", "curl"],
     )
     def test_adg_files_validated(
-        self, mock_cls, mock_time,
+        self, mock_cls, _bl, _save,
     ):
         p = _mock_pipeline()
         mock_cls.return_value = p
-        p.builder.build.return_value = True
+        p.builder.build.return_value = BuildResult(
+            success=True,
+        )
         p.spdx_gen.generate.return_value = (
             "/tmp/test.spdx.json"
         )
         p.adg_spdx.generate.return_value = [
             "/tmp/a.spdx.json",
             "/tmp/b.spdx.json",
-        ]
-        mock_time.side_effect = [
-            100.0, 110.0, 110.0, 112.0,
         ]
 
         with patch("builtins.print"):

--- a/tests/test_java_pipeline.py
+++ b/tests/test_java_pipeline.py
@@ -13,6 +13,10 @@ from app.pipeline.runners import (
     _run_java_pipeline,
     _generate_java_adg_spdx,
 )
+from app.pipeline.builder import BuildResult
+from app.pipeline.timing import (
+    TimingResult, StepMetrics,
+)
 
 
 class TestRunJavaPipeline(unittest.TestCase):
@@ -20,7 +24,9 @@ class TestRunJavaPipeline(unittest.TestCase):
 
     def _make_pipeline(self):
         p = MagicMock()
-        p.builder.build_java.return_value = True
+        p.builder.build_java.return_value = BuildResult(
+            success=True,
+        )
         p.spdx_gen.generate_java.return_value = (
             "/tmp/spdx.json"
         )
@@ -64,13 +70,13 @@ class TestRunJavaPipeline(unittest.TestCase):
             )
             pipeline = self._make_pipeline()
 
-            success, _cap, _spdx, tracer = _run_java_pipeline(
+            timing = _run_java_pipeline(
                 pipeline, "myapp", repo_cfg,
                 paths, java_cfg, "ts1",
             )
 
-            self.assertTrue(success)
-            self.assertEqual(tracer, "strace")
+            self.assertTrue(timing.success)
+            self.assertEqual(timing.tracer, "strace")
             pipeline.builder.build_java.assert_called_once()
             pipeline.spdx_gen.generate_java.assert_called_once()
             pipeline.metadata_collector.collect.assert_called_once()
@@ -92,14 +98,16 @@ class TestRunJavaPipeline(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             paths, repo_cfg, java_cfg = self._make_cfg(td)
             pipeline = self._make_pipeline()
-            pipeline.builder.build_java.return_value = False
+            pipeline.builder.build_java.return_value = (
+                BuildResult(success=False)
+            )
 
-            success, _cap, _spdx, _tracer = _run_java_pipeline(
+            timing = _run_java_pipeline(
                 pipeline, "myapp", repo_cfg,
                 paths, java_cfg, "ts1",
             )
 
-            self.assertFalse(success)
+            self.assertFalse(timing.success)
             pipeline.spdx_gen.generate_java.assert_not_called()
             pipeline.metadata_collector.collect.assert_not_called()
             pipeline.binary_collector.collect.assert_not_called()
@@ -118,12 +126,12 @@ class TestRunJavaPipeline(unittest.TestCase):
                 None
             )
 
-            success, _cap, _spdx, _tracer = _run_java_pipeline(
+            timing = _run_java_pipeline(
                 pipeline, "myapp", repo_cfg,
                 paths, java_cfg, "ts1",
             )
 
-            self.assertTrue(success)
+            self.assertTrue(timing.success)
             # No spdx file + no adg files + no syft
             pipeline.spdx_validator.validate.assert_not_called()
 
@@ -476,12 +484,20 @@ class TestJarMapFallbackMatching(unittest.TestCase):
 class TestMainJavaDispatch(unittest.TestCase):
     """Test that main() dispatches to Java pipeline."""
 
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
     @patch("app.pipeline.runners.run_java_pipeline")
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch("app.pipeline.runners.load_config")
     @patch("app.pipeline.runners.timestamp")
     def test_java_dispatch(
-        self, mock_ts, mock_cfg, mock_pipe, mock_java,
+        self, mock_ts, mock_cfg, mock_pipe,
+        mock_java, _bl, _save,
     ):
         mock_ts.return_value = "ts1"
         mock_cfg.return_value = {
@@ -509,7 +525,17 @@ class TestMainJavaDispatch(unittest.TestCase):
         }
         mock_pipe_inst = MagicMock()
         mock_pipe.return_value = mock_pipe_inst
-        mock_java.return_value = (True, 8.0, 2.0, "strace")
+        mock_java.return_value = TimingResult(
+            tracer="strace",
+            success=True,
+            steps=[
+                StepMetrics(
+                    name="build",
+                    phase="phase1",
+                    wall_sec=8.0,
+                ),
+            ],
+        )
 
         from app.pipeline.runners import main
         with patch(
@@ -520,12 +546,20 @@ class TestMainJavaDispatch(unittest.TestCase):
 
         mock_java.assert_called_once()
 
+    @patch(
+        "app.pipeline.timing.save_runtime_json",
+    )
+    @patch(
+        "app.pipeline.timing.load_baseline",
+        return_value=None,
+    )
     @patch("app.pipeline.runners.run_rust_pipeline")
     @patch("app.pipeline.runners.AnalysisPipeline")
     @patch("app.pipeline.runners.load_config")
     @patch("app.pipeline.runners.timestamp")
     def test_rust_dispatch(
-        self, mock_ts, mock_cfg, mock_pipe, mock_rust,
+        self, mock_ts, mock_cfg, mock_pipe,
+        mock_rust, _bl, _save,
     ):
         mock_ts.return_value = "ts1"
         mock_cfg.return_value = {
@@ -554,7 +588,17 @@ class TestMainJavaDispatch(unittest.TestCase):
         }
         mock_pipe_inst = MagicMock()
         mock_pipe.return_value = mock_pipe_inst
-        mock_rust.return_value = (True, 8.0, 2.0, "bomtrace2")
+        mock_rust.return_value = TimingResult(
+            tracer="bomtrace2",
+            success=True,
+            steps=[
+                StepMetrics(
+                    name="build",
+                    phase="phase1",
+                    wall_sec=8.0,
+                ),
+            ],
+        )
 
         from app.pipeline.runners import main
         with patch(

--- a/tests/test_java_pipeline_wire.py
+++ b/tests/test_java_pipeline_wire.py
@@ -17,6 +17,7 @@ from app.pipeline.interception import (
     MavenDepTreeStrategy,
     GradleDepTreeStrategy,
 )
+from app.pipeline.builder import BuildResult
 
 
 class TestSelectJavaStrategy(unittest.TestCase):
@@ -91,8 +92,12 @@ class TestRunJavaPipelineMode(unittest.TestCase):
 
     def _setup(self):
         pipeline = MagicMock()
-        pipeline.builder.build_java.return_value = True
-        pipeline.builder.build.return_value = True
+        pipeline.builder.build_java.return_value = (
+            BuildResult(success=True)
+        )
+        pipeline.builder.build.return_value = (
+            BuildResult(success=True)
+        )
         pipeline.spdx_gen.generate_java.return_value = (
             "/out/spdx.json"
         )
@@ -133,14 +138,14 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     def test_standalone_uses_build_java(self, _):
         pipeline = self._setup()
         with patch("builtins.print"):
-            ok, _cap, _spdx, tracer = run_java_pipeline(
+            timing = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
                 mode="standalone",
             )
-        self.assertTrue(ok)
-        self.assertEqual(tracer, "strace")
+        self.assertTrue(timing.success)
+        self.assertEqual(timing.tracer, "strace")
         pipeline.builder.build_java\
             .assert_called_once()
         pipeline.builder.build\
@@ -161,14 +166,16 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     ):
         pipeline = self._setup()
         with patch("builtins.print"):
-            ok, _cap, _spdx, tracer = run_java_pipeline(
+            timing = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
                 mode="sidecar",
             )
-        self.assertTrue(ok)
-        self.assertEqual(tracer, "maven-dep-tree")
+        self.assertTrue(timing.success)
+        self.assertEqual(
+            timing.tracer, "maven-dep-tree",
+        )
         pipeline.builder.build\
             .assert_called_once()
         # Verify strategy was passed
@@ -189,12 +196,12 @@ class TestRunJavaPipelineMode(unittest.TestCase):
     def test_default_mode_is_standalone(self, _):
         pipeline = self._setup()
         with patch("builtins.print"):
-            _ok, _cap, _spdx, tracer = run_java_pipeline(
+            timing = run_java_pipeline(
                 pipeline, "jsoup",
                 self._repo_cfg(), self._paths(),
                 self._omnibor(), "2024-01-01",
             )
-        self.assertEqual(tracer, "strace")
+        self.assertEqual(timing.tracer, "strace")
         # Default mode=standalone -> build_java
         pipeline.builder.build_java\
             .assert_called_once()

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -11,6 +11,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from app.pipeline.builder import BuildResult
 from app.pipeline.timing import (
     CONTENTION_THRESHOLD,
     StepMetrics,
@@ -20,6 +21,7 @@ from app.pipeline.timing import (
     save_runtime_json,
     load_baseline,
     save_baseline,
+    baseline_build_step,
     _safe_loadavg,
 )
 
@@ -511,57 +513,108 @@ class TestLoadBaseline(unittest.TestCase):
 class TestSaveBaseline(unittest.TestCase):
     """Tests for save_baseline."""
 
-    def test_writes_baseline_file(self):
-        m = StepMetrics(
-            name="build", phase="phase1",
-            wall_sec=30.0,
-            cpu_user_sec=25.0, cpu_sys_sec=3.0,
+    def _build_result(self, build_wall=30.0):
+        return BuildResult(
+            success=True,
+            steps=[
+                StepMetrics(
+                    name="clean", phase="phase1",
+                    wall_sec=2.0,
+                ),
+                StepMetrics(
+                    name="build", phase="phase1",
+                    wall_sec=build_wall,
+                    cpu_user_sec=25.0,
+                    cpu_sys_sec=3.0,
+                ),
+            ],
         )
+
+    def test_writes_baseline_file(self):
+        br = self._build_result(30.0)
         with tempfile.TemporaryDirectory() as td:
             paths = {"output_dir": td}
             repo_cfg = {"language": "rust"}
             with patch("builtins.print"):
                 result = save_baseline(
-                    m, paths, "oxipng", repo_cfg,
+                    br, paths, "oxipng", repo_cfg,
                 )
             self.assertTrue(Path(result).exists())
             data = json.loads(Path(result).read_text())
-            self.assertEqual(data["name"], "build")
-            self.assertEqual(data["wall_sec"], 30.0)
+            self.assertIn("steps", data)
+            build = next(
+                s for s in data["steps"]
+                if s["name"] == "build"
+            )
+            self.assertEqual(build["wall_sec"], 30.0)
 
     def test_creates_directory(self):
-        m = StepMetrics(
-            name="build", phase="phase1",
-            wall_sec=10.0,
-        )
+        br = self._build_result(10.0)
         with tempfile.TemporaryDirectory() as td:
             paths = {"output_dir": td}
             repo_cfg = {"language": "java"}
             with patch("builtins.print"):
                 result = save_baseline(
-                    m, paths, "checkstyle",
+                    br, paths, "checkstyle",
                     repo_cfg,
                 )
             self.assertIn("baseline.json", result)
             self.assertIn("java", result)
 
     def test_includes_run_ts(self):
-        m = StepMetrics(
-            name="build", phase="phase1",
-            wall_sec=5.0,
-        )
+        br = self._build_result(5.0)
         with tempfile.TemporaryDirectory() as td:
             paths = {"output_dir": td}
             repo_cfg = {"language": "go"}
             with patch("builtins.print"):
                 result = save_baseline(
-                    m, paths, "fzf", repo_cfg,
+                    br, paths, "fzf", repo_cfg,
                     run_ts="2026-05-11_0900",
                 )
             data = json.loads(Path(result).read_text())
             self.assertEqual(
                 data["run_ts"], "2026-05-11_0900",
             )
+
+
+# ============================================================
+# baseline_build_step
+# ============================================================
+
+class TestBaselineBuildStep(unittest.TestCase):
+    """Tests for baseline_build_step."""
+
+    def test_returns_none_for_none(self):
+        self.assertIsNone(baseline_build_step(None))
+
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(baseline_build_step({}))
+
+    def test_extracts_build_from_steps(self):
+        bl = {
+            "steps": [
+                {"name": "clean", "wall_sec": 2.0},
+                {"name": "build", "wall_sec": 30.0},
+            ],
+        }
+        result = baseline_build_step(bl)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["wall_sec"], 30.0)
+        self.assertEqual(result["name"], "build")
+
+    def test_returns_none_when_no_build_step(self):
+        bl = {
+            "steps": [
+                {"name": "clean", "wall_sec": 2.0},
+            ],
+        }
+        self.assertIsNone(baseline_build_step(bl))
+
+    def test_legacy_format(self):
+        bl = {"wall_sec": 42.0, "name": "baseline"}
+        result = baseline_build_step(bl)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["wall_sec"], 42.0)
 
 
 # ============================================================

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -16,6 +16,7 @@ from app.pipeline.timing import (
     StepMetrics,
     TimingResult,
     StepTimer,
+    infer_parallelism,
     save_runtime_json,
     load_baseline,
     save_baseline,
@@ -105,7 +106,61 @@ class TestStepMetrics(unittest.TestCase):
         self.assertEqual(m.cpu_user_sec, 0.0)
         self.assertEqual(m.cpu_sys_sec, 0.0)
         self.assertEqual(m.cpu_count, 1)
+        self.assertEqual(m.expected_parallelism, 1)
         self.assertFalse(m.contention)
+
+    def test_contention_severity_no_contention(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=10.0,
+            cpu_user_sec=8.0, cpu_sys_sec=1.5,
+            contention=False,
+        )
+        self.assertAlmostEqual(
+            m.contention_severity, 0.0,
+        )
+
+    def test_contention_severity_with_contention(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=10.0,
+            cpu_user_sec=1.0, cpu_sys_sec=0.0,
+            cpu_count=4,
+            expected_parallelism=4,
+            contention=True,
+        )
+        # efficiency = 0.1, threshold = min(4,4)*0.7 = 2.8
+        # severity = (1 - 0.1/2.8) * 100 = 96.4%
+        self.assertGreater(
+            m.contention_severity, 90.0,
+        )
+
+    def test_contention_severity_zero_wall(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=0.0, contention=True,
+        )
+        self.assertAlmostEqual(
+            m.contention_severity, 0.0,
+        )
+
+    def test_to_dict_includes_severity(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=10.0,
+            cpu_user_sec=1.0, cpu_sys_sec=0.0,
+            cpu_count=4,
+            expected_parallelism=4,
+            contention=True,
+        )
+        d = m.to_dict()
+        self.assertIn("contention_severity", d)
+        self.assertGreater(
+            d["contention_severity"], 0,
+        )
+        self.assertIn(
+            "expected_parallelism", d,
+        )
 
 
 # ============================================================
@@ -167,6 +222,41 @@ class TestTimingResult(unittest.TestCase):
         self.assertEqual(t.phase2_total, 0.0)
         self.assertEqual(t.total, 0.0)
 
+    def test_contention_steps_none(self):
+        t = self._make_timing()
+        self.assertEqual(len(t.contention_steps), 0)
+
+    def test_contention_steps_some(self):
+        t = TimingResult(
+            tracer="x", success=True,
+            steps=[
+                StepMetrics(
+                    name="a", phase="phase1",
+                    wall_sec=5.0, contention=True,
+                ),
+                StepMetrics(
+                    name="b", phase="phase1",
+                    wall_sec=10.0, contention=False,
+                ),
+                StepMetrics(
+                    name="c", phase="phase2",
+                    wall_sec=3.0, contention=True,
+                ),
+            ],
+        )
+        self.assertEqual(len(t.contention_steps), 2)
+        self.assertAlmostEqual(
+            t.contention_total_sec, 8.0,
+        )
+        # 8/18 * 100 = 44.4%
+        self.assertAlmostEqual(
+            t.contention_pct, 44.4, places=1,
+        )
+
+    def test_contention_pct_empty(self):
+        t = TimingResult(tracer="x", success=True)
+        self.assertAlmostEqual(t.contention_pct, 0.0)
+
     def test_to_dict(self):
         t = self._make_timing()
         d = t.to_dict()
@@ -177,6 +267,15 @@ class TestTimingResult(unittest.TestCase):
         self.assertEqual(d["total_sec"], 16.0)
         self.assertEqual(len(d["steps"]), 4)
         self.assertIsInstance(d["steps"][0], dict)
+
+    def test_to_dict_contention_summary(self):
+        t = self._make_timing()
+        d = t.to_dict()
+        cs = d["contention_summary"]
+        self.assertEqual(cs["steps_flagged"], 0)
+        self.assertEqual(cs["total_steps"], 4)
+        self.assertEqual(cs["duration_sec"], 0.0)
+        self.assertEqual(cs["pct_of_total"], 0.0)
 
     def test_to_dict_rounds(self):
         t = TimingResult(
@@ -440,10 +539,29 @@ class TestSaveBaseline(unittest.TestCase):
             repo_cfg = {"language": "java"}
             with patch("builtins.print"):
                 result = save_baseline(
-                    m, paths, "checkstyle", repo_cfg,
+                    m, paths, "checkstyle",
+                    repo_cfg,
                 )
             self.assertIn("baseline.json", result)
             self.assertIn("java", result)
+
+    def test_includes_run_ts(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=5.0,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            paths = {"output_dir": td}
+            repo_cfg = {"language": "go"}
+            with patch("builtins.print"):
+                result = save_baseline(
+                    m, paths, "fzf", repo_cfg,
+                    run_ts="2026-05-11_0900",
+                )
+            data = json.loads(Path(result).read_text())
+            self.assertEqual(
+                data["run_ts"], "2026-05-11_0900",
+            )
 
 
 # ============================================================
@@ -455,6 +573,176 @@ class TestContentionThreshold(unittest.TestCase):
 
     def test_threshold_value(self):
         self.assertEqual(CONTENTION_THRESHOLD, 0.70)
+
+
+# ============================================================
+# Doc writer formatting (contention-related)
+# ============================================================
+
+class TestFormatContention(unittest.TestCase):
+    """Tests for contention formatting in doc_writer."""
+
+    def test_no_contention_message(self):
+        from app.pipeline.doc_writer import (
+            _format_contention_summary,
+        )
+        t = TimingResult(
+            tracer="x", success=True,
+            steps=[
+                StepMetrics(
+                    name="build", phase="phase1",
+                    wall_sec=10.0,
+                ),
+            ],
+        )
+        result = _format_contention_summary(t)
+        self.assertIn("No contention detected", result)
+        self.assertIn("1 steps", result)
+
+    def test_contention_summary_content(self):
+        from app.pipeline.doc_writer import (
+            _format_contention_summary,
+        )
+        t = TimingResult(
+            tracer="x", success=True,
+            steps=[
+                StepMetrics(
+                    name="build", phase="phase1",
+                    wall_sec=40.0,
+                    cpu_user_sec=1.0, cpu_sys_sec=0.0,
+                    cpu_count=4,
+                    expected_parallelism=4,
+                    contention=True,
+                ),
+                StepMetrics(
+                    name="spdx_gen", phase="phase2",
+                    wall_sec=5.0,
+                ),
+            ],
+        )
+        result = _format_contention_summary(t)
+        self.assertIn("1 of 2", result)
+        self.assertIn("40.0s", result)
+        self.assertIn("Most severe", result)
+        self.assertIn("Build", result)
+
+    def test_timing_table_has_expected_col(self):
+        from app.pipeline.doc_writer import (
+            _format_timing_table,
+        )
+        t = TimingResult(
+            tracer="x", success=True,
+            steps=[
+                StepMetrics(
+                    name="build", phase="phase1",
+                    wall_sec=10.0,
+                    expected_parallelism=4,
+                    cpu_user_sec=8.0,
+                    cpu_sys_sec=1.0,
+                ),
+            ],
+        )
+        result = _format_timing_table(t)
+        self.assertIn("Expected", result)
+        self.assertIn("4x", result)
+        self.assertIn("\u2014", result)
+
+
+# ============================================================
+# infer_parallelism
+# ============================================================
+
+class TestInferParallelism(unittest.TestCase):
+    """Tests for infer_parallelism()."""
+
+    def test_make_j_nproc(self):
+        self.assertEqual(
+            infer_parallelism(
+                "make -j$(nproc)", cpu_count=8,
+            ), 8,
+        )
+
+    def test_make_j_number(self):
+        self.assertEqual(
+            infer_parallelism(
+                "make -j4", cpu_count=8,
+            ), 4,
+        )
+
+    def test_make_j1(self):
+        self.assertEqual(
+            infer_parallelism(
+                "make -j1", cpu_count=4,
+            ), 1,
+        )
+
+    def test_bare_make(self):
+        self.assertEqual(
+            infer_parallelism(
+                "make", cpu_count=4,
+            ), 1,
+        )
+
+    def test_make_clean(self):
+        self.assertEqual(
+            infer_parallelism(
+                "make clean", cpu_count=4,
+            ), 1,
+        )
+
+    def test_go_build(self):
+        self.assertEqual(
+            infer_parallelism(
+                "go build -a -trimpath -o fzf .",
+                cpu_count=4,
+            ), 4,
+        )
+
+    def test_cargo_build(self):
+        self.assertEqual(
+            infer_parallelism(
+                "cargo build --release",
+                cpu_count=8,
+            ), 8,
+        )
+
+    def test_mvn(self):
+        self.assertEqual(
+            infer_parallelism(
+                "mvn package -DskipTests -q",
+                cpu_count=4,
+            ), 1,
+        )
+
+    def test_gradlew(self):
+        self.assertEqual(
+            infer_parallelism(
+                "./gradlew :prov:build -x test",
+                cpu_count=4,
+            ), 4,
+        )
+
+    def test_unknown_tool(self):
+        self.assertEqual(
+            infer_parallelism(
+                "./build.sh", cpu_count=4,
+            ), 1,
+        )
+
+    def test_cmake_make_j(self):
+        self.assertEqual(
+            infer_parallelism(
+                "make -j$(nproc)", cpu_count=16,
+            ), 16,
+        )
+
+    def test_env_prefix_mvn(self):
+        self.assertEqual(
+            infer_parallelism(
+                "env JAVA_HOME=/usr mvn install",
+                cpu_count=4,
+            ), 1,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,461 @@
+"""
+Tests for app/pipeline/timing.py.
+
+Covers StepMetrics, TimingResult, StepTimer,
+save_runtime_json, load_baseline, and save_baseline.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app.pipeline.timing import (
+    CONTENTION_THRESHOLD,
+    StepMetrics,
+    TimingResult,
+    StepTimer,
+    save_runtime_json,
+    load_baseline,
+    save_baseline,
+    _safe_loadavg,
+)
+
+
+# ============================================================
+# StepMetrics
+# ============================================================
+
+class TestStepMetrics(unittest.TestCase):
+    """Tests for StepMetrics dataclass."""
+
+    def test_cpu_total_sec(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            cpu_user_sec=2.5, cpu_sys_sec=0.5,
+        )
+        self.assertAlmostEqual(m.cpu_total_sec, 3.0)
+
+    def test_cpu_efficiency_normal(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=10.0,
+            cpu_user_sec=8.0, cpu_sys_sec=1.5,
+        )
+        self.assertAlmostEqual(m.cpu_efficiency, 0.95)
+
+    def test_cpu_efficiency_zero_wall(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=0.0,
+        )
+        self.assertAlmostEqual(m.cpu_efficiency, 0.0)
+
+    def test_cpu_efficiency_negative_wall(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=-1.0,
+        )
+        self.assertAlmostEqual(m.cpu_efficiency, 0.0)
+
+    def test_to_dict_keys(self):
+        m = StepMetrics(
+            name="clean", phase="phase1",
+            wall_sec=1.234,
+            cpu_user_sec=0.5, cpu_sys_sec=0.3,
+            cpu_count=4,
+            load_avg_start=(1.1, 2.2, 3.3),
+            load_avg_end=(1.5, 2.5, 3.5),
+            contention=False,
+        )
+        d = m.to_dict()
+        self.assertEqual(d["name"], "clean")
+        self.assertEqual(d["phase"], "phase1")
+        self.assertEqual(d["wall_sec"], 1.23)
+        self.assertEqual(d["cpu_user_sec"], 0.5)
+        self.assertEqual(d["cpu_sys_sec"], 0.3)
+        self.assertAlmostEqual(d["cpu_total_sec"], 0.8)
+        self.assertAlmostEqual(
+            d["cpu_efficiency"], 0.65, places=2,
+        )
+        self.assertEqual(
+            d["load_avg_start"], [1.1, 2.2, 3.3],
+        )
+        self.assertEqual(
+            d["load_avg_end"], [1.5, 2.5, 3.5],
+        )
+        self.assertFalse(d["contention"])
+
+    def test_to_dict_rounds_floats(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=1.23456789,
+            cpu_user_sec=0.111111,
+            cpu_sys_sec=0.222222,
+        )
+        d = m.to_dict()
+        self.assertEqual(d["wall_sec"], 1.23)
+        self.assertEqual(d["cpu_user_sec"], 0.11)
+        self.assertEqual(d["cpu_sys_sec"], 0.22)
+
+    def test_defaults(self):
+        m = StepMetrics(name="x", phase="phase2")
+        self.assertEqual(m.wall_sec, 0.0)
+        self.assertEqual(m.cpu_user_sec, 0.0)
+        self.assertEqual(m.cpu_sys_sec, 0.0)
+        self.assertEqual(m.cpu_count, 1)
+        self.assertFalse(m.contention)
+
+
+# ============================================================
+# TimingResult
+# ============================================================
+
+class TestTimingResult(unittest.TestCase):
+    """Tests for TimingResult dataclass."""
+
+    def _make_timing(self):
+        return TimingResult(
+            tracer="bomtrace3",
+            success=True,
+            steps=[
+                StepMetrics(
+                    name="clean", phase="phase1",
+                    wall_sec=2.0,
+                ),
+                StepMetrics(
+                    name="build", phase="phase1",
+                    wall_sec=10.0,
+                ),
+                StepMetrics(
+                    name="spdx_gen", phase="phase2",
+                    wall_sec=3.0,
+                ),
+                StepMetrics(
+                    name="validate", phase="phase2",
+                    wall_sec=1.0,
+                ),
+            ],
+        )
+
+    def test_phase1_steps(self):
+        t = self._make_timing()
+        names = [s.name for s in t.phase1_steps]
+        self.assertEqual(names, ["clean", "build"])
+
+    def test_phase2_steps(self):
+        t = self._make_timing()
+        names = [s.name for s in t.phase2_steps]
+        self.assertEqual(names, ["spdx_gen", "validate"])
+
+    def test_phase1_total(self):
+        t = self._make_timing()
+        self.assertAlmostEqual(t.phase1_total, 12.0)
+
+    def test_phase2_total(self):
+        t = self._make_timing()
+        self.assertAlmostEqual(t.phase2_total, 4.0)
+
+    def test_total(self):
+        t = self._make_timing()
+        self.assertAlmostEqual(t.total, 16.0)
+
+    def test_empty_steps(self):
+        t = TimingResult(tracer="x", success=True)
+        self.assertEqual(t.phase1_total, 0.0)
+        self.assertEqual(t.phase2_total, 0.0)
+        self.assertEqual(t.total, 0.0)
+
+    def test_to_dict(self):
+        t = self._make_timing()
+        d = t.to_dict()
+        self.assertEqual(d["tracer"], "bomtrace3")
+        self.assertTrue(d["success"])
+        self.assertEqual(d["phase1_total_sec"], 12.0)
+        self.assertEqual(d["phase2_total_sec"], 4.0)
+        self.assertEqual(d["total_sec"], 16.0)
+        self.assertEqual(len(d["steps"]), 4)
+        self.assertIsInstance(d["steps"][0], dict)
+
+    def test_to_dict_rounds(self):
+        t = TimingResult(
+            tracer="x", success=True,
+            steps=[
+                StepMetrics(
+                    name="a", phase="phase1",
+                    wall_sec=1.23456789,
+                ),
+            ],
+        )
+        d = t.to_dict()
+        self.assertEqual(d["total_sec"], 1.23)
+
+    def test_defaults(self):
+        t = TimingResult()
+        self.assertEqual(t.tracer, "")
+        self.assertFalse(t.success)
+        self.assertEqual(t.steps, [])
+
+
+# ============================================================
+# StepTimer
+# ============================================================
+
+class TestStepTimer(unittest.TestCase):
+    """Tests for StepTimer context manager."""
+
+    def test_produces_metrics(self):
+        timer = StepTimer("test_step", "phase1")
+        with timer:
+            # Minimal work to generate some time
+            total = sum(range(1000))
+            _ = total
+        m = timer.metrics
+        self.assertIsInstance(m, StepMetrics)
+        self.assertEqual(m.name, "test_step")
+        self.assertEqual(m.phase, "phase1")
+        self.assertGreaterEqual(m.wall_sec, 0.0)
+        self.assertGreaterEqual(m.cpu_user_sec, 0.0)
+        self.assertGreaterEqual(m.cpu_sys_sec, 0.0)
+        self.assertGreaterEqual(m.cpu_count, 1)
+
+    def test_metrics_none_before_exit(self):
+        timer = StepTimer("x", "phase1")
+        self.assertIsNone(timer.metrics)
+
+    def test_wall_time_measured(self):
+        timer = StepTimer("sleep", "phase1")
+        with timer:
+            import time
+            time.sleep(0.05)
+        self.assertGreater(
+            timer.metrics.wall_sec, 0.01,
+        )
+
+    def test_contention_flag(self):
+        # With expected_parallelism=100, any real
+        # run will have contention (efficiency < 70)
+        timer = StepTimer(
+            "high_par", "phase1",
+            expected_parallelism=100,
+        )
+        with timer:
+            _ = sum(range(100))
+        self.assertTrue(timer.metrics.contention)
+
+    def test_no_contention_on_single_thread(self):
+        timer = StepTimer(
+            "single", "phase1",
+            expected_parallelism=1,
+        )
+        with timer:
+            _ = sum(range(100))
+        # Single-threaded: efficiency may be low due
+        # to minimal work, but contention threshold
+        # is forgiving for expected_parallelism=1
+        self.assertIsInstance(
+            timer.metrics.contention, bool,
+        )
+
+    def test_load_avg_recorded(self):
+        timer = StepTimer("load", "phase1")
+        with timer:
+            pass
+        m = timer.metrics
+        self.assertEqual(len(m.load_avg_start), 3)
+        self.assertEqual(len(m.load_avg_end), 3)
+
+
+# ============================================================
+# _safe_loadavg
+# ============================================================
+
+class TestSafeLoadavg(unittest.TestCase):
+    """Tests for _safe_loadavg helper."""
+
+    def test_returns_tuple_on_supported(self):
+        result = _safe_loadavg()
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 3)
+
+    def test_returns_zeros_on_error(self):
+        with patch(
+            "os.getloadavg",
+            side_effect=OSError("unsupported"),
+        ):
+            result = _safe_loadavg()
+        self.assertEqual(result, (0.0, 0.0, 0.0))
+
+    def test_returns_zeros_on_attribute_error(self):
+        with patch(
+            "os.getloadavg",
+            side_effect=AttributeError,
+        ):
+            result = _safe_loadavg()
+        self.assertEqual(result, (0.0, 0.0, 0.0))
+
+
+# ============================================================
+# save_runtime_json
+# ============================================================
+
+class TestSaveRuntimeJson(unittest.TestCase):
+    """Tests for save_runtime_json."""
+
+    def _make_timing(self):
+        return TimingResult(
+            tracer="bomtrace3",
+            success=True,
+            steps=[
+                StepMetrics(
+                    name="build", phase="phase1",
+                    wall_sec=10.0,
+                ),
+            ],
+        )
+
+    def test_writes_json_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            paths = {"output_dir": td}
+            repo_cfg = {"language": "c-cpp"}
+            with patch("builtins.print"):
+                result = save_runtime_json(
+                    self._make_timing(), paths,
+                    "curl", repo_cfg, "ts1",
+                )
+            self.assertTrue(Path(result).exists())
+            data = json.loads(Path(result).read_text())
+            self.assertEqual(data["tracer"], "bomtrace3")
+            self.assertTrue(data["success"])
+
+    def test_includes_baseline_when_provided(self):
+        with tempfile.TemporaryDirectory() as td:
+            paths = {"output_dir": td}
+            repo_cfg = {"language": "c-cpp"}
+            baseline = {"wall_sec": 5.0}
+            with patch("builtins.print"):
+                result = save_runtime_json(
+                    self._make_timing(), paths,
+                    "curl", repo_cfg, "ts1",
+                    baseline=baseline,
+                )
+            data = json.loads(Path(result).read_text())
+            self.assertEqual(
+                data["baseline"]["wall_sec"], 5.0,
+            )
+
+    def test_no_baseline_key_when_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            paths = {"output_dir": td}
+            repo_cfg = {"language": "c-cpp"}
+            with patch("builtins.print"):
+                result = save_runtime_json(
+                    self._make_timing(), paths,
+                    "curl", repo_cfg, "ts1",
+                )
+            data = json.loads(Path(result).read_text())
+            self.assertNotIn("baseline", data)
+
+    def test_creates_directory(self):
+        with tempfile.TemporaryDirectory() as td:
+            paths = {"output_dir": td}
+            repo_cfg = {"language": "go"}
+            with patch("builtins.print"):
+                result = save_runtime_json(
+                    self._make_timing(), paths,
+                    "fzf", repo_cfg, "ts1",
+                )
+            self.assertIn("runtime", result)
+            self.assertIn("go", result)
+            self.assertIn("fzf", result)
+
+
+# ============================================================
+# load_baseline
+# ============================================================
+
+class TestLoadBaseline(unittest.TestCase):
+    """Tests for load_baseline."""
+
+    def test_returns_none_when_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            paths = {"output_dir": td}
+            repo_cfg = {"language": "c-cpp"}
+            result = load_baseline(
+                paths, "curl", repo_cfg,
+            )
+            self.assertIsNone(result)
+
+    def test_returns_data_when_exists(self):
+        with tempfile.TemporaryDirectory() as td:
+            paths = {"output_dir": td}
+            repo_cfg = {"language": "c-cpp"}
+            bl_dir = (
+                Path(td) / "runtime"
+                / "c-cpp" / "curl"
+            )
+            bl_dir.mkdir(parents=True)
+            (bl_dir / "baseline.json").write_text(
+                json.dumps({"wall_sec": 42.0})
+            )
+            result = load_baseline(
+                paths, "curl", repo_cfg,
+            )
+            self.assertEqual(result["wall_sec"], 42.0)
+
+
+# ============================================================
+# save_baseline
+# ============================================================
+
+class TestSaveBaseline(unittest.TestCase):
+    """Tests for save_baseline."""
+
+    def test_writes_baseline_file(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=30.0,
+            cpu_user_sec=25.0, cpu_sys_sec=3.0,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            paths = {"output_dir": td}
+            repo_cfg = {"language": "rust"}
+            with patch("builtins.print"):
+                result = save_baseline(
+                    m, paths, "oxipng", repo_cfg,
+                )
+            self.assertTrue(Path(result).exists())
+            data = json.loads(Path(result).read_text())
+            self.assertEqual(data["name"], "build")
+            self.assertEqual(data["wall_sec"], 30.0)
+
+    def test_creates_directory(self):
+        m = StepMetrics(
+            name="build", phase="phase1",
+            wall_sec=10.0,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            paths = {"output_dir": td}
+            repo_cfg = {"language": "java"}
+            with patch("builtins.print"):
+                result = save_baseline(
+                    m, paths, "checkstyle", repo_cfg,
+                )
+            self.assertIn("baseline.json", result)
+            self.assertIn("java", result)
+
+
+# ============================================================
+# CONTENTION_THRESHOLD constant
+# ============================================================
+
+class TestContentionThreshold(unittest.TestCase):
+    """Verify threshold constant."""
+
+    def test_threshold_value(self):
+        self.assertEqual(CONTENTION_THRESHOLD, 0.70)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds baseline (non-instrumented) build timing, build-tool-aware contention analysis, and enhanced runtime reporting.

## Changes

### Baseline Builds
- `--baseline` CLI flag runs clean+prebuild+build without tracer
- `build_baseline()` on BomtraceBuilder — no code duplication
- Saves `baseline.json` with wall time, CPU metrics, timestamp

### Contention Analysis
- `infer_parallelism()` — determines expected CPU parallelism from build command patterns (make -j, go, cargo, mvn, gradle)
- `expected_parallelism` and `contention_severity` fields on StepMetrics
- Contention aggregates on TimingResult (step count, duration, % of total)
- Contention Analysis section in runtime.md with most-severe-step detail

### Timing Fixes
- StepTimer measures RUSAGE_SELF + RUSAGE_CHILDREN (fixes false contention on Python-internal steps)
- Renamed `configure` step to `prebuild` (generic across languages)
- Baseline loaded before doc writer so overhead appears in runtime.md

### Test Coverage
- 1377 tests pass, 98% overall coverage
- New tests: infer_parallelism (12 cases), contention_severity, TimingResult aggregates, baseline CLI, build_baseline, doc formatting
