### PR TITLE
feat: phase isolation infrastructure for Java sidecar

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -38,6 +38,9 @@ def lang_subdir(repo_cfg):
 VALID_MODES = ("standalone", "sidecar")
 DEFAULT_MODE = "standalone"
 
+# Valid phase isolation phases
+VALID_PHASES = ("build", "spdx")
+
 # Maps language names to their omnibor config keys
 _LANG_OMNIBOR_KEYS = {
     "c-cpp": "omnibor",

--- a/app/pipeline/lang_runners.py
+++ b/app/pipeline/lang_runners.py
@@ -205,18 +205,19 @@ def _select_java_strategy(
     )
 
 
-def run_java_pipeline(
+def run_java_phase1(
     pipeline, repo_name, repo_cfg,
     paths_cfg, omnibor_java_cfg, run_ts,
-    vcs_uri="NOASSERTION",
     mode="standalone",
 ):
-    """Java pipeline: build + SPDX generation.
+    """Java Phase 1: build interception only.
 
-    In standalone mode (default): strace + bomsh_create_bom_java.py.
+    In standalone mode: strace + bomsh_create_bom_java.py.
     In sidecar mode: dep:tree strategy (no strace needed).
 
-    Returns ``TimingResult`` with per-step metrics.
+    Returns ``(TimingResult, strategy)`` tuple.
+    The strategy is needed by Phase 2 dispatch but is
+    a Phase 1 decision, so it is returned here.
     """
     strategy = _select_java_strategy(
         repo_name, repo_cfg, paths_cfg, mode,
@@ -224,7 +225,6 @@ def run_java_pipeline(
     tracer = strategy.name if strategy else "strace"
     timing = TimingResult(tracer=tracer)
 
-    # Phase 1: Build
     if strategy:
         build_result = pipeline.builder.build(
             repo_name, repo_cfg,
@@ -240,28 +240,71 @@ def run_java_pipeline(
         )
     timing.steps.extend(build_result.steps)
     timing.success = build_result.success
-    if not build_result.success:
+    return timing, strategy
+
+
+def run_java_phase2(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_java_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+):
+    """Java Phase 2: SPDX generation + validation.
+
+    Runs post-build analysis: OmniBOR SBOM, metadata,
+    per-binary SPDX, validation, binary collection.
+
+    Returns list of ``StepMetrics``.
+    """
+    return _run_post_build(
+        pipeline, repo_name, repo_cfg,
+        paths_cfg, run_ts,
+        sbom_fn=lambda: (
+            pipeline.spdx_gen.generate_java(
+                repo_name, repo_cfg,
+                paths_cfg, omnibor_java_cfg,
+                run_ts=run_ts,
+            )
+        ),
+        spdx_gen_fn=lambda: (
+            generate_java_adg_spdx(
+                repo_name, repo_cfg,
+                paths_cfg, run_ts,
+                vcs_uri=vcs_uri,
+            )
+        ),
+    )
+
+
+def run_java_pipeline(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_java_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    mode="standalone",
+):
+    """Java pipeline: build + SPDX generation.
+
+    In standalone mode (default): strace + bomsh_create_bom_java.py.
+    In sidecar mode: dep:tree strategy (no strace needed).
+
+    Backward-compatible: calls Phase 1 then Phase 2
+    sequentially. For phase isolation, use
+    ``run_java_phase1`` / ``run_java_phase2`` directly.
+
+    Returns ``TimingResult`` with per-step metrics.
+    """
+    timing, _ = run_java_phase1(
+        pipeline, repo_name, repo_cfg,
+        paths_cfg, omnibor_java_cfg, run_ts,
+        mode=mode,
+    )
+    if not timing.success:
         return timing
 
-    # Phase 2: Post-build analysis
     timing.steps.extend(
-        _run_post_build(
+        run_java_phase2(
             pipeline, repo_name, repo_cfg,
-            paths_cfg, run_ts,
-            sbom_fn=lambda: (
-                pipeline.spdx_gen.generate_java(
-                    repo_name, repo_cfg,
-                    paths_cfg, omnibor_java_cfg,
-                    run_ts=run_ts,
-                )
-            ),
-            spdx_gen_fn=lambda: (
-                generate_java_adg_spdx(
-                    repo_name, repo_cfg,
-                    paths_cfg, run_ts,
-                    vcs_uri=vcs_uri,
-                )
-            ),
+            paths_cfg, omnibor_java_cfg, run_ts,
+            vcs_uri=vcs_uri,
         )
     )
     return timing

--- a/app/pipeline/manifest.py
+++ b/app/pipeline/manifest.py
@@ -1,0 +1,265 @@
+"""
+Phase 1 manifest writer and reader.
+
+The manifest is a small JSON pointer file (~1-2 KB) that records
+paths to Phase 1 artifacts (treedb, raw logfile, binaries, bom_dir)
+plus metadata (repo name, language, commit SHA, run timestamp).
+
+Purpose: Sidecar Phase 1 only mode — when Phase 2 runs in a
+different process or host, it reads the manifest to locate
+artifacts without needing config.yaml or the source tree.
+
+Standalone and Sidecar full modes do not use the manifest.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+
+MANIFEST_VERSION = "1.0"
+MANIFEST_FILENAME = "phase1_manifest.json"
+
+# Fields required in every manifest
+_REQUIRED_FIELDS = frozenset({
+    "version", "repo_name", "language", "mode", "tracer",
+    "run_ts", "commit_sha", "vcs_uri",
+    "artifacts", "paths",
+})
+
+# Fields required in the artifacts sub-object
+_REQUIRED_ARTIFACT_FIELDS = frozenset({
+    "bom_dir", "binaries",
+})
+
+# Fields required in the paths sub-object
+_REQUIRED_PATH_FIELDS = frozenset({
+    "repos_dir", "output_dir", "spdx_dir",
+})
+
+
+class ManifestError(Exception):
+    """Raised when manifest validation fails."""
+
+
+def write_manifest(
+    manifest_dir,
+    repo_name,
+    language,
+    mode,
+    tracer,
+    run_ts,
+    commit_sha,
+    vcs_uri,
+    artifacts,
+    paths,
+    repo_cfg=None,
+    omnibor_cfg=None,
+):
+    """Write phase1_manifest.json after Phase 1 completes.
+
+    Args:
+        manifest_dir: Directory to write the manifest into.
+        repo_name: Repository name (e.g. ``"jsoup"``).
+        language: Language string (e.g. ``"java"``).
+        mode: Execution mode (``"standalone"`` or ``"sidecar"``).
+        tracer: Interception method used.
+        run_ts: Run timestamp string.
+        commit_sha: Git commit SHA or None.
+        vcs_uri: VCS download location URI.
+        artifacts: Dict with artifact paths — must contain
+            ``bom_dir`` (str) and ``binaries`` (list of str).
+            May also contain ``treedb``, ``raw_logfile``,
+            ``strace_log``, ``dep_tree_json``.
+        paths: Dict with ``repos_dir``, ``output_dir``,
+            ``spdx_dir``.
+        repo_cfg: Optional subset of repo config needed by
+            Phase 2 (output_binaries, vendored_dirs, etc.).
+        omnibor_cfg: Optional resolved omnibor config section.
+
+    Returns:
+        Path to the written manifest file.
+
+    Raises:
+        ManifestError: If required fields are missing.
+    """
+    manifest_dir = Path(manifest_dir)
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+
+    _validate_artifacts(artifacts)
+    _validate_paths(paths)
+
+    data = {
+        "version": MANIFEST_VERSION,
+        "repo_name": repo_name,
+        "language": language,
+        "mode": mode,
+        "tracer": tracer,
+        "run_ts": run_ts,
+        "commit_sha": commit_sha,
+        "vcs_uri": vcs_uri,
+        "artifacts": artifacts,
+        "paths": paths,
+    }
+
+    if repo_cfg is not None:
+        data["repo_cfg"] = repo_cfg
+    if omnibor_cfg is not None:
+        data["omnibor_cfg"] = omnibor_cfg
+
+    # Compute gitoids for artifact files that exist
+    data["gitoids"] = _compute_gitoids(artifacts)
+
+    manifest_path = manifest_dir / MANIFEST_FILENAME
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=False)
+
+    return manifest_path
+
+
+def read_manifest(manifest_path):
+    """Read and validate a phase1_manifest.json.
+
+    Args:
+        manifest_path: Path to the manifest file.
+
+    Returns:
+        Parsed manifest dict.
+
+    Raises:
+        ManifestError: If the file is missing, malformed,
+            or fails validation.
+        FileNotFoundError: If the manifest file does not exist.
+    """
+    manifest_path = Path(manifest_path)
+    if not manifest_path.exists():
+        raise FileNotFoundError(
+            f"Manifest not found: {manifest_path}"
+        )
+
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ManifestError(
+            f"Malformed JSON in manifest: {e}"
+        ) from e
+
+    _validate_manifest(data)
+    return data
+
+
+def verify_gitoids(manifest):
+    """Verify artifact gitoids from a loaded manifest.
+
+    Args:
+        manifest: Parsed manifest dict (from read_manifest).
+
+    Returns:
+        Tuple of (passed, failed) where each is a list of
+        artifact paths. Files that don't exist are skipped.
+    """
+    gitoids = manifest.get("gitoids", {})
+    passed = []
+    failed = []
+
+    for artifact_path, expected_gitoid in gitoids.items():
+        p = Path(artifact_path)
+        if not p.exists():
+            continue
+        actual = _sha256_gitoid(p)
+        if actual == expected_gitoid:
+            passed.append(artifact_path)
+        else:
+            failed.append(artifact_path)
+
+    return passed, failed
+
+
+def _validate_manifest(data):
+    """Validate a parsed manifest dict."""
+    if not isinstance(data, dict):
+        raise ManifestError("Manifest must be a JSON object")
+
+    missing = _REQUIRED_FIELDS - set(data.keys())
+    if missing:
+        raise ManifestError(
+            f"Missing required fields: "
+            f"{', '.join(sorted(missing))}"
+        )
+
+    if data.get("version") != MANIFEST_VERSION:
+        raise ManifestError(
+            f"Unsupported manifest version: "
+            f"{data.get('version')} "
+            f"(expected {MANIFEST_VERSION})"
+        )
+
+    _validate_artifacts(data["artifacts"])
+    _validate_paths(data["paths"])
+
+
+def _validate_artifacts(artifacts):
+    """Validate the artifacts sub-object."""
+    if not isinstance(artifacts, dict):
+        raise ManifestError(
+            "artifacts must be a dict"
+        )
+    missing = _REQUIRED_ARTIFACT_FIELDS - set(
+        artifacts.keys()
+    )
+    if missing:
+        raise ManifestError(
+            f"Missing required artifact fields: "
+            f"{', '.join(sorted(missing))}"
+        )
+    if not isinstance(artifacts.get("binaries"), list):
+        raise ManifestError(
+            "artifacts.binaries must be a list"
+        )
+
+
+def _validate_paths(paths):
+    """Validate the paths sub-object."""
+    if not isinstance(paths, dict):
+        raise ManifestError("paths must be a dict")
+    missing = _REQUIRED_PATH_FIELDS - set(paths.keys())
+    if missing:
+        raise ManifestError(
+            f"Missing required path fields: "
+            f"{', '.join(sorted(missing))}"
+        )
+
+
+def _compute_gitoids(artifacts):
+    """Compute SHA-256 gitoids for artifact files.
+
+    Only computes for files that exist. Directories and
+    missing files are skipped.
+    """
+    gitoids = {}
+    # Collect all string-valued artifact paths
+    for key, value in artifacts.items():
+        if isinstance(value, str) and key != "bom_dir":
+            p = Path(value)
+            if p.is_file():
+                gitoids[value] = _sha256_gitoid(p)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, str):
+                    p = Path(item)
+                    if p.is_file():
+                        gitoids[item] = _sha256_gitoid(p)
+    return gitoids
+
+
+def _sha256_gitoid(file_path):
+    """Compute SHA-256 gitoid for a file.
+
+    GitOID format: ``blob <size>\\0<content>``
+    hashed with SHA-256.
+    """
+    file_path = Path(file_path)
+    content = file_path.read_bytes()
+    header = f"blob {len(content)}\0".encode("ascii")
+    return hashlib.sha256(header + content).hexdigest()

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -12,12 +12,15 @@ from pathlib import Path
 from app.config import (
     lang_subdir, load_config, resolve_omnibor_cfg,
     timestamp, VALID_MODES, DEFAULT_MODE,
+    VALID_PHASES,
 )
 from app.pipeline.facade import AnalysisPipeline
 from app.pipeline.lang_runners import (
     run_c_cpp_pipeline,
     run_rust_pipeline,
     run_java_pipeline,
+    run_java_phase1,
+    run_java_phase2,
     run_go_pipeline,
     generate_java_adg_spdx,
 )
@@ -72,7 +75,29 @@ def main():
             "baseline timing. No Phase 2 analysis."
         ),
     )
+    parser.add_argument(
+        "--phase",
+        choices=VALID_PHASES,
+        default=None,
+        help=(
+            "Run only Phase 1 (build) or "
+            "Phase 2 (spdx). Requires "
+            "--mode sidecar. Omit to run both."
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        type=str, default=None,
+        help=(
+            "Path to phase1_manifest.json "
+            "(required with --phase spdx)"
+        ),
+    )
     args = parser.parse_args()
+
+    # Validate phase isolation constraints
+    if args.phase:
+        _validate_phase_args(args, parser)
 
     config = load_config()
     # CLI --mode overrides config file
@@ -296,6 +321,35 @@ def main():
                     f"({overhead:+.1f}%)"
                 )
     print(f"{'#'*60}\n")
+
+
+def _validate_phase_args(args, parser):
+    """Validate --phase CLI constraints.
+
+    Rules:
+    - ``--phase`` requires ``--mode sidecar``
+      (standalone does not support phase isolation).
+    - ``--phase spdx`` requires ``--manifest``.
+    - ``--phase build`` must not have ``--manifest``.
+    """
+    mode = args.mode or DEFAULT_MODE
+    if mode != "sidecar":
+        parser.error(
+            "--phase requires --mode sidecar "
+            "(standalone does not support "
+            "phase isolation)"
+        )
+    if args.phase == "spdx" and not args.manifest:
+        parser.error(
+            "--phase spdx requires --manifest "
+            "<path to phase1_manifest.json>"
+        )
+    if args.phase == "build" and args.manifest:
+        parser.error(
+            "--manifest is not valid with "
+            "--phase build (manifest is an "
+            "output of Phase 1, not an input)"
+        )
 
 
 def _run_baseline(

--- a/docs/deep-dive/sidecar-c-cpp-design.md
+++ b/docs/deep-dive/sidecar-c-cpp-design.md
@@ -6,6 +6,12 @@
 
 ---
 
+> **Supported modes**: See `sidecar-phase-isolation-infrastructure.md` §1
+> for the authoritative definition of Standalone and Sidecar modes.
+> All modes apply to C/C++.
+
+---
+
 ## 1. Current State
 
 | Component | Status |

--- a/docs/deep-dive/sidecar-go-design.md
+++ b/docs/deep-dive/sidecar-go-design.md
@@ -1,0 +1,419 @@
+# Sidecar & Phase Isolation — Go
+
+> **Parent doc**: `sidecar-phase-isolation-infrastructure.md`
+> **Status**: Design proposal — not yet implemented
+> **Date**: 2026-06-12
+
+---
+
+> **Supported modes**: See `sidecar-phase-isolation-infrastructure.md` §1
+> for the authoritative definition of Standalone and Sidecar modes.
+> All modes apply to Go.
+
+---
+
+## 1. Current State
+
+| Component | Status |
+|-----------|--------|
+| Standalone pipeline (`bomtrace2`) | ✅ Production — 6 repos (fzf, lazygit, croc, dive, gdu, pocketbase) |
+| `PtraceStrategy` (standalone via `bomtrace2`) | ✅ Used implicitly via legacy path |
+| `GoToolexecStrategy` skeleton | ✅ Defined in `interception.py` — **not wired to CLI** |
+| `run_go_pipeline()` | ✅ Runs Phase 1 + Phase 2 sequentially, standalone only |
+| Phase 1/2 timing tags | ✅ Properly assigned |
+| `--mode sidecar` for Go | ❌ Not wired — runner does not accept `mode` |
+
+### 1.1 Current Code Path (Standalone)
+
+```
+runners.py main()
+  → run_go_pipeline()
+    → pipeline.builder.build()              # Phase 1: bomtrace2 go build
+      ├── clean_cmd (rm -f binary)
+      ├── "bomtrace2 -c bomtrace_go.conf go build -a -trimpath ..."
+      └── bomsh_create_bom.py               # ADG generation
+    → _run_post_build()                     # Phase 2
+      ├── bomsh_sbom.py                     # OmniBOR SBOM
+      ├── MetadataCollector.collect()
+      ├── AdgSpdxStep.generate()            # per-binary SPDX
+      ├── SpdxValidator.validate()
+      └── BinaryCollector.collect()
+```
+
+### 1.2 Key Go-Specific Details
+
+- **`-a` flag**: Forces rebuild of all packages, bypassing Go build cache.
+  Required for `bomtrace2` to capture all compilation steps. In sidecar mode
+  with `-toolexec`, `-a` is still needed for the same reason.
+- **`bomtrace_go.conf`**: Custom bomtrace config that watches Go compiler
+  tools (`compile`, `link`) and traces `openat` syscall.
+- **Static linking**: Go statically links all dependencies. `ldd` returns
+  "not a dynamic executable" — dynamic library analysis is not applicable.
+- **Release build flags**: `-trimpath -ldflags="-s -w"` strip paths and debug
+  info per project release-build policy.
+
+---
+
+## 2. Interception Strategies
+
+### 2.1 Standalone: `bomtrace2` with Go conf
+
+- **Mechanism**: `bomtrace2 -c /opt/bomsh/bin/bomtrace_go.conf go build -a ...`
+- **Capability needed**: `SYS_PTRACE` in Docker
+- **Output**: raw logfile at `/tmp/bomsh_hook_raw_logfile.sha1`
+- **ADG**: `bomsh_create_bom.py -r <raw_logfile> -b <bom_dir>`
+
+### 2.2 Sidecar: `GoToolexecStrategy`
+
+- **Mechanism**: `-toolexec=/opt/bomsh/bin/bomsh_hook.sh` injected into `go build`
+- **Capability needed**: None (`SYS_PTRACE` not required)
+- **How it works**: Go's `-toolexec` flag runs each tool invocation
+  (`compile`, `asm`, `link`) through the specified wrapper. The wrapper
+  records input/output file mappings before/after the real tool executes.
+- **Output**: Same raw logfile format as `bomtrace2`
+- **ADG**: Same `bomsh_create_bom.py` — wrapper output is format-compatible
+
+```python
+# From interception.py — already implemented:
+class GoToolexecStrategy(InterceptionStrategy):
+    def instrument_command(self, build_cmd, repo_dir):
+        cmd = build_cmd.replace(
+            "go build",
+            f"go build -toolexec={self._wrapper}",
+            1,
+        )
+        return cmd, {}
+
+    def generate_adg(self, repo_dir, bom_dir, omnibor_cfg):
+        strategy = PtraceStrategy()
+        return strategy.generate_adg(repo_dir, bom_dir, omnibor_cfg)
+```
+
+### 2.3 Wiring `GoToolexecStrategy` to the Pipeline
+
+Add `_select_go_strategy()` in `lang_runners.py`:
+
+```python
+def _select_go_strategy(repo_name, repo_cfg, paths_cfg, mode):
+    """Select interception strategy for Go builds.
+
+    In sidecar mode, uses -toolexec wrapper that avoids
+    ptrace entirely.
+
+    In standalone mode, returns None (legacy bomtrace2 path).
+    """
+    if mode != "sidecar":
+        return None
+    from app.pipeline.interception import GoToolexecStrategy
+    return GoToolexecStrategy()
+```
+
+Modify `run_go_pipeline()` to accept `mode=`:
+
+```python
+def run_go_pipeline(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_go_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    mode="standalone",        # NEW
+):
+    strategy = _select_go_strategy(
+        repo_name, repo_cfg, paths_cfg, mode,
+    )
+    ...
+    build_result = pipeline.builder.build(
+        ..., strategy=strategy,  # None for standalone, GoToolexecStrategy for sidecar
+    )
+```
+
+### 2.4 `-toolexec` and `-a` Flag Interaction
+
+The `-a` flag is critical for both modes:
+- **Standalone**: Without `-a`, Go's build cache serves cached artifacts and
+  `bomtrace2` never sees the compilation
+- **Sidecar**: Without `-a`, `-toolexec` is only invoked for uncached packages
+
+The `instrument_command()` inserts `-toolexec` but does **not** add `-a` —
+it expects `-a` to already be in the build command from `config.yaml`. All
+6 Go repos already include `-a` in their `build_steps`.
+
+**Future optimization**: In a warm-cache CI environment, `-a` forces a full
+rebuild every time. A future enhancement could use Go's `-toolexec` without
+`-a` and rely on Go's own cache invalidation for incremental builds. This
+is a performance optimization tracked separately in
+`sidecar-refactoring-plan.md §2.3`.
+
+---
+
+## 3. Phase 1 Artifacts
+
+| Artifact | Standalone | Sidecar | Location |
+|----------|-----------|---------|----------|
+| Raw logfile | ✅ `bomtrace2` writes | ✅ `-toolexec` wrapper writes same format | `/tmp/bomsh_hook_raw_logfile.sha1` |
+| Treedb (`bomsh_omnibor_treedb`) | ✅ `bomsh_create_bom.py` | ✅ same script | `bom_dir/metadata/bomsh/` |
+| `bomsh_omnibor_doc_mapping` | ✅ | ✅ | `bom_dir/metadata/bomsh/` |
+| Output binary (ELF, static) | ✅ in `repo_dir` | ✅ in `repo_dir` | Per `output_binaries` config |
+| `go.sum` | ✅ (in source tree) | ✅ | `repo_dir/go.sum` |
+| `go.mod` | ✅ (in source tree) | ✅ | `repo_dir/go.mod` |
+| `phase1_manifest.json` | ✅ (when `--phase build`) | ✅ | `bom_dir/phase1_manifest.json` |
+
+---
+
+## 4. Phase 2 Requirements
+
+| Operation | Module | Needs Binary? | Needs Source Tree? | Needs Treedb? |
+|-----------|--------|---------------|-------------------|---------------|
+| `bomsh_sbom.py` | `spdx_generator.py` | ✅ reads binary hashes | ❌ | ✅ |
+| `ldd` (dynamic deps) | `adg_spdx.py` | ❌ Go is static | ❌ | ❌ |
+| `AdgSpdxGenerator` (per-binary SPDX) | `adg_spdx.py` | ❌ | ✅ (`go.sum`/`go.mod` for versions) | ✅ |
+| `MetadataCollector` | `metadata_collector.py` | ❌ | ✅ (repo metadata) | ❌ |
+| `BinaryCollector` | `binary_collector.py` | ✅ (copies binary) | ❌ | ❌ |
+
+### 4.1 Source Tree Dependency
+
+Go's `AdgSpdxGenerator` needs:
+- `go.sum` — dependency versions and checksums
+- `go.mod` — direct vs indirect dependency classification
+
+These are small text files that can be copied to `bom_dir` during Phase 1
+for cross-host Phase 2.
+
+### 4.2 Binary Size
+
+Go binaries are statically linked and stripped (`-ldflags="-s -w"`).
+Typical sizes:
+
+| Repo | Binary | Approximate Size |
+|------|--------|-----------------|
+| fzf | `fzf` | ~3 MB |
+| lazygit | `lazygit` | ~15 MB |
+| croc | `croc` | ~8 MB |
+| dive | `dive_bin` | ~10 MB |
+| gdu | `gdu` | ~5 MB |
+| pocketbase | `pocketbase` | ~30 MB |
+
+Manageable for cross-host transfer without compression.
+
+---
+
+## 5. Config Schema
+
+### 5.1 Current (flat format)
+
+```yaml
+omnibor_go:
+  tracer: bomtrace2 -c /opt/bomsh/bin/bomtrace_go.conf
+  create_bom_script: bomsh_create_bom.py
+  sbom_script: bomsh_sbom.py
+  raw_logfile: /tmp/bomsh_hook_raw_logfile.sha1
+```
+
+### 5.2 Target (nested mode format)
+
+```yaml
+omnibor_go:
+  standalone:
+    tracer: bomtrace2 -c /opt/bomsh/bin/bomtrace_go.conf
+    create_bom_script: bomsh_create_bom.py
+    sbom_script: bomsh_sbom.py
+    raw_logfile: /tmp/bomsh_hook_raw_logfile.sha1
+  sidecar:
+    wrapper: /opt/bomsh/bin/bomsh_hook.sh
+    create_bom_script: bomsh_create_bom.py
+    sbom_script: bomsh_sbom.py
+```
+
+---
+
+## 6. Upstream `bomsh` Wrapper Requirements
+
+Go's `-toolexec` calls the wrapper with the tool path as the first argument
+followed by the tool's original arguments:
+
+```
+/opt/bomsh/bin/bomsh_hook.sh /usr/local/go/pkg/tool/linux_amd64/compile -o output.o input.go
+```
+
+`bomsh_hook2.py` already has Go-specific command parsers:
+- `get_all_subfiles_in_go_compile_cmdline()` — extracts `.go` → `.o` mappings
+- `get_all_subfiles_in_go_link_cmdline()` — extracts `.o` → binary mappings
+
+The wrapper script (`bomsh_hook.sh`) needs to:
+1. Record the command + file hashes in the raw logfile
+2. Execute the real tool
+3. Record output file hash
+
+**Status**: `bomsh_hook.sh` exists in upstream bomsh but may need testing
+with Go's `-toolexec` calling convention. The wrapper receives the real
+tool path as `$1`, which differs from CC wrapper mode where the wrapper
+*replaces* the compiler.
+
+---
+
+## 7. Phase Split Design
+
+### 7.1 `run_go_phase1()`
+
+```python
+def run_go_phase1(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_go_cfg, run_ts,
+    mode="standalone",
+    vcs_uri="NOASSERTION",
+    commit_sha=None,
+):
+    """Go Phase 1: build + treedb + manifest.
+
+    Returns TimingResult with Phase 1 steps only.
+    """
+    strategy = _select_go_strategy(
+        repo_name, repo_cfg, paths_cfg, mode,
+    )
+    tracer = strategy.name if strategy else omnibor_go_cfg.get("tracer", "bomtrace2")
+    timing = TimingResult(tracer=tracer)
+
+    build_result = pipeline.builder.build(
+        repo_name, repo_cfg, paths_cfg, omnibor_go_cfg,
+        run_ts=run_ts, strategy=strategy,
+    )
+    timing.steps.extend(build_result.steps)
+    timing.success = build_result.success
+
+    if build_result.success:
+        # Copy go.mod and go.sum to bom_dir for cross-host Phase 2
+        _copy_go_metadata(build_result.repo_dir, build_result.bom_dir)
+
+        ManifestWriter().write(
+            bom_dir=build_result.bom_dir,
+            repo_name=repo_name,
+            repo_cfg=repo_cfg,
+            paths_cfg=paths_cfg,
+            omnibor_cfg=omnibor_go_cfg,
+            run_ts=run_ts,
+            tracer=tracer,
+            mode=mode,
+            commit_sha=commit_sha,
+            vcs_uri=vcs_uri,
+            binaries=build_result.binaries,
+        )
+
+    return timing
+
+
+def _copy_go_metadata(repo_dir, bom_dir):
+    """Copy go.mod and go.sum to bom_dir for cross-host Phase 2."""
+    import shutil
+    from pathlib import Path
+    for fname in ("go.mod", "go.sum"):
+        src = Path(repo_dir) / fname
+        if src.exists():
+            dst = Path(bom_dir) / fname
+            shutil.copy2(str(src), str(dst))
+```
+
+### 7.2 `run_go_phase2()`
+
+```python
+def run_go_phase2(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_go_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    manifest=None,
+):
+    """Go Phase 2: SBOM → metadata → SPDX → validate → collect.
+
+    Returns TimingResult with Phase 2 steps only.
+    """
+    if manifest:
+        ctx = ManifestReader().read(manifest)
+
+    timing = TimingResult(tracer="phase2-only")
+    timing.steps.extend(
+        _run_post_build(
+            pipeline, repo_name, repo_cfg,
+            paths_cfg, run_ts,
+            sbom_fn=lambda: pipeline.spdx_gen.generate(...),
+            spdx_gen_fn=lambda: pipeline.adg_spdx.generate(...),
+        )
+    )
+    timing.success = True
+    return timing
+```
+
+### 7.3 `run_go_pipeline()` (backward compatible)
+
+```python
+def run_go_pipeline(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_go_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    mode="standalone",
+):
+    timing = run_go_phase1(...)
+    if not timing.success:
+        return timing
+    timing2 = run_go_phase2(...)
+    timing.steps.extend(timing2.steps)
+    return timing
+```
+
+---
+
+## 8. Testing
+
+### 8.1 Unit Tests
+
+| Test | What it validates |
+|------|-------------------|
+| `test_select_go_strategy_standalone` | Returns `None` (legacy path) |
+| `test_select_go_strategy_sidecar` | Returns `GoToolexecStrategy` |
+| `test_go_toolexec_instrument_command` | Inserts `-toolexec=` after `go build` |
+| `test_go_toolexec_preserves_flags` | `-a -trimpath -ldflags` remain intact |
+| `test_go_phase1_writes_manifest` | Manifest includes `go.mod`/`go.sum` copies |
+| `test_go_phase2_reads_manifest` | Phase 2 runs from manifest |
+| `test_go_pipeline_unchanged` | Full pipeline backward compatible |
+
+### 8.2 Integration Tests (EC2)
+
+| Test | Command | Validates |
+|------|---------|-----------|
+| Standalone full | `--repo fzf` | Current behavior unchanged |
+| Sidecar full | `--repo fzf --mode sidecar` | `-toolexec` produces valid SPDX |
+| Phase split | `--repo fzf --phase build` then `--phase spdx` | Matches golden |
+| Large repo | `--repo pocketbase --mode sidecar` | Complex dep graph handled |
+
+### 8.3 `-toolexec` Compatibility
+
+All 6 Go repos use standard `go build` commands. `-toolexec` is a Go-native
+mechanism — no build system compatibility concerns (unlike C/C++ `CC=` wrappers).
+
+---
+
+## 9. Implementation Tasks
+
+| # | Task | Effort | Depends On |
+|---|------|--------|------------|
+| 1 | Add `mode=` param to `run_go_pipeline()` | 0.25d | — |
+| 2 | Implement `_select_go_strategy()` | 0.25d | — |
+| 3 | Pass `mode` from `runners.py` → `run_go_pipeline()` | 0.25d | Task 1 |
+| 4 | Split into `run_go_phase1()` / `run_go_phase2()` | 0.5d | Infra manifest module |
+| 5 | Implement `_copy_go_metadata()` for cross-host Phase 2 | 0.25d | Task 4 |
+| 6 | Verify `bomsh_hook.sh` with `-toolexec` calling convention | 1d | External dependency |
+| 7 | Convert `config.yaml` `omnibor_go:` to nested format | 0.25d | — |
+| 8 | Unit tests | 0.5d | Tasks 1-5 |
+| 9 | Integration tests on EC2 (sidecar mode) | 1d | Task 6 |
+
+**Blocker**: Task 6 — verifying `bomsh_hook.sh` works with Go's `-toolexec`.
+Lower risk than C/C++ wrappers because `-toolexec` is a well-defined
+Go-native mechanism and `bomsh_hook2.py` already has Go command parsers.
+
+---
+
+## 10. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `bomsh_hook.sh` incompatible with `-toolexec` | Medium | Blocks sidecar E2E | Test wrapper in isolation first; prototype if needed |
+| `-a` flag forces full rebuild every time | Known | Slower CI | Future: explore incremental `-toolexec` without `-a` |
+| Go module download during build | Low | Build may fail in air-gapped environments | `go mod download` as a pre-build step |
+| CGO-enabled projects | Low | C compilation within Go build needs CC wrappers too | Add CGO detection; fall back to `bomtrace2` if CGO |

--- a/docs/deep-dive/sidecar-java-design.md
+++ b/docs/deep-dive/sidecar-java-design.md
@@ -1,0 +1,356 @@
+# Sidecar & Phase Isolation — Java
+
+> **Parent doc**: `sidecar-phase-isolation-infrastructure.md`
+> **Status**: Sidecar mode ✅ implemented; Phase isolation pending
+> **Date**: 2026-06-12
+
+---
+
+> **Supported modes**: See `sidecar-phase-isolation-infrastructure.md` §1
+> for the authoritative definition of Standalone and Sidecar modes.
+> All modes apply to Java.
+
+---
+
+## 1. Current State
+
+| Component | Status |
+|-----------|--------|
+| Standalone pipeline (strace) | ✅ Production — 8 repos |
+| `MavenDepTreeStrategy` (sidecar) | ✅ Fully wired and tested |
+| `GradleDepTreeStrategy` (sidecar) | ✅ Fully wired and tested |
+| `run_java_pipeline()` accepts `mode=` | ✅ Dispatches to correct strategy |
+| `_select_java_strategy()` | ✅ Auto-detects Maven vs Gradle |
+| Phase 1/2 timing tags | ✅ Properly assigned |
+| `--mode sidecar` for Java | ✅ **Works end-to-end** |
+| Phase 1/2 split (`--phase`) | ❌ Not yet implemented |
+
+**Java is the reference implementation for sidecar mode.** The patterns
+established here — `_select_java_strategy()`, strategy-based dispatch in
+`builder.build()`, and the `InterceptionStrategy` ABC — are the template
+for all other languages.
+
+### 1.1 Current Code Path (Standalone)
+
+```
+runners.py main()
+  → run_java_pipeline(mode="standalone")
+    → _select_java_strategy() → None (standalone)
+    → pipeline.builder.build_java()         # Phase 1: strace + bomsh_create_bom_java.py
+      ├── clean_cmd (mvn clean)
+      ├── prebuild steps
+      ├── "strace -f -s99999 ... mvn package"  # instrumented build
+      ├── bomsh_create_bom_java.py             # treedb generation
+      └── strace log archival
+    → _run_post_build()                     # Phase 2
+      ├── spdx_gen.generate_java() → None   # placeholder (Java SPDX via ADG)
+      ├── MetadataCollector.collect()
+      ├── generate_java_adg_spdx()          # per-JAR analyzed + build SPDX
+      ├── SpdxValidator.validate()
+      └── BinaryCollector.collect()
+```
+
+### 1.2 Current Code Path (Sidecar)
+
+```
+runners.py main()
+  → run_java_pipeline(mode="sidecar")
+    → _select_java_strategy() → MavenDepTreeStrategy or GradleDepTreeStrategy
+    → pipeline.builder.build(strategy=strategy)  # Phase 1
+      ├── clean_cmd
+      ├── prebuild steps
+      ├── "mvn package -DskipTests"           # unmodified build (no strace)
+      └── strategy.generate_adg()
+          ├── bomsh_create_bom_java.py        # treedb (SourceFile + path similarity)
+          └── mvn dependency:tree → maven_deps.json
+    → _run_post_build()                       # Phase 2 (same as standalone)
+```
+
+### 1.3 Configured Java Repos
+
+| Repo | Build System | Modules | Sidecar Tested? |
+|------|-------------|---------|-----------------|
+| jsoup | Maven | Single | ✅ |
+| checkstyle | Maven | Single (multi-module POM) | ✅ |
+| crawler4j | Maven | Multi (`-pl crawler4j`) | ✅ |
+| dependency-check | Maven | Multi (`-pl cli -am`) | ✅ |
+| logging-log4j2 | Maven | Multi (`-pl log4j-core -am`) | ✅ |
+| spring-boot | Gradle | Multi (`:spring-boot:build`) | ✅ |
+| bc-java | Gradle | Multi (`:prov:build`) | ✅ |
+| `omnibor-java-testapp` | Maven | Single (CI test app) | ✅ |
+
+---
+
+## 2. Interception Strategies
+
+### 2.1 Standalone: strace `openat`
+
+- **Mechanism**: `strace -f -s99999 --seccomp-bpf -e trace=openat` prefix
+- **Capability needed**: `SYS_PTRACE` in Docker
+- **Output**: strace log at `/tmp/strace_java_logfile`
+- **ADG**: `bomsh_create_bom_java.py -r <repo_dir> -j <treedb_file>`
+- **Strace log is archived** to `bom_dir/metadata/bomsh/strace_java_logfile`
+
+### 2.2 Sidecar: `MavenDepTreeStrategy`
+
+- **Mechanism**: Build runs unmodified (no strace prefix)
+- **Capability needed**: None
+- **Output**:
+  1. Treedb via `bomsh_create_bom_java.py` (uses `SourceFile` bytecode
+     attribute + path similarity instead of strace log)
+  2. `maven_deps.json` via `mvn dependency:tree -DoutputType=dot`
+- **Multi-module support**: `_extract_maven_modules()` passes `-pl` from
+  build steps to `run_maven_dep_tree()`
+
+### 2.3 Sidecar: `GradleDepTreeStrategy`
+
+- **Mechanism**: Build runs unmodified
+- **Capability needed**: None
+- **Output**:
+  1. Treedb via `bomsh_create_bom_java.py` (same as Maven sidecar)
+  2. `gradle_deps.json` via `./gradlew dependencies` per subproject
+
+### 2.4 Key Difference: Strace Evidence vs Workspace Scan
+
+| Aspect | Standalone (strace) | Sidecar (dep:tree) |
+|--------|--------------------|--------------------|
+| File access evidence | ✅ strace `openat` log | ❌ Workspace scan only |
+| `filesAnalyzed: true` confidence | High (strace-verified) | Medium (SourceFile heuristic) |
+| Dependency graph source | strace + treedb | `mvn dep:tree` / `gradlew dependencies` |
+| `SYS_PTRACE` required | ✅ | ❌ |
+
+The downstream SPDX generator (`JavaSpdxGenerator`) handles both cases:
+when `strace_accessed` is populated (standalone), it filters treedb results
+against strace evidence. When empty (sidecar), it trusts the workspace scan.
+
+---
+
+## 3. Phase 1 Artifacts
+
+| Artifact | Standalone | Sidecar | Location |
+|----------|-----------|---------|----------|
+| Treedb (`bomsh_omnibor_treedb`) | ✅ | ✅ | `bom_dir/metadata/bomsh/` |
+| Strace log | ✅ | ❌ | `bom_dir/metadata/bomsh/strace_java_logfile` |
+| `maven_deps.json` | ❌ | ✅ (Maven) | `bom_dir/maven_deps.json` |
+| `gradle_deps.json` | ❌ | ✅ (Gradle) | `bom_dir/gradle_deps.json` |
+| Output JARs | ✅ in `repo_dir` | ✅ in `repo_dir` | Per `output_binaries` glob |
+| `phase1_manifest.json` | ✅ (when `--phase build`) | ✅ | `bom_dir/phase1_manifest.json` |
+
+---
+
+## 4. Phase 2 Requirements
+
+| Operation | Module | Needs JAR? | Needs Source Tree? | Needs Treedb? |
+|-----------|--------|-----------|-------------------|---------------|
+| `JavaSpdxGenerator.generate()` | `java_generator.py` | ❌ (path only) | ❌ | ✅ |
+| Maven/Gradle dep parsing | `java_generator.py` | ❌ | ❌ (reads `pom.xml` in `repo_dir`) | ❌ |
+| `BinaryCollector` (copy JARs) | `binary_collector.py` | ✅ | ❌ | ❌ |
+| `MetadataCollector` | `metadata_collector.py` | ❌ | ✅ (repo metadata) | ❌ |
+
+### 4.1 Cross-Host Phase 2
+
+**Java is the easiest language for cross-host Phase 2** because:
+
+1. `JavaSpdxGenerator` does not call `ldd` or `readelf` — JARs are not ELF
+2. Dependency resolution reads `maven_deps.json` / `gradle_deps.json` from
+   Phase 1, not from the live build environment
+3. The treedb + dep tree JSON are the only required artifacts
+4. JAR paths are only needed for `BinaryCollector` (optional for SPDX)
+
+**Minimum artifact set for cross-host Phase 2**:
+- `phase1_manifest.json`
+- `bom_dir/metadata/bomsh/bomsh_omnibor_treedb`
+- `bom_dir/maven_deps.json` or `bom_dir/gradle_deps.json`
+- `pom.xml` / `build.gradle` (for version/groupId resolution)
+
+**Note**: `pom.xml` dependency resolution currently happens at Phase 2 time
+via `get_maven_deps()` / `get_gradle_deps()`. For cross-host, these could
+either:
+- Be pre-parsed in Phase 1 and included in the manifest, or
+- The `pom.xml`/`build.gradle` files could be copied to `bom_dir` during Phase 1
+
+---
+
+## 5. Config Schema
+
+### 5.1 Current (flat format)
+
+```yaml
+omnibor_java:
+  strace_opts: -f -s99999 --seccomp-bpf -e trace=openat -qqq
+  create_bom_script: bomsh_create_bom_java.py
+  strace_logfile: /tmp/strace_java_logfile
+```
+
+### 5.2 Target (nested mode format)
+
+```yaml
+omnibor_java:
+  standalone:
+    strace_opts: -f -s99999 --seccomp-bpf -e trace=openat -qqq
+    create_bom_script: bomsh_create_bom_java.py
+    strace_logfile: /tmp/strace_java_logfile
+  sidecar:
+    create_bom_script: bomsh_create_bom_java.py
+```
+
+The sidecar section is simpler because:
+- No `strace_opts` or `strace_logfile` (strace is not used)
+- `create_bom_script` is the same (workspace scan mode)
+
+---
+
+## 6. Phase Split Design
+
+### 6.1 `run_java_phase1()`
+
+```python
+def run_java_phase1(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_java_cfg, run_ts,
+    mode="standalone",
+    vcs_uri="NOASSERTION",
+    commit_sha=None,
+):
+    """Java Phase 1: build + treedb + dep tree + manifest.
+
+    Returns TimingResult with Phase 1 steps only.
+    """
+    strategy = _select_java_strategy(
+        repo_name, repo_cfg, paths_cfg, mode,
+    )
+    tracer = strategy.name if strategy else "strace"
+    timing = TimingResult(tracer=tracer)
+
+    if strategy:
+        build_result = pipeline.builder.build(
+            ..., strategy=strategy,
+        )
+    else:
+        build_result = pipeline.builder.build_java(...)
+
+    timing.steps.extend(build_result.steps)
+    timing.success = build_result.success
+
+    if build_result.success:
+        ManifestWriter().write(
+            bom_dir=build_result.bom_dir,
+            ...
+        )
+
+    return timing
+```
+
+### 6.2 `run_java_phase2()`
+
+```python
+def run_java_phase2(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_java_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    manifest=None,
+):
+    """Java Phase 2: SPDX generation from treedb + dep tree.
+
+    When manifest is provided, reads paths from it.
+    """
+    if manifest:
+        ctx = ManifestReader().read(manifest)
+
+    timing = TimingResult(tracer="phase2-only")
+    timing.steps.extend(
+        _run_post_build(
+            pipeline, repo_name, repo_cfg,
+            paths_cfg, run_ts,
+            sbom_fn=lambda: pipeline.spdx_gen.generate_java(...),
+            spdx_gen_fn=lambda: generate_java_adg_spdx(...),
+        )
+    )
+    timing.success = True
+    return timing
+```
+
+### 6.3 `run_java_pipeline()` (backward compatible)
+
+The existing `run_java_pipeline()` becomes a thin wrapper:
+
+```python
+def run_java_pipeline(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_java_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    mode="standalone",
+):
+    timing = run_java_phase1(...)
+    if not timing.success:
+        return timing
+    timing2 = run_java_phase2(...)
+    timing.steps.extend(timing2.steps)
+    return timing
+```
+
+---
+
+## 7. Testing
+
+### 7.1 Unit Tests
+
+| Test | What it validates |
+|------|-------------------|
+| `test_select_java_strategy_standalone` | Returns `None` |
+| `test_select_java_strategy_sidecar_maven` | Returns `MavenDepTreeStrategy` |
+| `test_select_java_strategy_sidecar_gradle` | Returns `GradleDepTreeStrategy` |
+| `test_extract_maven_modules` | Parses `-pl` from build steps |
+| `test_java_phase1_writes_manifest` | Manifest contains treedb + dep tree paths |
+| `test_java_phase2_reads_manifest` | Phase 2 runs from manifest |
+| `test_java_pipeline_unchanged` | Full pipeline backward compatible |
+
+### 7.2 Integration Tests
+
+| Test | Command | Validates |
+|------|---------|-----------|
+| Standalone full | `--repo jsoup` | Current behavior unchanged |
+| Sidecar full | `--repo jsoup --mode sidecar` | No `SYS_PTRACE`, valid SPDX |
+| Phase split (standalone) | `--repo jsoup --phase build` then `--phase spdx` | Matches golden |
+| Phase split (sidecar) | `--repo jsoup --mode sidecar --phase build` then `--phase spdx` | Matches golden |
+| Multi-module Maven | `--repo dependency-check --mode sidecar` | Per-module SPDX correct |
+| Gradle | `--repo spring-boot --mode sidecar` | Gradle dep tree parsed |
+
+### 7.3 Golden File Comparison
+
+Sidecar SPDX must match standalone golden files. Known expected differences:
+
+- `creationInfo.created` timestamp (always differs — excluded from comparison)
+- Tracer name in `creationInfo.creators` (`strace` vs `maven-dep-tree`)
+- `filesAnalyzed` confidence may differ (strace-verified vs heuristic)
+
+All structural content (packages, relationships, versions, checksums) must
+match. Any difference is a regression to investigate.
+
+---
+
+## 8. Implementation Tasks
+
+| # | Task | Effort | Depends On |
+|---|------|--------|------------|
+| 1 | Split `run_java_pipeline()` into `phase1`/`phase2` | 0.5d | Infra manifest module |
+| 2 | Write manifest in `run_java_phase1()` | 0.25d | Task 1 |
+| 3 | Read manifest in `run_java_phase2()` | 0.25d | Task 1 |
+| 4 | Convert `omnibor_java:` to nested format | 0.25d | — |
+| 5 | Unit tests for phase split | 0.5d | Tasks 1-3 |
+| 6 | Integration test: phase split on EC2 | 0.5d | Task 5 |
+| 7 | Cross-host Phase 2 test (transfer artifacts) | 0.5d | Task 6 |
+
+**No blockers** — Java sidecar already works. Phase isolation is purely a
+refactoring exercise with well-defined boundaries.
+
+---
+
+## 9. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `pom.xml` needed at Phase 2 time | Medium | Breaks cross-host Phase 2 | Pre-parse deps in Phase 1 or copy `pom.xml` to `bom_dir` |
+| Gradle daemon state | Low | `./gradlew dependencies` may behave differently across hosts | Use `--no-daemon` (already in all Gradle build steps) |
+| Multi-module `-pl` not captured in manifest | Low | Phase 2 runs dep:tree against wrong modules | `_extract_maven_modules()` result stored in manifest |
+| `SourceFile` heuristic divergence | Low | Sidecar treedb maps slightly different files than strace | Compare against golden files; investigate any diff |

--- a/docs/deep-dive/sidecar-phase-isolation-infrastructure.md
+++ b/docs/deep-dive/sidecar-phase-isolation-infrastructure.md
@@ -9,9 +9,10 @@
 
 ## Per-Language Design Documents
 
-This document covers **cross-cutting infrastructure** (manifest, CLI, config,
-Corona, Docker, testing framework). Each language has its own design doc with
-strategy details, Phase 1/2 artifacts, and implementation tasks:
+This document covers the **shared components** that all languages use:
+manifest format, CLI flags, config schema, Corona integration, Docker
+setup, and the testing framework. Each language has its own design doc
+with strategy details, Phase 1/2 artifacts, and implementation tasks:
 
 - **`sidecar-c-cpp-design.md`** — `CcWrapperStrategy`, upstream bomsh wrappers, version pre-computation
 - **`sidecar-java-design.md`** — `MavenDepTreeStrategy`/`GradleDepTreeStrategy` (already implemented)
@@ -23,22 +24,42 @@ strategy details, Phase 1/2 artifacts, and implementation tasks:
 
 ## 1. Executive Summary
 
-This document describes the shared infrastructure for:
+The `omnibor-analysis` pipeline supports two execution modes:
+**Standalone** and **Sidecar**. Both are permanent, first-class modes.
 
-1. **Isolating Phase 1 (build interception) from Phase 2 (SPDX generation)** so they
-   can run independently — in the same process, in separate CI stages, or across
-   entirely different hosts.
-2. **Enabling Phase 2 execution on either the sidecar container or a Corona daemon**,
-   using a well-defined artifact contract (`phase1_manifest.json`) as the only
-   coupling point.
-3. **CLI, config, and module changes** that apply to all languages.
+- **Sidecar** is the authoritative mode for all enterprise repository
+  build-interception SBOM generation projects. It uses the customer's
+  native toolchains and does not require `SYS_PTRACE`.
+- **Standalone** is the baseline for `omnibor-analysis` golden file
+  generation and the primary `omnibor-analysis` development/debug mode.
+  It is also used by enterprise teams with isolated black-box build
+  machines, where the Standalone container is customized to include their
+  specific build toolsets, operating systems, and configurations.
 
-Language-specific strategy wiring, artifacts, and testing are in the per-language
-docs above.
+**Standalone** always runs the full pipeline (Phase 1 + Phase 2) in a
+single container. There is no phase split for Standalone.
 
-The design preserves full backward compatibility: the default `--mode standalone`
-path is unchanged, and running without `--phase` executes both phases sequentially
-as today.
+**Sidecar** can run either way:
+- **Sidecar full** — Phase 1 + Phase 2 in one container (primary customer mode)
+- **Sidecar Phase 1 only** — Phase 1 produces artifacts and exits;
+  Phase 2 runs in a separate process, host, or Corona daemon
+
+This document describes the shared infrastructure:
+
+1. **Two modes: Standalone and Sidecar** — Standalone uses ptrace-based
+   interception (`bomtrace3`/`bomtrace2`) and requires `SYS_PTRACE`.
+   Sidecar uses build-system-native interception mechanisms and does
+   **not** require `SYS_PTRACE`. The specific mechanism varies by
+   language — see per-language design docs for details.
+2. **Phase isolation (Sidecar only)** — Phase 1 (build interception) and
+   Phase 2 (SPDX generation) can run independently, connected only by a
+   well-defined artifact contract (`phase1_manifest.json`).
+3. **Multiple Phase 2 executors** — Phase 2 can run in the sidecar
+   container, on a different host, or on a Corona daemon.
+4. **CLI, config, and module changes** that apply to all languages.
+
+Language-specific strategy wiring, artifacts, and testing are in the
+per-language docs listed above.
 
 ---
 
@@ -102,9 +123,25 @@ The following existing diagrams illustrate the target architecture:
 
 ## 4. Artifact Contract: `phase1_manifest.json`
 
-The manifest is the **only** interface between Phase 1 and Phase 2. It must contain
-everything Phase 2 needs to produce SPDX without access to config.yaml or the
-running pipeline state.
+The `phase1_manifest.json` is a small pointer file (~1-2 KB) that records
+the paths to the existing artifacts (treedb, raw logfile, binaries,
+bom_dir, etc.) plus metadata (repo name, language, commit SHA, run
+timestamp). The actual artifact files stay in their original format and
+location — nothing is converted or bundled.
+
+The purpose is purely for **Sidecar Phase 1 only** mode: when Phase 2
+runs in a different process or on a different host, it needs to know
+where all the Phase 1 artifacts are. Today that information is derived
+from `config.yaml` + convention, which requires the entire config and
+source tree to be available. The manifest decouples that.
+
+The manifest is written after Phase 1 completes (after the build and
+treedb generation), before Phase 2 starts. It is a single `json.dump()`
+call — effectively zero build-time overhead.
+
+In Standalone mode and Sidecar full mode, where Phase 1 and Phase 2 run
+in the same process, the manifest is not needed — Phase 2 already has
+everything in memory.
 
 ### 4.1 Schema
 
@@ -207,11 +244,41 @@ output/omnibor/{lang}/{repo}/{run_ts}/phase1_manifest.json
 
 This is inside `bom_dir`, co-located with the OmniBOR ADG artifacts.
 
-### 4.3 Provenance Integrity
+### 4.3 When the Manifest Is Written
 
-Each artifact path in the manifest includes a SHA-256 gitoid computed at Phase 1
-completion time. Phase 2 can optionally verify these gitoids before processing to
-detect tampering or corruption during transfer.
+The manifest is written **after** Phase 1 completes — after the build,
+treedb generation, and ADG creation have all finished. It does not run
+during the build and has zero impact on build time.
+
+| Mode | Manifest written? | Manifest read? |
+|------|------------------|----------------|
+| **Standalone** | No | No — Phase 2 has everything in memory |
+| **Sidecar full** | No | No — Phase 2 has everything in memory |
+| **Sidecar Phase 1 only** | Yes — `json.dump()` after build | No — Phase 2 runs in a separate invocation |
+| **Phase 2 from manifest** | No — Phase 1 already ran | Yes — reads manifest to locate artifacts |
+
+### 4.4 Why Not Reuse `config.yaml`?
+
+Today, Phase 2 derives artifact locations from `config.yaml` paths plus
+naming conventions (e.g., `output/omnibor/{lang}/{repo}/{run_ts}/`). This
+works when both phases run in the same process because the config, source
+tree, and build environment are all available.
+
+In Sidecar Phase 1 only mode, Phase 2 runs in a different process or on
+a different host. It may not have access to:
+- `config.yaml` (the sidecar container may be destroyed after Phase 1)
+- The source tree (not transferred to the analysis host)
+- The build environment (compiler paths, environment variables)
+
+The manifest captures exactly what Phase 2 needs — artifact paths,
+repo metadata, and resolved config — in a single self-contained file
+that can be transferred alongside the artifacts.
+
+### 4.5 Provenance Integrity
+
+Each artifact path in the manifest includes a SHA-256 gitoid computed at
+Phase 1 completion time. Phase 2 can optionally verify these gitoids
+before processing to detect tampering or corruption during transfer.
 
 ---
 
@@ -219,18 +286,19 @@ detect tampering or corruption during transfer.
 
 ### 5.1 CLI Interface Changes
 
-```
-# Current (unchanged — runs both phases)
+```bash
+# Standalone (always full pipeline — Phase 1 + Phase 2)
 python3 -m app.analyze --repo curl
+python3 -m app.analyze --repo curl --mode standalone  # explicit, same effect
 
-# Phase 1 only — build + treedb + manifest
-python3 -m app.analyze --repo curl --phase build
+# Sidecar full (Phase 1 + Phase 2, no SYS_PTRACE)
+python3 -m app.analyze --repo curl --mode sidecar
 
-# Phase 2 only — SPDX from manifest
-python3 -m app.analyze --repo curl --phase spdx --manifest /path/to/phase1_manifest.json
-
-# Sidecar + Phase 1 only
+# Sidecar Phase 1 only — Phase 2 runs elsewhere
 python3 -m app.analyze --repo curl --mode sidecar --phase build
+
+# Phase 2 from manifest (consumes artifacts from any Sidecar Phase 1 run)
+python3 -m app.analyze --repo curl --phase spdx --manifest /path/to/phase1_manifest.json
 ```
 
 New CLI arguments in `app/pipeline/runners.py`:
@@ -242,11 +310,11 @@ New CLI arguments in `app/pipeline/runners.py`:
 
 ### 5.2 Execution Patterns
 
-#### Pattern A: Default (Sequential — backward compatible)
+#### Pattern A: Standalone (full pipeline, single container)
 
 ```
 ┌─────────────────────────────────────────────┐
-│  Container (standalone or sidecar)          │
+│  Container (standalone, SYS_PTRACE)         │
 │                                             │
 │  Phase 1: clone → build → treedb → ADG     │
 │     ↓ (in-memory, no manifest needed)       │
@@ -254,27 +322,43 @@ New CLI arguments in `app/pipeline/runners.py`:
 └─────────────────────────────────────────────┘
 ```
 
-No manifest is written (or it's written but not read). This is today's behavior.
+This is the only Standalone pattern. Phase split is not supported in
+Standalone mode.
 
-#### Pattern B: Two-Stage CI (same container)
+#### Pattern B: Sidecar Full (Phase 1 + Phase 2, single container)
 
 ```
-┌──────────── CI Stage 1 ────────────┐
-│  --phase build                     │
+┌─────────────────────────────────────────────┐
+│  Container (sidecar, NO SYS_PTRACE)         │
+│                                             │
+│  Phase 1: clone → build → treedb → ADG     │
+│     ↓ (in-memory, no manifest needed)       │
+│  Phase 2: SBOM → metadata → SPDX → validate│
+└─────────────────────────────────────────────┘
+```
+
+Same flow as Standalone but using wrapper-based interception. This is
+the **primary customer deployment mode**.
+
+#### Pattern C: Sidecar Phase 1 + Separate Phase 2 (two-stage CI)
+
+```
+┌──── CI Stage 1 (sidecar) ─────────┐
+│  --mode sidecar --phase build      │
 │  Phase 1: clone → build → treedb   │
 │  → writes phase1_manifest.json     │
 └────────────┬───────────────────────┘
              │ manifest + bom_dir artifacts
 ┌────────────▼───────────────────────┐
-│  CI Stage 2 (--phase spdx)        │
-│  Phase 2: reads manifest           │
-│  → SBOM → metadata → SPDX         │
+│  CI Stage 2 (--phase spdx)         │
+│  Phase 2: reads manifest            │
+│  → SBOM → metadata → SPDX          │
 └────────────────────────────────────┘
 ```
 
-Phase 2 runs in a parallel or downstream CI stage, reducing the critical path.
+Phase 2 runs in a downstream CI stage, reducing the critical path.
 
-#### Pattern C: Cross-Host (sidecar → analysis host)
+#### Pattern D: Sidecar Phase 1 + Remote Phase 2 (cross-host)
 
 ```
 ┌──── Customer CI (sidecar) ─────┐     ┌──── Analysis Host ──────────┐
@@ -286,7 +370,7 @@ Phase 2 runs in a parallel or downstream CI stage, reducing the critical path.
 
 Artifacts are transferred via `rsync`, S3, or CI artifact upload.
 
-#### Pattern D: Corona Daemon (future)
+#### Pattern E: Corona Daemon (future extension of Pattern C/D)
 
 ```
 ┌──── Customer CI (sidecar) ─────┐     ┌──── Corona Service ─────────┐
@@ -552,71 +636,16 @@ output. This naturally separates because there is no binary artifact.
 
 ---
 
-## 8. Corona Integration Design
+## 8. Corona Integration
 
-### 8.1 Corona Agent
+Corona integration is a future capability where Sidecar Phase 1 uploads
+artifacts to a Corona service, which runs Phase 2 asynchronously. The
+phase-split architecture (manifest + artifact contract) in this document
+is a prerequisite for Corona integration.
 
-The Corona agent runs as a Phase 1 post-step, replacing `--phase spdx` with
-an HTTP upload:
-
-```python
-class CoronaAgent:
-    """Uploads Phase 1 artifacts to Corona for async Phase 2."""
-
-    def __init__(self, corona_url, api_key):
-        self.url = corona_url
-        self.api_key = api_key
-
-    def upload(self, manifest_path):
-        """Upload manifest + referenced artifacts to Corona.
-
-        POST /api/v1/analyze
-        Content-Type: multipart/form-data
-
-        Parts:
-          - manifest: phase1_manifest.json
-          - artifacts: tar.gz of bom_dir + binaries
-        """
-        ...
-```
-
-### 8.2 Corona Daemon Phase 2
-
-The Corona daemon receives the upload and runs Phase 2 using the same
-`run_{lang}_phase2()` functions — identical code path to `--phase spdx`.
-
-```
-Corona Daemon
-  ├── /api/v1/analyze    POST — accept manifest + artifacts
-  ├── /api/v1/status/:id GET  — poll analysis status
-  └── /api/v1/sbom/:id   GET  — retrieve completed SPDX
-```
-
-### 8.3 CLI Integration
-
-```bash
-# Upload to Corona instead of running Phase 2 locally
-python3 -m app.analyze --repo curl --mode sidecar --phase build \
-    --corona-url https://corona.internal/api/v1
-```
-
-When `--corona-url` is specified with `--phase build`, the pipeline:
-1. Runs Phase 1 normally
-2. Writes `phase1_manifest.json`
-3. Calls `CoronaAgent.upload()` instead of running Phase 2
-
-### 8.4 Graduated Adoption Path
-
-| Stage | CI/CD Pattern | Phase 2 Location | Complexity |
-|-------|---------------|-------------------|------------|
-| 0 | Current (no isolation) | Same process | None |
-| 1 | `--phase build` + `--phase spdx` | Same container, separate stages | Low |
-| 2 | Sidecar container → analysis host | Different host, `rsync` artifacts | Medium |
-| 3 | Sidecar → Corona daemon | HTTP API, async processing | High |
-
-Each stage is independently testable. Stage 0 → Stage 1 requires only the
-manifest module + CLI changes. Stage 1 → Stage 2 requires artifact transfer.
-Stage 2 → Stage 3 requires the Corona agent.
+**Design details are deferred to a dedicated Corona integration design
+document.** This document does not specify Corona APIs, upload protocols,
+or daemon architecture.
 
 ---
 
@@ -646,11 +675,11 @@ phase_isolation:
   # Whether to write phase1_manifest.json after Phase 1
   write_manifest: true  # default: true when --phase build
 
-  # Corona integration (optional)
-  corona:
-    url: https://corona.internal/api/v1
-    api_key_env: CORONA_API_KEY  # env var name, never hardcoded
-    upload_timeout_sec: 300
+  # Corona integration (future — see dedicated Corona design doc)
+  # corona:
+  #   url: https://corona.internal/api/v1
+  #   api_key_env: CORONA_API_KEY
+  #   upload_timeout_sec: 300
 ```
 
 ### 9.3 Per-Language Sidecar Config
@@ -838,16 +867,10 @@ wrappers for C/C++/Go/Rust — may be blocked on upstream).
 
 **Deliverable**: Phase 2 can run on a different host from Phase 1.
 
-### Phase V: Corona Agent (2-3 days — future)
+### Phase V: Corona Integration (future — see dedicated design doc)
 
-| # | Task | Files Modified | Effort |
-|---|------|---------------|--------|
-| 21 | Create `app/pipeline/corona.py` (agent) | New file | 1d |
-| 22 | Add `--corona-url` CLI flag | `runners.py` | 0.25d |
-| 23 | Corona daemon scaffold (FastAPI or Flask) | New service | 1d |
-| 24 | Integration test with mock Corona | `tests/` | 0.5d |
-
-**Deliverable**: Phase 1 can upload to Corona; Corona runs Phase 2 async.
+Deferred to a separate Corona integration design document. The
+phase-split architecture from Phases I–IV is a prerequisite.
 
 ---
 
@@ -866,19 +889,36 @@ wrappers for C/C++/Go/Rust — may be blocked on upstream).
 
 ## 15. Success Criteria
 
-1. **Backward compatible**: `python3 -m app.analyze --repo curl` (no new flags)
-   produces identical output to current behavior.
-2. **Phase isolation works**: `--phase build` + `--phase spdx --manifest ...`
-   produces SPDX matching the golden files.
-3. **Sidecar works for Java**: `--mode sidecar --repo jsoup` runs without
-   `SYS_PTRACE` and passes golden file comparison.
-4. **Sidecar strategies wired**: `--mode sidecar` selects the correct
-   `InterceptionStrategy` for each language.
-5. **Tests**: ≥97% overall coverage, ≥95% per file.
-6. **Performance**: Phase 1 (build-only) completes within 5% of baseline
-   build time (excluding Phase 2 overhead).
-7. **Documentation**: Updated architecture docs, usage guide, and config
-   reference.
+All three execution modes must pass independently:
+
+### Sidecar Full (authoritative enterprise mode)
+1. `--mode sidecar --repo jsoup` runs **both Phase 1 and Phase 2** without
+   `SYS_PTRACE` and produces complete SPDX output.
+2. Sidecar full SPDX matches standalone golden files (per golden file policy).
+3. `--mode sidecar` selects the correct `InterceptionStrategy` for each
+   language.
+
+### Sidecar Phase 1 Only + Separate Phase 2
+4. `--mode sidecar --phase build` produces `phase1_manifest.json` and all
+   referenced artifacts, then exits without producing SPDX.
+5. `--phase spdx --manifest <path>` consumes the manifest and produces
+   SPDX matching the golden files — without access to `config.yaml`,
+   the source tree, or the original build environment.
+6. The Phase 2 executor produces **identical SPDX** whether it runs in
+   the same container or on a different host.
+
+### Standalone Full (golden file baseline + black-box builds)
+7. `python3 -m app.analyze --repo curl` (no new flags) produces identical
+   output to current behavior — **zero regression**.
+8. Standalone remains the baseline for `omnibor-analysis` golden file
+   generation and development/debug mode.
+
+### Cross-Cutting
+9. **Tests**: ≥97% overall coverage, ≥95% per file.
+10. **Performance**: Phase 1 (build-only) completes within 5% of baseline
+    build time (excluding Phase 2 overhead).
+11. **Documentation**: Updated architecture docs, usage guide, config
+    reference, and per-language design docs.
 
 ---
 
@@ -887,8 +927,7 @@ wrappers for C/C++/Go/Rust — may be blocked on upstream).
 | File | Change Type | Description |
 |------|-------------|-------------|
 | `app/pipeline/manifest.py` | **New** | Manifest writer + reader |
-| `app/pipeline/corona.py` | **New** (Phase V) | Corona agent |
-| `app/pipeline/runners.py` | Modify | Add `--phase`, `--manifest`, `--corona-url` args |
+| `app/pipeline/runners.py` | Modify | Add `--phase`, `--manifest` args |
 | `app/pipeline/lang_runners.py` | Modify | Split runners into `phase1`/`phase2`/`pipeline` |
 | `app/pipeline/builder.py` | Modify | Add `bom_dir`/`repo_dir`/`binaries` to `BuildResult` |
 | `app/pipeline/interception.py` | No change | Already complete |

--- a/docs/deep-dive/sidecar-python-design.md
+++ b/docs/deep-dive/sidecar-python-design.md
@@ -1,0 +1,197 @@
+# Sidecar & Phase Isolation — Python
+
+> **Parent doc**: `sidecar-phase-isolation-infrastructure.md`
+> **Status**: Future — no pipeline exists yet
+> **Date**: 2026-06-12
+> **Prerequisite**: `docs/architecture/python-omnibor-support-analysis.md`
+
+---
+
+> **Supported modes**: See `sidecar-phase-isolation-infrastructure.md` §1
+> for the authoritative definition of Standalone and Sidecar modes.
+> All modes apply to Python.
+
+---
+
+## 1. Current State
+
+| Component | Status |
+|-----------|--------|
+| Python pipeline | ❌ Not implemented |
+| Python interception strategy | ❌ Not defined |
+| Python repos in `config.yaml` | ❌ None configured |
+| `bomsh_pylib.py` (upstream) | ⚠️ Exists but has gaps (see analysis doc) |
+
+Python is **fundamentally different** from the other four languages:
+- Pure Python packages have no compiled binaries to trace
+- Dependencies are declared in `pyproject.toml`/`setup.py`/`requirements.txt`
+  and resolved by `pip`
+- C extension modules (via `setuptools`, `maturin`, `scikit-build`) are the
+  only compilation events worth tracing
+
+The Python pipeline is **metadata-only for pure Python** and
+**strace/wrapper-based for C extensions**.
+
+---
+
+## 2. Interception Strategies
+
+### 2.1 Metadata-Only (Pure Python)
+
+- **Mechanism**: `pip install` + `pip show` / `importlib.metadata`
+- **Capability needed**: None
+- **Output**: Package metadata (name, version, license, dependencies)
+- **No build tracing**: Pure Python has no compilation step
+
+This is inherently a sidecar-compatible approach — no `SYS_PTRACE` needed.
+
+### 2.2 Strace (C Extensions — Standalone)
+
+- **Mechanism**: `strace -f pip install` to capture C compilation via
+  `setuptools`/`distutils`
+- **Capability needed**: `SYS_PTRACE` in Docker
+- **Output**: strace log showing `gcc`/`g++` invocations for `.c` → `.so`
+- **ADG**: `bomsh_create_bom.py` on strace output (same as Java standalone)
+
+### 2.3 CC Wrapper (C Extensions — Sidecar)
+
+- **Mechanism**: Same `CC=`/`CXX=` wrappers as C/C++ sidecar, but applied
+  during `pip install` of packages with C extensions
+- **Capability needed**: None
+- **Output**: Same raw logfile format
+- **Dependency**: Requires the C/C++ CC wrappers (shared with `CcWrapperStrategy`)
+
+### 2.4 Proposed Strategy Class
+
+```python
+class PythonMetadataStrategy(InterceptionStrategy):
+    """Python: metadata-only, no build tracing.
+
+    For pure Python packages, dependencies are fully
+    described by pip metadata. No compilation to trace.
+    """
+
+    @property
+    def name(self):
+        return "python-metadata"
+
+    def instrument_command(self, build_cmd, repo_dir):
+        # pip install runs unmodified
+        return build_cmd, {}
+
+    def generate_adg(self, repo_dir, bom_dir, omnibor_cfg):
+        # Parse pip metadata instead of treedb
+        from app.pipeline.pip_metadata_parser import (
+            collect_pip_metadata,
+        )
+        metadata = collect_pip_metadata(repo_dir)
+        # Write to bom_dir as JSON
+        ...
+        return True
+```
+
+---
+
+## 3. Phase 1 Artifacts
+
+| Artifact | Pure Python | C Extension (standalone) | C Extension (sidecar) |
+|----------|------------|------------------------|----------------------|
+| `pip_metadata.json` | ✅ | ✅ | ✅ |
+| Strace log | ❌ | ✅ | ❌ |
+| Raw logfile (CC wrappers) | ❌ | ❌ | ✅ |
+| Treedb | ❌ | ✅ (C compilation) | ✅ (C compilation) |
+| `.so` extension modules | ❌ | ✅ | ✅ |
+| `requirements.txt` / `pyproject.toml` | ✅ | ✅ | ✅ |
+| `phase1_manifest.json` | ✅ | ✅ | ✅ |
+
+---
+
+## 4. Phase 2 Requirements
+
+| Operation | Needs Binary? | Needs Source Tree? | Needs Treedb? |
+|-----------|---------------|-------------------|---------------|
+| SPDX from pip metadata | ❌ | ❌ | ❌ |
+| SPDX for C extensions | ✅ (`.so` files) | ❌ | ✅ |
+| `ldd` on `.so` extensions | ✅ | ❌ | ❌ |
+
+**Python is the easiest language for cross-host Phase 2** for pure packages.
+`pip_metadata.json` is the only required artifact.
+
+---
+
+## 5. SPDX Relationship Mapping
+
+| Python Concept | SPDX Relationship |
+|---------------|-------------------|
+| Direct `install_requires` dependency | `DEPENDS_ON` |
+| Transitive dependency | `DEPENDS_ON` (via pip resolver) |
+| C extension `.so` | `CONTAINED_BY` (part of the package) |
+| Build tool (`setuptools`, `wheel`) | `BUILD_TOOL_OF` |
+| `extras_require` optional dep | `OPTIONAL_DEPENDENCY_OF` |
+
+---
+
+## 6. Implementation Plan
+
+Python is Phase V (future) in the overall implementation plan. Prerequisites:
+
+1. **Phase I-III complete** — manifest infrastructure, CLI changes, and
+   phase split for existing languages must be stable
+2. **`bomsh_pylib.py` gaps addressed** — upstream script needs fixes for
+   import side effects and missing metadata fields (see analysis doc)
+3. **Test Python project identified** — need a representative open-source
+   Python project with C extensions for integration testing
+
+### 6.1 Proposed Implementation Phases
+
+| Phase | Scope | Effort | Dependency |
+|-------|-------|--------|------------|
+| MVP | Metadata-only SPDX for pure Python (`pip show` → SPDX) | 2 weeks | None |
+| Phase 2 | strace integration for C extension tracing | 1 week | Standalone Docker |
+| Phase 3 | `bomsh_pylib.py` improvements (no import side effects) | 1 week | Upstream bomsh |
+| Phase 4 | Advanced: maturin/Rust extensions, Fortran, editable installs | TBD | Per-case |
+
+### 6.2 MVP Scope
+
+The MVP produces SPDX for pure Python packages without any build tracing:
+
+```python
+def run_python_pipeline(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_python_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    mode="standalone",  # mode is irrelevant for pure Python
+):
+    # Phase 1: pip install + metadata collection
+    timing = run_python_phase1(...)
+    if not timing.success:
+        return timing
+    # Phase 2: SPDX generation from metadata
+    timing2 = run_python_phase2(...)
+    timing.steps.extend(timing2.steps)
+    return timing
+```
+
+---
+
+## 7. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `pip show` metadata incomplete | Medium | Missing dependencies in SPDX | Cross-validate with `pip freeze` and `importlib.metadata` |
+| C extension detection unreliable | Medium | Miss compiled `.so` files | Scan `site-packages` for `.so` files post-install |
+| Virtual environment isolation | Low | Wrong packages detected | Always use dedicated venv for analysis |
+| `bomsh_pylib.py` import side effects | Known | Scripts execute on import | Fix upstream or bypass with metadata-only approach |
+| Editable installs (`pip install -e`) | Low | Different file layout | Detect and handle separately |
+
+---
+
+## 8. Testing
+
+Integration testing for Python will use a representative project:
+- **Pure Python**: A project with only Python dependencies (e.g., `requests`,
+  `click`-based CLI tool)
+- **C Extension**: A project with compiled extensions (e.g., `lxml`, `numpy`)
+
+Unit tests will mock `pip show` output and verify SPDX generation from
+metadata JSON.

--- a/docs/deep-dive/sidecar-rust-design.md
+++ b/docs/deep-dive/sidecar-rust-design.md
@@ -1,0 +1,399 @@
+# Sidecar & Phase Isolation — Rust
+
+> **Parent doc**: `sidecar-phase-isolation-infrastructure.md`
+> **Status**: Design proposal — not yet implemented
+> **Date**: 2026-06-12
+
+---
+
+> **Supported modes**: See `sidecar-phase-isolation-infrastructure.md` §1
+> for the authoritative definition of Standalone and Sidecar modes.
+> All modes apply to Rust.
+
+---
+
+## 1. Current State
+
+| Component | Status |
+|-----------|--------|
+| Standalone pipeline (`bomtrace2`) | ✅ Production — 2 repos (oxipng, dura) |
+| `PtraceStrategy` (standalone via `bomtrace2`) | ✅ Used implicitly via legacy path |
+| `RustcWrapperStrategy` skeleton | ✅ Defined in `interception.py` — **not wired to CLI** |
+| `run_rust_pipeline()` | ✅ Runs Phase 1 + Phase 2 sequentially, standalone only |
+| Phase 1/2 timing tags | ✅ Properly assigned |
+| `--mode sidecar` for Rust | ❌ Not wired — runner does not accept `mode` |
+
+### 1.1 Current Code Path (Standalone)
+
+```
+runners.py main()
+  → run_rust_pipeline()
+    → pipeline.builder.build()              # Phase 1: bomtrace2 cargo build
+      ├── clean_cmd (cargo clean)
+      ├── "bomtrace2 cargo build --release"
+      └── bomsh_create_bom.py               # ADG generation
+    → _run_post_build()                     # Phase 2
+      ├── bomsh_sbom.py                     # OmniBOR SBOM
+      ├── MetadataCollector.collect()
+      ├── AdgSpdxStep.generate()            # per-binary SPDX
+      ├── SpdxValidator.validate()
+      └── BinaryCollector.collect()
+```
+
+### 1.2 Key Rust-Specific Details
+
+- **`cargo build --release`**: Required per release-build policy. Output goes
+  to `target/release/`, not `target/debug/`.
+- **`bomtrace2` without custom conf**: Unlike Go, Rust uses the default
+  `bomtrace.conf`. `bomsh_hook2.py` has a dedicated rustc command parser
+  (`get_all_subfiles_in_rustc_cmdline`) that extracts input `.rs` files and
+  output `.rlib` / binary files.
+- **Static linking**: Rust statically links crate dependencies. Only system
+  libraries (`libc`, `libgcc_s`, `libpthread`) are dynamically linked.
+- **`Cargo.lock`**: Contains exact resolved versions for all transitive
+  dependencies. This is the primary source for dependency version data.
+
+---
+
+## 2. Interception Strategies
+
+### 2.1 Standalone: `bomtrace2`
+
+- **Mechanism**: `bomtrace2 cargo build --release`
+- **Capability needed**: `SYS_PTRACE` in Docker
+- **Output**: raw logfile at `/tmp/bomsh_hook_raw_logfile.sha1`
+- **ADG**: `bomsh_create_bom.py -r <raw_logfile> -b <bom_dir>`
+
+### 2.2 Sidecar: `RustcWrapperStrategy`
+
+- **Mechanism**: `RUSTC_WRAPPER=/opt/bomsh/bin/bomsh_hook.sh` environment variable
+- **Capability needed**: None (`SYS_PTRACE` not required)
+- **How it works**: Cargo calls `RUSTC_WRAPPER rustc <args>` for every crate
+  compilation. The wrapper records input `.rs` files and output `.rlib`/binary
+  mappings, then invokes the real `rustc`.
+- **Output**: Same raw logfile format as `bomtrace2`
+- **ADG**: Same `bomsh_create_bom.py` — wrapper output is format-compatible
+
+```python
+# From interception.py — already implemented:
+class RustcWrapperStrategy(InterceptionStrategy):
+    def instrument_command(self, build_cmd, repo_dir):
+        return build_cmd, {
+            "RUSTC_WRAPPER": self._wrapper,
+        }
+
+    def generate_adg(self, repo_dir, bom_dir, omnibor_cfg):
+        strategy = PtraceStrategy()
+        return strategy.generate_adg(repo_dir, bom_dir, omnibor_cfg)
+```
+
+### 2.3 Wiring `RustcWrapperStrategy` to the Pipeline
+
+Add `_select_rust_strategy()` in `lang_runners.py`:
+
+```python
+def _select_rust_strategy(repo_name, repo_cfg, paths_cfg, mode):
+    """Select interception strategy for Rust builds.
+
+    In sidecar mode, uses RUSTC_WRAPPER that avoids
+    ptrace entirely.
+
+    In standalone mode, returns None (legacy bomtrace2 path).
+    """
+    if mode != "sidecar":
+        return None
+    from app.pipeline.interception import RustcWrapperStrategy
+    return RustcWrapperStrategy()
+```
+
+Modify `run_rust_pipeline()` to accept `mode=`:
+
+```python
+def run_rust_pipeline(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_rust_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    mode="standalone",        # NEW
+):
+    strategy = _select_rust_strategy(
+        repo_name, repo_cfg, paths_cfg, mode,
+    )
+    ...
+    build_result = pipeline.builder.build(
+        ..., strategy=strategy,
+    )
+```
+
+### 2.4 `RUSTC_WRAPPER` vs `RUSTC_WORKSPACE_WRAPPER`
+
+Cargo supports two wrapper environment variables:
+- **`RUSTC_WRAPPER`**: Wraps every `rustc` invocation (including build scripts,
+  proc macros, and all transitive dependencies)
+- **`RUSTC_WORKSPACE_WRAPPER`**: Only wraps workspace crates (skips
+  dependencies compiled by Cargo itself)
+
+For OmniBOR, we want `RUSTC_WRAPPER` because we need to trace **all**
+compilation steps including transitive dependencies. Using
+`RUSTC_WORKSPACE_WRAPPER` would miss most of the dependency graph.
+
+**Future optimization**: For large workspaces with many proc-macro crates,
+`RUSTC_WORKSPACE_WRAPPER` could be used as a fast mode that only traces
+first-party code. Track as a future enhancement.
+
+---
+
+## 3. Phase 1 Artifacts
+
+| Artifact | Standalone | Sidecar | Location |
+|----------|-----------|---------|----------|
+| Raw logfile | ✅ `bomtrace2` writes | ✅ `RUSTC_WRAPPER` wrapper writes same format | `/tmp/bomsh_hook_raw_logfile.sha1` |
+| Treedb (`bomsh_omnibor_treedb`) | ✅ `bomsh_create_bom.py` | ✅ same script | `bom_dir/metadata/bomsh/` |
+| `bomsh_omnibor_doc_mapping` | ✅ | ✅ | `bom_dir/metadata/bomsh/` |
+| Output binary (ELF) | ✅ `target/release/` | ✅ `target/release/` | Per `output_binaries` config |
+| `Cargo.lock` | ✅ (in source tree) | ✅ | `repo_dir/Cargo.lock` |
+| `Cargo.toml` | ✅ (in source tree) | ✅ | `repo_dir/Cargo.toml` |
+| `phase1_manifest.json` | ✅ (when `--phase build`) | ✅ | `bom_dir/phase1_manifest.json` |
+
+---
+
+## 4. Phase 2 Requirements
+
+| Operation | Module | Needs Binary? | Needs Source Tree? | Needs Treedb? |
+|-----------|--------|---------------|-------------------|---------------|
+| `bomsh_sbom.py` | `spdx_generator.py` | ✅ reads binary hashes | ❌ | ✅ |
+| `ldd` (dynamic deps) | `adg_spdx.py` | ✅ (only system libs) | ❌ | ❌ |
+| `AdgSpdxGenerator` (per-binary SPDX) | `adg_spdx.py` | ❌ | ✅ (`Cargo.lock`/`Cargo.toml`) | ✅ |
+| `MetadataCollector` | `metadata_collector.py` | ❌ | ✅ (repo metadata) | ❌ |
+| `BinaryCollector` | `binary_collector.py` | ✅ (copies binary) | ❌ | ❌ |
+
+### 4.1 Source Tree Dependency
+
+Rust's `AdgSpdxGenerator` needs:
+- `Cargo.lock` — exact dependency versions and checksums
+- `Cargo.toml` — direct vs transitive dependency classification,
+  `[features]` enabled
+
+These are small text files. Copy to `bom_dir` during Phase 1 for
+cross-host Phase 2.
+
+### 4.2 Binary Size
+
+Rust binaries are statically linked (crate deps) with some dynamic system
+libraries. Release builds with default optimization:
+
+| Repo | Binary | Approximate Size |
+|------|--------|-----------------|
+| oxipng | `target/release/oxipng` | ~4 MB |
+| dura | `target/release/dura` | ~8 MB |
+
+Small enough for direct cross-host transfer.
+
+---
+
+## 5. Config Schema
+
+### 5.1 Current (flat format)
+
+```yaml
+omnibor_rust:
+  tracer: bomtrace2
+  create_bom_script: bomsh_create_bom.py
+  sbom_script: bomsh_sbom.py
+  raw_logfile: /tmp/bomsh_hook_raw_logfile.sha1
+```
+
+### 5.2 Target (nested mode format)
+
+```yaml
+omnibor_rust:
+  standalone:
+    tracer: bomtrace2
+    create_bom_script: bomsh_create_bom.py
+    sbom_script: bomsh_sbom.py
+    raw_logfile: /tmp/bomsh_hook_raw_logfile.sha1
+  sidecar:
+    wrapper: /opt/bomsh/bin/bomsh_hook.sh
+    create_bom_script: bomsh_create_bom.py
+    sbom_script: bomsh_sbom.py
+```
+
+---
+
+## 6. Upstream `bomsh` Wrapper Requirements
+
+Rust's `RUSTC_WRAPPER` calls the wrapper as:
+
+```
+/opt/bomsh/bin/bomsh_hook.sh rustc <crate_args...>
+```
+
+The wrapper receives `rustc` as `$1` followed by all original rustc arguments.
+
+`bomsh_hook2.py` already has:
+- `get_all_subfiles_in_rustc_cmdline()` — parses `rustc` arguments to extract
+  input `.rs` files, `--extern` crate references, and output `.rlib`/binary paths
+
+**Status**: `bomsh_hook.sh` needs verification that it correctly handles:
+1. The `RUSTC_WRAPPER` calling convention (tool as first arg)
+2. `rustc` command-line parsing via `bomsh_hook2.py`
+3. Proc-macro compilation (separate compilation unit)
+4. Build script execution (`build.rs`)
+
+**Key difference from Go**: Go's `-toolexec` passes the tool path directly.
+Rust's `RUSTC_WRAPPER` always passes `rustc` as `$1` — the wrapper doesn't
+need to discover the real compiler path.
+
+---
+
+## 7. Phase Split Design
+
+### 7.1 `run_rust_phase1()`
+
+```python
+def run_rust_phase1(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_rust_cfg, run_ts,
+    mode="standalone",
+    vcs_uri="NOASSERTION",
+    commit_sha=None,
+):
+    """Rust Phase 1: build + treedb + manifest."""
+    strategy = _select_rust_strategy(
+        repo_name, repo_cfg, paths_cfg, mode,
+    )
+    tracer = strategy.name if strategy else omnibor_rust_cfg.get("tracer", "bomtrace2")
+    timing = TimingResult(tracer=tracer)
+
+    build_result = pipeline.builder.build(
+        repo_name, repo_cfg, paths_cfg, omnibor_rust_cfg,
+        run_ts=run_ts, strategy=strategy,
+    )
+    timing.steps.extend(build_result.steps)
+    timing.success = build_result.success
+
+    if build_result.success:
+        _copy_cargo_metadata(build_result.repo_dir, build_result.bom_dir)
+        ManifestWriter().write(...)
+
+    return timing
+
+
+def _copy_cargo_metadata(repo_dir, bom_dir):
+    """Copy Cargo.lock and Cargo.toml to bom_dir for cross-host Phase 2."""
+    import shutil
+    from pathlib import Path
+    for fname in ("Cargo.lock", "Cargo.toml"):
+        src = Path(repo_dir) / fname
+        if src.exists():
+            dst = Path(bom_dir) / fname
+            shutil.copy2(str(src), str(dst))
+```
+
+### 7.2 `run_rust_phase2()`
+
+```python
+def run_rust_phase2(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_rust_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    manifest=None,
+):
+    """Rust Phase 2: SBOM → metadata → SPDX → validate → collect."""
+    if manifest:
+        ctx = ManifestReader().read(manifest)
+
+    timing = TimingResult(tracer="phase2-only")
+    timing.steps.extend(
+        _run_post_build(
+            pipeline, repo_name, repo_cfg,
+            paths_cfg, run_ts,
+            sbom_fn=lambda: pipeline.spdx_gen.generate(...),
+            spdx_gen_fn=lambda: pipeline.adg_spdx.generate(...),
+        )
+    )
+    timing.success = True
+    return timing
+```
+
+### 7.3 `run_rust_pipeline()` (backward compatible)
+
+```python
+def run_rust_pipeline(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_rust_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+    mode="standalone",
+):
+    timing = run_rust_phase1(...)
+    if not timing.success:
+        return timing
+    timing2 = run_rust_phase2(...)
+    timing.steps.extend(timing2.steps)
+    return timing
+```
+
+---
+
+## 8. Testing
+
+### 8.1 Unit Tests
+
+| Test | What it validates |
+|------|-------------------|
+| `test_select_rust_strategy_standalone` | Returns `None` (legacy path) |
+| `test_select_rust_strategy_sidecar` | Returns `RustcWrapperStrategy` |
+| `test_rustc_wrapper_instrument_command` | Sets `RUSTC_WRAPPER` env var, command unchanged |
+| `test_rustc_wrapper_generate_adg` | Delegates to `PtraceStrategy.generate_adg()` |
+| `test_rust_phase1_writes_manifest` | Manifest includes `Cargo.lock`/`Cargo.toml` copies |
+| `test_rust_phase2_reads_manifest` | Phase 2 runs from manifest |
+| `test_rust_pipeline_unchanged` | Full pipeline backward compatible |
+
+### 8.2 Integration Tests (EC2)
+
+| Test | Command | Validates |
+|------|---------|-----------|
+| Standalone full | `--repo oxipng` | Current behavior unchanged |
+| Sidecar full | `--repo oxipng --mode sidecar` | `RUSTC_WRAPPER` produces valid SPDX |
+| Phase split | `--repo oxipng --phase build` then `--phase spdx` | Matches golden |
+| Complex deps | `--repo dura --mode sidecar` | 42 direct + 35 transitive crates |
+
+### 8.3 `RUSTC_WRAPPER` Compatibility
+
+Both repos use standard `cargo build --release`. `RUSTC_WRAPPER` is a
+Cargo-native mechanism — no build system compatibility concerns.
+
+**Potential issue**: If a project uses `RUSTC_WRAPPER` for another tool
+(e.g., `sccache`), our wrapper conflicts. Mitigation: chain wrappers or
+detect existing `RUSTC_WRAPPER` and warn.
+
+---
+
+## 9. Implementation Tasks
+
+| # | Task | Effort | Depends On |
+|---|------|--------|------------|
+| 1 | Add `mode=` param to `run_rust_pipeline()` | 0.25d | — |
+| 2 | Implement `_select_rust_strategy()` | 0.25d | — |
+| 3 | Pass `mode` from `runners.py` → `run_rust_pipeline()` | 0.25d | Task 1 |
+| 4 | Split into `run_rust_phase1()` / `run_rust_phase2()` | 0.5d | Infra manifest module |
+| 5 | Implement `_copy_cargo_metadata()` for cross-host Phase 2 | 0.25d | Task 4 |
+| 6 | Verify `bomsh_hook.sh` with `RUSTC_WRAPPER` convention | 1d | External dependency |
+| 7 | Convert `config.yaml` `omnibor_rust:` to nested format | 0.25d | — |
+| 8 | Unit tests | 0.5d | Tasks 1-5 |
+| 9 | Integration tests on EC2 (sidecar mode) | 0.5d | Task 6 |
+
+**Blocker**: Task 6 — verifying `bomsh_hook.sh` works as `RUSTC_WRAPPER`.
+Same risk level as Go (`-toolexec`). `bomsh_hook2.py` already has the rustc
+parser, so the risk is in the wrapper shell script, not the Python analysis.
+
+---
+
+## 10. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `bomsh_hook.sh` incompatible with `RUSTC_WRAPPER` | Medium | Blocks sidecar E2E | Test in isolation first |
+| Existing `RUSTC_WRAPPER` conflict (e.g., `sccache`) | Low | User's wrapper overwritten | Detect + warn; support wrapper chaining |
+| Proc-macro compilation not traced | Low | Missing dependencies in SPDX | Verify `bomsh_hook2.py` handles proc-macro crates |
+| Build script (`build.rs`) side effects | Low | Extra files in treedb | `bomsh_hook2.py` should filter build script artifacts |
+| Workspace projects with multiple binaries | Low | Need per-binary SPDX | Already handled by `AdgSpdxStep.generate()` |

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,302 @@
+"""Unit tests for app.pipeline.manifest module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.pipeline.manifest import (
+    MANIFEST_FILENAME,
+    MANIFEST_VERSION,
+    ManifestError,
+    read_manifest,
+    verify_gitoids,
+    write_manifest,
+    _sha256_gitoid,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def manifest_dir(tmp_path):
+    """Temporary directory for manifest output."""
+    return tmp_path / "bom_dir"
+
+
+@pytest.fixture
+def sample_artifacts(tmp_path):
+    """Sample artifact paths with real files."""
+    treedb = tmp_path / "treedb"
+    treedb.write_text("treedb-content")
+    binary = tmp_path / "app.jar"
+    binary.write_text("jar-content")
+    return {
+        "bom_dir": str(tmp_path / "bom"),
+        "treedb": str(treedb),
+        "binaries": [str(binary)],
+    }
+
+
+@pytest.fixture
+def sample_paths(tmp_path):
+    """Sample paths config."""
+    return {
+        "repos_dir": str(tmp_path / "repos"),
+        "output_dir": str(tmp_path / "output"),
+        "spdx_dir": str(tmp_path / "spdx"),
+    }
+
+
+@pytest.fixture
+def sample_kwargs(
+    manifest_dir, sample_artifacts, sample_paths,
+):
+    """Common kwargs for write_manifest."""
+    return {
+        "manifest_dir": str(manifest_dir),
+        "repo_name": "jsoup",
+        "language": "java",
+        "mode": "sidecar",
+        "tracer": "maven-dep-tree",
+        "run_ts": "2026-05-12_0900",
+        "commit_sha": "abc123def456",
+        "vcs_uri": "https://github.com/jhy/jsoup.git@abc123",
+        "artifacts": sample_artifacts,
+        "paths": sample_paths,
+    }
+
+
+# ── write_manifest ───────────────────────────────────────
+
+
+class TestWriteManifest:
+    """Tests for write_manifest."""
+
+    def test_creates_manifest_file(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        assert path.exists()
+        assert path.name == MANIFEST_FILENAME
+
+    def test_creates_parent_dirs(self, sample_kwargs):
+        sample_kwargs["manifest_dir"] = str(
+            Path(sample_kwargs["manifest_dir"]) / "deep" / "nested"
+        )
+        path = write_manifest(**sample_kwargs)
+        assert path.exists()
+
+    def test_manifest_content(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        data = json.loads(path.read_text())
+        assert data["version"] == MANIFEST_VERSION
+        assert data["repo_name"] == "jsoup"
+        assert data["language"] == "java"
+        assert data["mode"] == "sidecar"
+        assert data["tracer"] == "maven-dep-tree"
+        assert data["run_ts"] == "2026-05-12_0900"
+        assert data["commit_sha"] == "abc123def456"
+        assert data["vcs_uri"].startswith("https://")
+
+    def test_artifacts_preserved(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        data = json.loads(path.read_text())
+        assert "bom_dir" in data["artifacts"]
+        assert isinstance(
+            data["artifacts"]["binaries"], list,
+        )
+
+    def test_paths_preserved(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        data = json.loads(path.read_text())
+        assert "repos_dir" in data["paths"]
+        assert "output_dir" in data["paths"]
+        assert "spdx_dir" in data["paths"]
+
+    def test_gitoids_computed(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        data = json.loads(path.read_text())
+        assert "gitoids" in data
+        # treedb file exists, so it should have a gitoid
+        treedb_path = sample_kwargs["artifacts"]["treedb"]
+        assert treedb_path in data["gitoids"]
+
+    def test_optional_repo_cfg(self, sample_kwargs):
+        sample_kwargs["repo_cfg"] = {
+            "output_binaries": ["**/target/*.jar"],
+        }
+        path = write_manifest(**sample_kwargs)
+        data = json.loads(path.read_text())
+        assert "repo_cfg" in data
+
+    def test_optional_omnibor_cfg(self, sample_kwargs):
+        sample_kwargs["omnibor_cfg"] = {
+            "strace_opts": "-f -e trace=openat",
+        }
+        path = write_manifest(**sample_kwargs)
+        data = json.loads(path.read_text())
+        assert "omnibor_cfg" in data
+
+    def test_no_optional_fields_by_default(
+        self, sample_kwargs,
+    ):
+        path = write_manifest(**sample_kwargs)
+        data = json.loads(path.read_text())
+        assert "repo_cfg" not in data
+        assert "omnibor_cfg" not in data
+
+    def test_missing_bom_dir_raises(self, sample_kwargs):
+        del sample_kwargs["artifacts"]["bom_dir"]
+        with pytest.raises(ManifestError, match="bom_dir"):
+            write_manifest(**sample_kwargs)
+
+    def test_missing_binaries_raises(self, sample_kwargs):
+        del sample_kwargs["artifacts"]["binaries"]
+        with pytest.raises(
+            ManifestError, match="binaries",
+        ):
+            write_manifest(**sample_kwargs)
+
+    def test_binaries_not_list_raises(self, sample_kwargs):
+        sample_kwargs["artifacts"]["binaries"] = "not-a-list"
+        with pytest.raises(
+            ManifestError, match="must be a list",
+        ):
+            write_manifest(**sample_kwargs)
+
+    def test_missing_repos_dir_raises(self, sample_kwargs):
+        del sample_kwargs["paths"]["repos_dir"]
+        with pytest.raises(
+            ManifestError, match="repos_dir",
+        ):
+            write_manifest(**sample_kwargs)
+
+    def test_null_commit_sha(self, sample_kwargs):
+        sample_kwargs["commit_sha"] = None
+        path = write_manifest(**sample_kwargs)
+        data = json.loads(path.read_text())
+        assert data["commit_sha"] is None
+
+
+# ── read_manifest ────────────────────────────────────────
+
+
+class TestReadManifest:
+    """Tests for read_manifest."""
+
+    def test_round_trip(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        data = read_manifest(path)
+        assert data["repo_name"] == "jsoup"
+        assert data["version"] == MANIFEST_VERSION
+
+    def test_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_manifest(tmp_path / "nonexistent.json")
+
+    def test_malformed_json(self, tmp_path):
+        bad_file = tmp_path / MANIFEST_FILENAME
+        bad_file.write_text("{not valid json")
+        with pytest.raises(ManifestError, match="Malformed"):
+            read_manifest(bad_file)
+
+    def test_missing_required_field(self, tmp_path):
+        bad_file = tmp_path / MANIFEST_FILENAME
+        bad_file.write_text(json.dumps({"version": "1.0"}))
+        with pytest.raises(
+            ManifestError, match="Missing required",
+        ):
+            read_manifest(bad_file)
+
+    def test_wrong_version(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        data = json.loads(path.read_text())
+        data["version"] = "99.0"
+        path.write_text(json.dumps(data))
+        with pytest.raises(
+            ManifestError, match="Unsupported.*version",
+        ):
+            read_manifest(path)
+
+    def test_not_a_dict(self, tmp_path):
+        bad_file = tmp_path / MANIFEST_FILENAME
+        bad_file.write_text(json.dumps([1, 2, 3]))
+        with pytest.raises(
+            ManifestError, match="must be a JSON object",
+        ):
+            read_manifest(bad_file)
+
+
+# ── verify_gitoids ───────────────────────────────────────
+
+
+class TestVerifyGitoids:
+    """Tests for verify_gitoids."""
+
+    def test_verification_passes(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        manifest = read_manifest(path)
+        passed, failed = verify_gitoids(manifest)
+        assert len(passed) > 0
+        assert len(failed) == 0
+
+    def test_tampered_file_fails(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        manifest = read_manifest(path)
+
+        # Tamper with a file after manifest was written
+        treedb_path = sample_kwargs["artifacts"]["treedb"]
+        Path(treedb_path).write_text(
+            "tampered!", encoding="utf-8",
+        )
+
+        _passed, failed = verify_gitoids(manifest)
+        assert treedb_path in failed
+
+    def test_missing_file_skipped(self, sample_kwargs):
+        path = write_manifest(**sample_kwargs)
+        manifest = read_manifest(path)
+
+        # Remove a file after manifest was written
+        treedb_path = sample_kwargs["artifacts"]["treedb"]
+        Path(treedb_path).unlink()
+
+        passed, failed = verify_gitoids(manifest)
+        assert treedb_path not in passed
+        assert treedb_path not in failed
+
+    def test_no_gitoids_key(self):
+        manifest = {
+            "gitoids": {},
+        }
+        passed, failed = verify_gitoids(manifest)
+        assert passed == []
+        assert failed == []
+
+
+# ── _sha256_gitoid ───────────────────────────────────────
+
+
+class TestSha256Gitoid:
+    """Tests for gitoid computation."""
+
+    def test_deterministic(self, tmp_path):
+        f = tmp_path / "test.txt"
+        f.write_text("hello")
+        g1 = _sha256_gitoid(f)
+        g2 = _sha256_gitoid(f)
+        assert g1 == g2
+
+    def test_different_content(self, tmp_path):
+        f1 = tmp_path / "a.txt"
+        f1.write_text("hello")
+        f2 = tmp_path / "b.txt"
+        f2.write_text("world")
+        assert _sha256_gitoid(f1) != _sha256_gitoid(f2)
+
+    def test_hex_string(self, tmp_path):
+        f = tmp_path / "test.txt"
+        f.write_text("x")
+        gitoid = _sha256_gitoid(f)
+        assert len(gitoid) == 64
+        assert all(c in "0123456789abcdef" for c in gitoid)


### PR DESCRIPTION
## Summary

Phase isolation infrastructure for Java sidecar mode. Enables running Phase 1 (build) and Phase 2 (SPDX generation) independently via `--phase build` / `--phase spdx` CLI flags. Sidecar-only feature — standalone mode is unaffected.

## Changes

### New: `app/pipeline/manifest.py`
- Generic manifest writer/reader for all languages
- `write_manifest()` produces `phase1_manifest.json` after Phase 1
- `read_manifest()` + `verify_gitoids()` for Phase 2 consumption
- SHA-256 gitoid provenance for artifact integrity

### New: `tests/test_manifest.py`
- 27 unit tests covering write, read, validation, gitoid verification

### Modified: `app/pipeline/runners.py`
- Added `--phase {build,spdx}` and `--manifest <path>` CLI args
- `_validate_phase_args()` enforces: phase requires sidecar mode, `--phase spdx` requires manifest

### Modified: `app/pipeline/lang_runners.py`
- Extracted `run_java_phase1()` and `run_java_phase2()` from `run_java_pipeline()`
- `run_java_pipeline()` is now a backward-compatible wrapper calling both

### Modified: `app/config.py`
- Added `VALID_PHASES = ("build", "spdx")` constant

### Design docs (6 files)
- Master doc: corrected standalone mode (no phase split), clarified manifest, deferred Corona
- Per-language docs: cross-reference master doc for mode characterization

## Testing

- 1409 passed, 75 skipped, 0 failed
- Zero regressions — `run_java_pipeline()` behavior unchanged

## Next steps (same branch, next PR)
- Wire `--phase` dispatch in `main()` for Java
- Integration tests for full phase split round-trip
- EC2 regression on all 8 Java repos


