### PR TITLE
feat: wire --phase dispatch + phase isolation integration tests

### DIFF
--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -230,12 +230,28 @@ def main():
         )
     elif lang == "java":
         mode = config.get("mode", DEFAULT_MODE)
-        timing = run_java_pipeline(
-            pipeline, args.repo, repo_cfg,
-            paths_cfg, omnibor_cfg, run_ts,
-            vcs_uri=vcs_uri,
-            mode=mode,
-        )
+        if args.phase == "build":
+            timing = _run_phase1_only(
+                pipeline, args.repo, repo_cfg,
+                paths_cfg, omnibor_cfg, run_ts,
+                mode=mode, lang=lang,
+                commit_sha=commit_sha,
+                vcs_uri=vcs_uri,
+            )
+        elif args.phase == "spdx":
+            timing = _run_phase2_only(
+                pipeline, args.repo,
+                args.manifest, paths_cfg,
+                omnibor_cfg, run_ts,
+                vcs_uri=vcs_uri,
+            )
+        else:
+            timing = run_java_pipeline(
+                pipeline, args.repo, repo_cfg,
+                paths_cfg, omnibor_cfg, run_ts,
+                vcs_uri=vcs_uri,
+                mode=mode,
+            )
     else:
         timing = run_go_pipeline(
             pipeline, args.repo, repo_cfg,
@@ -350,6 +366,155 @@ def _validate_phase_args(args, parser):
             "--phase build (manifest is an "
             "output of Phase 1, not an input)"
         )
+
+
+def _run_phase1_only(
+    pipeline, repo_name, repo_cfg,
+    paths_cfg, omnibor_cfg, run_ts,
+    mode, lang, commit_sha, vcs_uri,
+):
+    """Run Phase 1 only and write manifest.
+
+    Used with ``--phase build --mode sidecar``.
+    Runs the build, then writes a manifest that
+    Phase 2 can consume independently.
+
+    Returns ``TimingResult``.
+    """
+    from app.pipeline.manifest import write_manifest
+
+    timing, _ = run_java_phase1(
+        pipeline, repo_name, repo_cfg,
+        paths_cfg, omnibor_cfg, run_ts,
+        mode=mode,
+    )
+    if not timing.success:
+        return timing
+
+    # Determine artifact paths for the manifest
+    bom_dir = (
+        Path(paths_cfg["output_dir"])
+        / "omnibor" / lang / repo_name / run_ts
+    )
+    spdx_dir = (
+        Path(paths_cfg["output_dir"])
+        / "spdx" / lang / repo_name / run_ts
+    )
+
+    # Resolve output binary paths
+    repo_dir = (
+        Path(paths_cfg["repos_dir"]) / repo_name
+    )
+    bin_paths = []
+    for pattern in repo_cfg.get(
+        "output_binaries", [],
+    ):
+        if "*" in pattern or "?" in pattern:
+            bin_paths.extend(
+                str(p) for p in repo_dir.glob(pattern)
+            )
+        else:
+            p = repo_dir / pattern
+            if p.exists():
+                bin_paths.append(str(p))
+
+    artifacts = {
+        "bom_dir": str(bom_dir),
+        "binaries": bin_paths,
+    }
+
+    # Include strace log if present (standalone)
+    strace_log = omnibor_cfg.get("strace_logfile")
+    if strace_log and Path(strace_log).exists():
+        artifacts["strace_log"] = strace_log
+
+    paths = {
+        "repos_dir": paths_cfg["repos_dir"],
+        "output_dir": paths_cfg["output_dir"],
+        "spdx_dir": str(spdx_dir),
+    }
+
+    manifest_path = write_manifest(
+        manifest_dir=str(bom_dir),
+        repo_name=repo_name,
+        language=lang,
+        mode=mode,
+        tracer=timing.tracer,
+        run_ts=run_ts,
+        commit_sha=commit_sha,
+        vcs_uri=vcs_uri,
+        artifacts=artifacts,
+        paths=paths,
+        repo_cfg={
+            k: repo_cfg[k] for k in (
+                "output_binaries", "language",
+                "build_steps",
+            ) if k in repo_cfg
+        },
+        omnibor_cfg=omnibor_cfg,
+    )
+    print(
+        f"[OK] Phase 1 manifest: {manifest_path}"
+    )
+
+    return timing
+
+
+def _run_phase2_only(
+    pipeline, repo_name,
+    manifest_path, paths_cfg,
+    omnibor_cfg, run_ts,
+    vcs_uri="NOASSERTION",
+):
+    """Run Phase 2 only from a manifest.
+
+    Used with ``--phase spdx --manifest <path>``.
+    Reads the manifest to locate Phase 1 artifacts,
+    then runs SPDX generation + validation.
+
+    Returns ``TimingResult``.
+    """
+    from app.pipeline.manifest import (
+        read_manifest, verify_gitoids,
+    )
+    from app.pipeline.timing import TimingResult
+
+    manifest = read_manifest(manifest_path)
+
+    # Verify artifact integrity
+    passed, failed = verify_gitoids(manifest)
+    if failed:
+        print(
+            f"[WARN] {len(failed)} artifact(s) "
+            f"failed gitoid verification"
+        )
+        for f in failed:
+            print(f"  - {f}")
+    if passed:
+        print(
+            f"[OK] {len(passed)} artifact(s) "
+            f"verified via gitoid"
+        )
+
+    # Use manifest values, fall back to CLI args
+    m_repo_cfg = manifest.get("repo_cfg", {})
+    m_omnibor = manifest.get(
+        "omnibor_cfg", omnibor_cfg,
+    )
+    m_vcs = manifest.get("vcs_uri", vcs_uri)
+    m_ts = manifest.get("run_ts", run_ts)
+    tracer = manifest.get("tracer", "unknown")
+
+    timing = TimingResult(tracer=tracer)
+    timing.success = True
+
+    phase2_steps = run_java_phase2(
+        pipeline, repo_name, m_repo_cfg,
+        paths_cfg, m_omnibor, m_ts,
+        vcs_uri=m_vcs,
+    )
+    timing.steps.extend(phase2_steps)
+    return timing
 
 
 def _run_baseline(

--- a/tests/test_phase_isolation.py
+++ b/tests/test_phase_isolation.py
@@ -1,0 +1,435 @@
+"""Tests for phase isolation (--phase build / --phase spdx).
+
+Covers CLI validation, Phase 1 manifest write,
+Phase 2 manifest read, and the round-trip flow.
+"""
+
+import json
+import tempfile
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.pipeline.manifest import (
+    MANIFEST_FILENAME,
+    MANIFEST_VERSION,
+    read_manifest,
+)
+from app.pipeline.runners import (
+    _run_phase1_only,
+    _run_phase2_only,
+    _validate_phase_args,
+)
+from app.pipeline.builder import BuildResult
+
+
+# ── Fixtures ─────────────────────────────────────────────
+
+
+def _make_pipeline():
+    """Create a mock AnalysisPipeline."""
+    p = MagicMock()
+    p.builder.build.return_value = BuildResult(
+        success=True,
+    )
+    p.builder.build_java.return_value = BuildResult(
+        success=True,
+    )
+    p.spdx_gen.generate_java.return_value = (
+        "/tmp/spdx.json"
+    )
+    p.metadata_collector.collect.return_value = None
+    p.spdx_validator.validate.return_value = None
+    p.binary_collector.collect.return_value = None
+    return p
+
+
+def _make_cfg(td):
+    """Create test config dicts in a temp dir."""
+    paths_cfg = {
+        "output_dir": str(Path(td) / "output"),
+        "repos_dir": str(Path(td) / "repos"),
+    }
+    repo_cfg = {
+        "language": "java",
+        "url": "https://github.com/test/test.git",
+        "build_steps": ["mvn package -DskipTests -q"],
+        "output_binaries": ["**/target/*.jar"],
+    }
+    omnibor_cfg = {
+        "strace_opts": "-f",
+        "create_bom_script": "bomsh_bom_java.py",
+        "strace_logfile": "/tmp/strace.log",
+    }
+    return paths_cfg, repo_cfg, omnibor_cfg
+
+
+# ── _validate_phase_args ─────────────────────────────────
+
+
+class TestValidatePhaseArgs:
+    """Tests for _validate_phase_args."""
+
+    def _make_parser(self):
+        """Minimal mock parser with error method."""
+        parser = MagicMock()
+        parser.error.side_effect = SystemExit(2)
+        return parser
+
+    def test_phase_requires_sidecar(self):
+        parser = self._make_parser()
+        args = Namespace(
+            phase="build", mode=None, manifest=None,
+        )
+        with pytest.raises(SystemExit):
+            _validate_phase_args(args, parser)
+        parser.error.assert_called_once()
+        assert "sidecar" in str(
+            parser.error.call_args
+        )
+
+    def test_phase_build_with_standalone_fails(self):
+        parser = self._make_parser()
+        args = Namespace(
+            phase="build", mode="standalone",
+            manifest=None,
+        )
+        with pytest.raises(SystemExit):
+            _validate_phase_args(args, parser)
+
+    def test_phase_spdx_requires_manifest(self):
+        parser = self._make_parser()
+        args = Namespace(
+            phase="spdx", mode="sidecar",
+            manifest=None,
+        )
+        with pytest.raises(SystemExit):
+            _validate_phase_args(args, parser)
+        assert "manifest" in str(
+            parser.error.call_args
+        ).lower()
+
+    def test_phase_build_rejects_manifest(self):
+        parser = self._make_parser()
+        args = Namespace(
+            phase="build", mode="sidecar",
+            manifest="/tmp/m.json",
+        )
+        with pytest.raises(SystemExit):
+            _validate_phase_args(args, parser)
+
+    def test_phase_build_sidecar_passes(self):
+        parser = self._make_parser()
+        args = Namespace(
+            phase="build", mode="sidecar",
+            manifest=None,
+        )
+        _validate_phase_args(args, parser)
+        parser.error.assert_not_called()
+
+    def test_phase_spdx_with_manifest_passes(self):
+        parser = self._make_parser()
+        args = Namespace(
+            phase="spdx", mode="sidecar",
+            manifest="/tmp/m.json",
+        )
+        _validate_phase_args(args, parser)
+        parser.error.assert_not_called()
+
+
+# ── _run_phase1_only ─────────────────────────────────────
+
+
+class TestRunPhase1Only:
+    """Tests for _run_phase1_only."""
+
+    @patch(
+        "app.pipeline.lang_runners"
+        "._select_java_strategy",
+    )
+    def test_writes_manifest(self, mock_strategy):
+        mock_strategy.return_value = None
+        pipeline = _make_pipeline()
+
+        with tempfile.TemporaryDirectory() as td:
+            paths, repo_cfg, omnibor = _make_cfg(td)
+
+            # Create a fake JAR so binary resolution works
+            repo_dir = Path(td) / "repos" / "myapp"
+            target_dir = repo_dir / "target"
+            target_dir.mkdir(parents=True)
+            jar = target_dir / "myapp-1.0.jar"
+            jar.write_text("fake-jar")
+
+            timing = _run_phase1_only(
+                pipeline, "myapp", repo_cfg,
+                paths, omnibor, "ts1",
+                mode="sidecar", lang="java",
+                commit_sha="abc123",
+                vcs_uri="https://example.com",
+            )
+
+            assert timing.success
+
+            # Manifest should exist in bom_dir
+            bom_dir = (
+                Path(td) / "output" / "omnibor"
+                / "java" / "myapp" / "ts1"
+            )
+            manifest_path = bom_dir / MANIFEST_FILENAME
+            assert manifest_path.exists()
+
+            data = json.loads(
+                manifest_path.read_text()
+            )
+            assert data["version"] == MANIFEST_VERSION
+            assert data["repo_name"] == "myapp"
+            assert data["language"] == "java"
+            assert data["mode"] == "sidecar"
+            assert data["commit_sha"] == "abc123"
+            assert len(data["artifacts"]["binaries"]) == 1
+            assert "repo_cfg" in data
+            assert "omnibor_cfg" in data
+
+    @patch(
+        "app.pipeline.lang_runners"
+        "._select_java_strategy",
+    )
+    def test_build_failure_skips_manifest(
+        self, mock_strategy,
+    ):
+        mock_strategy.return_value = None
+        pipeline = _make_pipeline()
+        pipeline.builder.build_java.return_value = (
+            BuildResult(success=False)
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            paths, repo_cfg, omnibor = _make_cfg(td)
+
+            timing = _run_phase1_only(
+                pipeline, "myapp", repo_cfg,
+                paths, omnibor, "ts1",
+                mode="sidecar", lang="java",
+                commit_sha="abc123",
+                vcs_uri="https://example.com",
+            )
+
+            assert not timing.success
+
+            # No manifest should be written
+            bom_dir = (
+                Path(td) / "output" / "omnibor"
+                / "java" / "myapp" / "ts1"
+            )
+            assert not (
+                bom_dir / MANIFEST_FILENAME
+            ).exists()
+
+
+# ── _run_phase2_only ─────────────────────────────────────
+
+
+class TestRunPhase2Only:
+    """Tests for _run_phase2_only."""
+
+    @patch(
+        "app.pipeline.lang_runners"
+        ".generate_java_adg_spdx",
+    )
+    def test_reads_manifest_and_runs(self, mock_adg):
+        mock_adg.return_value = ["/tmp/adg.spdx.json"]
+        pipeline = _make_pipeline()
+
+        with tempfile.TemporaryDirectory() as td:
+            paths, repo_cfg, omnibor = _make_cfg(td)
+
+            # Write a valid manifest
+            manifest_dir = Path(td) / "manifest"
+            manifest_dir.mkdir()
+            manifest_file = (
+                manifest_dir / MANIFEST_FILENAME
+            )
+            manifest_data = {
+                "version": MANIFEST_VERSION,
+                "repo_name": "myapp",
+                "language": "java",
+                "mode": "sidecar",
+                "tracer": "maven-dep-tree",
+                "run_ts": "ts1",
+                "commit_sha": "abc123",
+                "vcs_uri": "https://example.com",
+                "artifacts": {
+                    "bom_dir": str(td),
+                    "binaries": [],
+                },
+                "paths": {
+                    "repos_dir": paths["repos_dir"],
+                    "output_dir": paths["output_dir"],
+                    "spdx_dir": str(td),
+                },
+                "repo_cfg": repo_cfg,
+                "omnibor_cfg": omnibor,
+                "gitoids": {},
+            }
+            manifest_file.write_text(
+                json.dumps(manifest_data)
+            )
+
+            timing = _run_phase2_only(
+                pipeline, "myapp",
+                str(manifest_file), paths,
+                omnibor, "ts1",
+                vcs_uri="https://example.com",
+            )
+
+            assert timing.success
+            assert timing.tracer == "maven-dep-tree"
+            # Phase 2 steps should be present
+            assert len(timing.steps) > 0
+
+    def test_missing_manifest_raises(self):
+        pipeline = _make_pipeline()
+
+        with tempfile.TemporaryDirectory() as td:
+            paths, _, omnibor = _make_cfg(td)
+
+            with pytest.raises(FileNotFoundError):
+                _run_phase2_only(
+                    pipeline, "myapp",
+                    "/nonexistent/manifest.json",
+                    paths, omnibor, "ts1",
+                )
+
+    @patch(
+        "app.pipeline.lang_runners"
+        ".generate_java_adg_spdx",
+    )
+    def test_tampered_artifact_warns(self, mock_adg):
+        mock_adg.return_value = []
+        pipeline = _make_pipeline()
+
+        with tempfile.TemporaryDirectory() as td:
+            paths, repo_cfg, omnibor = _make_cfg(td)
+
+            # Create an artifact file and record its gitoid
+            artifact = Path(td) / "treedb"
+            artifact.write_text("original")
+
+            from app.pipeline.manifest import (
+                _sha256_gitoid,
+            )
+            original_gitoid = _sha256_gitoid(artifact)
+
+            manifest_dir = Path(td) / "manifest"
+            manifest_dir.mkdir()
+            manifest_file = (
+                manifest_dir / MANIFEST_FILENAME
+            )
+            manifest_data = {
+                "version": MANIFEST_VERSION,
+                "repo_name": "myapp",
+                "language": "java",
+                "mode": "sidecar",
+                "tracer": "maven-dep-tree",
+                "run_ts": "ts1",
+                "commit_sha": "abc123",
+                "vcs_uri": "https://example.com",
+                "artifacts": {
+                    "bom_dir": str(td),
+                    "treedb": str(artifact),
+                    "binaries": [],
+                },
+                "paths": {
+                    "repos_dir": paths["repos_dir"],
+                    "output_dir": paths["output_dir"],
+                    "spdx_dir": str(td),
+                },
+                "gitoids": {
+                    str(artifact): original_gitoid,
+                },
+            }
+            manifest_file.write_text(
+                json.dumps(manifest_data)
+            )
+
+            # Tamper with the artifact
+            artifact.write_text("tampered!")
+
+            timing = _run_phase2_only(
+                pipeline, "myapp",
+                str(manifest_file), paths,
+                omnibor, "ts1",
+            )
+
+            # Should still succeed (warning, not error)
+            assert timing.success
+
+
+# ── Round-trip ───────────────────────────────────────────
+
+
+class TestPhaseRoundTrip:
+    """End-to-end: Phase 1 writes manifest,
+    Phase 2 reads it."""
+
+    @patch(
+        "app.pipeline.lang_runners"
+        "._select_java_strategy",
+    )
+    @patch(
+        "app.pipeline.lang_runners"
+        ".generate_java_adg_spdx",
+    )
+    def test_round_trip(
+        self, mock_adg, mock_strategy,
+    ):
+        mock_strategy.return_value = None
+        mock_adg.return_value = ["/tmp/adg.spdx.json"]
+        pipeline = _make_pipeline()
+
+        with tempfile.TemporaryDirectory() as td:
+            paths, repo_cfg, omnibor = _make_cfg(td)
+
+            # Create fake JAR
+            repo_dir = Path(td) / "repos" / "myapp"
+            target_dir = repo_dir / "target"
+            target_dir.mkdir(parents=True)
+            jar = target_dir / "myapp-1.0.jar"
+            jar.write_text("fake-jar")
+
+            # Phase 1: build + manifest
+            timing1 = _run_phase1_only(
+                pipeline, "myapp", repo_cfg,
+                paths, omnibor, "ts1",
+                mode="sidecar", lang="java",
+                commit_sha="abc123",
+                vcs_uri="https://example.com",
+            )
+            assert timing1.success
+
+            # Find the manifest
+            bom_dir = (
+                Path(td) / "output" / "omnibor"
+                / "java" / "myapp" / "ts1"
+            )
+            manifest_path = bom_dir / MANIFEST_FILENAME
+            assert manifest_path.exists()
+
+            # Phase 2: read manifest + SPDX
+            timing2 = _run_phase2_only(
+                pipeline, "myapp",
+                str(manifest_path), paths,
+                omnibor, "ts1",
+                vcs_uri="https://example.com",
+            )
+            assert timing2.success
+            assert len(timing2.steps) > 0
+
+            # Verify manifest was read correctly
+            manifest = read_manifest(manifest_path)
+            assert manifest["repo_name"] == "myapp"
+            assert manifest["language"] == "java"
+            assert manifest["mode"] == "sidecar"


### PR DESCRIPTION
## Summary

Wires `--phase build` / `--phase spdx` dispatch in `main()` for Java sidecar, with full integration test suite. Follows PR #176 which added the infrastructure (manifest, CLI args, phase1/phase2 split).

## Changes

### Modified: `app/pipeline/runners.py`
- `_run_phase1_only()` — runs Phase 1 build + writes `phase1_manifest.json` with artifact paths and gitoids
- `_run_phase2_only()` — reads manifest, verifies gitoids, runs Phase 2 SPDX generation
- Java `elif` branch now dispatches to phase-specific functions when `--phase` is set
- No `--phase` → existing `run_java_pipeline()` (zero behavior change)

### New: `tests/test_phase_isolation.py`
- 12 integration tests covering:
  - CLI validation (6 tests): sidecar requirement, manifest constraints
  - Phase 1 only (2 tests): manifest write, build failure skip
  - Phase 2 only (3 tests): manifest read, missing manifest, tampered artifact warning
  - Round-trip (1 test): Phase 1 writes manifest → Phase 2 reads it

## Testing

- **1421 passed**, 75 skipped, 0 failed
- **98% overall coverage** — all files ≥95%
- `manifest.py` 98%, `runners.py` 96%, `lang_runners.py` 95%

## Next: EC2 regression testing
- All 8 Java repos with `--mode sidecar` (no `--phase` — backward compat validation)
- Golden file comparison
- Build time comparison


