### PR TITLE
feat(java): wire shade plugin detector + Maven -am flag

### DIFF
--- a/app/pipeline/lang_runners.py
+++ b/app/pipeline/lang_runners.py
@@ -325,6 +325,9 @@ def generate_java_adg_spdx(
     were compiled into that specific JAR (traced via
     bomsh treedb hash_tree).
     """
+    from app.pipeline.maven_plugin_detector import (
+        detect_repackaging_plugins,
+    )
     from app.spdx.java_generator import JavaSpdxGenerator
     from app.spdx.parser import AdgParser
 
@@ -389,6 +392,14 @@ def generate_java_adg_spdx(
             f"{repo_name}"
         )
         return []
+
+    # Detect shade/assembly plugins for SPDX annotation
+    plugin_result = detect_repackaging_plugins(
+        str(repo_dir),
+    )
+    if plugin_result.is_uber_jar:
+        for det in plugin_result.detections:
+            print(f"[WARN] {repo_name}: {det.warning}")
 
     gen = JavaSpdxGenerator(
         bom_dir=str(bom_dir),
@@ -463,6 +474,7 @@ def generate_java_adg_spdx(
             sbom_type="analyzed",
             jar_files=jar_files,
             pom_dir=pom_dir,
+            plugin_detection=plugin_result,
         )
         if result:
             results.append(result)
@@ -478,6 +490,7 @@ def generate_java_adg_spdx(
             sbom_type="build",
             jar_files=jar_files,
             pom_dir=pom_dir,
+            plugin_detection=plugin_result,
         )
         if result:
             results.append(result)

--- a/app/pipeline/maven_dep_tree_parser.py
+++ b/app/pipeline/maven_dep_tree_parser.py
@@ -242,7 +242,7 @@ def run_maven_dep_tree(
         "-DoutputType=dot",
     ]
     if maven_modules:
-        cmd.extend(["-pl", maven_modules])
+        cmd.extend(["-pl", maven_modules, "-am"])
 
     # runner is accepted for interface consistency
     # with other pipeline functions but not yet used

--- a/app/pipeline/maven_plugin_detector.py
+++ b/app/pipeline/maven_plugin_detector.py
@@ -93,10 +93,11 @@ class DetectionResult:
         """
         if not self.detections:
             return ""
-        lines = []
+        seen = []
         for d in self.detections:
-            lines.append(d.warning)
-        return "; ".join(lines)
+            if d.warning not in seen:
+                seen.append(d.warning)
+        return "; ".join(seen)
 
     @property
     def plugin_ids(self) -> List[str]:

--- a/app/spdx/java_generator.py
+++ b/app/spdx/java_generator.py
@@ -397,7 +397,7 @@ class JavaSpdxGenerator:
     def generate(
         self, output_path, binary_name=None,
         sbom_type="build", jar_files=None,
-        pom_dir=None,
+        pom_dir=None, plugin_detection=None,
     ):
         """Generate SPDX for a Java JAR.
 
@@ -414,6 +414,10 @@ class JavaSpdxGenerator:
             pom_dir: optional directory containing the
                 module's pom.xml for per-module Maven
                 dependency resolution.
+            plugin_detection: optional ``DetectionResult``
+                from ``maven_plugin_detector``. When present
+                and a shade/assembly plugin is detected,
+                the SPDX ``creationInfo`` is annotated.
 
         Returns output path on success, None on failure.
         """
@@ -509,6 +513,7 @@ class JavaSpdxGenerator:
         doc = self._build_spdx(
             bin_name, source_files, maven_deps,
             sbom_type=sbom_type,
+            plugin_detection=plugin_detection,
         )
 
         # Write output
@@ -536,9 +541,35 @@ class JavaSpdxGenerator:
 
         return str(out)
 
+    @staticmethod
+    def _creation_info(created_ts, plugin_detection=None):
+        """Build SPDX ``creationInfo`` block.
+
+        When a repackaging plugin (shade, assembly) is
+        detected, appends the warning to the ``comment``
+        field so downstream consumers know the SBOM may
+        not reflect the full JAR contents.
+        """
+        info = {
+            "created": created_ts,
+            "creators": [
+                "Tool: omnibor-analysis",
+                "Tool: bomsh_create_bom_java.py",
+            ],
+            "licenseListVersion": "3.19",
+        }
+        if (
+            plugin_detection
+            and plugin_detection.spdx_comment
+        ):
+            info["comment"] = (
+                plugin_detection.spdx_comment
+            )
+        return info
+
     def _build_spdx(
         self, bin_name, source_files, maven_deps,
-        sbom_type="build",
+        sbom_type="build", plugin_detection=None,
     ):
         """Build SPDX 2.3 document.
 
@@ -546,6 +577,10 @@ class JavaSpdxGenerator:
           'analyzed' — only source files compiled into
               the JAR (thin JAR has zero bundled deps)
           'build' — full Maven dependency graph
+
+        plugin_detection: optional ``DetectionResult``;
+          when present, annotates ``creationInfo.comment``
+          with repackaging plugin warnings.
         """
         now = datetime.now(timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
@@ -566,14 +601,9 @@ class JavaSpdxGenerator:
                 f"https://omnibor.io/spdx/"
                 f"{self.repo_name}/{doc_uuid}"
             ),
-            "creationInfo": {
-                "created": now,
-                "creators": [
-                    "Tool: omnibor-analysis",
-                    "Tool: bomsh_create_bom_java.py",
-                ],
-                "licenseListVersion": "3.19",
-            },
+            "creationInfo": self._creation_info(
+                now, plugin_detection,
+            ),
             "packages": [],
             "files": [],
             "relationships": [],

--- a/tests/test_java_generator.py
+++ b/tests/test_java_generator.py
@@ -1963,5 +1963,56 @@ class TestAddBuildToolsGradle(unittest.TestCase):
         self.assertIn("javac", names)
 
 
+class TestCreationInfo(unittest.TestCase):
+    """Tests for _creation_info static method."""
+
+    def test_without_plugin_detection(self):
+        info = JavaSpdxGenerator._creation_info(
+            "2026-01-01T00:00:00Z",
+        )
+        self.assertEqual(
+            info["created"], "2026-01-01T00:00:00Z",
+        )
+        self.assertIn(
+            "Tool: omnibor-analysis", info["creators"],
+        )
+        self.assertNotIn("comment", info)
+
+    def test_with_no_plugins_detected(self):
+        from app.pipeline.maven_plugin_detector import (
+            DetectionResult,
+        )
+        result = DetectionResult()
+        info = JavaSpdxGenerator._creation_info(
+            "2026-01-01T00:00:00Z", result,
+        )
+        self.assertNotIn("comment", info)
+
+    def test_with_shade_plugin(self):
+        from app.pipeline.maven_plugin_detector import (
+            DetectionResult,
+            PluginDetection,
+        )
+        result = DetectionResult(detections=[
+            PluginDetection(
+                plugin_id="maven-shade-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="shade detected — uber-JAR",
+                pom_path="/pom.xml",
+            ),
+        ])
+        info = JavaSpdxGenerator._creation_info(
+            "2026-01-01T00:00:00Z", result,
+        )
+        self.assertIn("comment", info)
+        self.assertIn("shade", info["comment"])
+
+    def test_with_none_plugin_detection(self):
+        info = JavaSpdxGenerator._creation_info(
+            "2026-01-01T00:00:00Z", None,
+        )
+        self.assertNotIn("comment", info)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_maven_dep_tree_parser.py
+++ b/tests/test_maven_dep_tree_parser.py
@@ -471,6 +471,43 @@ class TestRunMavenDepTree(unittest.TestCase):
                 result = run_maven_dep_tree(td)
             self.assertIsNone(result)
 
+    @patch("app.pipeline.maven_dep_tree_parser"
+           ".subprocess.run")
+    def test_maven_modules_passes_pl_and_am(
+        self, mock_run,
+    ):
+        """When maven_modules is set, -pl and -am must
+        both be passed to mvn dependency:tree."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "pom.xml").touch()
+            run_maven_dep_tree(
+                td, maven_modules="crawler4j",
+            )
+        args = mock_run.call_args
+        cmd = args[0][0]
+        self.assertIn("-pl", cmd)
+        self.assertIn("crawler4j", cmd)
+        self.assertIn("-am", cmd)
+
+    @patch("app.pipeline.maven_dep_tree_parser"
+           ".subprocess.run")
+    def test_no_maven_modules_no_pl(self, mock_run):
+        """Without maven_modules, -pl and -am must NOT
+        appear in the command."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "pom.xml").touch()
+            run_maven_dep_tree(td)
+        args = mock_run.call_args
+        cmd = args[0][0]
+        self.assertNotIn("-pl", cmd)
+        self.assertNotIn("-am", cmd)
+
 
 # ============================================================
 # Tests: InterceptionStrategy / MavenDepTreeStrategy

--- a/tests/test_maven_plugin_detector.py
+++ b/tests/test_maven_plugin_detector.py
@@ -388,6 +388,54 @@ class TestDetectionResult(unittest.TestCase):
             r.plugin_ids, ["maven-shade-plugin"],
         )
 
+    def test_spdx_comment_dedup(self):
+        """Duplicate warnings from multi-module POMs
+        should appear only once in spdx_comment."""
+        r = DetectionResult(detections=[
+            PluginDetection(
+                plugin_id="maven-shade-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="shade detected",
+                pom_path="/core/pom.xml",
+            ),
+            PluginDetection(
+                plugin_id="maven-shade-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="shade detected",
+                pom_path="/cli/pom.xml",
+            ),
+        ])
+        self.assertEqual(
+            r.spdx_comment, "shade detected",
+        )
+
+    def test_spdx_comment_dedup_mixed(self):
+        """Different warnings are preserved, duplicates
+        are collapsed."""
+        r = DetectionResult(detections=[
+            PluginDetection(
+                plugin_id="maven-shade-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="shade",
+                pom_path="/a/pom.xml",
+            ),
+            PluginDetection(
+                plugin_id="maven-shade-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="shade",
+                pom_path="/b/pom.xml",
+            ),
+            PluginDetection(
+                plugin_id="maven-assembly-plugin",
+                group_id="org.apache.maven.plugins",
+                warning="assembly",
+                pom_path="/c/pom.xml",
+            ),
+        ])
+        self.assertEqual(
+            r.spdx_comment, "shade; assembly",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Replaces closed PR #157 (stale branch with 423K-line diff). Clean reimplementation of two features on a fresh branch from current `main`.

## Changes

### Feature 1: Shade plugin SPDX annotation

- `generate_java_adg_spdx()` now calls `detect_repackaging_plugins()` before SPDX generation
- When shade/assembly plugins detected, prints `[WARN]` and passes `DetectionResult` to generator
- `JavaSpdxGenerator.generate()` accepts `plugin_detection` parameter
- New `_creation_info()` static method annotates SPDX `creationInfo.comment` with plugin warnings
- `DetectionResult.spdx_comment` deduplicates identical warnings from multi-module POMs

### Feature 2: Maven `-am` flag for multi-module dep:tree

- `run_maven_dep_tree()` now always passes `-am` (also-make) alongside `-pl`
- Required for correct dependency resolution when targeting submodules

### Tests added

- `test_spdx_comment_dedup` / `test_spdx_comment_dedup_mixed` — dedup validation
- `test_maven_modules_passes_pl_and_am` / `test_no_maven_modules_no_pl` — command construction
- `TestCreationInfo` class (4 tests) — `_creation_info()` with/without plugin detection

## Verification

- 1433 tests pass, 0 failures
- 98% overall coverage, all files ≥95%
- Import clean (`import app` succeeds)
