### PR TITLE
feat: optimize Phase 1 ADG step (split timing, offline mode, skip flags)

### DIFF
--- a/app/pipeline/gradle_dep_tree_parser.py
+++ b/app/pipeline/gradle_dep_tree_parser.py
@@ -30,6 +30,12 @@ def run_gradle_dep_tree(
 ):
     """Run ``./gradlew dependencies`` for a project.
 
+    Runs in offline mode (``--offline``) because this is
+    called after a successful build — the Gradle cache is
+    guaranteed complete.  Omits ``--no-daemon`` so the build
+    daemon (if still warm from the build) can serve the
+    query without a cold JVM start.
+
     Args:
         repo_dir: Path to the repository root.
         project: Optional Gradle subproject name.
@@ -56,7 +62,7 @@ def run_gradle_dep_tree(
             [
                 str(gradlew), task,
                 "--configuration", "runtimeClasspath",
-                "--no-daemon", "-q",
+                "--offline", "-q",
             ],
             cwd=str(repo_path),
             capture_output=True,

--- a/app/pipeline/interception.py
+++ b/app/pipeline/interception.py
@@ -17,7 +17,27 @@ Design reference:
     Implementation Design §4.4 — Interception Strategy
 """
 
+import json
+import time
 from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+def _write_adg_substeps(bom_path, substeps):
+    """Write ADG sub-step timings to ``adg_substeps.json``.
+
+    Called by ``generate_adg()`` implementations to persist
+    the wall-clock breakdown (treedb vs dep:tree) for
+    performance analysis.
+
+    Args:
+        bom_path: ``Path`` to the OmniBOR output directory.
+        substeps: List of timing dicts with ``name``,
+            ``tool``, and ``wall_sec`` keys.
+    """
+    out = bom_path / "adg_substeps.json"
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(substeps, f, indent=2)
 
 
 class InterceptionStrategy(ABC):
@@ -294,17 +314,19 @@ class MavenDepTreeStrategy(InterceptionStrategy):
         2. ``mvn dependency:tree`` captures the declared
            Maven dependency graph.
 
+        Sub-step wall-clock timings are written to
+        ``adg_substeps.json`` in *bom_dir* for
+        performance analysis.
+
         Returns:
             True on success, False on failure.
         """
-        import json
-        from pathlib import Path
-
         from app.pipeline.maven_dep_tree_parser import (
             parse_dot_output,
             run_maven_dep_tree,
         )
 
+        substeps = []
         bom_path = Path(bom_dir)
         bom_path.mkdir(parents=True, exist_ok=True)
         meta_dir = bom_path / "metadata" / "bomsh"
@@ -318,6 +340,7 @@ class MavenDepTreeStrategy(InterceptionStrategy):
             "bomsh_create_bom_java.py",
         )
         treedb_file = meta_dir / "bomsh_omnibor_treedb"
+        t0 = time.monotonic()
         rc = self._runner.run(
             f"{create_bom} -r {repo_dir} "
             f"-j {treedb_file}",
@@ -327,24 +350,39 @@ class MavenDepTreeStrategy(InterceptionStrategy):
                 "for Java workspace"
             ),
         )
+        treedb_sec = time.monotonic() - t0
+        substeps.append({
+            "name": "treedb",
+            "tool": "bomsh_create_bom_java.py",
+            "wall_sec": round(treedb_sec, 2),
+        })
         if rc != 0:
             print(
                 "[ERROR] bomsh_create_bom_java.py "
                 "failed"
             )
+            _write_adg_substeps(bom_path, substeps)
             return False
 
         print(
             f"[OK] OmniBOR treedb written to "
-            f"{treedb_file}"
+            f"{treedb_file} ({treedb_sec:.1f}s)"
         )
 
         # Step 2: Capture Maven dependency graph
+        t0 = time.monotonic()
         dot_output = run_maven_dep_tree(
             repo_dir, runner=self._runner,
             maven_modules=self._maven_modules,
         )
+        deptree_sec = time.monotonic() - t0
+        substeps.append({
+            "name": "dep_tree",
+            "tool": "mvn dependency:tree",
+            "wall_sec": round(deptree_sec, 2),
+        })
         if dot_output is None:
+            _write_adg_substeps(bom_path, substeps)
             return False
 
         deps = parse_dot_output(dot_output)
@@ -361,7 +399,9 @@ class MavenDepTreeStrategy(InterceptionStrategy):
         print(
             f"[OK] Maven dep:tree: "
             f"{len(deps)} dependencies → {out_file}"
+            f" ({deptree_sec:.1f}s)"
         )
+        _write_adg_substeps(bom_path, substeps)
         return True
 
 
@@ -409,16 +449,18 @@ class GradleDepTreeStrategy(InterceptionStrategy):
         2. ``./gradlew dependencies`` captures the declared
            Gradle dependency graph per subproject.
 
+        Sub-step wall-clock timings are written to
+        ``adg_substeps.json`` in *bom_dir* for
+        performance analysis.
+
         Returns:
             True on success, False on failure.
         """
-        import json
-        from pathlib import Path
-
         from app.pipeline.gradle_dep_tree_parser import (
             get_all_gradle_deps,
         )
 
+        substeps = []
         bom_path = Path(bom_dir)
         bom_path.mkdir(parents=True, exist_ok=True)
         meta_dir = bom_path / "metadata" / "bomsh"
@@ -432,6 +474,7 @@ class GradleDepTreeStrategy(InterceptionStrategy):
             "bomsh_create_bom_java.py",
         )
         treedb_file = meta_dir / "bomsh_omnibor_treedb"
+        t0 = time.monotonic()
         rc = self._runner.run(
             f"{create_bom} -r {repo_dir} "
             f"-j {treedb_file}",
@@ -441,20 +484,34 @@ class GradleDepTreeStrategy(InterceptionStrategy):
                 "for Java workspace"
             ),
         )
+        treedb_sec = time.monotonic() - t0
+        substeps.append({
+            "name": "treedb",
+            "tool": "bomsh_create_bom_java.py",
+            "wall_sec": round(treedb_sec, 2),
+        })
         if rc != 0:
             print(
                 "[ERROR] bomsh_create_bom_java.py "
                 "failed"
             )
+            _write_adg_substeps(bom_path, substeps)
             return False
 
         print(
             f"[OK] OmniBOR treedb written to "
-            f"{treedb_file}"
+            f"{treedb_file} ({treedb_sec:.1f}s)"
         )
 
         # Step 2: Capture Gradle dependency graph
+        t0 = time.monotonic()
         deps = get_all_gradle_deps(repo_dir)
+        deptree_sec = time.monotonic() - t0
+        substeps.append({
+            "name": "dep_tree",
+            "tool": "gradlew dependencies",
+            "wall_sec": round(deptree_sec, 2),
+        })
         if not deps:
             print(
                 "[WARN] No dependencies found in "
@@ -468,5 +525,7 @@ class GradleDepTreeStrategy(InterceptionStrategy):
         print(
             f"[OK] Gradle dep:tree: "
             f"{len(deps)} dependencies → {out_file}"
+            f" ({deptree_sec:.1f}s)"
         )
+        _write_adg_substeps(bom_path, substeps)
         return True

--- a/app/pipeline/maven_dep_tree_parser.py
+++ b/app/pipeline/maven_dep_tree_parser.py
@@ -216,6 +216,11 @@ def run_maven_dep_tree(
 ):
     """Run ``mvn dependency:tree -DoutputType=dot``.
 
+    Runs in offline mode (``-o``) because this is called
+    after a successful build — the local ``.m2/repository``
+    cache is guaranteed complete.  Skip flags prevent
+    lifecycle plugins from firing unnecessarily.
+
     Args:
         repo_dir: Path to the repository root (must
             contain ``pom.xml``).
@@ -240,6 +245,11 @@ def run_maven_dep_tree(
     cmd = [
         "mvn", "dependency:tree",
         "-DoutputType=dot",
+        "-o",
+        "-DskipTests",
+        "-Dmaven.javadoc.skip=true",
+        "-Denforcer.skip=true",
+        "-Dcheckstyle.skip=true",
     ]
     if maven_modules:
         cmd.extend(["-pl", maven_modules, "-am"])

--- a/docs/deep-dive/bomsh-java-performance-optimization.md
+++ b/docs/deep-dive/bomsh-java-performance-optimization.md
@@ -1,0 +1,277 @@
+# `bomsh_create_bom_java.py` Performance Optimization
+
+| **Status** | TODO — analysis complete, implementation pending |
+|---|---|
+| **Date** | June 16, 2026 |
+| **Author** | OmniBOR Analysis project |
+| **Related** | `docs/deep-dive/phase-isolation-build-time-analysis.md` |
+
+---
+
+## 1. Problem Statement
+
+Split timing data from EC2 runs (June 16, 2026) revealed that
+`bomsh_create_bom_java.py` is the dominant bottleneck in the Phase 1
+post-build `adg` step — not the JVM dep:tree commands as originally
+hypothesized.
+
+| Repo | `bomsh_create_bom_java.py` | dep:tree | % treedb |
+|------|---------------------------|----------|----------|
+| dependency-check (Maven) | 240.85s | 3.47s | **98.6%** |
+| spring-boot (Gradle) | 486.09s | 139.64s | **77.7%** |
+
+The script processes 55,673 treedb entries for dependency-check and
+113,524 for spring-boot.
+
+---
+
+## 2. Script Architecture
+
+The upstream script (`/opt/bomsh/scripts/bomsh_create_bom_java.py`,
+918 lines, from [omnibor/bomsh](https://github.com/omnibor/bomsh))
+processes each JAR file through the following pipeline:
+
+1. **Extract JAR** — `jar -xf` to `/tmp/bomjdir/<jar>/`
+2. **Find `.class` files** — `find ... -name "*.class"`
+3. **Read `SourceFile` attributes** — already optimized (pure-Python
+   bytecode reader, see `docker/patches/bomsh_java_fast_classreader.py`)
+4. **Per `.class` file loop**:
+   - Match against built `.class` files via `diff -q` (subprocess)
+   - Compute `git hash-object` for the `.class` file (subprocess)
+   - Resolve source `.java` file via path similarity
+   - Compute `git hash-object` for the `.java` file (subprocess)
+   - Update treedb and gitBOM doc structures
+5. **Serialize treedb** — `json.dump()` with `indent=4, sort_keys=True`
+
+---
+
+## 3. Root Cause: Subprocess Spawning Per File
+
+The script shells out to external commands for operations that have
+trivial pure-Python equivalents. For a project with N `.class` files,
+this creates **~3N subprocess spawns** (two `git hash-object` + one
+`diff -q` per file), plus overhead from `find` and `jar -xf`.
+
+### Subprocess Call Inventory
+
+| Function | Line | Command | Calls per JAR | Purpose |
+|----------|------|---------|---------------|---------|
+| `get_git_file_hash` | 761 | `git hash-object <file>` | 2 × N `.class` files | SHA-1 hash of class + source |
+| `is_same_file_content` | 204 | `diff -q <a> <b>` | N `.class` files | Match unbundled to built |
+| `find_all_suffix_files` | 217 | `find <dir> -name "*.class"` | 1 per JAR | List extracted classes |
+| `unbundle_jar_file` | 669 | `rm -rf; mkdir; jar -xf` | 1 per JAR | Extract JAR contents |
+| `get_filetype` | 146 | `file <jar>` | 1 per JAR | Check if file is archive |
+
+### Cost Model
+
+Each `fork+exec` costs ~3-5ms on Linux. For dependency-check:
+
+- ~6,000 `.class` files × 3 subprocess calls = **~18,000 subprocesses**
+- At 5ms each = **~90 seconds** in process creation alone
+- Remaining time: disk I/O (extract, read, hash) + JSON serialization
+
+For spring-boot (113K treedb entries), the subprocess count is
+proportionally higher.
+
+---
+
+## 4. Optimization Plan
+
+All optimizations use the same Docker patch pattern established by
+`docker/patches/apply_fast_javap.py` — monkey-patching upstream
+functions at Docker build time without modifying the upstream repo.
+
+### 4.1 Pure-Python `git hash-object` (Highest Impact)
+
+**Eliminates: ~12,000+ subprocess spawns**
+
+Git's object hash is `SHA-1("blob <size>\0<content>")`. This is a
+one-line Python replacement:
+
+```python
+import hashlib
+
+def get_git_file_hash(afile):
+    with open(afile, 'rb') as f:
+        data = f.read()
+    header = f"blob {len(data)}\0".encode()
+    return hashlib.sha1(header + data).hexdigest()
+```
+
+Python's `hashlib.sha1` uses OpenSSL's hardware-accelerated
+implementation. Each call takes ~10μs vs ~5ms for `git hash-object`.
+
+**Estimated savings: 60–120s** (dependency-check), proportionally
+more for spring-boot.
+
+### 4.2 Python `filecmp.cmp()` Instead of `diff -q` (High Impact)
+
+**Eliminates: ~6,000 subprocess spawns**
+
+`is_same_file_content` (line 204) shells out to `diff -q` to compare
+file contents. Python's `filecmp.cmp(shallow=False)` does a
+byte-for-byte comparison without forking:
+
+```python
+import filecmp
+
+def is_same_file_content(afile, bfile):
+    return filecmp.cmp(afile, bfile, shallow=False)
+```
+
+**Estimated savings: 30–60s.**
+
+### 4.3 Python `os.walk()` Instead of `find` (Medium Impact)
+
+**Eliminates: ~10 subprocess spawns + avoids shell quoting issues**
+
+`find_all_suffix_files` (line 217) shells out to `find`. Python's
+`os.walk` is faster for small-to-medium directory trees and avoids
+shell injection risks from filenames with special characters:
+
+```python
+def find_all_suffix_files(builddir, suffix):
+    result = []
+    for root, _dirs, files in os.walk(builddir):
+        for f in files:
+            if f.endswith(suffix):
+                result.append(os.path.join(root, f))
+    return result
+```
+
+**Estimated savings: <1s** (few calls), but improves correctness.
+
+### 4.4 Python `zipfile` Instead of `jar -xf` (Medium Impact)
+
+**Eliminates: disk I/O for extraction + subprocess spawns**
+
+JARs are ZIP files. Python's `zipfile` can extract them, or better,
+read `.class` file contents **in-memory** without writing to disk:
+
+```python
+import zipfile
+
+def process_jar_file_fast(jarfile, rootdir):
+    with zipfile.ZipFile(jarfile) as zf:
+        classfiles = [n for n in zf.namelist()
+                      if n.endswith('.class')]
+        for name in classfiles:
+            data = zf.read(name)
+            # Parse SourceFile from data (already have bytecode reader)
+            # Compute git hash from data (no disk write needed)
+```
+
+This eliminates the entire `unbundle_jar_file` → `find` →
+`shutil.rmtree` cycle. However, this is a deeper refactor since the
+current `process_class_file` function expects file paths, not
+in-memory data. A simpler first step is to just replace `jar -xf`
+with `zipfile.extractall()`.
+
+**Estimated savings: 5–10s** (eliminates temp dir lifecycle).
+
+### 4.5 Parallel File Hashing (Medium Impact)
+
+**CPU parallelism for I/O-bound + hash-bound workload**
+
+Even with pure-Python hashing, processing 12,000+ files sequentially
+has I/O latency. Thread-based parallelism helps because file reads
+release the GIL:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+def hash_files_parallel(files, max_workers=4):
+    with ThreadPoolExecutor(max_workers) as pool:
+        return dict(zip(files, pool.map(get_git_file_hash, files)))
+```
+
+**Estimated savings: 30–50% of remaining time** after patches 4.1–4.4.
+
+### 4.6 Faster JSON Serialization (Low Impact)
+
+`save_json_db` (line 173) uses `json.dump(db, f, indent=4,
+sort_keys=True)`. For 113K entries, this is measurable. Options:
+
+- Drop `indent=4` (compact JSON) — saves string allocation
+- Use `orjson` or `ujson` if available (3–5x faster)
+- Use MessagePack/CBOR for binary format (not human-readable)
+
+**Estimated savings: 2–5s** for spring-boot scale.
+
+---
+
+## 5. Implementation Priority
+
+| Priority | Optimization | Patch file | Subprocess calls eliminated | Est. savings |
+|----------|-------------|------------|---------------------------|-------------|
+| **P0** | Pure-Python `git hash-object` | `apply_fast_hashing.py` | ~12,000+ | 60–120s |
+| **P1** | Python `filecmp.cmp()` | `apply_fast_hashing.py` | ~6,000 | 30–60s |
+| **P2** | Python `os.walk()` | `apply_fast_hashing.py` | ~10 | <1s |
+| **P3** | Python `zipfile.extractall()` | `apply_fast_hashing.py` | ~10 | 5–10s |
+| **P4** | Parallel file hashing | `apply_fast_hashing.py` | 0 (parallelism) | 30–50% |
+| **P5** | Faster JSON serialization | `apply_fast_hashing.py` | 0 | 2–5s |
+
+P0 + P1 alone should reduce the treedb step from **240s → ~30-60s**
+for dependency-check and from **486s → ~100-150s** for spring-boot.
+
+---
+
+## 6. Implementation Approach
+
+All patches will be applied via a new Docker patch script following
+the established pattern:
+
+```text
+docker/patches/
+├── apply_fast_javap.py          # existing: javap → bytecode reader
+├── apply_fast_hashing.py        # new: git/diff/find → pure Python
+└── bomsh_java_fast_classreader.py  # existing: bytecode reader module
+```
+
+The Dockerfile will add a step after the existing `apply_fast_javap.py`:
+
+```dockerfile
+COPY docker/patches/apply_fast_hashing.py /tmp/
+RUN python3 /tmp/apply_fast_hashing.py && rm /tmp/apply_fast_hashing.py
+```
+
+### Validation
+
+After implementing each patch:
+
+1. Run dependency-check + spring-boot on EC2
+2. Verify `adg_substeps.json` shows reduced treedb time
+3. Compare SPDX output against golden files (must be identical)
+4. Verify treedb entry counts match previous runs
+
+---
+
+## 7. Previously Completed Optimization
+
+The `javap` → pure-Python bytecode reader optimization was implemented
+in a prior session and is already deployed:
+
+| Before | After |
+|--------|-------|
+| `javap` subprocess per `.class` file (~1s each) | Pure-Python `.class` parser (~10μs each) |
+| 6,000 class files: ~100 minutes | 6,000 class files: <1 second |
+
+**Patch**: `docker/patches/apply_fast_javap.py`
+
+**Module**: `docker/patches/bomsh_java_fast_classreader.py`
+
+This optimization eliminated the `javap` bottleneck completely, which
+is what exposed `git hash-object` and `diff -q` as the next-largest
+costs.
+
+---
+
+## 8. Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Pure-Python SHA-1 produces different hash than `git hash-object` | Unit test: hash known files, compare against `git hash-object` output |
+| `filecmp.cmp` has different semantics than `diff -q` | Both do byte-for-byte comparison; `shallow=False` ensures no stat-only shortcut |
+| `zipfile` cannot read corrupted/non-standard JARs | Fall back to `jar -xf` on `BadZipFile` exception |
+| Parallel hashing introduces race conditions in treedb | Hash in parallel, update treedb sequentially (collect results first) |
+| Upstream bomsh updates may conflict with patches | `apply_fast_hashing.py` uses regex matching like `apply_fast_javap.py`; pin bomsh commit in Dockerfile |

--- a/docs/deep-dive/phase-isolation-build-time-analysis.md
+++ b/docs/deep-dive/phase-isolation-build-time-analysis.md
@@ -330,14 +330,122 @@ are the only ones that benefit from the optimizations above.
 
 ---
 
-## 7. Next Steps
+## 7. EC2 Validation Results (June 16, 2026)
 
-1. **Run on EC2** with split timing enabled against dependency-check
-   (Maven) and spring-boot (Gradle) to get actual treedb vs dep:tree
-   breakdown
+Both repos ran successfully with split timing. SPDX output compared
+against golden files with **zero regressions**.
+
+### Split Timing Breakdown
+
+#### dependency-check (Maven)
+
+| Sub-step | Tool | Wall time | % of `adg` |
+|----------|------|-----------|------------|
+| **treedb** | `bomsh_create_bom_java.py` | **240.85s** | **98.6%** |
+| **dep_tree** | `mvn dependency:tree` | **3.47s** | **1.4%** |
+| **Total `adg`** | — | **244.32s** | 100% |
+
+#### spring-boot (Gradle)
+
+| Sub-step | Tool | Wall time | % of `adg` |
+|----------|------|-----------|------------|
+| **treedb** | `bomsh_create_bom_java.py` | **486.09s** | **77.7%** |
+| **dep_tree** | `gradlew dependencies` | **139.64s** | **22.3%** |
+| **Total `adg`** | — | **625.74s** | 100% |
+
+### Before/After Comparison
+
+| Repo | Previous `adg` (May 12) | Current `adg` (Jun 16) | Change |
+|------|------------------------|------------------------|--------|
+| dependency-check | 218.45s | 244.32s | +12% (run variance) |
+| spring-boot | 1,222.88s | **625.74s** | **-49% improvement** |
+
+### Golden File Validation
+
+```text
+dependency-check: RESULT: All files identical — no changes
+spring-boot:      RESULT: All files identical — no changes
+```
+
+### Key Findings
+
+1. **`bomsh_create_bom_java.py` is the real bottleneck**, not
+   `mvn dependency:tree`. For Maven, dep:tree is only 1.4% of
+   the `adg` step after adding `-o` and skip flags.
+
+2. **Gradle improvement is massive (49%).** The previous 1,222s
+   `adg` step dropped to 625s. The `--no-daemon` → `--offline`
+   change cut Gradle dep:tree from an estimated ~750s to 139s
+   (a ~5x improvement) by reusing the warm Gradle daemon.
+
+3. **For Maven, optimization effort should shift to
+   `bomsh_create_bom_java.py`** — the JVM dep:tree command
+   was never the bottleneck. The 3.47s dep:tree proves that
+   offline mode + skip flags effectively eliminate it as a
+   concern.
+
+4. **For Gradle, further optimization is available** through
+   single-invocation multi-project queries (currently runs
+   per-subproject, each starting the daemon query process).
+
+5. **No SPDX regressions** — golden files are identical,
+   confirming that offline mode does not change dependency
+   resolution results (as expected, since the cache was just
+   populated by the build).
+
+---
+
+## 8. Revised Bottleneck Analysis
+
+The original hypothesis was that JVM startup for dep:tree commands
+was the primary Phase 1 post-build bottleneck. Split timing
+**disproved** this for Maven and **partially confirmed** it for
+Gradle:
+
+| Repo | True bottleneck | Secondary |
+|------|----------------|-----------|
+| dependency-check (Maven) | `bomsh_create_bom_java.py` (98.6%) | `mvn dep:tree` (1.4%) |
+| spring-boot (Gradle) | `bomsh_create_bom_java.py` (77.7%) | `gradlew deps` (22.3%) |
+
+### Why `bomsh_create_bom_java.py` is slow
+
+The script processes 113,524 checksums for spring-boot (55,673 for
+dependency-check). For each `.class` file it must:
+
+1. Read the `.class` file and compute SHA-256
+2. Parse the `SourceFile` bytecode attribute
+3. Walk the source tree to resolve the `.java` file by path
+   similarity
+4. Compute SHA-256 for the source file
+5. Update the treedb JSON structure
+
+This is fundamentally I/O-bound (thousands of small file reads) and
+CPU-bound (SHA-256 computation + JSON serialization). Optimization
+paths include:
+
+- **Parallel file processing** — `bomsh_create_bom_java.py` appears
+  to be single-threaded. Parallelizing file reads + hashing across
+  CPU cores could cut time proportionally.
+- **Pre-computed source hashes** — if the build system already has
+  source file checksums (e.g., from incremental compilation cache),
+  reuse them instead of rehashing.
+- **Binary treedb format** — JSON serialization of 113K entries is
+  expensive. A binary format (MessagePack, CBOR) would be faster.
+
+These are upstream `bomsh` optimizations, not changes to
+`omnibor-analysis`.
+
+---
+
+## 9. Next Steps
+
+1. ~~Run on EC2 with split timing~~ — **Done** (June 16, 2026)
 2. **Implement parallel execution** of treedb + dep:tree
-   (`concurrent.futures.ThreadPoolExecutor`)
-3. **Wire aggressive `-pl` module targeting** from `config.yaml` for
-   multi-module Maven projects
-4. **Measure before/after** — compare the optimized `adg` timings
-   against the pre-optimization baselines documented in this file
+   (`concurrent.futures.ThreadPoolExecutor`) — still beneficial
+   for Gradle where dep:tree is 22% of `adg`
+3. **Wire aggressive `-pl` module targeting** from `config.yaml`
+   for multi-module Maven projects
+4. **Investigate `bomsh_create_bom_java.py` parallelization** —
+   this is now the dominant bottleneck for both orchestrators
+5. **Single-invocation Gradle query** — reduce per-subproject
+   JVM overhead in `get_all_gradle_deps()`

--- a/docs/deep-dive/phase-isolation-build-time-analysis.md
+++ b/docs/deep-dive/phase-isolation-build-time-analysis.md
@@ -1,0 +1,343 @@
+# Phase Isolation: Build-Time Impact Analysis
+
+**Date:** June 16, 2026
+
+**Context:** Deep-dive investigation into Phase 1 build-time impact,
+source tree access in Phase 2, and ADG step optimization. This document
+captures the full Q&A exchange that led to the optimizations implemented
+in `feat/adg-phase1-optimization`.
+
+**Related documents:**
+
+- `docs/features/phase-isolation/phase-isolation-system-test.md`
+- `docs/deep-dive/phase-isolation-gap-analysis.md`
+- `docs/deep-dive/sidecar-java-design.md`
+
+---
+
+## 1. The Phase 2 Source Tree Question
+
+### User Question
+
+> "But an SBOM generator shouldn't need the source tree in Phase 2 — it
+> should work entirely from build artifacts" is arguably not correct,
+> especially if `omnibor-analysis` overall benefits from a less impactful
+> build-time execution because Phase 2 could be generating SHAs from
+> source files, if necessary. DO NOT FORGET BUILD TIME SPEED IS CRITICAL,
+> or rather Phase 1 impact on build time speed is critical, must be as
+> minimal as possible.
+
+### Analysis
+
+The blanket statement "Phase 2 shouldn't need the source tree" was a
+premature architectural pronouncement. The correct lens is: **what
+minimizes Phase 1's impact on the customer's build time?**
+
+Phase 1 currently performs two post-build operations in the `adg` step:
+
+1. `bomsh_create_bom_java.py` — scans `.class` files for `SourceFile`
+   bytecode attributes, resolves to `.java` source files via path
+   similarity, computes SHA-256 hashes for every source file and class
+   file, writes treedb
+2. `mvn dependency:tree` / `./gradlew dependencies` — starts a new JVM,
+   resolves the full dependency graph
+
+Real timing data from EC2 runs (combined `adg` step):
+
+| Repo | Orchestrator | `adg` wall time | Build time | adg as % of build |
+|------|-------------|-----------------|------------|-------------------|
+| dependency-check | Maven | **218s** | 30s | 727% |
+| spring-boot | Gradle | **1,223s** (20 min) | 56s | 2,184% |
+| jsoup | Maven | 4s | 26s | 15% |
+
+For large projects, the Phase 1 post-build overhead **dwarfs** the
+actual build.
+
+### Key Constraint (User Correction)
+
+> "Also REMEMBER, we are NOT doing a git clone in Phase 1, the native
+> build environment is. There has not been any reason for
+> `omnibor-analysis` to have credentialed access to dev team repos!"
+
+- The customer's CI/CD pipeline clones their repo
+- Phase 1 sidecar reads the already-cloned workspace via shared volume
+- `omnibor-analysis` has never needed and should never need credentialed
+  access to customer repos
+- The `actions/checkout` in `omnibor-java-testapp`'s Phase 2 job is a
+  **test convenience**, not the enterprise architecture
+
+---
+
+## 2. Source File SHA Computation — Does It Matter?
+
+### User Question
+
+> "Phase 2 would compute the SHA-256 hashes later" — but only source
+> code hashes. What about intermediate files like class files, object
+> files, etc.? If Phase 1 already has to create hashes for these
+> intermediate files, does creating a hash for the corresponding source
+> file add a significant impact that would make it valuable to do in
+> Phase 2?
+
+### Analysis: No — Source File Hashing Is Negligible
+
+If Phase 1 is already:
+
+1. Reading every `.class` file (to extract the `SourceFile` bytecode
+   attribute)
+2. Computing SHA-256 for every `.class` file
+3. Computing SHA-256 for the `.jar` file
+
+...then the marginal cost of also computing SHA-256 for the
+corresponding `.java` source file is **negligible**:
+
+- **`.java` files are smaller than `.class` files.** Source files have
+  no constant pool, no bytecode instructions, no attribute tables. A
+  typical `.java` file is a few KB.
+- **SHA-256 is hardware-accelerated.** Modern CPUs (x86 with SHA-NI,
+  ARM with crypto extensions) compute SHA-256 at memory bandwidth
+  speed. Hashing a 5KB file takes microseconds.
+- **The source file is likely already in OS page cache.** The Java
+  compiler just read it seconds ago during the build.
+- **The I/O pattern is sequential.** One `open()` + `read()` +
+  `close()` per file, on warm cache.
+
+For context: dependency-check has ~1,300 source files. At ~5KB average,
+that's ~6.5MB of source file I/O and hashing — **sub-second** on any
+modern disk or SSD, buried in noise compared to the 218 seconds the
+`adg` step takes overall.
+
+### Conclusion
+
+The suggestion to defer source file hashing to Phase 2 was solving a
+non-problem. The source file hashing is a rounding error on top of the
+intermediate file processing that Phase 1 must do anyway.
+
+The data Phase 1 captures (treedb + `maven_deps.json` + manifest)
+should be **everything** Phase 2 needs. There is no valid reason for
+Phase 2 to need the source tree for SHA computation.
+
+---
+
+## 3. The Real Bottleneck: JVM Startup for Dependency Resolution
+
+### User Question
+
+> Is there anything that can be done about the real bottleneck in
+> Phase 1 — the `mvn dependency:tree` call with its JVM startup
+> overhead?
+
+### Analysis
+
+Yes. Several optimizations are viable without touching the customer's
+build:
+
+#### 3a. Offline Mode — Biggest Win, One Flag
+
+The build just ran `mvn package`, which downloaded every dependency into
+the local `.m2/repository` cache. Running `mvn dependency:tree`
+immediately after re-checks remote repositories for SNAPSHOT updates and
+metadata freshness. Adding `-o` (offline) skips all network I/O.
+
+This is standard Maven practice. Maven's own documentation recommends
+`-o` when the local cache is known complete. Since the build just
+succeeded, the cache is guaranteed complete.
+
+**Implemented:** `-o` added to `run_maven_dep_tree()` in
+`app/pipeline/maven_dep_tree_parser.py`.
+
+#### 3b. Skip Flags — Prevent Lifecycle Plugin Overhead
+
+`dependency:tree` doesn't compile anything, but Maven lifecycle plugins
+may still fire. Adding skip flags prevents unnecessary work:
+
+```text
+-DskipTests
+-Dmaven.javadoc.skip=true
+-Denforcer.skip=true
+-Dcheckstyle.skip=true
+```
+
+**Implemented:** All four flags added to `run_maven_dep_tree()`.
+
+#### 3c. Parallel Execution — Free Wall-Time Reduction
+
+`bomsh_create_bom_java.py` (treedb generation) and
+`mvn dependency:tree` are independent operations. Treedb reads `.class`
+files; dep:tree reads `pom.xml`. They can run concurrently.
+
+Wall time drops from `treedb_time + deptree_time` to
+`max(treedb_time, deptree_time)`.
+
+**Status:** Pending — requires `concurrent.futures` threading, planned
+for a follow-up commit.
+
+#### 3d. Module Targeting (`-pl`) — Already Partially Implemented
+
+The `maven_modules` parameter in `run_maven_dep_tree()` already
+supports `-pl`. For multi-module projects where only a subset of
+modules produce output JARs, targeting specific modules skips
+irrelevant ones.
+
+For spring-boot (30+ modules, only 3 produce output JARs), this
+could eliminate 90% of the dep:tree work.
+
+**Status:** Pending — needs config schema extension to specify which
+modules produce output JARs.
+
+#### 3e. Direct POM Parsing — Last Resort (Not Recommended)
+
+Parsing `pom.xml` directly in Python would eliminate JVM startup
+entirely, but loses:
+
+- Property interpolation (`${project.version}`, etc.)
+- BOM / `dependencyManagement` resolution
+- Transitive dependency resolution
+- Version conflict mediation (nearest-wins rule)
+- Profile activation
+
+This would produce a less accurate dependency graph. **Not
+recommended** unless overhead is still unacceptable after
+options 3a–3d.
+
+---
+
+## 4. Gradle Has the Same Bottleneck — Worse
+
+### User Question
+
+> This is for Maven, what about Gradle or other orchestrators? Is
+> there a similar bottleneck that can be dealt with in this same
+> optimized manner to reduce build time impact?
+
+### Analysis
+
+Yes — Gradle has the **same bottleneck**, and it was worse due to a
+configuration mistake:
+
+| Repo | Orchestrator | `adg` wall time | Build time | Ratio |
+|------|-------------|-----------------|------------|-------|
+| dependency-check | Maven | 218s | 30s | 7.3x |
+| spring-boot | Gradle | **1,223s** | 56s | **21.8x** |
+
+Two reasons Gradle was worse:
+
+1. **`--no-daemon` was being used for dep:tree** (line 59 of
+   `gradle_dep_tree_parser.py`). This forced a cold JVM start for
+   every `./gradlew dependencies` call. The Gradle Daemon exists
+   specifically to avoid this — it keeps a warm JVM in memory. The
+   build command in `config.yaml` correctly uses `--no-daemon`
+   (deterministic sidecar behavior), but our **post-build query**
+   doesn't need it — the build daemon may still be warm.
+
+2. **Per-subproject execution** — `get_all_gradle_deps()` runs
+   `./gradlew dependencies` once per subproject. Spring-boot has
+   many subprojects. Each invocation was a separate cold JVM start
+   with `--no-daemon`.
+
+### Fixes Applied
+
+- **`--offline`** — Same as Maven's `-o`. Dependencies are already
+  cached from the build.
+- **Removed `--no-daemon`** — Allows reuse of the warm Gradle daemon
+  from the build, eliminating cold JVM start overhead.
+
+### Fixes Pending
+
+- **Single-invocation multi-project query** — Running
+  `./gradlew dependencies` at root already aggregates all
+  subprojects. Avoids N separate JVM starts.
+- **Parallel execution** — Same as Maven: run treedb + dep:tree
+  concurrently.
+
+---
+
+## 5. Split Timing Implementation
+
+### Rationale
+
+The `adg` step timing (218s for dependency-check, 1,223s for
+spring-boot) was a **combined** measurement of
+`bomsh_create_bom_java.py` + dep:tree. Without knowing the split,
+optimization decisions were guesswork.
+
+### What Was Implemented
+
+Both `MavenDepTreeStrategy.generate_adg()` and
+`GradleDepTreeStrategy.generate_adg()` now separately time each
+sub-step using `time.monotonic()` and write the breakdown to
+`adg_substeps.json` in `bom_dir`:
+
+```json
+[
+  {
+    "name": "treedb",
+    "tool": "bomsh_create_bom_java.py",
+    "wall_sec": 12.34
+  },
+  {
+    "name": "dep_tree",
+    "tool": "mvn dependency:tree",
+    "wall_sec": 205.67
+  }
+]
+```
+
+Console output also includes per-substep timings:
+
+```text
+[OK] OmniBOR treedb written to .../bomsh_omnibor_treedb (12.3s)
+[OK] Maven dep:tree: 47 dependencies → .../maven_deps.json (205.7s)
+```
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `app/pipeline/interception.py` | `_write_adg_substeps()` helper; split timing in both Maven and Gradle `generate_adg()` |
+| `app/pipeline/maven_dep_tree_parser.py` | Added `-o`, `-DskipTests`, `-Dmaven.javadoc.skip=true`, `-Denforcer.skip=true`, `-Dcheckstyle.skip=true` |
+| `app/pipeline/gradle_dep_tree_parser.py` | Replaced `--no-daemon` with `--offline` |
+| `tests/test_maven_dep_tree_parser.py` | Tests for `adg_substeps.json` structure and offline/skip flags |
+| `tests/test_gradle_dep_tree_parser.py` | Tests for `adg_substeps.json` structure and `--offline`/no `--no-daemon` |
+
+### Test Results
+
+- **1453 passed**, 75 skipped
+- **98% overall coverage**
+- Modified files: 95–97% coverage each
+
+---
+
+## 6. Applicability to Other Languages
+
+| Language | Dep Resolution Method | JVM Startup? | Same Bottleneck? |
+|---|---|---|---|
+| **Java (Maven)** | `mvn dependency:tree` | Yes | **Yes — fixed with `-o` + skip flags** |
+| **Java (Gradle)** | `./gradlew dependencies` | Yes | **Yes — fixed with `--offline`, removed `--no-daemon`** |
+| **C/C++** | No dep resolution in Phase 1 (strace/`LD_PRELOAD`/eBPF captures I/O inline) | No | No |
+| **Go** | No dep resolution in Phase 1 (strace captures I/O inline) | No | No |
+| **Rust** | No dep resolution in Phase 1 (strace captures I/O inline) | No | No |
+
+For kernel-level interception (strace, `LD_PRELOAD`, eBPF), SHA hashes
+are computed **during** the build as files are read/written — they
+cannot be deferred because the tracer observes actual I/O. There is no
+separate dep resolution step.
+
+For Java sidecar (post-build analysis), `bomsh_create_bom_java.py` and
+the dep:tree command are discrete steps that run **after** the build.
+These are the only steps where JVM startup overhead applies, and they
+are the only ones that benefit from the optimizations above.
+
+---
+
+## 7. Next Steps
+
+1. **Run on EC2** with split timing enabled against dependency-check
+   (Maven) and spring-boot (Gradle) to get actual treedb vs dep:tree
+   breakdown
+2. **Implement parallel execution** of treedb + dep:tree
+   (`concurrent.futures.ThreadPoolExecutor`)
+3. **Wire aggressive `-pl` module targeting** from `config.yaml` for
+   multi-module Maven projects
+4. **Measure before/after** — compare the optimized `adg` timings
+   against the pre-optimization baselines documented in this file

--- a/tests/test_gradle_dep_tree_parser.py
+++ b/tests/test_gradle_dep_tree_parser.py
@@ -5,6 +5,7 @@ Tests the Gradle dependency tree parser wrapper and
 GradleDepTreeStrategy with realistic fixture data.
 """
 
+import json
 import subprocess
 import tempfile
 import unittest
@@ -322,6 +323,23 @@ class TestGradleDepTreeStrategy(unittest.TestCase):
             self.assertTrue(
                 (bom_dir / "gradle_deps.json").exists()
             )
+            substeps_file = (
+                bom_dir / "adg_substeps.json"
+            )
+            self.assertTrue(substeps_file.exists())
+            substeps = json.loads(
+                substeps_file.read_text()
+            )
+            self.assertEqual(len(substeps), 2)
+            self.assertEqual(
+                substeps[0]["name"], "treedb",
+            )
+            self.assertEqual(
+                substeps[1]["name"], "dep_tree",
+            )
+            self.assertIn(
+                "wall_sec", substeps[0],
+            )
             mock_runner.run.assert_called_once()
 
     @patch(
@@ -382,6 +400,23 @@ class TestRunGradleDepTreeEdge(unittest.TestCase):
         mock_run.side_effect = FileNotFoundError
         result = run_gradle_dep_tree("/repo")
         self.assertIsNone(result)
+
+    @patch(
+        "app.pipeline.gradle_dep_tree_parser"
+        ".subprocess.run"
+    )
+    def test_offline_no_daemon(self, mock_run):
+        """dep:tree must use --offline and omit --no-daemon
+        to reuse the warm Gradle daemon."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "gradlew").touch()
+            run_gradle_dep_tree(td)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--offline", cmd)
+        self.assertNotIn("--no-daemon", cmd)
 
 
 class TestFindGradleSubprojectsEdge(unittest.TestCase):

--- a/tests/test_maven_dep_tree_parser.py
+++ b/tests/test_maven_dep_tree_parser.py
@@ -5,6 +5,7 @@ Tests the Maven ``dependency:tree`` DOT format parser
 with realistic fixture data from real Maven projects.
 """
 
+import json
 import subprocess
 import tempfile
 import unittest
@@ -508,6 +509,30 @@ class TestRunMavenDepTree(unittest.TestCase):
         self.assertNotIn("-pl", cmd)
         self.assertNotIn("-am", cmd)
 
+    @patch("app.pipeline.maven_dep_tree_parser"
+           ".subprocess.run")
+    def test_offline_and_skip_flags(self, mock_run):
+        """dep:tree must run offline with skip flags to
+        minimise Phase 1 build-time impact."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "pom.xml").touch()
+            run_maven_dep_tree(td)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("-o", cmd)
+        self.assertIn("-DskipTests", cmd)
+        self.assertIn(
+            "-Dmaven.javadoc.skip=true", cmd,
+        )
+        self.assertIn(
+            "-Denforcer.skip=true", cmd,
+        )
+        self.assertIn(
+            "-Dcheckstyle.skip=true", cmd,
+        )
+
 
 # ============================================================
 # Tests: InterceptionStrategy / MavenDepTreeStrategy
@@ -550,6 +575,23 @@ class TestMavenDepTreeStrategy(unittest.TestCase):
             self.assertTrue(ok)
             self.assertTrue(
                 (bom_dir / "maven_deps.json").exists()
+            )
+            substeps_file = (
+                bom_dir / "adg_substeps.json"
+            )
+            self.assertTrue(substeps_file.exists())
+            substeps = json.loads(
+                substeps_file.read_text()
+            )
+            self.assertEqual(len(substeps), 2)
+            self.assertEqual(
+                substeps[0]["name"], "treedb",
+            )
+            self.assertEqual(
+                substeps[1]["name"], "dep_tree",
+            )
+            self.assertIn(
+                "wall_sec", substeps[0],
             )
             mock_runner.run.assert_called_once()
 


### PR DESCRIPTION
## Summary

Optimizes the Phase 1 sidecar ADG step (`generate_adg`) for Java Maven and
Gradle projects, and adds split timing instrumentation to measure where time
is spent (treedb generation vs. dependency-tree extraction).

## Changes

### Code

- **`app/pipeline/interception.py`** — added `_write_adg_substeps()` helper
  that persists sub-step wall-clock timing to `adg_substeps.json`; wired
  split timing into both `MavenDepTreeStrategy.generate_adg()` and
  `GradleDepTreeStrategy.generate_adg()`.
- **`app/pipeline/maven_dep_tree_parser.py`** — `mvn dependency:tree` now runs
  with `-o` (offline) plus skip flags (`-DskipTests`,
  `-Dmaven.javadoc.skip=true`, `-Denforcer.skip=true`,
  `-Dcheckstyle.skip=true`). The local `.m2` cache is complete after the build,
  so network I/O and lifecycle plugins are unnecessary.
- **`app/pipeline/gradle_dep_tree_parser.py`** — replaced `--no-daemon` with
  `--offline` to reuse the warm Gradle daemon and skip remote repository checks.

### Tests

- **`tests/test_maven_dep_tree_parser.py`** — assert `adg_substeps.json` is
  written; verify `-o` + skip flags are passed.
- **`tests/test_gradle_dep_tree_parser.py`** — assert `adg_substeps.json` is
  written; verify `--offline` (not `--no-daemon`) is passed.

### Docs

- **`docs/deep-dive/phase-isolation-build-time-analysis.md`** — Phase 1
  build-time impact analysis with EC2 split-timing results.
- **`docs/deep-dive/bomsh-java-performance-optimization.md`** — TODO deep-dive
  on the dominant bottleneck (`bomsh_create_bom_java.py` subprocess spawns).

## EC2 Results (sidecar mode — the authoritative 99% path)

| Repo | treedb | dep:tree | total adg | Before |
|------|--------|----------|-----------|--------|
| dependency-check (Maven) | 240.85s (98.6%) | 3.47s (1.4%) | 244.32s | — |
| spring-boot (Gradle) | 486.09s (77.7%) | 139.64s (22.3%) | 625.74s | 1,222.88s (**-49%**) |

## Validation

- Full test suite: **1,453 passed, 75 skipped**
- `import app`: OK
- Golden files: **zero regressions** for both repos

## Key Finding

`bomsh_create_bom_java.py` (not the JVM dep:tree command) is the dominant cost.
Future optimization should target it — documented in the new deep-dive as TODO.
