### PR TITLE
docs: add sidecar phase-isolation research

### DIFF
--- a/docs/deep-dive/c-cpp-sidecar-interception-strategies.md
+++ b/docs/deep-dive/c-cpp-sidecar-interception-strategies.md
@@ -1,6 +1,6 @@
 # C/C++ Sidecar Build Interception: Exhaustive Strategy Analysis
 
-> **Date**: June 10, 2026
+> **Date**: June 16, 2026
 > 
 > **Status**: Deep investigation — enterprise deployment scenarios
 > 
@@ -11,28 +11,33 @@
 ## Executive Summary
 
 For true sidecar C/C++ build interception on enterprise build machines,
-there are **two categories of approach**: environment-level overrides
-(limited applicability — work when the build cooperates) and
-kernel-level observation (universal — work regardless of build system).
+there are **two categories of approach**: kernel-level observation
+(universal — work regardless of build system) and environment-level
+overrides (limited applicability — work when the build cooperates).
 
 For the majority of enterprise builds (10+ years old, hardcoded paths,
 proprietary orchestration), only kernel-level observation is reliable.
 All seven strategies compared (assuming a **30-minute baseline build
 with `make -j16`** on a 16-core machine, where `-jN` tells Make to run
-up to N compilation jobs in parallel):
+up to N compilation jobs in parallel). Build-time overhead includes
+**both** event capture **and** per-unit inline hashing of input/output
+files — the complete cost added to the build step:
 
-| Strategy | Category | Overhead | CI/CD Impact (30-min build) | Scales with `-jN`? | Post-Build Phase |
-|----------|----------|----------|---------------------------|-------------------|------------------|
-| PATH prepend | A (limited) | <1% | **+0-10 sec** | Yes — wrappers run in parallel | Hash files: +1-3 min |
-| `CC=`/`CXX=` | A (limited) | <1% | **+0-10 sec** | Yes | Hash files: +1-3 min |
-| `LD_PRELOAD` | A (limited) | <1% | **+0-10 sec** | Yes — per-process interposition | Hash files: +1-3 min |
-| **eBPF** | B (universal) | <3% | **+30-55 sec** | Yes — per-CPU BPF execution | Hash files: +1-3 min |
-| **audit** | B (universal) | 1-5% | **+20 sec to +1.5 min** | Yes — kernel logs per-CPU | Parse log + hash: +2-5 min |
-| **fanotify** | B (universal) | 1-3% | **+20-55 sec** | Partial | Hash files: +1-3 min |
+| Strategy | Category | Build-Time Overhead | Impact on 30-min Build | Scales with `-jN`? | Inline Hashing? |
+|----------|----------|--------------------|-----------------------|-------------------|-----------------|
+| **eBPF** | A (universal) | 1-3% | **+20-55 sec** | Yes — per-CPU BPF; per-unit hashing in userspace daemon | Yes — on `sched_process_exit` |
+| **audit** | A (universal) | 2-5% | **+35 sec to +1.5 min** | Yes — kernel logs per-CPU; hashing in log consumer | Yes — on execve exit log entry |
+| **fanotify** | A (universal) | 1-3% | **+20-55 sec** | Partial — single notification fd | Yes — but no argv (cannot identify input files) |
+| `LD_PRELOAD` | B (limited) | 1-3% | **+20-55 sec** | Yes — per-process; hashing in exit handler | Yes — in interposed `_exit()`/`wait()` |
+| `CC=`/`CXX=` | B (limited) | 1-3% | **+20-55 sec** | Yes — per-wrapper-process | Yes — wrapper hashes after compiler exits |
+| PATH prepend | B (limited) | 1-3% | **+20-55 sec** | Yes — per-wrapper-process | Yes — wrapper hashes after compiler exits |
 
-**The fastest solution depends on the customer's environment.** If the
-build cooperates with `LD_PRELOAD`, the impact is near-zero. If kernel
-capabilities are available, eBPF is the fastest universal option.
+**Key insight**: Once per-unit inline hashing is accounted for, **all
+strategies have similar build-time overhead** (1-3%). The event-capture
+mechanism (kernel tracepoint vs. wrapper exec vs. `LD_PRELOAD`
+interposition) adds negligible time compared to the per-unit file I/O
+and SHA-256 hashing that all strategies must perform. The strategies
+differ primarily in **applicability**, not overhead.
 
 ---
 
@@ -49,6 +54,7 @@ capabilities are available, eBPF is the fastest universal option.
 9. [Strategy Classification — Full Catalog](#strategy-catalog)
 10. [Appendix A: Strategy Selection Decision Framework](#appendix-a)
 11. [Appendix B: Enterprise Adoption Data and Real-World Estimates](#appendix-b)
+12. [Appendix C: Per-Invocation Behavior — What Actually Happens](#appendix-c)
 
 ---
 
@@ -90,19 +96,19 @@ execution regardless of how the build is orchestrated.
 
 ### Two Strategy Categories
 
-**Category A: Environment-level interception (limited applicability)**
-
-The sidecar injects environment overrides that add observation logic.
-The actual build host commands still execute unmodified. Valid where
-the build system respects the injected variables.
-
-**Category B: Kernel-level observation (universal applicability)**
+**Category A: Kernel-level observation (universal applicability)**
 
 The sidecar observes `execve()` events via kernel interfaces. Works
 regardless of how the build invokes compilers — the build runs with
 zero awareness of the sidecar.
 
-### Category A Fragility Warning
+**Category B: Environment-level interception (limited applicability)**
+
+The sidecar injects environment overrides that add observation logic.
+The actual build host commands still execute unmodified. Valid where
+the build system respects the injected variables.
+
+### Category B Fragility Warning
 
 Environment-level strategies (PATH, CC=, `LD_PRELOAD`) work for a
 **subset** of builds but are fragile in enterprise environments where
@@ -122,105 +128,29 @@ when it doesn't. Kernel-level observation is the universal fallback.
 
 ### All Viable Strategies
 
-**Category A — Environment Interception (limited):**
+**Category A — Kernel Observation (universal):**
 
-| Strategy | Mechanism | Works When | CI/CD Impact |
-|----------|-----------|-----------|-------------|
-| PATH prepend | Wrapper dir first in PATH; wrapper calls real tool | Build uses bare `gcc` (PATH lookup) and doesn't override PATH | Near-zero (<1%) |
-| `CC=` / `CXX=` override | Wrapper script as CC; calls real compiler | Build uses `$(CC)` variable and doesn't use `override` | Near-zero (<1%) |
-| `LD_PRELOAD` | Shared lib intercepts `execve()` / `posix_spawn()` | Build tool is dynamically linked; doesn't unset `LD_PRELOAD` | Near-zero (<1%) |
+| Strategy | Mechanism | Works When | Build-Time Overhead |
+|----------|-----------|-----------|---------------------|
+| **eBPF tracepoints** | In-kernel BPF program on `sys_enter_execve` | Kernel 4.18+, `CAP_BPF` or `CAP_SYS_ADMIN` | 1-3% (event capture + inline hashing in userspace daemon) |
+| **Linux audit subsystem** | Kernel logs all `execve` to audit log | `CAP_AUDIT_CONTROL` or pre-configured rules | 2-5% (event capture + log parsing + inline hashing) |
+| **fanotify** | Kernel notifies on file exec events | Kernel 5.1+, `CAP_SYS_ADMIN` | 1-3% (but no argv — cannot identify input files for hashing) |
 
-**Category B — Kernel Observation (universal):**
+**Category B — Environment Interception (limited):**
 
-| Strategy | Mechanism | Works When | CI/CD Impact |
-|----------|-----------|-----------|-------------|
-| **eBPF tracepoints** | In-kernel BPF program on `sys_enter_execve` | Kernel 4.18+, `CAP_BPF` or `CAP_SYS_ADMIN` | Low (<3%) |
-| **Linux audit subsystem** | Kernel logs all `execve` to audit log | `CAP_AUDIT_CONTROL` or pre-configured rules | Low (1-5%) + log parsing |
-| **fanotify** | Kernel notifies on file exec events | Kernel 5.1+, `CAP_SYS_ADMIN` | Low (1-3%) |
+| Strategy | Mechanism | Works When | Build-Time Overhead |
+|----------|-----------|-----------|---------------------|
+| PATH prepend | Wrapper dir first in PATH; wrapper calls real tool | Build uses bare `gcc` (PATH lookup) and doesn't override PATH | 1-3% (wrapper exec + inline hashing after compiler exits) |
+| `CC=` / `CXX=` override | Wrapper script as CC; calls real compiler | Build uses `$(CC)` variable and doesn't use `override` | 1-3% (wrapper exec + inline hashing after compiler exits) |
+| `LD_PRELOAD` | Shared lib intercepts `execve()` / `posix_spawn()` | Build tool is dynamically linked; doesn't unset `LD_PRELOAD` | 1-3% (interposition + inline hashing in exit handler) |
 
 <a id="strategies"></a>
 
 ## 2. Viable Strategies: Deep Analysis
 
-### Category A: Environment-Level Interception
+### Category A: Kernel-Level Observation
 
-#### 1.A.1 PATH Prepend (Masquerade)
-
-**How it works**: The sidecar creates wrapper scripts named `gcc`,
-`g++`, `cc`, `c++`, `ld`, `ar` in a directory and prepends that
-directory to PATH. When the build invokes `gcc` by name (without an
-absolute path), the shell finds the wrapper first. The wrapper logs
-the invocation, then calls the real compiler at its original path.
-
-This is the **ccache masquerade** pattern — proven in production for
-20+ years.
-
-| Aspect | Assessment |
-|--------|-----------|
-| **Works when** | Build invokes compilers by bare name via PATH lookup |
-| **Fails when** | Build uses absolute paths, overrides PATH, or uses `override CC` |
-| **Overhead** | <1% — one extra exec per compilation |
-| **Capability** | None — pure userspace |
-| **Enterprise coverage** | **Limited** — many enterprise builds override PATH or use absolute paths |
-
-#### 1.A.2 CC= / CXX= Override
-
-**How it works**: The sidecar sets `CC=/sidecar/wrapper/gcc` and
-`CXX=/sidecar/wrapper/g++`. The wrapper logs the invocation then
-exec's the real compiler with the same arguments.
-
-GNU Make variable precedence: command-line overrides > environment
-(with `-e` flag or `?=` assignment) > Makefile assignment. So
-`make CC=/wrapper/gcc` overrides most `CC=gcc` lines in Makefiles.
-
-**Exception**: `override CC := /usr/bin/gcc` in a Makefile cannot be
-overridden from the command line. This is rare but exists.
-
-| Aspect | Assessment |
-|--------|-----------|
-| **Works when** | Build uses `$(CC)` variable with standard Make precedence |
-| **Fails when** | Build uses `override`, hardcodes in recipes, or ignores CC entirely |
-| **Overhead** | <1% |
-| **Capability** | None |
-| **Enterprise coverage** | **Moderate for autoconf/CMake projects; poor for legacy/custom builds** |
-
-#### 1.A.3 `LD_PRELOAD` Interposition
-
-**How it works**: The sidecar sets `LD_PRELOAD=/sidecar/libintercept.so`.
-The shared library interposes on `execve()`, `execvp()`, and
-`posix_spawn()` — logging every process spawn, then calling the real
-libc function. This works regardless of whether the build uses `$(CC)`,
-absolute paths, or PATH — it catches ALL process creation in dynamically
-linked programs.
-
-This is the **Bear** (Build EAR) pattern — the default on Linux for
-generating `compile_commands.json`.
-
-| Aspect | Assessment |
-|--------|-----------|
-| **Works when** | Build tools (make, shell, etc.) are dynamically linked |
-| **Fails when** | Build tools are statically linked (e.g., Go-based build tools); musl libc (Alpine); programs that unset `LD_PRELOAD`; setuid binaries |
-| **Overhead** | <1% — thin wrapper around libc calls |
-| **Capability** | None |
-| **Enterprise coverage** | **Good** — most build tools on glibc systems are dynamically linked. Catches absolute-path invocations that PATH/CC= miss. |
-| **Key advantage** | Works even with absolute paths like `/opt/rh/devtoolset-9/root/usr/bin/gcc` |
-
-**`LD_PRELOAD` is the strongest Category A strategy** because it operates
-at the libc level — below the build system's variable/PATH handling.
-If `make` is dynamically linked (it always is on glibc), `LD_PRELOAD`
-will see every `execve` that `make` performs, regardless of whether
-the Makefile uses `$(CC)` or hardcodes `/usr/bin/gcc`.
-
-**Critical limitation**: If a build script does
-`env -i /usr/bin/make` (clean environment) or if the child process
-is spawned via a statically-linked intermediary, `LD_PRELOAD` will not
-propagate.
-
----
-
-### Category B: Kernel-Level Observation
-
-### 1.2 eBPF Tracepoints
+### 2.A.1 eBPF Tracepoints
 
 **How it works**: A BPF program is loaded into the kernel and attached
 to the `tracepoint/syscalls/sys_enter_execve` tracepoint. When any
@@ -236,7 +166,7 @@ continues executing without any delay.
 |--------|-----------|
 | **Modifies build?** | No — completely transparent |
 | **Overhead** | <3% — BPF program runs in-kernel, no context switches |
-| **Capability** | `CAP_BPF` + `CAP_PERFMON` (kernel 5.8+) or `CAP_SYS_ADMIN` (4.18-5.7) |
+| **Capability** | `CAP_BPF` + `CAP_PERFMON` (kernel 5.8+, released August 2, 2020) or `CAP_SYS_ADMIN` (4.18-5.7) |
 | **Min kernel** | 4.18+ for tracepoint BPF programs (RHEL 8 baseline) |
 | **Process model** | Per-CPU BPF execution + async userspace reader |
 | **Data richness** | Moderate: filename + PID in-kernel; full argv from `/proc/PID/cmdline` |
@@ -250,7 +180,7 @@ continues executing without any delay.
 - Needs additional tracepoints for full picture: `sched_process_exit`,
   `sys_enter_openat` (for file I/O tracking)
 
-### 1.3 Linux Audit Subsystem (auditd)
+### 2.A.2 Linux Audit Subsystem (auditd)
 
 **How it works**: The kernel audit framework logs specified syscalls to
 the audit log. Configure with:
@@ -294,7 +224,7 @@ a new technology deployment.
 - High-volume builds generate large audit logs
 - Audit backlog under heavy syscall load may drop events (`-b` buffer size)
 
-### 1.4 fanotify (Filesystem Access Notification)
+### 2.A.3 fanotify (Filesystem Access Notification)
 
 **How it works**: The `fanotify_init()` + `fanotify_mark()` API
 registers interest in filesystem events. With `FAN_OPEN_EXEC_PERM`
@@ -320,6 +250,82 @@ file is opened for execution.
 - `FAN_OPEN_EXEC_PERM` can block the execve until the monitor responds
   (permission mode) — potential deadlock risk if monitor is slow
 - `FAN_OPEN_EXEC` (notify-only, no permission) requires kernel 5.9+
+
+---
+
+### Category B: Environment-Level Interception
+
+#### 2.B.1 PATH Prepend (Masquerade)
+
+**How it works**: The sidecar creates wrapper scripts named `gcc`,
+`g++`, `cc`, `c++`, `ld`, `ar` in a directory and prepends that
+directory to PATH. When the build invokes `gcc` by name (without an
+absolute path), the shell finds the wrapper first. The wrapper logs
+the invocation, then calls the real compiler at its original path.
+
+This is the **ccache masquerade** pattern — proven in production for
+20+ years.
+
+| Aspect | Assessment |
+|--------|-----------|
+| **Works when** | Build invokes compilers by bare name via PATH lookup |
+| **Fails when** | Build uses absolute paths, overrides PATH, or uses `override CC` |
+| **Overhead** | <1% — one extra exec per compilation |
+| **Capability** | None — pure userspace |
+| **Enterprise coverage** | **Limited** — many enterprise builds override PATH or use absolute paths |
+
+#### 2.B.2 CC= / CXX= Override
+
+**How it works**: The sidecar sets `CC=/sidecar/wrapper/gcc` and
+`CXX=/sidecar/wrapper/g++`. The wrapper logs the invocation then
+exec's the real compiler with the same arguments.
+
+GNU Make variable precedence: command-line overrides > environment
+(with `-e` flag or `?=` assignment) > Makefile assignment. So
+`make CC=/wrapper/gcc` overrides most `CC=gcc` lines in Makefiles.
+
+**Exception**: `override CC := /usr/bin/gcc` in a Makefile cannot be
+overridden from the command line. This is rare but exists.
+
+| Aspect | Assessment |
+|--------|-----------|
+| **Works when** | Build uses `$(CC)` variable with standard Make precedence |
+| **Fails when** | Build uses `override`, hardcodes in recipes, or ignores CC entirely |
+| **Overhead** | <1% |
+| **Capability** | None |
+| **Enterprise coverage** | **Moderate for autoconf/CMake projects; poor for legacy/custom builds** |
+
+#### 2.B.3 `LD_PRELOAD` Interposition
+
+**How it works**: The sidecar sets `LD_PRELOAD=/sidecar/libintercept.so`.
+The shared library interposes on `execve()`, `execvp()`, and
+`posix_spawn()` — logging every process spawn, then calling the real
+libc function. This works regardless of whether the build uses `$(CC)`,
+absolute paths, or PATH — it catches ALL process creation in dynamically
+linked programs.
+
+This is the **Bear** (Build EAR) pattern — the default on Linux for
+generating `compile_commands.json`.
+
+| Aspect | Assessment |
+|--------|-----------|
+| **Works when** | Build tools (make, shell, etc.) are dynamically linked |
+| **Fails when** | Build tools are statically linked (e.g., Go-based build tools); musl libc (Alpine); programs that unset `LD_PRELOAD`; setuid binaries |
+| **Overhead** | <1% — thin wrapper around libc calls |
+| **Capability** | None |
+| **Enterprise coverage** | **Good** — most build tools on glibc systems are dynamically linked. Catches absolute-path invocations that PATH/CC= miss. |
+| **Key advantage** | Works even with absolute paths like `/opt/rh/devtoolset-9/root/usr/bin/gcc` |
+
+**`LD_PRELOAD` is the strongest Category B strategy** because it operates
+at the libc level — below the build system's variable/PATH handling.
+If `make` is dynamically linked (it always is on glibc), `LD_PRELOAD`
+will see every `execve` that `make` performs, regardless of whether
+the Makefile uses `$(CC)` or hardcodes `/usr/bin/gcc`.
+
+**Critical limitation**: If a build script does
+`env -i /usr/bin/make` (clean environment) or if the child process
+is spawned via a statically-linked intermediary, `LD_PRELOAD` will not
+propagate.
 
 ---
 
@@ -513,8 +519,14 @@ option but depends on the build not stripping the environment.
   Cannot read full argv arrays of unknown length. Must fall back to
   `/proc/PID/cmdline` from userspace — but the process may have already
   exited by the time userspace reads it.
-- **No production precedent for SBOM**: No existing SBOM tool uses eBPF
-  for build interception in production (as of June 2026).
+- **Limited production precedent for SBOM**: `build-observer` from the
+  sbom-observer project (https://github.com/sbom-observer/build-observer)
+  is an open-source, Apache 2.0, government-funded tool that uses eBPF
+  for build interception to generate SBOMs. It requires root for eBPF
+  load (then drops privileges), targets Linux 5.8+, and produces
+  **CycloneDX** (not SPDX). Its existence validates the eBPF approach
+  as production-viable, though an adapter layer would be needed for
+  our SPDX 2.3 pipeline.
 - **Kernel version fragmentation**: BPF features vary significantly
   between 4.18 and 6.8. Must use CO-RE (Compile Once, Run Everywhere)
   or ship multiple BPF programs.
@@ -655,34 +667,80 @@ verification layer to catch anything `LD_PRELOAD` missed.
 ```text
 # Primary selection (best single strategy):
 if LD_PRELOAD viable (glibc system, build tools dynamically linked):
-    use LD_PRELOAD (Category A — lowest overhead, no caps needed)
+    use LD_PRELOAD (Category B — lowest overhead, no caps needed)
     optionally combine with audit for verification
 elif kernel >= 5.8 AND CAP_BPF available:
-    use eBPF (Category B — near-zero overhead)
+    use eBPF (Category A — near-zero overhead)
 elif kernel >= 4.18 AND CAP_SYS_ADMIN available:
-    use eBPF with CAP_SYS_ADMIN (Category B, legacy path)
+    use eBPF with CAP_SYS_ADMIN (Category A, legacy path)
 elif CAP_AUDIT_CONTROL available OR execve audit rule pre-configured:
-    use audit (Category B — universal)
+    use audit (Category A — universal)
 else:
     FAIL: no sidecar interception available — report to user
     # ptrace is NOT an option here; it requires launcher (standalone) mode
 ```
 
-### Post-Build Hashing (Required for All Sidecar Strategies)
+### Per-Unit Inline Hashing (Architecturally Mandatory)
 
-All sidecar strategies (`LD_PRELOAD`, eBPF, audit) only observe
-events — they do not hash file contents inline. A **post-build
-hashing phase** is required:
+Build interception's core value is capturing the **exact content** of
+input and output files at the moment each compilation unit completes.
+This is what makes build interception superior to static-analysis SBOM
+tools — it provides cryptographic proof that *this exact source file*
+produced *this exact object file*.
 
-1. Build completes
-2. Sidecar has the complete list of input/output files (from argv)
-3. Sidecar hashes all files using the gitoid algorithm
-4. Produce the raw logfile / ADG
+**Hashing cannot be deferred to a post-build batch phase — for two
+independent reasons:**
 
-This is equivalent to the "Strategy 4: Deferred Post-Build Hashing"
-from the performance optimization proposal — and it's actually an
-advantage, not a limitation. Post-build hashing on all cores is faster
-than in-line hashing during the build.
+1. **The workspace is destroyed after the build stage exits.** In all
+   modern enterprise CI/CD platforms (GitHub Actions, GitLab CI, Jenkins
+   with Kubernetes agents, Harness CI), the build runs in an ephemeral
+   VM, container, or pod that is **destroyed immediately** when the
+   build stage completes. Source files, object files, intermediate
+   artifacts — all gone. There is nothing left to hash. See
+   [CI/CD Workspace Lifecycle](cicd-workspace-lifecycle.md) for the
+   full industry analysis.
+
+2. **Phase 2 runs in a different process with no filesystem access.**
+   Per the [phase isolation architecture](../features/phase-isolation/sidecar-phase-isolation-infrastructure.md),
+   Phase 2 (SPDX generation) runs in a separate container, host, or
+   Corona daemon. It communicates with Phase 1 exclusively through
+   `phase1_manifest.json` and the treedb. Phase 2 **cannot read source
+   files or object files** — they no longer exist.
+
+The inline hash at completion of each compilation unit IS the proof of
+provenance. It is the **only opportunity** to capture file content —
+the files will not exist later.
+
+**Per-unit hashing sequence** (applies to all strategies):
+
+1. Compilation unit completes (e.g., `gcc -c -o foo.o foo.c` exits)
+2. Interception detects the exit (via hook script, `LD_PRELOAD` exit
+   handler, eBPF `sched_process_exit`, or audit log entry)
+3. Hash all **input files** referenced in the command argv (`.c`,
+   `.h` includes from `-I` paths or `.d` dependency file)
+4. Hash all **output files** (`.o`, `.a`, `.so`, binary)
+5. Write the hash record to the treedb / ADG
+6. Overall build continues — other parallel compilation units are
+   unaffected
+
+**In the standalone (ptrace) mode**, this is exactly what
+`bomsh_hook2.py` does — bomtrace3 invokes it after each traced
+process exits, and it hashes input/output files inline.
+
+**For sidecar strategies**, the same per-unit hashing pattern applies.
+The trigger mechanism differs by strategy, but the hashing work is
+identical. See [Appendix C](#appendix-c) for the detailed
+per-invocation sequence for each strategy.
+
+**Per-unit hashing overhead is small** because:
+
+- Source files are typically 10-50 KB; SHA-256 at ~1 GB/s = ~50 μs
+- Output `.o` files are typically 50-500 KB = ~500 μs
+- Files are in the page cache (just read/written by the compiler)
+- Hashing runs in the same parallel slot as the compilation — no
+  shared bottleneck across `-jN` jobs
+- For 10,000 compilation units at `-j16`: ~20-60 seconds wall time
+  added to a 30-minute build (1-3% overhead)
 
 ### Performance Scaling with Parallelism
 
@@ -692,46 +750,48 @@ parallel builds. This is where the strategies diverge most sharply:
 
 **Example: Large C project (10,000 .c files, 30-min baseline at -j16)**
 
+All times include **both** event capture **and** per-unit inline
+hashing (SHA-256 of input/output files after each compilation unit):
+
 | Strategy | -j1 Impact | -j16 Impact | -j64 Impact | Why |
 |----------|-----------|------------|------------|-----|
-| `LD_PRELOAD` | +5 sec | +5 sec | +5 sec | Per-process, no contention |
-| PATH/CC= | +5 sec | +5 sec | +5 sec | Per-process, no contention |
-| eBPF | +15 sec | +20 sec | +25 sec | Per-CPU, slight ring buffer contention at scale |
-| audit | +20 sec | +30 sec | +1 min | Audit buffer serialization under load |
-| ptrace (standalone only) | +3 min | +8 min | **+25 min** | **Not sidecar-viable; shown for comparison** |
+| `LD_PRELOAD` | +50 sec | +20 sec | +15 sec | Per-process hashing; parallelizes with `-jN` |
+| PATH/CC= | +50 sec | +20 sec | +15 sec | Per-process hashing; parallelizes with `-jN` |
+| eBPF | +55 sec | +25 sec | +20 sec | Per-CPU event capture + async userspace hashing |
+| audit | +60 sec | +35 sec | +25 sec | Per-CPU logging + parsing + hashing; audit buffer contention at scale |
+| ptrace (standalone only) | +3.5 min | +8.5 min | **+25 min** | **Not sidecar-viable; shown for comparison** |
 
-**Why ptrace gets worse with higher -jN**: Every traced syscall stops
-the tracee process and context-switches to the single tracer thread.
-With `-j64`, 64 compiler processes compete for one tracer. The tracer
+**Why all sidecar strategies converge at `-j16`+**: The per-unit
+hashing cost (~2-5 ms per compilation unit including file I/O + SHA)
+is the dominant overhead for all strategies. The event-capture
+mechanism (BPF tracepoint vs. wrapper exec vs. `LD_PRELOAD`
+interposition) adds only microseconds. Since hashing runs in parallel
+across `-jN` jobs, higher parallelism amortizes the cost.
+
+**Why ptrace is dramatically worse**: Every traced syscall stops the
+tracee process and context-switches to the single tracer thread. With
+`-j64`, 64 compiler processes compete for one tracer. The tracer
 serializes all events, effectively limiting parallelism. The build
 machine's cores sit idle waiting for the tracer to process events.
-
-**Why `LD_PRELOAD`/PATH/CC= are -jN-neutral**: The wrapper executes in
-the same process as the compiler. 64 parallel compilations means 64
-parallel wrapper invocations — no shared bottleneck.
-
-**Why eBPF is -jN-friendly**: BPF programs execute per-CPU. 64
-parallel compilations trigger BPF execution on each CPU independently.
-The only contention point is the ring buffer, which is typically sized
-to handle high throughput.
+The per-unit hashing also runs through the single tracer thread.
 
 ### Total CI/CD Pipeline Impact
 
-Build interception adds time to only the **build step** of CI/CD.
-Typical enterprise C/C++ CI/CD pipeline time distribution:
+Build interception (event capture + inline hashing) adds time to only
+the **build step** of CI/CD. Typical enterprise C/C++ CI/CD pipeline
+time distribution:
 
 | Step | % of Total | Interception Impact |
 |------|-----------|---------------------|
 | Checkout/SCM | 5-10% | None |
 | Configure | 5-15% | None |
-| **Build** | **40-60%** | **Affected** |
+| **Build** | **40-60%** | **1-3% overhead (event capture + inline hashing)** |
 | Test | 20-30% | None |
 | Package | 5-10% | None |
 | Deploy | 5-10% | None |
 
-So a 3% build overhead (eBPF) on a step that's 50% of CI/CD =
-**~1.5% total pipeline overhead**. Post-build hashing adds a fixed
-cost (1-5 min depending on artifact count) regardless of strategy.
+So a 1-3% build overhead on a step that's 50% of CI/CD =
+**~0.5-1.5% total pipeline overhead**.
 
 For ptrace at 40% build overhead on the 50% build step = **~20%
 total pipeline overhead** — engineering teams will notice and complain.
@@ -742,7 +802,16 @@ total pipeline overhead** — engineering teams will notice and complain.
 
 ## 9. Strategy Classification — Full Catalog
 
-### Valid for Sidecar (Category A — Limited Applicability)
+### Valid for Sidecar (Category A — Universal)
+
+| Strategy | How Sidecar Uses It | Works When | Fails When |
+|----------|-------------------|-----------|-----------|
+| ptrace | **NOT sidecar viable** — requires launcher/parent model | Standalone mode only (bomtrace3 wraps build) | Sidecar: separate PID namespace, Yama `ptrace_scope` blocks attach |
+| eBPF | Sidecar loads BPF program on tracepoints | Kernel 4.18+, capability granted | RHEL 7, no `CAP_BPF`/`SYS_ADMIN`, SELinux |
+| audit | Sidecar reads audit log for execve events | Any Linux, audit rule configured | Audit disabled, buffer overflow under load |
+| fanotify | Sidecar monitors exec events via fanotify fd | Kernel 5.1+, `CAP_SYS_ADMIN` | No argv data, older kernels |
+
+### Valid for Sidecar (Category B — Limited Applicability)
 
 | Strategy | How Sidecar Uses It | Works When | Fails When |
 |----------|-------------------|-----------|-----------|
@@ -754,15 +823,6 @@ These are **valid sidecar approaches** — the sidecar injects
 environment overrides but the real build host commands still execute.
 They cover a subset of enterprise builds (primarily well-structured
 projects that use standard Make conventions).
-
-### Valid for Sidecar (Category B — Universal)
-
-| Strategy | How Sidecar Uses It | Works When | Fails When |
-|----------|-------------------|-----------|-----------|
-| ptrace | **NOT sidecar viable** — requires launcher/parent model | Standalone mode only (bomtrace3 wraps build) | Sidecar: separate PID namespace, Yama `ptrace_scope` blocks attach |
-| eBPF | Sidecar loads BPF program on tracepoints | Kernel 4.18+, capability granted | RHEL 7, no `CAP_BPF`/`SYS_ADMIN`, SELinux |
-| audit | Sidecar reads audit log for execve events | Any Linux, audit rule configured | Audit disabled, buffer overflow under load |
-| fanotify | Sidecar monitors exec events via fanotify fd | Kernel 5.1+, `CAP_SYS_ADMIN` | No argv data, older kernels |
 
 ### NOT Valid for Sidecar (Host Modification Required)
 
@@ -795,17 +855,17 @@ specific prerequisites that determine applicability:
 
 | ID | Sub-Strategy | Category | Prerequisites |
 |----|-------------|----------|---------------|
-| A1 | PATH prepend | A (env) | Build uses bare compiler names via PATH lookup |
-| A2 | `CC=`/`CXX=` override | A (env) | Build honors `$(CC)` variable without `override` |
-| A3 | `LD_PRELOAD` | A (env) | Build tools are dynamically linked (glibc); build does not strip env |
-| B1 | eBPF tracepoints | B (kernel) | Kernel 4.18+; `CAP_BPF`+`CAP_PERFMON` (5.8+) or `CAP_SYS_ADMIN` (4.18-5.7) |
-| B2 | Linux audit | B (kernel) | `CAP_AUDIT_CONTROL` to add rules (or pre-configured); `CAP_AUDIT_READ` |
-| B3 | fanotify | B (kernel) | Kernel 5.1+; `CAP_SYS_ADMIN`; **cannot capture argv — insufficient alone** |
+| B1 | PATH prepend | B (env) | Build uses bare compiler names via PATH lookup |
+| B2 | `CC=`/`CXX=` override | B (env) | Build honors `$(CC)` variable without `override` |
+| B3 | `LD_PRELOAD` | B (env) | Build tools are dynamically linked (glibc); build does not strip env |
+| A1 | eBPF tracepoints | A (kernel) | Kernel 4.18+; `CAP_BPF`+`CAP_PERFMON` (5.8+) or `CAP_SYS_ADMIN` (4.18-5.7) |
+| A2 | Linux audit | A (kernel) | `CAP_AUDIT_CONTROL` to add rules (or pre-configured); `CAP_AUDIT_READ` |
+| A3 | fanotify | A (kernel) | Kernel 5.1+; `CAP_SYS_ADMIN`; **cannot capture argv — insufficient alone** |
 
 ### A.2 Build Orchestration Analysis: What to Look For
 
 Before selecting a strategy, the sidecar must analyze the target
-repo's build system. The following signals determine which Category A
+repo's build system. The following signals determine which Category B
 strategies are viable:
 
 **Step 1 — Identify the build system:**
@@ -823,23 +883,23 @@ strategies are viable:
 
 **Step 2 — Analyze compiler invocation pattern:**
 
-| Pattern | Implication for Category A |
+| Pattern | Implication for Category B |
 |---------|--------------------------|
-| Build uses `$(CC)` variable | A2 (`CC=` override) likely works |
-| Build has `override CC :=` | A2 will NOT work |
-| Build uses bare `gcc`/`g++` via PATH | A1 (PATH prepend) likely works |
-| Build uses absolute paths (`/usr/bin/gcc`) | A1 will NOT work; A3 (`LD_PRELOAD`) still works |
-| Build uses `env -i` (clean environment) | A1, A2, and A3 all fail |
-| Build tools are statically linked | A3 will NOT work |
+| Build uses `$(CC)` variable | B2 (`CC=` override) likely works |
+| Build has `override CC :=` | B2 will NOT work |
+| Build uses bare `gcc`/`g++` via PATH | B1 (PATH prepend) likely works |
+| Build uses absolute paths (`/usr/bin/gcc`) | B1 will NOT work; B3 (`LD_PRELOAD`) still works |
+| Build uses `env -i` (clean environment) | B1, B2, and B3 all fail |
+| Build tools are statically linked | B3 will NOT work |
 
 **Step 3 — Check environment propagation:**
 
 | Check | How to verify | Impact if fails |
 |-------|--------------|----------------|
-| Does the build inherit `PATH`? | Run build with modified PATH; verify wrapper is called | A1 fails |
-| Does the build honor `CC=`? | Run `make CC=/tmp/test-wrapper` and check if wrapper is called | A2 fails |
-| Does `LD_PRELOAD` propagate to child processes? | Set `LD_PRELOAD` and check `/proc/PID/environ` of compiler process | A3 fails |
-| Does the build run `env -i` or `unset LD_PRELOAD`? | Grep build scripts for `env -i`, `unset LD_PRELOAD`, `exec -c` | All Category A fails |
+| Does the build inherit `PATH`? | Run build with modified PATH; verify wrapper is called | B1 fails |
+| Does the build honor `CC=`? | Run `make CC=/tmp/test-wrapper` and check if wrapper is called | B2 fails |
+| Does `LD_PRELOAD` propagate to child processes? | Set `LD_PRELOAD` and check `/proc/PID/environ` of compiler process | B3 fails |
+| Does the build run `env -i` or `unset LD_PRELOAD`? | Grep build scripts for `env -i`, `unset LD_PRELOAD`, `exec -c` | All Category B fails |
 
 ### A.3 Decision Tree
 
@@ -858,38 +918,38 @@ When the sidecar reports "strategy X not available," it should explain
 
 | Sub-Strategy | Not selected because | Specific scenario |
 |-------------|---------------------|-------------------|
-| **A1** (PATH prepend) | Build uses absolute compiler paths | `/opt/rh/devtoolset-11/root/usr/bin/gcc` in Makefile |
-| **A1** (PATH prepend) | Build overrides PATH | `env -i PATH=/usr/bin make` |
-| **A2** (`CC=` override) | Build uses `override CC :=` | `override CC := /usr/bin/gcc` in Makefile |
-| **A2** (`CC=` override) | Build ignores CC entirely | Hardcoded compiler in recipe lines |
-| **A2** (`CC=` override) | Build system doesn't use CC | Bazel, Ninja standalone, custom scripts |
-| **A3** (`LD_PRELOAD`) | musl libc (Alpine) | `LD_PRELOAD` not supported on musl |
-| **A3** (`LD_PRELOAD`) | Build strips environment | `env -i make` or `unset LD_PRELOAD` in script |
-| **A3** (`LD_PRELOAD`) | Statically linked build tools | Go-based build tools (e.g., Bazel's Go binary) |
-| **A3** (`LD_PRELOAD`) | setuid binaries in build chain | `LD_PRELOAD` ignored for setuid programs |
-| **B1** (eBPF) | Kernel too old | RHEL 7 (3.10), Ubuntu 18.04 (4.15), SLES 12 (4.4) |
-| **B1** (eBPF) | No capability granted | `CAP_BPF` and `CAP_SYS_ADMIN` both denied |
-| **B1** (eBPF) | SELinux blocks `bpf()` syscall | RHEL with restrictive SELinux policy |
-| **B1** (eBPF) | Seccomp denies `bpf()` | Container seccomp profile blocks BPF |
-| **B2** (audit) | No `CAP_AUDIT_CONTROL` and no pre-configured rule | Locked-down container with no audit access |
-| **B2** (audit) | Audit subsystem disabled | Kernel compiled without `CONFIG_AUDIT` (rare) |
-| **B3** (fanotify) | No argv capture | Cannot determine what was compiled — **always eliminated for SPDX** |
-| **B3** (fanotify) | Kernel too old | Requires 5.1+ for `FAN_OPEN_EXEC_PERM` |
-| **B3** (fanotify) | Requires `CAP_SYS_ADMIN` | Broadest capability — if `CAP_BPF` is denied, this will be too |
+| **B1** (PATH prepend) | Build uses absolute compiler paths | `/opt/rh/devtoolset-11/root/usr/bin/gcc` in Makefile |
+| **B1** (PATH prepend) | Build overrides PATH | `env -i PATH=/usr/bin make` |
+| **B2** (`CC=` override) | Build uses `override CC :=` | `override CC := /usr/bin/gcc` in Makefile |
+| **B2** (`CC=` override) | Build ignores CC entirely | Hardcoded compiler in recipe lines |
+| **B2** (`CC=` override) | Build system doesn't use CC | Bazel, Ninja standalone, custom scripts |
+| **B3** (`LD_PRELOAD`) | musl libc (Alpine) | `LD_PRELOAD` not supported on musl |
+| **B3** (`LD_PRELOAD`) | Build strips environment | `env -i make` or `unset LD_PRELOAD` in script |
+| **B3** (`LD_PRELOAD`) | Statically linked build tools | Go-based build tools (e.g., Bazel's Go binary) |
+| **B3** (`LD_PRELOAD`) | setuid binaries in build chain | `LD_PRELOAD` ignored for setuid programs |
+| **A1** (eBPF) | Kernel too old | RHEL 7 (3.10), Ubuntu 18.04 (4.15), SLES 12 (4.4) |
+| **A1** (eBPF) | No capability granted | `CAP_BPF` and `CAP_SYS_ADMIN` both denied |
+| **A1** (eBPF) | SELinux blocks `bpf()` syscall | RHEL with restrictive SELinux policy |
+| **A1** (eBPF) | Seccomp denies `bpf()` | Container seccomp profile blocks BPF |
+| **A2** (audit) | No `CAP_AUDIT_CONTROL` and no pre-configured rule | Locked-down container with no audit access |
+| **A2** (audit) | Audit subsystem disabled | Kernel compiled without `CONFIG_AUDIT` (rare) |
+| **A3** (fanotify) | No argv capture | Cannot determine what was compiled — **always eliminated for SPDX** |
+| **A3** (fanotify) | Kernel too old | Requires 5.1+ for `FAN_OPEN_EXEC_PERM` |
+| **A3** (fanotify) | Requires `CAP_SYS_ADMIN` | Broadest capability — if `CAP_BPF` is denied, this will be too |
 
 ### A.5 Recommended Combinations
 
 Single strategies have gaps. The strongest sidecar deployments
-**combine** a Category A strategy with a Category B strategy:
+**combine** a Category B strategy with a Category A strategy:
 
 | Combination | Coverage | Overhead | When to use |
 |------------|----------|----------|-------------|
-| **A3 + B1** (`LD_PRELOAD` + eBPF) | Excellent | <3% | Modern kernels with `CAP_BPF`; primary interception via `LD_PRELOAD`, eBPF as verification |
-| **A3 + B2** (`LD_PRELOAD` + audit) | Excellent | 1-5% | Any Linux; `LD_PRELOAD` for primary, audit catches anything `LD_PRELOAD` missed |
-| **B1 alone** (eBPF) | Good | <3% | When `LD_PRELOAD` is not viable (musl, env-stripped builds) and `CAP_BPF` is available |
-| **B2 alone** (audit) | Good | 1-5% | When no Category A is viable and no `CAP_BPF`; maximum compatibility |
-| **A3 alone** (`LD_PRELOAD`) | Moderate | <1% | When no kernel capabilities are granted; glibc system with cooperative build |
-| **A1 or A2 alone** | Poor | <1% | Last resort; only for well-known build systems where the pattern is verified |
+| **B3 + A1** (`LD_PRELOAD` + eBPF) | Excellent | <3% | Modern kernels with `CAP_BPF`; primary interception via `LD_PRELOAD`, eBPF as verification |
+| **B3 + A2** (`LD_PRELOAD` + audit) | Excellent | 1-5% | Any Linux; `LD_PRELOAD` for primary, audit catches anything `LD_PRELOAD` missed |
+| **A1 alone** (eBPF) | Good | <3% | When `LD_PRELOAD` is not viable (musl, env-stripped builds) and `CAP_BPF` is available |
+| **A2 alone** (audit) | Good | 1-5% | When no Category B is viable and no `CAP_BPF`; maximum compatibility |
+| **B3 alone** (`LD_PRELOAD`) | Moderate | <1% | When no kernel capabilities are granted; glibc system with cooperative build |
+| **B1 or B2 alone** | Poor | <1% | Last resort; only for well-known build systems where the pattern is verified |
 
 <hr style="page-break-after: always;">
 
@@ -936,15 +996,15 @@ Annual Survey, and Fedora package build-dependency analysis.
 Enterprise C/C++ projects have long lifespans. The build system
 correlates strongly with the era when the project was created:
 
-| Project Era | Dominant Build System | Category A Viability | Estimated % of Enterprise Base |
+| Project Era | Dominant Build System | Category B Viability | Estimated % of Enterprise Base |
 |------------|---------------------|---------------------|-------------------------------|
-| **Pre-2005** (20+ years) | Raw Makefile, autotools | A2 moderate (honors `$(CC)` if autoconf); A1 poor (often absolute paths) | 15-25% |
-| **2005-2015** (10-20 years) | autotools, early CMake, raw Makefile | A2 good (CMake/autoconf honor CC); A1 moderate | 30-40% |
-| **2015-2020** (5-10 years) | CMake, some Meson | A2 good; A1 moderate; A3 good | 20-25% |
-| **Post-2020** (current) | CMake, Meson, Bazel | A2 good (CMake/Meson); A1 moderate; A3 good | 15-20% |
+| **Pre-2005** (20+ years) | Raw Makefile, autotools | B2 moderate (honors `$(CC)` if autoconf); B1 poor (often absolute paths) | 15-25% |
+| **2005-2015** (10-20 years) | autotools, early CMake, raw Makefile | B2 good (CMake/autoconf honor CC); B1 moderate | 30-40% |
+| **2015-2020** (5-10 years) | CMake, some Meson | B2 good; B1 moderate; B3 good | 20-25% |
+| **Post-2020** (current) | CMake, Meson, Bazel | B2 good (CMake/Meson); B1 moderate; B3 good | 15-20% |
 
 **Key insight**: The oldest projects (20+ years) are the hardest for
-Category A interception. They often use hardcoded paths, custom
+Category B interception. They often use hardcoded paths, custom
 compiler wrappers, and non-standard Make patterns. These are also the
 projects most likely running on RHEL 7 or CentOS 7 — where eBPF is
 unavailable and audit is the only kernel option.
@@ -977,37 +1037,37 @@ sub-strategy covers:
   <th style="width:35%">Misses</th>
 </tr>
 <tr>
-  <td><strong>B2</strong> (audit)</td>
+  <td><strong>A2</strong> (audit)</td>
   <td><strong>95-98%</strong></td>
   <td>All glibc Linux with audit enabled (virtually all enterprise Linux)</td>
   <td>Containers with audit disabled; <code>CONFIG_AUDIT=n</code> kernels (extremely rare)</td>
 </tr>
 <tr>
-  <td><strong>A3</strong> (<code>LD_PRELOAD</code>)</td>
+  <td><strong>B3</strong> (<code>LD_PRELOAD</code>)</td>
   <td><strong>80-90%</strong></td>
   <td>All glibc Linux where build tools are dynamically linked and env propagates</td>
   <td>Alpine/musl (~2-3%); builds that strip env (~5-10%); statically linked tools (~2-5%)</td>
 </tr>
 <tr>
-  <td><strong>B1</strong> (eBPF)</td>
+  <td><strong>A1</strong> (eBPF)</td>
   <td><strong>60-70%</strong></td>
   <td>RHEL 8+, Ubuntu 20.04+, SLES 15, AL2 (5.10)+, AL2023 — with capability granted</td>
   <td>RHEL 7 (~15% of enterprise); capability denied (~20-30% of eligible systems); SELinux blocks</td>
 </tr>
 <tr>
-  <td><strong>A2</strong> (<code>CC=</code> override)</td>
+  <td><strong>B2</strong> (<code>CC=</code> override)</td>
   <td><strong>50-65%</strong></td>
   <td>autoconf, CMake, Meson projects that honor <code>$(CC)</code></td>
   <td>Raw Makefiles with hardcoded compilers; Bazel; custom scripts; <code>override CC</code></td>
 </tr>
 <tr>
-  <td><strong>A1</strong> (PATH prepend)</td>
+  <td><strong>B1</strong> (PATH prepend)</td>
   <td><strong>30-45%</strong></td>
   <td>Projects that invoke compilers by bare name via PATH</td>
   <td>Projects using absolute paths (devtoolset, custom toolchains); PATH-overriding builds</td>
 </tr>
 <tr>
-  <td><strong>B3</strong> (fanotify)</td>
+  <td><strong>A3</strong> (fanotify)</td>
   <td><strong>0%</strong> (for SPDX)</td>
   <td>N/A — cannot capture argv, insufficient for SBOM generation</td>
   <td>Everything — eliminated due to missing argv data</td>
@@ -1018,19 +1078,19 @@ sub-strategy covers:
 
 | Combination | Estimated Coverage | Rationale |
 |------------|-------------------|-----------|
-| **B2 + A3** (audit + `LD_PRELOAD`) | **97-99%** | Audit covers everything; `LD_PRELOAD` provides richer data with lower overhead where available |
-| **B1 + B2** (eBPF + audit fallback) | **95-98%** | eBPF where available for best performance; audit fallback for older kernels |
-| **B1 + A3** (eBPF + `LD_PRELOAD`) | **85-92%** | Good on modern kernels; misses RHEL 7 entirely and env-stripped builds |
-| **B2 alone** (audit only) | **95-98%** | Universal but higher overhead and noisier than combinations |
-| **A3 alone** (`LD_PRELOAD` only) | **80-90%** | No kernel dependency but silent failures possible |
+| **A2 + B3** (audit + `LD_PRELOAD`) | **97-99%** | Audit covers everything; `LD_PRELOAD` provides richer data with lower overhead where available |
+| **A1 + A2** (eBPF + audit fallback) | **95-98%** | eBPF where available for best performance; audit fallback for older kernels |
+| **A1 + B3** (eBPF + `LD_PRELOAD`) | **85-92%** | Good on modern kernels; misses RHEL 7 entirely and env-stripped builds |
+| **A2 alone** (audit only) | **95-98%** | Universal but higher overhead and noisier than combinations |
+| **B3 alone** (`LD_PRELOAD` only) | **80-90%** | No kernel dependency but silent failures possible |
 
 ### B.6 The "Fully Locked Down" Gap
 
 An estimated **1-3%** of enterprise build environments cannot be
 intercepted by any sidecar strategy:
 
-- No capabilities granted (blocks all Category B)
-- Build strips environment (blocks all Category A)
+- No capabilities granted (blocks all Category A)
+- Build strips environment (blocks all Category B)
 - Container with audit disabled and no BPF access
 
 For these environments, the only option is **standalone mode** where
@@ -1068,6 +1128,354 @@ than observed from a sidecar.
 
 ---
 
-*Investigation conducted June 10, 2026.*
+<a id="appendix-c"></a>
+
+## Appendix C: Per-Invocation Behavior — What Actually Happens
+
+This appendix describes, in exact detail, what occurs for **each
+compilation unit** during build interception. The example command is:
+
+```bash
+gcc -c -I/usr/include -o foo.o foo.c
+```
+
+For every strategy, the goal is identical: capture that `foo.c` (and
+its included headers) were compiled into `foo.o`, and produce
+cryptographic hashes (gitoid SHA-256) of all input and output files
+**at the exact moment the compilation completes**.
+
+### C.1 Standalone: ptrace (bomtrace3 + `bomsh_hook2.py`)
+
+**What the developer runs:**
+
+```bash
+bomtrace3 make -j16
+```
+
+**Per-invocation sequence:**
+
+1. `make` calls `execve("/usr/bin/gcc", ["gcc", "-c", "-I/usr/include", "-o", "foo.o", "foo.c"])`
+2. bomtrace3 intercepts the `execve` syscall via `PTRACE_SYSCALL`
+3. bomtrace3 records: PID, program path, full argv, cwd, timestamp
+4. bomtrace3 allows the `execve` to proceed — gcc runs normally
+5. bomtrace3 intercepts subsequent syscalls (open, read, write, etc.)
+   but only logs them to the raw logfile — no stopping for hashing
+6. gcc finishes — bomtrace3 intercepts the exit
+7. **bomtrace3 invokes `bomsh_hook2.py`** with the process metadata
+8. `bomsh_hook2.py` parses argv to identify input files (`foo.c`) and
+   output files (`foo.o`)
+9. `bomsh_hook2.py` reads the `.d` dependency file (if `-MD`/`-MMD`
+   was used) or the `-I` paths to identify header dependencies
+10. **`bomsh_hook2.py` hashes every input and output file (inline)**:
+    - `sha256(foo.c)` → gitoid of input source
+    - `sha256(foo.o)` → gitoid of output object
+    - `sha256(header1.h)`, `sha256(header2.h)`, ... → gitoid of each
+      included header
+11. `bomsh_hook2.py` writes the hash record to the treedb:
+    `output_gitoid ← [input_gitoid_1, input_gitoid_2, ...]`
+12. Control returns to bomtrace3; other parallel compilation units
+    continue unaffected
+
+**Overhead per invocation**: ~2-5 ms (dominated by file I/O for
+hashing; SHA-256 computation is ~50-500 μs for typical file sizes)
+
+**Why ptrace is slow at scale**: Step 2-6 above happen for EVERY
+syscall, not just execve. A single `gcc` invocation makes thousands
+of syscalls (open, read, write, mmap, etc.). Each one stops the
+process and context-switches to the tracer. At `-j64`, this
+serialization destroys parallelism.
+
+### C.2 Sidecar Category B: `LD_PRELOAD`
+
+**What the sidecar injects:**
+
+```bash
+export LD_PRELOAD=/sidecar/libintercept.so
+```
+
+**Per-invocation sequence:**
+
+1. `make` calls `execve("/usr/bin/gcc", [...])`
+2. The dynamic linker loads `libintercept.so` before gcc's own code
+3. `libintercept.so` interposes on libc functions:
+   - `execve()` / `execvp()` / `posix_spawn()` — to detect child
+     process creation
+   - `_exit()` / `exit()` — to detect process completion
+4. The interposed `execve()` logs the event: program path, full argv,
+   PID, PPID, cwd, timestamp → writes to shared log (file or socket)
+5. The interposed `execve()` calls the **real** `execve()` — gcc runs
+6. gcc compiles `foo.c` → `foo.o` (normal compilation, unaffected)
+7. gcc calls `_exit(0)` — the interposed `_exit()` fires
+8. **The exit handler hashes input and output files (inline)**:
+   - Parse argv to identify `foo.c` (input) and `foo.o` (output)
+   - Read `.d` dependency file or scan `-I` paths for headers
+   - `sha256(foo.c)`, `sha256(foo.o)`, `sha256(header*.h)`
+   - Write hash record to treedb/ADG via shared memory or socket
+9. The real `_exit(0)` is called — gcc process terminates
+10. `make` sees gcc exited with status 0 and proceeds to next unit
+
+**Overhead per invocation**: ~2-5 ms (same hashing cost as ptrace,
+but NO per-syscall interception — only execve entry and process exit)
+
+**Key difference from ptrace**: `LD_PRELOAD` only interposes on
+specific libc calls, not every syscall. gcc runs at full speed
+between the interposed `execve()` and `_exit()`. No tracing overhead
+during the actual compilation.
+
+**Limitation**: If gcc spawns child processes (e.g., `cc1`, `as`),
+`LD_PRELOAD` propagates to them via the environment. But if any
+process in the chain calls `execve()` after clearing the environment
+or is statically linked, the interposition is lost.
+
+### C.3 Sidecar Category B: CC= / PATH Wrappers
+
+**What the sidecar injects:**
+
+```bash
+export CC=/sidecar/wrappers/gcc   # CC= override
+# or
+export PATH=/sidecar/wrappers:$PATH   # PATH prepend
+```
+
+**Per-invocation sequence:**
+
+1. `make` invokes `gcc -c -o foo.o foo.c`
+2. Shell/make finds `/sidecar/wrappers/gcc` (via CC= or PATH)
+3. The wrapper script executes:
+   ```bash
+   #!/bin/bash
+   # Log the invocation
+   echo "$$ $(date +%s.%N) $PWD $@" >> /sidecar/event.log
+   # Call the real compiler and capture exit status
+   /usr/bin/gcc "$@"
+   status=$?
+   ```
+4. The real `gcc` compiles `foo.c` → `foo.o` (normal compilation)
+5. gcc exits — the wrapper script regains control
+6. **The wrapper hashes input and output files (inline)**:
+   ```bash
+   # Parse argv for -o flag to find output file
+   # Parse argv for input .c files
+   # Read .d file for header dependencies
+   /sidecar/hasher --input foo.c --output foo.o \
+       --deps foo.d --treedb /sidecar/treedb
+   ```
+7. The wrapper exits with gcc's original exit status
+8. `make` sees exit status 0 and proceeds to next unit
+
+**Overhead per invocation**: ~3-8 ms (shell script startup ~1-2 ms +
+hashing ~2-5 ms). Slightly higher than `LD_PRELOAD` due to the
+shell script overhead.
+
+**Key difference from `LD_PRELOAD`**: The wrapper is a separate
+process, not an injected library. This means:
+
+- **Advantage**: Simpler to implement and debug (it's a shell script)
+- **Disadvantage**: Extra fork+exec for the wrapper process itself
+- **Disadvantage**: Only intercepts the top-level compiler call, not
+  child processes spawned by gcc (e.g., `cc1`, `as`) unless those
+  also go through PATH
+
+### C.4 Sidecar Category A: eBPF
+
+**What the sidecar loads:**
+
+```bash
+# Sidecar daemon loads BPF program into kernel
+bpf_load(tracepoint/syscalls/sys_enter_execve, program)
+bpf_load(tracepoint/sched/sched_process_exit, program)
+```
+
+**Per-invocation sequence:**
+
+1. `make` calls `execve("/usr/bin/gcc", [...])`
+2. Kernel hits `sys_enter_execve` tracepoint — BPF program fires
+3. BPF program (in-kernel, ~microseconds):
+   - Reads PID from task struct
+   - Reads filename (first arg to execve) — limited to ~256 bytes
+   - Writes `{pid, filename, timestamp}` to BPF ring buffer
+   - **Cannot read full argv in-kernel** (512-byte BPF stack limit,
+     argv is variable-length array in user memory)
+4. Kernel completes execve — gcc runs at full speed (zero overhead)
+5. Sidecar userspace daemon reads ring buffer entry asynchronously
+6. Daemon reads `/proc/PID/cmdline` to get full argv (race: must
+   read before gcc exits)
+7. Daemon reads `/proc/PID/cwd` for working directory
+8. gcc compiles `foo.c` → `foo.o` (unaffected by BPF)
+9. gcc exits — kernel hits `sched_process_exit` tracepoint
+10. BPF program writes `{pid, exit_code, timestamp}` to ring buffer
+11. **Sidecar daemon detects gcc exit and hashes files (inline)**:
+    - Uses previously captured argv to identify `foo.c` and `foo.o`
+    - `sha256(foo.c)`, `sha256(foo.o)`, `sha256(header*.h)`
+    - Writes hash record to treedb/ADG
+12. `make` proceeds to next unit (gcc already exited in step 9 — make
+    doesn't wait for the sidecar daemon's hashing)
+
+**Overhead per invocation**: ~2-5 ms for hashing (same as other
+strategies), but **the hashing does not block the build**. The sidecar
+daemon hashes asynchronously after gcc exits. `make` sees gcc's exit
+immediately and can launch the next compilation unit.
+
+**This is eBPF's key advantage**: The build is never blocked by
+interception or hashing. The sidecar daemon does its work in parallel
+with ongoing compilation. **Critical constraint**: the daemon MUST
+keep up with compilation throughput. If it falls behind, files may be
+deleted (e.g., `make clean` at end of build script) or the workspace
+may be destroyed (ephemeral CI/CD) before the daemon can hash them.
+The daemon must complete all hashing before the build stage exits —
+there is no "catch up later" in ephemeral environments.
+
+**argv race condition**: If gcc exits before the daemon reads
+`/proc/PID/cmdline`, the data is lost. Mitigation: monitor
+`sched_process_exit` and prioritize cmdline reads for short-lived
+processes, or capture argv via `sys_enter_execve` args (partial, up
+to BPF stack limit).
+
+### C.5 Sidecar Category A: Linux Audit
+
+**What the sidecar configures:**
+
+```bash
+auditctl -a always,exit -F arch=b64 -S execve -k omnibor
+```
+
+**Per-invocation sequence:**
+
+1. `make` calls `execve("/usr/bin/gcc", [...])`
+2. Kernel audit subsystem logs the event to the audit buffer:
+   ```text
+   type=EXECVE msg=audit(1718464800.123:4567):
+     argc=6 a0="gcc" a1="-c" a2="-I/usr/include"
+     a3="-o" a4="foo.o" a5="foo.c"
+   type=CWD msg=audit(...): cwd="/build/src"
+   type=PATH msg=audit(...): name="/usr/bin/gcc"
+   type=SYSCALL msg=audit(...): pid=12345 ppid=12300
+     uid=1000 exit=0
+   ```
+3. gcc runs at full speed (audit logging is asynchronous)
+4. gcc finishes — the exit is also logged (exit code, timestamp)
+5. auditd writes the audit record to `/var/log/audit/audit.log`
+6. **Sidecar log consumer reads the audit log entry**:
+   - Parses the structured log to extract argv, cwd, PID, exit code
+   - Filters to only compiler-related execve events (gcc, g++, cc,
+     ar, ld, as) using the process executable path
+   - Identifies input files (`foo.c`) and output files (`foo.o`)
+     from parsed argv
+7. **Sidecar hashes input and output files (inline)**:
+   - `sha256(foo.c)`, `sha256(foo.o)`, `sha256(header*.h)`
+   - Writes hash record to treedb/ADG
+8. `make` has already moved on (audit is non-blocking)
+
+**Overhead per invocation**: ~3-8 ms (audit log parsing ~1-3 ms +
+hashing ~2-5 ms). The parsing overhead is higher than eBPF because
+audit log entries are text-based and require string parsing.
+
+**Key advantage over eBPF**: Full argv is logged by the kernel —
+no race condition, no `/proc/PID/cmdline` read needed. The audit
+record contains the complete command line regardless of length.
+
+**Key advantage over all other strategies**: audit works on **every
+enterprise Linux** from RHEL 7 (kernel 3.10) onward. No minimum
+kernel version. No `CAP_BPF`. auditd is already running in most
+enterprise environments for security compliance.
+
+**Key disadvantage**: The audit log is system-wide. On a busy build
+machine, the sidecar must filter thousands of non-build-related
+execve events (shells, CI/CD tooling, monitoring agents). This
+filtering overhead grows with system load.
+
+### C.6 Sidecar Category A: fanotify
+
+**Per-invocation sequence:**
+
+1. `make` calls `execve("/usr/bin/gcc", [...])`
+2. Kernel sends `FAN_OPEN_EXEC` notification to the sidecar's
+   fanotify fd: `{pid, fd_to_executable}`
+3. Sidecar reads the notification — knows that PID 12345 executed
+   `/usr/bin/gcc`
+4. **Sidecar does NOT know argv** — fanotify provides no command-line
+   data. Cannot determine that `foo.c` was compiled into `foo.o`.
+5. gcc compiles and exits
+6. Sidecar cannot hash input files because it doesn't know which
+   input files were used
+
+**Verdict**: fanotify **cannot perform inline hashing** of input
+files because it lacks argv data. It knows THAT gcc ran but not WHAT
+it compiled. This makes it **insufficient for SPDX generation** as
+a standalone strategy. Eliminated from consideration.
+
+### C.7 Summary: Per-Unit Overhead Comparison
+
+<table>
+<tr>
+  <th style="width:18%">Strategy</th>
+  <th style="width:12%">Per-Unit Cost</th>
+  <th style="width:35%">What Happens Inline</th>
+  <th style="width:15%">Blocks Build?</th>
+  <th style="width:20%">Has Full Argv?</th>
+</tr>
+<tr>
+  <td><strong>ptrace</strong> (standalone)</td>
+  <td>2-5 ms + per-syscall tracing</td>
+  <td>Every syscall intercepted; <code>bomsh_hook2.py</code> hashes on exit</td>
+  <td><strong>Yes</strong> — every syscall pauses the process</td>
+  <td>Yes — captured via ptrace</td>
+</tr>
+<tr>
+  <td><strong><code>LD_PRELOAD</code></strong></td>
+  <td>2-5 ms</td>
+  <td>Log execve at entry; hash files in <code>_exit()</code> handler</td>
+  <td>Minimal — only at execve entry and process exit</td>
+  <td>Yes — captured at execve interposition</td>
+</tr>
+<tr>
+  <td><strong>CC= / PATH</strong></td>
+  <td>3-8 ms</td>
+  <td>Wrapper logs args; calls real compiler; hashes on return</td>
+  <td>Yes — wrapper holds the process slot until hashing completes</td>
+  <td>Yes — wrapper receives full argv</td>
+</tr>
+<tr>
+  <td><strong>eBPF</strong></td>
+  <td>2-5 ms</td>
+  <td>BPF captures PID+filename; daemon hashes after exit event</td>
+  <td><strong>No</strong> — hashing is async in daemon</td>
+  <td>Partial — race on <code>/proc/PID/cmdline</code></td>
+</tr>
+<tr>
+  <td><strong>audit</strong></td>
+  <td>3-8 ms</td>
+  <td>Kernel logs full entry; daemon parses + hashes</td>
+  <td><strong>No</strong> — hashing is async in log consumer</td>
+  <td>Yes — kernel logs full argv</td>
+</tr>
+<tr>
+  <td><strong>fanotify</strong></td>
+  <td>N/A</td>
+  <td>Kernel notifies exec event; no argv available</td>
+  <td>No</td>
+  <td><strong>No</strong> — eliminated for SPDX</td>
+</tr>
+</table>
+
+**Key takeaway**: The per-unit hashing cost (2-8 ms) is similar
+across all viable strategies. The strategies differ in:
+
+- **Whether hashing blocks the build**: CC= wrappers block (the
+  wrapper holds make's process slot). `LD_PRELOAD` blocks minimally
+  (exit handler). eBPF and audit do not block at all.
+- **Argv reliability**: audit provides the strongest guarantee (kernel
+  logs full argv). `LD_PRELOAD` and wrappers capture argv directly.
+  eBPF has a race condition on `/proc/PID/cmdline`.
+- **Applicability**: Category A works universally. Category B requires
+  build system cooperation.
+
+---
+
+*Investigation conducted June 10, 2026. Updated June 16, 2026 with
+build-observer (sbom-observer) external validation, kernel 5.8
+release date context, per-invocation hashing analysis, and CI/CD
+workspace lifecycle constraints (inline hashing is architecturally
+mandatory — ephemeral build environments destroy all files on exit).*
 *Constraint: true sidecar = no host filesystem modification.*
 *Environment overrides valid but limited; kernel observation universal.*

--- a/docs/deep-dive/cicd-workspace-lifecycle.md
+++ b/docs/deep-dive/cicd-workspace-lifecycle.md
@@ -1,0 +1,444 @@
+# CI/CD Workspace Lifecycle: When Source and Build Artifacts Disappear
+
+> **Date**: June 16, 2026
+>
+> **Status**: Industry best practices research — architectural constraint for sidecar Phase 1
+>
+> **Context**: The OmniBOR sidecar Phase 1 must hash files during the build because the workspace is destroyed after the build stage completes. This document establishes the industry-standard CI/CD workspace lifecycle and its implications for build interception architecture.
+
+---
+
+## Executive Summary
+
+**The build workspace is ephemeral.** In every major CI/CD platform used
+by enterprise C/C++ teams, source files, object files, and intermediate
+build artifacts are **destroyed** when the build stage/job/pod completes.
+There is no guarantee that any file — source or binary — will exist after
+the build step finishes.
+
+This is not an edge case. It is the **default behavior** of:
+
+- GitHub Actions (hosted runners)
+- GitLab CI/CD (Docker/Kubernetes executors)
+- Jenkins (Kubernetes agents, ephemeral Docker agents)
+- Harness CI (Kubernetes pods)
+- Azure DevOps (hosted agents)
+- CircleCI (Docker executors)
+- TeamCity (cloud agents)
+
+**Architectural implication**: Phase 1 (build interception) MUST hash
+all input and output files **inline, per compilation unit, during the
+build** — not in a post-build batch. When the build stage exits, the
+files are gone forever.
+
+---
+
+## 1. The Five Workspace Lifecycle Models
+
+Enterprise CI/CD platforms implement one of five workspace lifecycle
+models. In all models except Model E (legacy persistent), the workspace
+is destroyed at stage or job boundary.
+
+### Model A: Ephemeral VM (destroyed after each job)
+
+**Platforms**: GitHub Actions (hosted), Azure DevOps (hosted agents)
+
+Each job runs on a **fresh virtual machine** that is destroyed when the
+job completes. The entire filesystem — source checkout, build artifacts,
+temporary files — is gone.
+
+```yaml
+# GitHub Actions — each job is a fresh VM
+jobs:
+  build:
+    runs-on: ubuntu-latest     # Fresh VM
+    steps:
+      - uses: actions/checkout@v4
+      - run: make -j$(nproc)
+      # When this job ends, the VM is destroyed
+      # Source code, .o files, binaries — ALL gone
+
+  test:
+    runs-on: ubuntu-latest     # DIFFERENT fresh VM
+    needs: build
+    steps:
+      # Source code does NOT exist here
+      # Must download artifacts explicitly
+      - uses: actions/download-artifact@v4
+```
+
+**GitHub documentation**: "Each job runs in a fresh instance of the
+virtual environment specified by `runs-on`." Files created in one job
+are not available in subsequent jobs without explicit artifact upload.
+
+### Model B: Ephemeral Container (destroyed after each stage)
+
+**Platforms**: GitLab CI (Docker executor), CircleCI (Docker)
+
+Each stage runs in a **fresh container**. The container is removed when
+the stage completes. Source code is re-checked-out in each stage unless
+`GIT_STRATEGY: none` is set.
+
+```yaml
+# GitLab CI — each stage is a fresh container
+stages:
+  - build
+  - test
+
+build_job:
+  stage: build
+  script:
+    - ./configure && make -j$(nproc)
+  artifacts:
+    paths:
+      - build/output-binary  # Only artifacts survive
+
+test_job:
+  stage: test
+  script:
+    # Source code is re-cloned here (fresh container)
+    # Object files from build stage do NOT exist
+    # Only explicitly declared artifacts are available
+    - ./build/output-binary --self-test
+```
+
+**GitLab documentation** (Runner Issue #336): "GitLab CI, by default,
+starts each stage with a clean environment, which means files created
+in one stage (like compiled binaries or build outputs) are not
+automatically available in subsequent stages."
+
+### Model C: Ephemeral Kubernetes Pod (destroyed after each stage)
+
+**Platforms**: Jenkins (Kubernetes plugin), Harness CI, Tekton, Argo Workflows
+
+Each build stage creates a Kubernetes pod. The pod is **destroyed
+immediately** when the stage completes — even if other stages in the
+same pipeline are still running.
+
+**Harness CI documentation**: "Build pod cleanup takes place immediately
+after the completion of a stage's execution. This is true even if there
+are multiple CI stages in the same pipeline; as each build stage ends,
+the pod for that stage is cleaned up."
+
+**Jenkins with Kubernetes agents**: The pod is the workspace. When the
+build stage finishes, the pod is terminated and its filesystem is lost.
+
+### Model D: Persistent Workspace with Explicit Cleanup
+
+**Platforms**: Jenkins (persistent agents), TeamCity (on-prem agents)
+
+The workspace persists on a long-lived agent, but **best practice is
+explicit cleanup after each build**. The Jenkins Workspace Cleanup
+Plugin (`ws-cleanup`) is one of the most installed Jenkins plugins.
+
+```groovy
+// Jenkins Declarative Pipeline — standard pattern
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            steps {
+                sh './configure && make -j$(nproc)'
+            }
+        }
+    }
+    post {
+        always {
+            // THIS IS THE STANDARD PATTERN
+            // Workspace is wiped after every build
+            cleanWs(deleteDirs: true, disableDeferredWipeout: true)
+        }
+    }
+}
+```
+
+Even on persistent agents, workspace cleanup is the **default
+recommendation** because:
+
+- Disk space: C/C++ builds produce GBs of object files
+- Reproducibility: stale files from previous builds cause failures
+- Security: source code and secrets must not persist on shared agents
+- Compliance: SOC 2 / FedRAMP require workspace sanitization
+
+### Model E: Persistent Workspace (legacy — declining)
+
+**Platforms**: Jenkins (traditional persistent agents without cleanup)
+
+Workspace persists between builds on the same agent. Source and build
+artifacts remain on disk until the next build or manual cleanup.
+
+**This model is actively being phased out** in enterprise environments
+due to security, reproducibility, and disk space concerns. The industry
+trend is overwhelmingly toward ephemeral environments.
+
+---
+
+## 2. Enterprise C/C++ Build Cleanup Patterns
+
+Enterprise C/C++ builds are particularly aggressive about cleanup because
+of the large artifact sizes involved. A typical large C/C++ project
+produces 5-50 GB of intermediate object files during a `-j64` build.
+
+### 2.1 Common Cleanup Patterns in Enterprise C/C++ CI
+
+| Pattern | When It Runs | What Gets Deleted | Prevalence |
+|---------|-------------|-------------------|-----------|
+| Pod/VM destruction | Immediately after stage completes | Everything — source, objects, binaries | ~60% of enterprise (K8s/cloud) |
+| `cleanWs()` (Jenkins) | Post-build `always` block | Entire workspace directory | ~25% of enterprise (Jenkins persistent) |
+| `make clean` / `make distclean` | End of build script | Object files, libraries (source remains) | ~10% (within persistent agents) |
+| Docker volume removal | Container exit | Container filesystem | ~40% (Docker-in-Docker builds) |
+| No cleanup (rely on next checkout) | Never explicit | Nothing explicitly | ~5% (legacy, declining) |
+
+### 2.2 What `make clean` and `make distclean` Delete
+
+For builds on persistent agents that don't destroy the entire workspace,
+build scripts frequently run `make clean` as a final step:
+
+| Target | Deletes | Source Code Survives? |
+|--------|---------|----------------------|
+| `make clean` | `.o`, `.a`, `.so`, binaries | Yes |
+| `make distclean` | Above + configure output, `.d` files, `Makefile` (generated) | Yes (but build is not re-runnable) |
+| `rm -rf build/` (out-of-tree) | Entire build directory | Yes (source is separate) |
+| Pod/container destruction | Everything | **No** |
+
+### 2.3 The Overwhelming Industry Trend: Ephemeral
+
+Enterprise CI/CD is moving rapidly toward ephemeral build environments:
+
+- **Security**: Ephemeral runners eliminate credential persistence and
+  cross-job contamination. ARC (Actions Runner Controller) documentation
+  states: "secrets, tokens, and build artifacts from one job can leak
+  into the next" on persistent runners.
+- **Reproducibility**: Fresh environments guarantee no stale state
+- **Compliance**: SOC 2, FedRAMP, and PCI-DSS require build isolation
+- **Cost optimization**: Cloud-native CI only pays for compute during
+  the actual build, not idle time with persistent workspaces
+- **Kubernetes-native**: All modern CI platforms support or prefer K8s
+  pod-per-job execution
+
+---
+
+## 3. Implications for OmniBOR Sidecar Architecture
+
+### 3.1 Phase 1 MUST Be Self-Contained
+
+Phase 1 (build interception) runs **inside** the build stage. When the
+build stage completes, the workspace is destroyed. Phase 1 cannot rely
+on ANY file existing after the stage exits.
+
+This means Phase 1 must, **before the build stage exits**:
+
+1. Hash ALL input and output files per compilation unit (inline)
+2. Persist all hash records to the treedb
+3. Push all Phase 1 artifacts to durable storage:
+   - `phase1_manifest.json`
+   - treedb (OmniBOR ADG with gitoid hashes)
+   - Event log (raw syscall/interception data)
+4. Compute and record gitoid of the final build output (binary/library)
+
+### 3.2 Phase 2 Has NO Access to Source or Build Artifacts
+
+Phase 2 (SPDX generation) runs in a **different process, container,
+host, or time**. It has access ONLY to:
+
+- `phase1_manifest.json` (from durable storage)
+- treedb (from durable storage)
+- Event log (from durable storage)
+- The final binary (if uploaded as an artifact)
+
+Phase 2 does NOT have access to:
+
+- Source files (`.c`, `.h`)
+- Object files (`.o`)
+- Libraries (`.a`, `.so`)
+- Build directory structure
+- The build host filesystem
+- Any intermediate artifacts
+
+This is not a hypothetical constraint — it is the **architecture we
+designed** in `sidecar-async-spdx-architecture.md` (principle P5:
+"Fail-Safe for Phase 2 — Ephemeral Build Environments").
+
+### 3.3 Why Inline Hashing Is Non-Negotiable
+
+Given the above, the per-unit inline hashing described in Appendix C of
+the interception strategies document is **architecturally mandatory**,
+not a performance optimization:
+
+| Scenario | Inline hash available? | Post-build hash possible? | Outcome |
+|----------|----------------------|--------------------------|---------|
+| Ephemeral VM (GitHub Actions) | ✅ During build | ❌ VM destroyed | Only inline works |
+| Ephemeral pod (K8s/Harness) | ✅ During build | ❌ Pod destroyed | Only inline works |
+| Ephemeral container (GitLab) | ✅ During build | ❌ Container removed | Only inline works |
+| Jenkins + `cleanWs()` | ✅ During build | ❌ Workspace wiped | Only inline works |
+| Jenkins persistent (no cleanup) | ✅ During build | ⚠️ Files exist but risky | Inline is still required for provenance |
+
+**Even in the rare case where files persist** (Model E), inline hashing
+is still required because:
+
+- A concurrent build on the same agent could modify files
+- Source files could be `git pull`'d between build and hash
+- The provenance guarantee requires hash-at-build-time, not hash-later
+
+### 3.4 What Phase 1 Artifacts Must Contain
+
+Because Phase 2 cannot read source or object files, Phase 1 must
+capture ALL metadata needed for SPDX generation:
+
+| Data | Captured By | Stored In |
+|------|------------|-----------|
+| Input file gitoids (SHA-256) | Per-unit inline hashing | treedb |
+| Output file gitoids (SHA-256) | Per-unit inline hashing | treedb |
+| Input→output mappings | Event log (argv parsing) | treedb |
+| Compiler flags and version | Event log | manifest |
+| Header dependencies | `.d` file parsing during build | treedb |
+| Process tree (parent→child) | PID/PPID tracking | event log |
+| Build timestamp per unit | Interception event | event log |
+| Final binary gitoid | Post-build hash (before stage exits) | manifest |
+
+Phase 2 uses ONLY the treedb, event log, and manifest to generate
+the SPDX document. It never needs to read a source file.
+
+---
+
+## 4. Platform-Specific Evidence
+
+### 4.1 GitHub Actions
+
+```yaml
+# Standard enterprise C++ workflow
+name: Build
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest  # Ephemeral VM
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          make -j$(nproc)
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-binary
+          path: build/myapp
+    # VM IS DESTROYED HERE — source, .o files, everything gone
+```
+
+### 4.2 GitLab CI
+
+```yaml
+# Standard enterprise C++ pipeline
+stages:
+  - build
+  - scan
+  - deploy
+
+build:
+  stage: build
+  image: gcc:13
+  script:
+    - mkdir build && cd build
+    - cmake .. -DCMAKE_BUILD_TYPE=Release
+    - make -j$(nproc)
+  artifacts:
+    paths:
+      - build/myapp
+    expire_in: 1 hour
+  # Container destroyed — source gone, only artifact survives
+
+sbom_scan:
+  stage: scan
+  image: sbom-tool:latest
+  script:
+    # NO SOURCE CODE HERE — only the artifact from build stage
+    - sbom-generate --binary build/myapp
+```
+
+### 4.3 Jenkins (Kubernetes agents)
+
+```groovy
+pipeline {
+    agent {
+        kubernetes {
+            yaml '''
+            spec:
+              containers:
+              - name: gcc
+                image: gcc:13
+            '''
+        }
+    }
+    stages {
+        stage('Build') {
+            steps {
+                container('gcc') {
+                    sh 'cmake -B build && cmake --build build -j$(nproc)'
+                }
+            }
+        }
+    }
+    // Pod destroyed when pipeline completes
+    // No source, no objects, no binaries remain
+}
+```
+
+### 4.4 Jenkins (persistent agents with standard cleanup)
+
+```groovy
+pipeline {
+    agent { label 'linux-x86_64' }
+    stages {
+        stage('Build') {
+            steps {
+                sh './configure && make -j$(nproc)'
+                archiveArtifacts artifacts: 'build/myapp'
+            }
+        }
+    }
+    post {
+        always {
+            // Standard practice: clean workspace after every build
+            cleanWs(deleteDirs: true, disableDeferredWipeout: true)
+        }
+    }
+}
+```
+
+---
+
+## 5. Summary: The Five Rules
+
+1. **Assume the workspace is destroyed after the build stage exits.**
+   This is true for ~95% of enterprise CI/CD environments.
+
+2. **Phase 1 must hash every file inline during the build.** There is
+   no opportunity to "come back later" and hash files.
+
+3. **Phase 1 must push all artifacts to durable storage before exiting.**
+   The treedb, event log, and manifest must survive workspace destruction.
+
+4. **Phase 2 operates exclusively on Phase 1 artifacts.** It never
+   reads source files, object files, or the build directory.
+
+5. **The final binary must be hashed before the build stage exits.**
+   The binary's gitoid binds the SPDX document to the exact artifact.
+
+---
+
+## 6. Data Sources
+
+| Source | Finding |
+|--------|---------|
+| GitHub Actions docs | "Each job runs in a fresh instance of the virtual environment" |
+| GitLab Runner Issue #336 | "starts each stage with a clean environment...files created in one stage are not automatically available in subsequent stages" |
+| Harness CI FAQ | "Build pod cleanup takes place immediately after the completion of a stage's execution" |
+| Jenkins Workspace Cleanup Plugin | One of the most installed plugins; `post { always { cleanWs() } }` is standard |
+| ARC (Actions Runner Controller) | "secrets, tokens, and build artifacts from one job can leak into the next" — reason for ephemeral |
+| GitHub community discussion | "All files and directories created during a workflow run are ephemeral and automatically cleaned up on GitHub-hosted runners" |
+| Stack Overflow (GitLab) | `GIT_STRATEGY: none` required to even attempt workspace sharing; default is full re-clone per stage |
+
+---
+
+*Research conducted June 16, 2026. Based on current documentation from
+GitHub, GitLab, Jenkins, Harness, and industry DevOps practices.*

--- a/docs/deep-dive/phase-isolation-gap-analysis.md
+++ b/docs/deep-dive/phase-isolation-gap-analysis.md
@@ -1,0 +1,552 @@
+# Phase Isolation Gap Analysis: Phase 2 Dependencies on `repo_dir`
+
+> **Date**: June 16, 2026
+>
+> **Status**: Architecture gap analysis — Phase 2 cannot run independently
+>
+> **Requirement**: Phase isolation is MANDATORY. Phase 2 must operate
+> exclusively on Phase 1 artifacts (treedb, manifest, `bom_dir`). Phase 2
+> must NEVER read from `repo_dir` (cloned source tree) because `repo_dir`
+> does not exist when Phase 2 runs.
+
+---
+
+## 1. The Problem
+
+Phase 2 (SPDX generation) currently reads directly from `repo_dir` in
+multiple places across all languages. In an ephemeral CI/CD environment,
+`repo_dir` is destroyed when the build stage (Phase 1) exits. Phase 2
+runs in a different process, container, or host — the source tree, object
+files, and build outputs are gone.
+
+**Current state**: Phase 1 and Phase 2 run sequentially in the same
+container via `run_*_pipeline()`. This masks the dependency on `repo_dir`
+because the files happen to still exist. But phase isolation — a
+mandatory requirement established before Java sidecar implementation —
+requires Phase 2 to work without `repo_dir`.
+
+---
+
+## 2. Complete Audit: What Phase 2 Reads from `repo_dir`
+
+### 2.1 Java (sidecar implemented, phase split NOT implemented)
+
+| Phase 2 Operation | File | What it reads from `repo_dir` | How it reads |
+|---|---|---|---|
+| `get_maven_deps()` | `maven_parser.py:32` | Runs `mvn dependency:tree` subprocess | Needs Maven, `pom.xml`, resolved deps |
+| `get_gradle_deps()` | `gradle_parser.py:43` | Runs `./gradlew dependencies` subprocess | Needs Gradle, `build.gradle`, wrapper |
+| `get_version()` | `maven_parser.py:224` | Parses `pom.xml` for `<version>` tag | Reads XML from disk |
+| `get_gradle_version()` | `gradle_parser.py:249` | Parses `build.gradle` for version | Reads file from disk |
+| `get_project_group_id()` | `maven_parser.py:293` | Parses `pom.xml` for `<groupId>` | Reads XML from disk |
+| `get_gradle_group()` | `gradle_parser.py:295` | Parses `build.gradle` for group | Reads file from disk |
+| `_detect_gradle_version()` | `java_generator.py:234` | Reads `gradle-wrapper.properties` | Reads file from disk |
+| `detect_repackaging_plugins()` | `maven_plugin_detector.py` | Reads `pom.xml` for shade/assembly plugins | Reads XML from disk |
+| `is_gradle_project()` | `gradle_parser.py:337` | Checks if `gradlew` or `build.gradle` exists | `Path.exists()` |
+| JAR globbing | `lang_runners.py:370` | Globs for output JAR files | `repo_dir.glob(pattern)` |
+| JAR module detection | `lang_runners.py:452` | Walks up from JAR path to find `pom.xml`/`build.gradle` | `Path.exists()` |
+| `BinaryCollector.collect()` | `binary_collector.py:90` | Copies JARs from `repo_dir` | `shutil.copy2()` |
+
+**Irony**: Phase 1 sidecar already runs `mvn dependency:tree` and saves
+`maven_deps.json` to `bom_dir`. Phase 2 ignores this and re-runs the
+same command against the live source tree.
+
+### 2.2 C/C++ (sidecar NOT implemented, standalone only)
+
+| Phase 2 Operation | File | What it reads from `repo_dir` |
+|---|---|---|
+| `SpdxGenerator.generate()` | `spdx_generator.py:349` | Resolves binary paths via `repo_dir / rel_path` |
+| `AdgSpdxStep.generate()` | `adg_spdx.py:67` | Globs for binaries via `repo_dir.glob(pattern)` |
+| `AdgParser.parse()` | `parser.py:95` | Uses `repos_dir` prefix to classify project vs system files |
+| `AdgSpdxGenerator.__init__()` | `generator.py:29` | Stores `repos_dir` for path classification |
+| `SpdxEmitter.emit()` | `emitter.py:574` | Reads `Cargo.lock` from `repos_dir/repo_name/` |
+| `MetadataCollector.collect()` | `metadata_collector.py:93` | Resolves binary paths via `repo_dir / rel_path` |
+| `collect_metadata.main()` | `collect_metadata.py:64` | Scans `repo_dir` for version files, headers |
+| `collect_dynamic_libs.main()` | `collect_dynamic_libs.py:30` | Runs `ldd` and `readelf` on binary at `repo_dir` path |
+
+### 2.3 Rust (sidecar NOT implemented, standalone only)
+
+Same as C/C++ above, plus:
+
+| Phase 2 Operation | File | What it reads from `repo_dir` |
+|---|---|---|
+| `parse_cargo_lock()` | `lang_parsers.py:252` | Reads `Cargo.lock` from `repos_dir/repo_name/` |
+| `parse_cargo_toml()` | `lang_parsers.py:281` | Reads `Cargo.toml` from `repos_dir/repo_name/` |
+
+### 2.4 Go (sidecar NOT implemented, standalone only)
+
+Same as C/C++ above, plus:
+
+| Phase 2 Operation | File | What it reads from `repo_dir` |
+|---|---|---|
+| `parse_go_mod()` | `lang_parsers.py:136` | Reads `go.mod` from project files |
+| `parse_go_modules_txt()` | `lang_parsers.py:167` | Reads `vendor/modules.txt` from project files |
+
+### 2.5 Cross-cutting
+
+| Phase 2 Operation | File | What it reads from `repo_dir` |
+|---|---|---|
+| `_detect_repo_version()` | `collect_metadata.py:64` | Iterates `repo_dir` files, scans `include/*.h`, `src/*.h` |
+
+---
+
+## 3. The Async SPDX Architecture Doc Also Has This Gap
+
+`sidecar-async-spdx-architecture.md` line 533 explicitly states:
+
+> "Phase 2 needs: Access to the source tree (for Go module parsing,
+> Java dep:tree)"
+
+And line 543:
+
+> "Java: JDK + Gradle/Maven in container — Dep:tree resolution
+> requires build toolchain"
+
+This directly contradicts the ephemeral workspace constraint and
+principle P5 (Fail-Safe for Ephemeral Build Environments). **The
+architecture doc itself is internally inconsistent** — it says Phase 2
+needs the source tree, while simultaneously saying the source tree is
+destroyed when Phase 1 exits.
+
+---
+
+## 4. Foundational Constraint: Zero Modification to the Host Build
+
+The sidecar requires **ZERO modifications** to the customer's:
+
+- **Build system** — no `pom.xml` changes, no `build.gradle` changes,
+  no Makefile changes
+- **Build commands** — no wrapping `make` with `omnibor-build -- make`,
+  no adding flags
+- **CI/CD pipeline config** — no changing the pipeline YAML, Jenkinsfile,
+  or `.gitlab-ci.yml`
+
+The sidecar is purely **additive infrastructure** — a container,
+DaemonSet, or system-level service added by the DevOps/platform team.
+The build team changes nothing. The build does not know the sidecar
+exists.
+
+### 4.1 What This Rules Out
+
+Several approaches that work for non-sidecar tools are **invalid**
+under this constraint:
+
+| Approach | Why it's invalid |
+|---|---|
+| Wrapper script (`cov-build make`, `bear -- make`) | Changes the build command |
+| Maven lifecycle hook (`<phase>verify</phase>` in `pom.xml`) | Modifies the project's `pom.xml` |
+| Gradle `finalizedBy` task / init script | Modifies build config or requires `-I` flag |
+| `RUSTC_WRAPPER=wrapper cargo build` | Requires setting env var in build command |
+| `go build -toolexec=wrapper` | Requires adding flag to build command |
+| CI/CD platform hooks (`post:`, `after_script`) | Modifies pipeline config |
+
+Note: Coverity (`cov-build`), SonarQube (`build-wrapper`), and Bear
+all use the wrapper pattern. These tools require build command changes.
+The OmniBOR sidecar cannot use this pattern.
+
+### 4.2 Valid Sidecar Integration Patterns
+
+The sidecar must intercept at the **kernel/system level** — transparent
+to the build system. The valid patterns are:
+
+#### Pattern 1: K8s Mutating Webhook + `LD_PRELOAD` Injection
+
+A Kubernetes `MutatingAdmissionWebhook` automatically injects the
+OmniBOR sidecar into build pods. An init container copies the
+interception shared library into a shared `emptyDir` volume and sets
+`LD_PRELOAD` in the build container's environment. The build command
+is unmodified — the dynamic linker loads the interception library
+before any other libraries.
+
+```yaml
+# Injected automatically by the webhook — customer never sees this
+spec:
+  initContainers:
+    - name: omnibor-init
+      image: omnibor-env:init
+      command: ["cp", "/opt/omnibor/libintercept.so", "/omnibor/"]
+      volumeMounts:
+        - name: omnibor-lib
+          mountPath: /omnibor
+    - name: omnibor-sidecar
+      image: omnibor-env:sidecar
+      restartPolicy: Always    # K8s 1.28+ native sidecar
+      volumeMounts:
+        - name: workspace
+          mountPath: /workspace
+        - name: omnibor-artifacts
+          mountPath: /artifacts
+  containers:
+    - name: build
+      # Customer's original build container — UNCHANGED
+      image: customer-build:latest
+      command: ["make", "-j16"]  # UNCHANGED
+      env:
+        - name: LD_PRELOAD        # Injected by webhook
+          value: /omnibor/libintercept.so
+      volumeMounts:
+        - name: workspace
+          mountPath: /workspace
+        - name: omnibor-lib
+          mountPath: /omnibor
+```
+
+Industry precedent: This is exactly how `EnvProxy` (Vault secret
+injection), Istio service mesh, and Dynatrace APM work — mutating
+webhooks inject sidecars and `LD_PRELOAD` libraries transparently.
+
+**Applicability**: C/C++ (all build systems), Rust, Go, Java
+(for compiler interception). Works with any dynamically-linked binary.
+
+#### Pattern 2: K8s Native Sidecar with eBPF (K8s 1.28+)
+
+The OmniBOR container runs as a native sidecar container (KEP-753).
+It loads eBPF programs that attach to kernel tracepoints
+(`sched_process_exec`, `sched_process_exit`, `sys_enter_openat`) to
+intercept compiler invocations inline. No `LD_PRELOAD` needed — works
+even with statically-linked binaries.
+
+K8s sidecar termination guarantee (kubernetes.io): "Upon Pod
+termination, the kubelet postpones terminating sidecar containers
+until the main application container has fully stopped."
+
+**Applicability**: All languages. Requires `CAP_BPF` / `CAP_SYS_ADMIN`
+in the sidecar container.
+
+#### Pattern 3: Node-Level eBPF DaemonSet
+
+A DaemonSet runs on every build node, loading eBPF programs that
+monitor all compiler invocations system-wide. Build pods do not need
+any modification — the eBPF programs observe from the kernel.
+
+**Applicability**: All languages, all build systems. Requires
+privileged DaemonSet on the node.
+
+#### Pattern 4: Container Image with Pre-Configured Interception
+
+The customer uses an OmniBOR-enabled base image for their build
+containers. The image has `LD_PRELOAD` and the interception library
+pre-installed. The build command is unchanged.
+
+**Applicability**: Requires the customer to change their base image.
+This is an infrastructure change (platform team), not a build system
+change (dev team). Common pattern for enterprise build environments
+that standardize on approved base images.
+
+### 4.3 Build Completion Detection
+
+The sidecar does NOT control the build process. It must detect when
+the build finishes so it can run post-build capture before the
+workspace is destroyed.
+
+| Detection Mechanism | How it works | Reliability |
+|---|---|---|
+| **eBPF `sched_process_exit`** | Kernel tracepoint fires when the build process exits. Sidecar receives ring buffer event with PID + exit code. | ✅ Kernel-level, no race conditions |
+| **Process monitoring** | Sidecar watches the build PID (via `/proc` or `waitpid` on shared PID namespace). | ✅ Reliable with shared PID namespace |
+| **`inotify`/`fanotify`** | Watch for creation of known build output files (JARs, ELF binaries). | ⚠️ May trigger before build fully completes |
+| **Shared volume signal** | `LD_PRELOAD` library writes a completion marker file when the build process exits. | ✅ If using `LD_PRELOAD` pattern |
+
+The eBPF `sched_process_exit` tracepoint is the most reliable: it
+fires exactly when the build process terminates and includes the PID,
+exit code, and parent PID. Tools like `exitsnoop` (bcc/libbpf)
+demonstrate this pattern. The sidecar can register a callback for the
+build process PID and immediately begin post-build capture when it
+fires.
+
+### 4.4 Post-Build Capture Window
+
+Once the sidecar detects build completion, it has a limited window to
+capture metadata before workspace destruction. The window depends on
+the deployment model:
+
+| Deployment | Window guarantee |
+|---|---|
+| **K8s native sidecar** | Sidecar runs until SIGTERM after main container exits. `terminationGracePeriodSeconds` (default 30s) provides the window. |
+| **K8s non-native sidecar** | No guarantee — sidecar may be terminated simultaneously with build container. |
+| **Same-container** | Sidecar process runs inside the build container. Window lasts until the container's entrypoint exits. |
+| **DaemonSet** | Runs on the node — survives pod termination. Can access pod volumes until garbage-collected. |
+
+**Critical constraint**: For K8s native sidecars, the default 30-second
+`terminationGracePeriodSeconds` may not be enough for Java dep:tree
+(5-15 minutes). The pod spec must set a longer grace period — but this
+is an infrastructure config change (platform team), not a build change.
+
+---
+
+## 5. Build-Time Impact Reassessment (All Languages)
+
+Everything that must access `repo_dir` runs inside the build stage.
+The workspace is destroyed after the stage exits. The sidecar cannot
+modify the build command, so all metadata capture happens either:
+
+- **Inline** — via `LD_PRELOAD` or eBPF during the build
+- **Post-build** — by the sidecar after detecting build completion,
+  within the capture window (section 4.4)
+
+### 5.1 C/C++
+
+| Operation | Time | When it runs | Mechanism |
+|---|---|---|---|
+| `make -j16` (native build) | ~30 min | Customer's build — unchanged | N/A |
+| Inline interception + hashing | +1-3% | During build | `LD_PRELOAD` or eBPF |
+| `ldd` + `readelf` per binary | 5-30 sec | Post-build (sidecar) | Sidecar runs on shared volume |
+| Version detection from source files | <5 sec | Post-build (sidecar) | Sidecar reads shared volume |
+| Copy binaries to `bom_dir` | <10 sec | Post-build (sidecar) | File copy from shared volume |
+
+**Total overhead**: ~1-3% in-band + <1 min post-build = **~3-4%**.
+
+**C/C++ is the cleanest case**: inline interception adds minimal
+overhead, and post-build capture is seconds. The 30-second default
+K8s `terminationGracePeriodSeconds` is more than enough.
+
+### 5.2 Rust
+
+| Operation | Time | When it runs | Mechanism |
+|---|---|---|---|
+| `cargo build --release` (native) | varies | Customer's build — unchanged | N/A |
+| Inline interception + hashing | +1-3% | During build | `LD_PRELOAD` or eBPF |
+| Copy `Cargo.lock`, `Cargo.toml` | <1 sec | Post-build (sidecar) | File copy |
+| Copy binaries | <5 sec | Post-build (sidecar) | File copy |
+
+**Total overhead**: ~1-3% in-band + ~5 sec post-build = **~3-4%**.
+
+No live commands needed post-build. `Cargo.lock` and `Cargo.toml` are
+small static files that the sidecar copies from the shared volume.
+
+### 5.3 Go
+
+| Operation | Time | When it runs | Mechanism |
+|---|---|---|---|
+| `go build` (native) | varies | Customer's build — unchanged | N/A |
+| Inline interception + hashing | +1-3% | During build | `LD_PRELOAD` or eBPF |
+| Copy `go.mod`, `vendor/modules.txt` | <1 sec | Post-build (sidecar) | File copy |
+| Copy binaries | <5 sec | Post-build (sidecar) | File copy |
+
+**Total overhead**: ~1-3% in-band + ~5 sec post-build = **~3-4%**.
+
+Same as Rust — trivial post-build capture.
+
+### 5.4 Java — The Hard Problem
+
+Java is fundamentally different from the other languages because the
+sidecar needs **dependency graph information** that is not available
+from inline interception alone. The treedb (JAR → class → source)
+captures what went INTO the JAR, but the full dependency graph
+(transitive Maven/Gradle dependencies) requires running the build
+tool's dependency resolver.
+
+| Operation | Time | When it runs | Mechanism |
+|---|---|---|---|
+| `mvn package` or `./gradlew build` (native) | 3-10 min | Customer's build — unchanged | N/A |
+| `bomsh_create_bom_java.py` (treedb) | ~2 min | Post-build (sidecar) | Sidecar runs on shared volume |
+| `mvn dependency:tree` | 5-15 min | Post-build (sidecar) | **Problem** — see below |
+| Parse `pom.xml` for version/groupId | <1 sec | Post-build (sidecar) | Read from shared volume |
+| Copy JARs | <5 sec | Post-build (sidecar) | File copy |
+
+**Total overhead**: ~2 min treedb + **5-15 min dep:tree** + seconds
+= **7-17 min post-build**.
+
+**The dep:tree problem**: The sidecar cannot modify the build command
+to include `dependency:tree` as a lifecycle phase. It must run
+`mvn dependency:tree` (or `./gradlew dependencies`) as a **separate
+subprocess** after the build completes. This requires:
+
+1. Maven or Gradle installed in the sidecar container
+2. The `pom.xml` / `build.gradle` still on the shared volume
+3. The local dependency cache (`~/.m2/repository` or `~/.gradle/caches`)
+   still accessible — populated during the build
+4. A long enough capture window (5-15 minutes)
+
+**This is the single biggest phase isolation challenge.** The K8s
+`terminationGracePeriodSeconds` must be set high enough (e.g., 900s)
+to allow the sidecar to complete dep:tree before the pod is killed.
+This is an infrastructure config change (platform team).
+
+### 5.5 Java: Alternative Approaches to dep:tree
+
+Given that running `mvn dependency:tree` post-build takes 5-15 minutes
+and requires a long capture window, are there faster alternatives?
+
+#### Option A: Parse `pom.xml` Offline (No Maven Required)
+
+Parse `pom.xml` and its parent POMs directly to extract `<dependencies>`
+declarations. Read the local Maven cache (`~/.m2/repository`) to
+resolve transitive dependencies by walking each dependency's POM.
+
+- **Pro**: No Maven subprocess. Runs in seconds. Python-only.
+- **Con**: Must reimplement Maven's dependency resolution algorithm
+  (version ranges, exclusions, BOM imports, profiles, property
+  interpolation). Complex and fragile.
+
+#### Option B: Extract from JAR `META-INF/maven/`
+
+Every JAR built by Maven contains `META-INF/maven/<groupId>/<artifactId>/pom.xml`
+and `pom.properties`. The embedded `pom.xml` includes `<dependencies>`.
+
+- **Pro**: No Maven subprocess. Data is in the build output.
+- **Con**: Only contains the dependencies declared in THAT module's
+  POM, not the fully resolved transitive graph. Dependency versions
+  may use property references (`${project.version}`) that are resolved
+  at build time but not in the embedded POM.
+
+#### Option C: Read Maven's Resolved Dependency Files
+
+After `mvn package`, Maven writes resolved dependency information to:
+
+- `target/maven-status/maven-compiler-plugin/compile/default-compile/`
+  — input file lists
+- `~/.m2/repository/` — the full resolved dependency tree is cached here
+
+The sidecar could walk the local repo cache, cross-referencing with
+the POM's declared dependencies, to reconstruct the dependency graph.
+
+- **Pro**: No Maven subprocess. Data already exists.
+- **Con**: Requires understanding Maven's cache layout. More complex
+  than running `mvn dependency:tree`.
+
+#### Option D: eBPF Interception of Maven's Dependency Resolution
+
+During `mvn package`, Maven resolves all dependencies and downloads
+them. The sidecar could use eBPF to intercept Maven's JVM file system
+calls (reading `pom.xml` files, writing to `~/.m2/repository/`) and
+build the dependency graph from those observations.
+
+- **Pro**: Captured inline during the build — no post-build cost.
+  Zero modification to the build.
+- **Con**: Extremely complex. Must understand Maven's internal file
+  access patterns. High engineering effort.
+
+#### Option E: Keep the Current Subprocess Approach
+
+Run `mvn dependency:tree` or `./gradlew dependencies` in the sidecar
+post-build, with a sufficiently long `terminationGracePeriodSeconds`.
+
+- **Pro**: Simple. Already implemented. Correct results.
+- **Con**: 5-15 minute post-build cost. Requires Maven/Gradle in the
+  sidecar container. Requires long capture window.
+
+#### Option F: `mvn dependency:tree -o` (Offline Mode)
+
+After `mvn package` populates the local cache, run
+`mvn dependency:tree -o` (offline mode). This skips all network
+access (no checking Maven Central for updates) and resolves only from
+the local cache. Significantly faster than a full dep:tree.
+
+- **Pro**: Much faster (seconds to 1-2 minutes vs 5-15 minutes).
+  Still uses Maven's own resolver — correct results.
+- **Con**: Still requires Maven in the sidecar container. Still a
+  subprocess call. Fails if the local cache is incomplete (rare after
+  a successful build).
+
+**Recommended for Java**: Option F (`-o` offline mode) as the primary
+approach, with Option A (offline POM parsing) as a longer-term
+replacement that eliminates the Maven dependency entirely.
+
+### 5.6 Summary: Build Stage Overhead by Language
+
+| Language | Native Build | In-Band Overhead | Post-Build Capture | Capture Window Needed | Total Overhead |
+|---|---|---|---|---|---|
+| **C/C++** | 30 min | 1-3% (~30 sec) | <1 min | 30 sec (default) | **~3%** |
+| **Rust** | varies | 1-3% | ~5 sec | 30 sec (default) | **~3%** |
+| **Go** | varies | 1-3% | ~5 sec | 30 sec (default) | **~3%** |
+| **Java** | 3-10 min | 0% (no inline interception) | 2-17 min | **15+ min** | **~70-500%** |
+| **Java (with `-o`)** | 3-10 min | 0% | 2-4 min | **5 min** | **~40-130%** |
+
+**Java remains the outlier** but the offline mode approach (`-o`)
+significantly reduces the post-build window requirement from 15+
+minutes to ~5 minutes
+
+---
+
+## 6. Phase Isolation Architecture Under Sidecar Constraint
+
+Given that the sidecar cannot modify the build, the phase isolation
+architecture must work as follows:
+
+### 6.1 What the Sidecar Captures During the Build (Inline)
+
+| What | How | All languages? |
+|---|---|---|
+| Compiler/tool invocations | `LD_PRELOAD` or eBPF tracepoint interception | ✅ |
+| Input/output file hashes | Inline hashing in interception library | ✅ |
+| File open/read/write events | eBPF `sys_enter_openat` or `LD_PRELOAD` `open()` | ✅ |
+| Process tree (parent → child) | eBPF `sched_process_fork`/`sched_process_exec` | ✅ |
+
+### 6.2 What the Sidecar Captures Post-Build (Capture Window)
+
+| What | How | Language |
+|---|---|---|
+| `ldd` + `readelf` on binaries | Sidecar subprocess on shared volume | C/C++ |
+| Treedb generation | `bomsh_create_bom_java.py` on shared volume | Java |
+| Dependency graph | `mvn dependency:tree -o` on shared volume | Java (Maven) |
+| Dependency graph | `./gradlew dependencies --offline` on shared volume | Java (Gradle) |
+| Static file copies | `cp` from shared volume to `bom_dir` | All |
+| Output binary copies | `cp` from shared volume to `bom_dir/binaries/` | All |
+| Version detection | Parse files on shared volume | All |
+| `project_metadata.json` | Extract from files on shared volume | All |
+| `phase1_manifest.json` | Write to `bom_dir` | All |
+| Push to durable storage | `rsync` / S3 upload / artifact store | All |
+
+### 6.3 What Phase 2 Reads (Exclusively from `bom_dir`)
+
+Phase 2 runs on a different host/container/time. It has NO access to
+`repo_dir`. It reads only from `bom_dir`:
+
+| Phase 2 Input | Source | Currently exists? |
+|---|---|---|
+| Treedb | `bom_dir/metadata/bomsh/bomsh_omnibor_treedb` | ✅ |
+| Dependency graph | `bom_dir/maven_deps.json` or `gradle_deps.json` | ✅ (but Phase 2 ignores it) |
+| Project metadata | `bom_dir/project_metadata.json` | ❌ Must create |
+| Binary copies | `bom_dir/binaries/` | ❌ Must create |
+| Static files | `bom_dir/source_snapshot/` | ❌ Must create |
+| Dynamic lib info | `bom_dir/metadata/<binary>/dynamic_libs.json` | ⚠️ Currently in Phase 2 |
+| Phase 1 manifest | `bom_dir/phase1_manifest.json` | ⚠️ Partially exists |
+
+---
+
+## 7. What Currently Exists vs What Must Be Built
+
+| Item | Status | Action needed |
+|---|---|---|
+| `maven_deps.json` capture | ✅ Phase 1 sidecar already does this | Wire Phase 2 to read it instead of re-running `mvn dep:tree` |
+| `gradle_deps.json` capture | ✅ Phase 1 sidecar already does this | Wire Phase 2 to read it instead of re-running `./gradlew dependencies` |
+| `project_metadata.json` | ❌ Does not exist | Create writer (version, groupId, build system, plugins) |
+| `resolved_binaries.json` | ❌ Does not exist | Create writer (resolved globs → actual paths) |
+| Static file copies to `bom_dir` | ❌ Not done | Copy `pom.xml`, `Cargo.lock`, `go.mod`, etc. |
+| Binary copies to `bom_dir` | ❌ Not done | Copy JARs/ELF binaries to `bom_dir/binaries/` |
+| `ldd`/`readelf` capture | ⚠️ Runs in Phase 2 | Move to sidecar post-build capture |
+| Phase 2 reads from `bom_dir` only | ❌ Reads from `repo_dir` | Refactor all parsers and generators |
+| Phase 2 re-runs dep:tree | ❌ Ignores captured JSON | Wire to read `maven_deps.json`/`gradle_deps.json` |
+| Build completion detection | ❌ Not implemented | eBPF `sched_process_exit` or PID monitoring |
+| `mvn dep:tree -o` (offline) | ❌ Not implemented | Add offline flag to sidecar dep:tree call |
+
+---
+
+## 8. Data Sources
+
+- `app/pipeline/lang_runners.py` — Phase 1/2 orchestration
+- `app/pipeline/builder.py` — `strategy.generate_adg()` invocation
+- `app/pipeline/interception.py` — `MavenDepTreeStrategy`, `GradleDepTreeStrategy`
+- `app/spdx/java_generator.py` — `repo_dir` dependencies in Phase 2
+- `app/spdx/maven_parser.py` — live `mvn dependency:tree` execution in Phase 2
+- `app/spdx/gradle_parser.py` — live `./gradlew dependencies` execution in Phase 2
+- `app/spdx/lang_parsers.py` — `Cargo.lock`, `Cargo.toml`, `go.mod` parsing from `repo_dir`
+- `app/pipeline/binary_collector.py` — binary copying from `repo_dir`
+- `app/pipeline/metadata_collector.py` — `ldd`/`readelf` on binaries in `repo_dir`
+- `app/collect_metadata.py` — version detection from source files in `repo_dir`
+- `app/spdx/parser.py` — `repos_dir` prefix for file classification
+- `docs/deep-dive/sidecar-async-spdx-architecture.md` — architecture doc
+  (internally inconsistent: says Phase 2 needs source tree access)
+- `docs/features/phase-isolation/sidecar-phase-isolation-infrastructure.md`
+  — phase isolation design
+- Kubernetes KEP-753 (kubernetes.io) — native sidecar container lifecycle
+- eBPF `sched_process_exit` tracepoint (iovisor/bcc `exitsnoop`)
+- `EnvProxy` (github.com/minivolk/EnvProxy) — `LD_PRELOAD` + K8s webhook precedent
+- Maven Dependency Plugin `-o` offline mode (maven.apache.org)
+
+---
+
+*Analysis conducted June 16, 2026. Corrected to enforce the sidecar
+constraint: zero modifications to customer build system, commands, or
+CI/CD pipeline config. Wrapper patterns and lifecycle hooks are invalid
+under this constraint. Phase isolation is a mandatory architectural
+requirement established before Java sidecar implementation.*

--- a/docs/deep-dive/sidecar-strategy-evaluation.md
+++ b/docs/deep-dive/sidecar-strategy-evaluation.md
@@ -1,0 +1,339 @@
+# Sidecar Interception Strategies — Comprehensive Evaluation
+
+> **Date**: June 15, 2026
+>
+> **Status**: Active evaluation — corrections applied from prior analysis
+>
+> **Prerequisite docs**: `c-cpp-sidecar-interception-strategies.md`,
+> `ebpf-investigation-report.md`, `sidecar-async-spdx-architecture.md`,
+> `../features/phase-isolation/sidecar-phase-isolation-infrastructure.md`
+
+---
+
+## 1. Strategic Context
+
+**Sidecar is the ONLY actual strategy.** It is the authoritative and
+sole target mode for enterprise build-interception SBOM generation.
+The entire `omnibor-analysis` project exists to serve enterprise C/C++
+(and other language) build environments.
+
+**Standalone mode is being phased out.** It exists only as:
+
+- A legacy fallback for extreme corner cases where a dev team forks
+  and embeds their own OS, tools, and build orchestration into
+  standalone mode (which would be a fork they own)
+
+- A transitional baseline — golden files are being **migrated from
+  standalone to sidecar** as each language gets sidecar support (Java
+  complete; C/C++ is next)
+
+Development should always use sidecar when the sidecar approach is
+available for a given language. Standalone is not a strategy — it is
+a stepping stone being phased out.
+
+---
+
+## 2. Per-Language Sidecar Strategy Status
+
+| Language | Sidecar Strategy | Status | Phase Split | Priority |
+|----------|-----------------|--------|-------------|----------|
+| **Java** | `MavenDepTreeStrategy` / `GradleDepTreeStrategy` | ✅ Fully wired, tested, golden files migrated | ✅ Complete | Done |
+| **C/C++** | **TBD — active investigation** (see §4) | ❌ Not implemented | ❌ Not started | **NEXT — #1** |
+| **Go** | `GoToolexecStrategy` (`-toolexec=`) | ⚠️ Skeleton only — not wired | ❌ Not started | #2 |
+| **Rust** | `RustcWrapperStrategy` (`RUSTC_WRAPPER=`) | ⚠️ Skeleton only — not wired | ❌ Not started | #3 |
+| **Python** | Metadata-only pipeline (future) | ❌ Not designed | ❌ N/A | #4 (may move up) |
+
+---
+
+## 3. Go and Rust — Low Risk, Clear Path
+
+Both have well-defined, language-native wrapper mechanisms that are
+first-class features of their respective build tools:
+
+- **Go `-toolexec`**: Every Go project uses `go build`. `-toolexec`
+  is a Go-native flag — no build system compatibility concerns.
+  `bomsh_hook2.py` already has Go command parsers. Same raw logfile
+  format as ptrace.
+
+- **Rust `RUSTC_WRAPPER`**: Every Rust project uses
+  `cargo build --release`. `RUSTC_WRAPPER` is a Cargo-native env var.
+  `bomsh_hook2.py` has the `rustc` parser. Only risk: conflict with
+  existing wrappers like `sccache`.
+
+Implementation for each follows the Java pattern (~3 days each): add
+`_select_{lang}_strategy()`, accept `mode=`, wire to CLI.
+
+**Blocker**: Verifying `bomsh_hook.sh` with `-toolexec` and
+`RUSTC_WRAPPER` calling conventions.
+
+---
+
+## 4. C/C++ — The Critical Enterprise Problem
+
+This is the hardest and most important language to solve. C/C++ is the
+primary enterprise target.
+
+### 4.1 Viable Enterprise C/C++ Sidecar Strategies
+
+The strategies that can intercept compiler invocations **without
+requiring build system cooperation** — sorted by enterprise coverage
+(highest to lowest):
+
+<table>
+<tr>
+  <th style="width:14%">Strategy</th>
+  <th style="width:8%">Overhead</th>
+  <th style="width:20%">Enterprise Coverage</th>
+  <th style="width:20%">Capabilities Needed</th>
+  <th style="width:18%">Maturity</th>
+  <th style="width:20%">Key Limitation</th>
+</tr>
+<tr>
+  <td><strong>eBPF tracepoints</strong></td>
+  <td>1–3%</td>
+  <td><strong>High</strong> — kernel-level, works regardless of build system</td>
+  <td><code>CAP_BPF</code>+<code>CAP_PERFMON</code> (kernel 5.8+) or <code>CAP_SYS_ADMIN</code> (older)</td>
+  <td><code>build-observer</code> shipped (Apache 2.0, open-source). <code>ebomf</code> private.</td>
+  <td>Kernel 5.8+ for <code>CAP_BPF</code>; older kernels need <code>CAP_SYS_ADMIN</code>; SELinux may block</td>
+</tr>
+<tr>
+  <td><strong>Linux audit (<code>auditd</code>)</strong></td>
+  <td>5–15%</td>
+  <td><strong>High</strong> — kernel-level <code>execve</code> tracing</td>
+  <td>Root or <code>CAP_AUDIT_CONTROL</code></td>
+  <td>Proven for security monitoring; not proven for SBOM</td>
+  <td>Higher overhead; verbose logging; may conflict with existing audit policies</td>
+</tr>
+<tr>
+  <td><strong><code>LD_PRELOAD</code></strong></td>
+  <td>1–3%</td>
+  <td><strong>Medium</strong> — works on any dynamically-linked build tool regardless of <code>CC=</code> compliance</td>
+  <td>None</td>
+  <td>Proven (Bear uses this for 10+ years)</td>
+  <td>Fails on statically-linked build tools. Fails on musl/Alpine. Fails if build sanitizes env.</td>
+</tr>
+<tr>
+  <td><strong>CC= wrappers</strong></td>
+  <td>3–5%</td>
+  <td><strong>Low</strong> — only compliant builds that respect <code>$(CC)</code></td>
+  <td>None</td>
+  <td>Pattern proven (ccache/distcc/sccache) but wrappers not written</td>
+  <td>Majority of enterprise builds do NOT respect <code>CC=</code></td>
+</tr>
+</table>
+
+See `c-cpp-sidecar-interception-strategies.md` for exhaustive analysis
+of each strategy, including devil's advocate challenges, data capture
+capabilities, compatibility matrices, and enterprise adoption data.
+
+### 4.2 eBPF — Kernel Version Reality Check
+
+Linux 5.8 was released **August 2, 2020** — less than 6 years ago.
+For enterprise environments running 10+ year old build infrastructure:
+
+| Enterprise OS | Kernel | eBPF Tracepoints | `CAP_BPF` (needs 5.8+) | Still in Use? |
+|--------------|--------|-----------------|----------------------|---------------|
+| **RHEL 7** | 3.10 (2014) | ❌ No eBPF | ❌ No | Yes — EOL but extended support until 2028 |
+| **RHEL 8** | 4.18 (2019) | ✅ Backported | ❌ Needs `CAP_SYS_ADMIN` | **Very common** |
+| **Ubuntu 18.04** | 4.15 (2018) | ⚠️ Limited | ❌ Needs `CAP_SYS_ADMIN` | Still exists in legacy |
+| **Ubuntu 20.04** | 5.4 (2020) | ✅ Available | ❌ Needs `CAP_SYS_ADMIN` | Common |
+| **RHEL 9** | 5.14 (2022) | ✅ Available | ✅ Available | Growing |
+| **Ubuntu 22.04+** | 5.15+ | ✅ Available | ✅ Available | Current |
+
+**Problem**: On RHEL 7 (kernel 3.10), eBPF is simply unavailable. On
+RHEL 8 and Ubuntu 20.04 (the most common enterprise platforms today),
+eBPF works but requires `CAP_SYS_ADMIN` — a significantly harder ask
+than `CAP_BPF` in locked-down enterprise environments. SELinux (RHEL
+default) may also block BPF program loading.
+
+**Implication**: eBPF is not a universal enterprise solution *today*,
+though it will become one as older kernels age out. For legacy
+environments, `LD_PRELOAD` or Linux audit may be the only sidecar
+options that work without kernel capabilities.
+
+### 4.3 `build-observer` (sbom-observer) — Key External Validation
+
+`build-observer` from the sbom-observer project is an **open-source,
+government-funded, Apache 2.0** tool that uses eBPF for build
+interception to generate SBOMs. It validates the eBPF approach as
+production-viable.
+
+**Repository**: https://github.com/sbom-observer/build-observer
+
+**Important distinction**: `build-observer` produces **CycloneDX**
+SBOMs, not SPDX. This project supports **SPDX 2.3 only** (with 3.x
+coming). The observation log format from `build-observer` could
+potentially be adapted to feed our SPDX generators, but the SBOM
+output itself is not directly compatible.
+
+Key facts:
+
+- Requires root for eBPF load, then drops privileges
+- Linux 5.8+ kernel
+- Claims "minimal performance impact — only added a few percent"
+- JSON observation log of all files read, written, or executed
+- Uses eBPF perf ring buffer for event delivery
+- Language-agnostic — tested with C, Rust, Java, Python, Node.js
+- Would need an adapter layer to produce our treedb/raw-logfile
+  format for `bomsh_create_bom.py`, or a new pipeline path
+
+### 4.4 Why CC= Wrappers Are NOT Viable for Enterprise
+
+`CcWrapperStrategy` (setting `CC=`, `CXX=`, `AR=`, `LD=` env vars)
+**has been evaluated and dismissed as inadequate for enterprise C/C++
+builds** across multiple evaluations. It is the **last resort**,
+applicable only to a very small subset of well-structured open-source
+projects that happen to use `$(CC)` variable expansion.
+
+**Enterprise C/C++ reality** (the sole target of this program):
+
+- **Hardcoded compiler paths** in Makefiles and scripts (10+ years
+  old) — literal `/usr/bin/gcc` or `/opt/vendor/bin/cc` instead of
+  `$(CC)`
+
+- **Proprietary or custom build systems** that ignore `CC=` env vars
+  entirely
+
+- **Multi-layer build orchestrations** — wrapper around wrapper around
+  compiler; env vars don't propagate
+
+- **Generated Makefiles** — `gyp`, legacy autoconf caches, code
+  generators that embed absolute paths
+
+- **Configure-time compiler caching** — autoconf captures the compiler
+  path at `./configure` time and bakes it in
+
+The 6 open-source C/C++ test repos (curl, ffmpeg, openosc, nmap,
+openssl, redis) are **not enterprise repos** and are **not
+representative** of enterprise build environments. They work with
+`CC=` because they are well-structured open-source projects.
+
+CC= wrappers also have a **critical upstream blocker**: the wrapper
+scripts (`bomsh_cc_wrapper.sh` etc.) don't exist yet in upstream bomsh.
+
+**Bottom line**: `CcWrapperStrategy` may have a niche role for the
+small subset of compliant builds, but it is **not the enterprise C/C++
+sidecar solution**.
+
+### 4.5 Recommended C/C++ Strategy — Multi-Tier with Graceful Fallback
+
+Since no single strategy covers all enterprise environments, a
+**tiered fallback** is needed:
+
+<table>
+<tr>
+  <th style="width:12%">Tier</th>
+  <th style="width:18%">Strategy</th>
+  <th style="width:35%">Target Environment</th>
+  <th style="width:35%">When to Use</th>
+</tr>
+<tr>
+  <td><strong>1 (primary)</strong></td>
+  <td><strong><code>LD_PRELOAD</code></strong></td>
+  <td>Enterprise builds with dynamically-linked toolchains (majority)</td>
+  <td>Default sidecar strategy — no capabilities needed, high coverage</td>
+</tr>
+<tr>
+  <td><strong>2 (advanced)</strong></td>
+  <td><strong>eBPF</strong></td>
+  <td>Environments with 5.8+ kernels AND <code>CAP_BPF</code> granted AND <code>LD_PRELOAD</code> fails (static tools, env sanitization)</td>
+  <td>Config-selectable; evaluate <code>build-observer</code> as reference</td>
+</tr>
+<tr>
+  <td><strong>3 (fallback)</strong></td>
+  <td><strong>CC= wrappers</strong></td>
+  <td>Well-structured builds that respect <code>$(CC)</code> where <code>LD_PRELOAD</code> is unavailable</td>
+  <td>Last resort for niche cases</td>
+</tr>
+<tr>
+  <td><strong>4 (legacy)</strong></td>
+  <td><strong>ptrace (standalone fork)</strong></td>
+  <td>Extreme corner cases — team forks standalone with custom OS/tools</td>
+  <td>Not a sidecar strategy; team-owned fork</td>
+</tr>
+</table>
+
+**`LD_PRELOAD` should be the primary enterprise strategy** because:
+
+- Zero special capabilities needed
+- Works regardless of whether the build system respects `CC=`
+- Covers any dynamically-linked build tool (gcc, g++, clang, make,
+  cmake, etc.)
+- 10+ years of production use in Bear
+- Available on every kernel version (no 5.8+ requirement)
+- Only fails on statically-linked tools (uncommon for compilers) or
+  env-sanitizing builds
+
+eBPF is the **future primary strategy** as older kernels age out and
+`CAP_BPF` becomes standard in enterprise container policies.
+
+See `c-cpp-sidecar-interception-strategies.md` §8 for the full
+auto-detection decision tree and recommended strategy combinations
+with coverage estimates.
+
+---
+
+## 5. Phase Isolation — Solid Foundation
+
+The manifest-based phase split is well-designed and validated for Java:
+
+- `phase1_manifest.json` is the sole contract between phases
+- Gitoid integrity verification
+- Proven in CI/CD across 3 Azure runners
+- 35 unit tests (22 manifest + 13 phase isolation)
+
+Scaling to C/C++ (and then Go/Rust) requires:
+
+- Splitting monolithic runners into `phase1()`/`phase2()`
+- Pre-computing version metadata in Phase 1 for cross-host Phase 2
+- Handling binary transfer for `bomsh_sbom.py` and `BinaryCollector`
+
+See `../features/phase-isolation/sidecar-phase-isolation-infrastructure.md`
+for full manifest schema, execution patterns, and implementation plan.
+
+---
+
+## 6. Prioritized Action Plan
+
+| Priority | Action | Effort | Impact |
+|----------|--------|--------|--------|
+| **1** | Design and implement `LdPreloadStrategy` for C/C++ sidecar | ~5–7d | Primary enterprise C/C++ solution |
+| **2** | Evaluate `build-observer` (sbom-observer) for eBPF reference | ~2d | Validates eBPF path; informs Tier 2 strategy |
+| **3** | Split C/C++ runner into `phase1()`/`phase2()` | ~2d | Enables phase isolation for C/C++ |
+| **4** | Wire Go sidecar (`GoToolexecStrategy`) | ~3d | Covers 6 Go repos |
+| **5** | Wire Rust sidecar (`RustcWrapperStrategy`) | ~3d | Covers 2 Rust repos |
+| **6** | Full eBPF strategy (using `build-observer` or in-house) | ~6d | Future primary for 5.8+ environments |
+| **7** | Python sidecar design (metadata-only) | TBD | May move up based on side project |
+
+---
+
+## 7. Key Corrections Documented
+
+This evaluation corrects errors from prior analysis:
+
+1. **Sidecar is the ONLY strategy** — standalone is a legacy niche
+   being phased out, not a co-equal mode
+
+2. **CC= wrappers are NOT the enterprise C/C++ proposal** — they are
+   the last resort for a small subset of compliant builds, not the
+   current strategy
+
+3. **eBPF requires kernel 5.8+** (released August 2, 2020) — not
+   available on RHEL 7; requires `CAP_SYS_ADMIN` on RHEL 8 and
+   Ubuntu 20.04
+
+4. **SPDX only** — `build-observer` produces CycloneDX, not SPDX;
+   adapter needed for our pipeline
+
+5. **Enterprise coverage assessment corrected** — ptrace standalone is
+   not a sidecar strategy and must not appear in sidecar coverage
+   comparisons
+
+6. **Language priority**: C/C++ is NEXT, then Go, then Rust, then
+   Python (may move up)
+
+---
+
+*Evaluation conducted June 15, 2026. Corrections applied from prior
+sessions where CC= wrappers were incorrectly presented as the current
+enterprise C/C++ proposal.*


### PR DESCRIPTION
## Summary

Documentation-only PR adding sidecar phase-isolation research to
`docs/deep-dive/`. No code changes. Focuses on the authoritative sidecar
deployment mode (the primary 99% path), not standalone.

## Changes

- **`docs/deep-dive/phase-isolation-gap-analysis.md`** (new) — complete audit
  of where Phase 2 currently reads from `repo_dir` across all languages, the
  zero-build-modification sidecar constraint, valid K8s integration patterns
  (mutating webhook + `LD_PRELOAD`, native sidecar + eBPF, node DaemonSet),
  build-completion detection, and per-language build-stage overhead. Identifies
  the Java `dependency:tree` post-build window as the biggest phase-isolation
  challenge and evaluates six alternatives.
- **`docs/deep-dive/cicd-workspace-lifecycle.md`** (new) — CI/CD workspace
  lifecycle analysis for ephemeral build environments.
- **`docs/deep-dive/sidecar-strategy-evaluation.md`** (new) — evaluation of
  sidecar interception strategies.
- **`docs/deep-dive/c-cpp-sidecar-interception-strategies.md`** (updated) —
  expanded C/C++ sidecar interception strategy analysis.

## Validation

Documentation-only change — no pipeline, SPDX, parser, or config impact.
Per `workflow/regression-gate.md`, docs-only changes do not require a
regression run.
