### PR TITLE
docs: phase-isolation planning user stories + C/C++ design draft relocation

### DIFF
--- a/docs/deep-dive/pr94-cc-revision-DRAFT.md
+++ b/docs/deep-dive/pr94-cc-revision-DRAFT.md
@@ -1,0 +1,169 @@
+# DRAFT for Review — PR #94 C/C++ Sidecar Revision (SI-1)
+
+| | |
+|---|---|
+| **Purpose** | Proposed replacement content for PR #94 `sidecar-implementation-design.md` §5 (C/C++) and a re-label of the §3.3 strategy taxonomy |
+| **Author** | Cascade (for Ted G. review) |
+| **Drafted** | 2026-06-23 |
+| **Status** | DRAFT — review before applying to branch `feat/q4fy26-sidecar-design-docs` |
+| **Basis** | `phase-isolation-gap-analysis.md` (June 16) which supersedes the May 1 wrapper approach |
+| **Scope** | **C/C++ sidecar only.** Rust (PR #94 §6) and Go (§7) raise analogous wrapper-vs-sidecar concerns but are out of scope here — see Open Question 3. |
+
+> Nothing has been committed to the PR #94 branch. This file is the
+> proposed text for your approval. On approval I will apply §5 and the
+> §3.3 relabel to the feature branch.
+
+---
+
+## Summary of the change
+
+PR #94 §5 currently designs C/C++ sidecar mode entirely around compiler
+**wrapper injection** (`CC=/opt/omnibor/gcc-wrapper make`,
+`CcWrapperStrategy`). The June 16 gap-analysis proves this is **not truly
+sidecar**: setting `CC=`/`CXX=`/`AR=`/`LD=` modifies the build invocation,
+violating the zero-build-modification constraint. This revision:
+
+1. Re-labels the wrapper/env-var strategies as **standalone-without-ptrace**
+   (a valid mode, just not sidecar).
+2. Replaces §5 with a **three-tier truly-sidecar model**: primary
+   `LD_PRELOAD`, secondary eBPF, tertiary per-repo `ptrace` override.
+3. Documents **least-build-time-impact** by moving all non-inline capture
+   (`ldd`/`readelf`, binary copy) to the post-build capture window.
+
+---
+
+## Proposed §3.3 relabel (strategy taxonomy)
+
+Replace the "WrapperStrategy = sidecar" framing with three categories:
+
+| Category | Strategies | Modifies build invocation? | Mode |
+|---|---|---|---|
+| **Standalone (ptrace)** | `PtraceStrategy` (`bomtrace3`/`bomtrace2`) | No (wraps the *runner*, needs `SYS_PTRACE`) | standalone |
+| **Standalone (no ptrace)** | `CcWrapperStrategy`, `GoToolexecStrategy`, `RustcWrapperStrategy` | **Yes** (`CC=`, `-toolexec`, `RUSTC_WRAPPER`) | standalone alt — **not sidecar** |
+| **Sidecar (transparent)** | `LdPreloadStrategy`, `EbpfStrategy` | **No** (kernel/linker-level, injected by infra) | sidecar |
+
+Key correction: env-var/wrapper injection is retained as a useful
+**standalone** option, but it is explicitly **not** a sidecar mechanism.
+
+---
+
+## Proposed replacement for §5
+
+### 5. Per-Language Implementation: C/C++ (Truly-Sidecar)
+
+#### 5.1 Current state and why wrappers are not sidecar
+
+The implemented `CcWrapperStrategy`
+(`@app/pipeline/interception.py`) sets `CC`/`CXX`/`AR`/`LD` to OmniBOR
+wrapper scripts. This works without `SYS_PTRACE`, but it **changes the
+build command's environment**, which the sidecar model forbids.
+
+Approaches ruled out by the zero-modification constraint:
+
+| Approach | Why invalid |
+|---|---|
+| `CC=/opt/omnibor/gcc-wrapper make` | Sets a build env var (changes invocation) |
+| `bear -- make`, `cov-build make` | Wraps/changes the build command |
+| `RUSTC_WRAPPER=`, `go build -toolexec=` | Requires env/flag on the build command |
+| Makefile / lifecycle hooks | Modifies the project's build config |
+
+The sidecar must intercept at the **kernel or dynamic-linker level**,
+transparent to the build system (industry precedent: Istio, Dynatrace,
+Vault all inject via mutating webhooks + `LD_PRELOAD`).
+
+#### 5.2 Three-tier interception model
+
+| Tier | Mechanism | Coverage | In-band overhead | Static binaries? | Build modification |
+|---|---|---|---|---|---|
+| **Primary** | `LD_PRELOAD` shim injected by K8s mutating webhook (init container + shared `emptyDir`) | ~80% — all dynamically-linked builds, any build system | +1–3% | No | None |
+| **Secondary** | Node-level **eBPF** DaemonSet on kernel tracepoints | All languages incl. statically-linked | Minimal kernel cost | Yes | None |
+| **Tertiary** | Per-repo `interception: ptrace` override (`bomtrace3`) | Hermetic builds (Bazel, Nix, Yocto) | 20–60% (ptrace) | Yes | None (needs `SYS_PTRACE`) |
+
+Resolution order: per-repo `interception` override > global `mode` >
+default. Hermetic build systems opt into the tertiary tier per-project
+without affecting others.
+
+#### 5.3 Primary tier — `LD_PRELOAD` shim
+
+A small shared library is injected via `LD_PRELOAD`, set by infrastructure
+(a K8s `MutatingAdmissionWebhook` + init container that copies
+`libomnibor_intercept.so` into a shared volume), never by the build
+command.
+
+The shim interposes `execve`, `open`/`openat`, and `close` to:
+
+1. Record each compiler/linker `argv` to the raw-logfile format consumed by
+   `bomsh_create_bom.py`.
+2. Hash compilation inputs and outputs **inline** (gitoid), keeping the
+   data on the build's critical path minimal.
+3. `exec()` the real tool so the build environment is otherwise identical.
+
+Failure isolation (retain PR #94 P7): the shim must never fail the
+customer build — on any internal error it logs and lets the real tool
+proceed; the SBOM is reported incomplete rather than the build broken.
+
+#### 5.4 Secondary tier — eBPF node DaemonSet
+
+For statically-linked builds (where `LD_PRELOAD` cannot interpose) the
+secondary tier runs a privileged DaemonSet loading eBPF programs on
+`sched_process_exec`, `sched_process_exit`, and `sys_enter_openat`. It
+observes compiler invocations system-wide with no pod modification. The
+`sched_process_exit` tracepoint also provides reliable **build-completion
+detection** for the post-build capture window. Requires `CAP_BPF` /
+`CAP_SYS_ADMIN` on the DaemonSet.
+
+#### 5.5 Tertiary tier — per-repo `ptrace` override
+
+For hermetic build systems that defeat both `LD_PRELOAD` and eBPF, a
+per-repo `interception: ptrace` setting falls back to the existing
+`PtraceStrategy` (`bomtrace3`). The `build_system` field is recorded in the
+SPDX `creationInfo` comment for traceability.
+
+#### 5.6 Least-build-time-impact
+
+Only inline hashing runs on the build's critical path (+1–3%). Everything
+else moves to the **post-build capture window** on the shared volume:
+
+| Operation | When | Cost |
+|---|---|---|
+| Tool invocation + I/O hashing | Inline (during build) | +1–3% |
+| `ldd` + `readelf` per binary | Post-build (sidecar) | 5–30 s |
+| Version detection from source | Post-build (sidecar) | <5 s |
+| Copy binaries to `bom_dir` | Post-build (sidecar) | <10 s |
+
+Total: ~1–3% in-band + <1 min post-build ≈ **~3%**. C/C++ is the cleanest
+case; the default 30 s K8s `terminationGracePeriodSeconds` is sufficient.
+
+#### 5.7 omnibor-analysis changes
+
+| File | Change |
+|---|---|
+| `interception.py` | Add `LdPreloadStrategy`, `EbpfStrategy`; re-label `CcWrapperStrategy` docstring as standalone-without-ptrace |
+| `config.yaml` | `mode: sidecar` selects `LD_PRELOAD`; per-repo `interception` override for tiers |
+| `metadata_collector.py` | `ldd`/`readelf` run in the post-build capture window on `bom_dir`, not Phase 2 on `repo_dir` |
+| `builder.py` | Capture window hook after build completion (PID/eBPF signal) |
+
+#### 5.8 Effort and ROI (revised, AI-days)
+
+| Work Item | Effort |
+|---|---|
+| Design (this revision) | ~2 |
+| `LD_PRELOAD` shim + plumbing (primary) | ~3 |
+| eBPF DaemonSet (secondary) | ~3 |
+| ptrace override (tertiary, mostly exists) | ~0.5 |
+
+Recommendation: **primary `LD_PRELOAD` first** (covers ~80% with ~3%
+overhead and zero build modification); eBPF secondary tier is deferrable
+and only needed for statically-linked builds.
+
+---
+
+## Open questions for your review
+
+1. **Webhook ownership** — is the K8s mutating-webhook + init-container
+   injection in scope for our repo, or owned by a platform team (we just
+   ship the shim + manifest)?
+2. **Upstream bomsh** — should the `LD_PRELOAD` shim live in `omnibor/bomsh`
+   (like the wrappers) or in this repo?
+3. **Rust/Go** — apply the same tier model to §6/§7, or keep this revision
+   scoped to C/C++ for now?

--- a/docs/planning/phase1-build-speed-subissues.md
+++ b/docs/planning/phase1-build-speed-subissues.md
@@ -1,0 +1,148 @@
+# Sub-Issue Drafts — Phase 1 Build-Speed & Efficiency
+
+| | |
+|---|---|
+| **Parent issue** | TBD — assigned by the user |
+| **Author** | Ted G. |
+| **Drafted** | 2026-06-24 (Cascade) |
+| **Status** | Draft — ready to attach under the chosen parent issue |
+| **Scope** | **Java builds** (Maven and Gradle). Other languages capture inline during the build and are not affected. |
+| **Origin** | Verified findings from `docs/deep-dive/phase-isolation-gap-analysis.md` and `docs/deep-dive/phase-isolation-build-time-analysis.md`. |
+
+---
+
+## Conventions
+
+- **Template:** standard User Story (`As a … I want … so that …`) with
+  **Acceptance Criteria** in Given/When/Then form.
+- **Granularity:** each story is consolidated to cover at least two days of
+  work.
+- **Validation gate:** every change MUST be validated on a real build host
+  and produce SBOMs identical to the golden baselines before it is
+  accepted. No change ships on a "looks faster" basis alone.
+
+---
+
+## US-1 — Reuse captured dependency data instead of resolving it twice
+
+**Applies to:** Java builds (Maven and Gradle)
+
+**Estimate:** ~3 AI-days
+
+**Priority:** Highest — largest measured win, and it also advances the
+mandatory phase-isolation goal (see related SI-4 in
+`sidecar-phase-isolation-subissues.md`).
+
+**User Story**
+
+As a release engineer,
+I want the SBOM step to reuse the dependency information already captured
+during the build instead of recalculating it,
+so that we do not pay for the same expensive dependency resolution twice
+and reporting runs faster.
+
+**Why this matters**
+
+Today the build's dependency graph is resolved during capture and saved,
+then the reporting step throws that away and resolves it a second time
+against the original workspace. On large projects the duplicated step costs
+minutes and also forces the reporting step to depend on a workspace that no
+longer exists in modern pipelines.
+
+**Acceptance Criteria**
+
+- Given a build whose dependency information was captured, when the SBOM is
+  generated, then it uses the captured data and does not re-run the build
+  tool's dependency resolver.
+- Given the captured data is used, when the resulting SBOM is compared to
+  the previously trusted output, then the two are identical.
+- Given a build where the captured data is missing or incomplete, when the
+  SBOM is generated, then it fails clearly (or uses a documented fallback)
+  rather than silently producing a wrong SBOM.
+- Given the change, when it is validated on representative Maven and Gradle
+  projects on a real build host, then all produce identical, golden-clean
+  results.
+
+---
+
+## US-2 — Capture dependencies efficiently for multi-module Java projects
+
+**Applies to:** Java builds (Gradle multi-project in particular)
+
+**Estimate:** ~2 AI-days
+
+**Priority:** Medium — clear win for large multi-module Gradle projects;
+needs careful validation because it changes how dependency data is
+gathered.
+
+**User Story**
+
+As a product build team with a large multi-module Java project,
+I want dependency capture to query the project efficiently rather than
+starting a fresh tool process for every module,
+so that the reporting step does not scale poorly with the number of
+modules.
+
+**Why this matters**
+
+Multi-module Gradle capture currently starts a separate query process per
+subproject. For projects with many modules this multiplies start-up cost
+many times over, which dominates the capture time for those builds.
+
+**Acceptance Criteria**
+
+- Given a multi-module Java project, when dependency information is
+  captured, then it is gathered with the minimum number of build-tool
+  invocations needed for completeness.
+- Given the more efficient capture, when its output is compared to the
+  previous per-module result, then the set of dependencies is identical.
+- Given a single-module project, when capture runs, then its behavior and
+  results are unchanged.
+- Given the change, when it is validated on a representative multi-module
+  project on a real build host, then the SBOM is golden-clean.
+
+---
+
+## US-3 — Overlap independent post-build steps only when it measurably helps
+
+**Applies to:** Java builds
+
+**Estimate:** ~1 AI-day (conditional — only pursued if measurement justifies it)
+
+**Priority:** Low / conditional. Earlier optimizations (faster component
+hashing and offline dependency resolution) shrank the remaining gap, so
+this is worth doing only where measurement shows a real reduction.
+
+**User Story**
+
+As a platform engineer,
+I want independent post-build capture steps to run at the same time when it
+measurably reduces total time,
+so that build-host time is used efficiently — without adding complexity
+where the gain is negligible.
+
+**Acceptance Criteria**
+
+- Given two independent capture steps, when running them concurrently
+  measurably reduces total time on a representative build, then they run
+  concurrently.
+- Given a build type where concurrency shows no measurable benefit, when
+  capture runs, then it stays sequential to avoid needless complexity.
+- Given concurrent execution, when the SBOM is produced, then it is
+  identical to the sequential result.
+
+---
+
+## Already delivered (no new work)
+
+For reference, the following earlier recommendations are already in place
+and are **not** part of this set:
+
+| Recommendation | Status |
+|----------------|--------|
+| Offline dependency resolution after the build | Done |
+| Skip unnecessary build-lifecycle work during resolution | Done |
+| Reuse the warm build daemon instead of a cold start | Done |
+| Per-step timing breakdown for diagnosis | Done |
+| Faster per-component processing (the former dominant bottleneck) | Done |
+| Targeting only the modules that produce output | Functional today |

--- a/docs/planning/retro-subissue-java-treedb-perf.md
+++ b/docs/planning/retro-subissue-java-treedb-perf.md
@@ -1,0 +1,83 @@
+# Retro Sub-Issue — Faster SBOM generation for Java builds (already delivered)
+
+| | |
+|---|---|
+| **Parent issue** | TBD — to be assigned by the user |
+| **Type** | Retrospective (work already completed) |
+| **Scope** | **Java builds only** (Maven and Gradle). |
+| **Status** | DONE — merged & EC2-validated golden-clean (June 22, 2026) |
+| **Delivering PRs** | #189 (primary), #187, #191 |
+| **Author** | Ted G. |
+| **Drafted** | 2026-06-23 (Cascade) |
+| **Effort (actual)** | ~3 AI-days across analysis, implementation, EC2 validation |
+
+---
+
+## SI-R1 — Speed up SBOM generation for Java builds
+
+**User Story**
+
+As a build and release engineer,
+I want SBOM generation for Java projects to run quickly,
+so that adding software bill-of-materials reporting to our Java builds does
+not noticeably slow down our pipelines.
+
+**Background (Conversation)**
+
+Timing on a real build host showed that, for Java projects, the SBOM step
+was overwhelmingly dominated by a single slow stage that processed each
+compiled component one at a time — accounting for roughly 78–99% of that
+step's time on large projects. This made SBOM generation impractically slow
+for big Java codebases and was the clear bottleneck to address.
+
+**What was delivered**
+
+The slow per-component stage — which repeatedly launched small external
+helper programs for every compiled file — was replaced with fast built-in
+processing. On a large project this removed on the order of tens of
+thousands of external program launches. The improvement is applied to the
+shared build tooling without forking it, and is locked to a known-good
+version so behavior stays stable over time.
+
+**Headline result:** SBOM generation for Java projects is now substantially
+faster — the previously dominant stage dropped from roughly four minutes to
+a matter of seconds on the projects measured — with no change to the
+resulting SBOM. Full measurements are in
+`docs/deep-dive/bomsh-java-performance-optimization.md`.
+
+**Acceptance Criteria (Confirmation — all met)**
+
+- Given a Java project, when its SBOM is generated, then the stage that was
+  previously the dominant cost is now a minor part of the total time.
+- Given the faster method, when its SBOM output is compared to the
+  previously trusted output, then the two are identical — no loss of
+  accuracy or completeness.
+- Given the change, when it is validated on a range of representative Java
+  projects on a real build host, then all produce identical, correct
+  results.
+- Given a future change in the underlying build tooling, when that tooling
+  changes unexpectedly, then the build fails loudly rather than silently
+  shipping unverified results.
+
+**Known follow-ups (not part of this work)**
+
+- A further speed-up that processes components entirely in memory is
+  possible and has been deferred to a later change.
+- One very large multi-module Java project remains slower in absolute
+  terms simply because of its size; the improvement still applies.
+
+**Engineering reference**
+
+Delivered in PRs #189 (primary), #187, and #191. Full technical detail,
+method, and measurements live in
+`docs/deep-dive/bomsh-java-performance-optimization.md`.
+
+---
+
+## Note on the headline number
+
+Avoid quoting a single blended "percent faster" figure: some raw build-time
+comparisons were skewed by cached dependencies left over from earlier runs.
+The most defensible statement is the one above — the previously dominant
+stage went from roughly four minutes to seconds — because it reflects the
+improvement directly.

--- a/docs/planning/sidecar-phase-isolation-subissues.md
+++ b/docs/planning/sidecar-phase-isolation-subissues.md
@@ -1,0 +1,179 @@
+# Sub-Issue Drafts — Build-Based SBOM Capture & Delivery
+
+| | |
+|---|---|
+| **Parent issue** | TBD — to be assigned by the user |
+| **Author** | Ted G. |
+| **Drafted** | 2026-06-23 (Cascade) |
+| **Status** | Draft — ready to attach under the chosen parent issue |
+| **Scope** | **Multi-language — NOT C/C++ only.** SI-1 and SI-2 are C/C++-specific; SI-3 and SI-5 apply across languages; SI-4 spans Java, C/C++, Rust, and Go. See the **Applies to** tag on each sub-issue. |
+
+---
+
+## Conventions
+
+- **Template:** standard User Story (`As a … I want … so that …`) with
+  explicit **Acceptance Criteria**.
+- **Granularity:** tasks are **consolidated** so each sub-issue covers
+  **at least 2 days of AI work**. Small related tasks are grouped rather
+  than split into separate issues.
+- **Estimates** are in **AI-work days** (Cascade effort), not human
+  engineering days, and are rough order-of-magnitude pre-grooming.
+
+---
+
+## SI-1 — Agree on how we observe C/C++ builds without changing them
+
+**Applies to:** C/C++ builds
+
+**Estimate:** ~2 AI-days
+
+**User Story**
+
+As a platform architect,
+I want a clear, agreed approach for capturing the components of a C/C++
+build without changing how teams build their software,
+so that product teams can adopt SBOM generation with no disruption to their
+existing build pipelines.
+
+**Acceptance Criteria**
+
+- Given the design is complete, when a platform architect reviews it, then
+  it describes a primary approach plus fallbacks and confirms that none of
+  them require changes to build commands, build settings, or CI
+  configuration.
+- Given each proposed approach, when it is reviewed, then it states what it
+  covers, its effect on build time, and its limitations.
+- Given the earlier proposal that required build changes, when the two are
+  compared, then the new design explains why it is preferred and closes
+  that gap.
+
+---
+
+## SI-2 — Automatically capture C/C++ software components during a normal build
+
+**Applies to:** C/C++ builds
+
+**Estimate:** ~3 AI-days
+
+**User Story**
+
+As a product build team,
+I want my C/C++ builds to be observed automatically so their software
+components are captured,
+so that I receive a complete and accurate bill of materials without
+changing the way I build.
+
+**Acceptance Criteria**
+
+- Given a standard C/C++ build, when it runs with observation enabled, then
+  the components it produces and consumes are captured with no change to
+  the build command.
+- Given a build the primary method cannot observe, when it runs, then the
+  system degrades gracefully and never causes the build to fail.
+- Given an observed build, when its bill of materials is produced, then it
+  matches the result of the existing trusted method.
+- Given a typical build, when observation is enabled, then build time
+  increases by no more than a few percent.
+
+---
+
+## SI-3 — Extend automatic capture to self-contained (statically linked) builds
+
+**Applies to:** Any language that produces self-contained binaries (mainly C/C++ and Go)
+
+**Estimate:** ~3 AI-days
+
+**User Story**
+
+As a product build team that ships self-contained binaries,
+I want those builds captured as well,
+so that statically linked software is covered by SBOMs just like everything
+else.
+
+**Acceptance Criteria**
+
+- Given a build that produces self-contained binaries, when it runs, then
+  its components are captured even though the primary method cannot observe
+  it.
+- Given such a build, when its bill of materials is produced, then it
+  matches the trusted baseline.
+- Given this capability runs at the system level, when it is deployed, then
+  its operating requirements and permissions are documented for
+  operations.
+
+---
+
+## SI-4 — Generate SBOMs from captured build data without needing the original workspace
+
+**Applies to:** All languages — Java, C/C++, Rust, Go
+
+**Estimate:** ~4 AI-days
+
+**User Story**
+
+As a release engineer,
+I want SBOMs to be generated from captured build evidence alone,
+so that we can produce SBOMs in modern CI/CD pipelines where the build and
+reporting steps run on different machines and the original workspace is
+discarded.
+
+**Acceptance Criteria**
+
+- Given a completed build, when the original source workspace is removed,
+  then a complete SBOM can still be generated from the captured evidence
+  alone.
+- Given the same project, when its SBOM is generated this way, then it is
+  identical to the SBOM produced with the workspace still present.
+- Given a pipeline that builds on one machine and reports on another, when
+  it runs, then SBOM generation needs nothing from the build machine
+  except the captured evidence.
+- Given any supported language, when its SBOM is generated, then the result
+  is verified against the trusted baseline.
+
+---
+
+## SI-5 — Deliver build evidence to the central SBOM system (Corona)
+
+**Applies to:** All languages
+
+**Estimate:** ~2 AI-days
+
+**User Story**
+
+As a release manager,
+I want captured build evidence delivered automatically to our central SBOM
+system,
+so that every product release has a discoverable, correctly filed SBOM
+without manual steps.
+
+**Acceptance Criteria**
+
+- Given a build that has completed, when its evidence is ready, then it is
+  delivered to the central SBOM system automatically.
+- Given delivered evidence, when it arrives, then it is filed under the
+  correct product, release, and image.
+- Given the delivery path, when security reviews it, then the
+  authentication and authorization model is documented and approved.
+- Given existing company patterns for this kind of intake, when the design
+  is produced, then it reuses them rather than inventing a new mechanism
+  (see the
+  [integration wiki](https://github.com/CiscoSecurityServices/gambit/wiki/Omnibor-Build-Based-SBOM-Integration)).
+
+---
+
+## Consolidation Note
+
+Consolidated from an initial 10 fine-grained items into 5 sub-issues, each
+covering at least two days of work:
+
+| Sub-issue | Covers |
+|-----------|--------|
+| SI-1 | Agreeing the approach for observing C/C++ builds |
+| SI-2 | Building the primary C/C++ capture, with fallback |
+| SI-3 | Extending capture to self-contained builds |
+| SI-4 | Generating SBOMs from captured data, and proving it works |
+| SI-5 | Delivering evidence to the central SBOM system |
+
+If the total must stay under two weeks, SI-3 (extending capture to
+self-contained builds) is the largest and most deferrable item.


### PR DESCRIPTION
## Summary

Lands planning and design documentation produced during the sidecar
phase-isolation and build-speed review. Docs-only — no code changes.

## Contents

- `docs/planning/sidecar-phase-isolation-subissues.md` — 5 consolidated,
  management-readable sub-issues (Connextra user stories + Given/When/Then
  acceptance criteria) covering build-based SBOM capture and delivery.
- `docs/planning/retro-subissue-java-treedb-perf.md` — retrospective
  sub-issue for the delivered Java SBOM-generation speed-up.
- `docs/planning/phase1-build-speed-subissues.md` — new high-level user
  stories for the remaining beneficial Phase 1 build-speed work (reuse
  captured dependency data; efficient multi-module Gradle capture;
  conditional concurrency).
- `docs/deep-dive/pr94-cc-revision-DRAFT.md` — C/C++ sidecar design draft,
  relocated from `docs/planning/` to sit with the other design docs.

## Notes

- Docs-only change; full test suite unaffected.
- The `phase1-build-speed-subissues.md` user stories are derived from
  verified findings in `phase-isolation-gap-analysis.md` and
  `phase-isolation-build-time-analysis.md`.
