### PR TITLE
feat(java): Phase 2 generates SBOMs from Phase 1 metadata, no source tree (#11003)

### DIFF
--- a/app/pipeline/gradle_dep_tree_parser.py
+++ b/app/pipeline/gradle_dep_tree_parser.py
@@ -25,6 +25,17 @@ from app.spdx.gradle_parser import (
 )
 
 
+def _normalize_project_key(project):
+    """Return a Gradle project path key (``:name`` form).
+
+    ``settings.gradle`` ``include`` directives may use either
+    ``'core'`` or ``':core'``; both map to the project path ``:core``,
+    which also matches the subproject directory name used in the JAR
+    output path (``core/build/libs/...``).
+    """
+    return project if project.startswith(":") else ":" + project
+
+
 def run_gradle_dep_tree(
     repo_dir, project=None, runner=None,
 ):
@@ -88,39 +99,6 @@ def run_gradle_dep_tree(
         return None
 
 
-def parse_gradle_output(output):
-    """Parse Gradle dependency tree into structured dicts.
-
-    Delegates to ``gradle_parser.parse_gradle_dep_tree()``
-    and normalises the output to match the Maven DOT
-    parser format (adds ``is_test``, ``module``,
-    ``packaging`` fields).
-
-    Args:
-        output: Raw stdout from ``./gradlew dependencies``.
-
-    Returns:
-        List of dependency dicts with keys matching
-        ``maven_dep_tree_parser.parse_dot_output()``.
-    """
-    raw_deps = parse_gradle_dep_tree(output)
-    deps = []
-    for d in raw_deps:
-        scope = d.get("scope", "compile")
-        deps.append({
-            "groupId": d["groupId"],
-            "artifactId": d["artifactId"],
-            "version": d["version"],
-            "scope": scope,
-            "packaging": "jar",
-            "direct": d.get("direct", False),
-            "parent": d.get("parent"),
-            "is_test": scope == "test",
-            "module": None,
-        })
-    return deps
-
-
 def find_gradle_subprojects(repo_dir):
     """Discover Gradle subprojects from settings.gradle.
 
@@ -178,46 +156,53 @@ def get_all_gradle_deps(
     repo_dir: str,
     include_subprojects: bool = True,
 ) -> List[dict]:
-    """Get dependencies from all Gradle subprojects.
+    """Get per-subproject dependency subtrees for Phase 1 capture.
+
+    Each Gradle subproject (and the root project) is captured as its
+    own subtree so that Phase 2 can generate a per-subproject
+    ``_build`` SBOM from this metadata alone. There is **no**
+    de-duplication across subprojects — a component used by two
+    subprojects appears under both.
 
     Args:
         repo_dir: Path to the repository root.
-        include_subprojects: If True, iterate over
-            subprojects discovered from settings.gradle.
+        include_subprojects: If True, iterate over subprojects
+            discovered from ``settings.gradle``.
 
     Returns:
-        Combined deduplicated dependency list.
+        A list of module dicts, each with keys:
+
+        - ``key`` — Gradle project path (``":"`` for the root,
+          ``":<name>"`` for a subproject)
+        - ``project`` — the ``settings.gradle`` include name, or
+          None for the root project
+        - ``deps`` — list of dependency dicts in the shape produced
+          by ``app.spdx.gradle_parser.parse_gradle_dep_tree``
+          (``groupId``, ``artifactId``, ``version``, ``scope``,
+          ``direct``, ``optional``, ``parent``, ``depth``).
     """
-    all_deps = []
-    seen = set()
+    modules = []
 
     # Root project
     output = run_gradle_dep_tree(repo_dir)
-    if output:
-        deps = parse_gradle_output(output)
-        for d in deps:
-            key = (d["groupId"], d["artifactId"])
-            if key not in seen:
-                seen.add(key)
-                all_deps.append(d)
+    if output is not None:
+        modules.append({
+            "key": ":",
+            "project": None,
+            "deps": parse_gradle_dep_tree(output),
+        })
 
     # Subprojects
     if include_subprojects:
-        subprojects = find_gradle_subprojects(repo_dir)
-        for proj in subprojects:
+        for proj in find_gradle_subprojects(repo_dir):
             output = run_gradle_dep_tree(
                 repo_dir, project=proj,
             )
-            if output:
-                deps = parse_gradle_output(output)
-                for d in deps:
-                    d["module"] = proj
-                    key = (
-                        d["groupId"],
-                        d["artifactId"],
-                    )
-                    if key not in seen:
-                        seen.add(key)
-                        all_deps.append(d)
+            if output is not None:
+                modules.append({
+                    "key": _normalize_project_key(proj),
+                    "project": proj,
+                    "deps": parse_gradle_dep_tree(output),
+                })
 
-    return all_deps
+    return modules

--- a/app/pipeline/interception.py
+++ b/app/pipeline/interception.py
@@ -322,7 +322,7 @@ class MavenDepTreeStrategy(InterceptionStrategy):
             True on success, False on failure.
         """
         from app.pipeline.maven_dep_tree_parser import (
-            parse_dot_output,
+            parse_text_output,
             run_maven_dep_tree,
         )
 
@@ -369,9 +369,12 @@ class MavenDepTreeStrategy(InterceptionStrategy):
             f"{treedb_file} ({treedb_sec:.1f}s)"
         )
 
-        # Step 2: Capture Maven dependency graph
+        # Step 2: Capture Maven dependency graph (per-module).
+        # Default text output is parsed into per-module subtrees so
+        # Phase 2 can generate per-module ``_build`` SBOMs from this
+        # metadata alone, with no source-tree access.
         t0 = time.monotonic()
-        dot_output = run_maven_dep_tree(
+        tree_output = run_maven_dep_tree(
             repo_dir, runner=self._runner,
             maven_modules=self._maven_modules,
         )
@@ -381,24 +384,26 @@ class MavenDepTreeStrategy(InterceptionStrategy):
             "tool": "mvn dependency:tree",
             "wall_sec": round(deptree_sec, 2),
         })
-        if dot_output is None:
+        if tree_output is None:
             _write_adg_substeps(bom_path, substeps)
             return False
 
-        deps = parse_dot_output(dot_output)
-        if not deps:
+        modules = parse_text_output(tree_output)
+        capture = {"tool": "maven", "modules": modules}
+        if not modules:
             print(
-                "[WARN] No dependencies found in "
+                "[WARN] No modules found in "
                 "mvn dependency:tree output"
             )
 
         out_file = bom_path / "maven_deps.json"
         with open(out_file, "w", encoding="utf-8") as f:
-            json.dump(deps, f, indent=2)
+            json.dump(capture, f, indent=2)
 
+        dep_total = sum(len(m["deps"]) for m in modules)
         print(
-            f"[OK] Maven dep:tree: "
-            f"{len(deps)} dependencies → {out_file}"
+            f"[OK] Maven dep:tree: {len(modules)} modules, "
+            f"{dep_total} dependencies → {out_file}"
             f" ({deptree_sec:.1f}s)"
         )
         _write_adg_substeps(bom_path, substeps)
@@ -503,28 +508,33 @@ class GradleDepTreeStrategy(InterceptionStrategy):
             f"{treedb_file} ({treedb_sec:.1f}s)"
         )
 
-        # Step 2: Capture Gradle dependency graph
+        # Step 2: Capture Gradle dependency graph (per-subproject).
+        # Captured per subproject so Phase 2 can generate per-module
+        # ``_build`` SBOMs from this metadata alone, with no
+        # source-tree access.
         t0 = time.monotonic()
-        deps = get_all_gradle_deps(repo_dir)
+        modules = get_all_gradle_deps(repo_dir)
+        capture = {"tool": "gradle", "modules": modules}
         deptree_sec = time.monotonic() - t0
         substeps.append({
             "name": "dep_tree",
             "tool": "gradlew dependencies",
             "wall_sec": round(deptree_sec, 2),
         })
-        if not deps:
+        if not modules:
             print(
-                "[WARN] No dependencies found in "
+                "[WARN] No subprojects found in "
                 "Gradle dependency tree"
             )
 
         out_file = bom_path / "gradle_deps.json"
         with open(out_file, "w", encoding="utf-8") as f:
-            json.dump(deps, f, indent=2)
+            json.dump(capture, f, indent=2)
 
+        dep_total = sum(len(m["deps"]) for m in modules)
         print(
-            f"[OK] Gradle dep:tree: "
-            f"{len(deps)} dependencies → {out_file}"
+            f"[OK] Gradle dep:tree: {len(modules)} subprojects, "
+            f"{dep_total} dependencies → {out_file}"
             f" ({deptree_sec:.1f}s)"
         )
         _write_adg_substeps(bom_path, substeps)

--- a/app/pipeline/lang_runners.py
+++ b/app/pipeline/lang_runners.py
@@ -310,6 +310,31 @@ def run_java_pipeline(
     return timing
 
 
+def _find_module_dir(jar_path):
+    """Find the build-module directory for an output JAR.
+
+    Walks up from the JAR's build-output directory to the nearest
+    ancestor containing a build file (``pom.xml`` /
+    ``build.gradle`` / ``build.gradle.kts``). Used only by the
+    co-located dev/test live-resolution fallback; the enterprise
+    path never reads the source tree.
+
+    Returns the module directory as a string, or None if not found.
+    """
+    jar_dir = jar_path.parent
+    build_files = (
+        "pom.xml", "build.gradle", "build.gradle.kts",
+    )
+    for parent in [
+        jar_dir, jar_dir.parent, jar_dir.parent.parent,
+    ]:
+        if any(
+            (parent / bf).exists() for bf in build_files
+        ):
+            return str(parent)
+    return None
+
+
 def generate_java_adg_spdx(
     repo_name, repo_cfg, paths_cfg, run_ts,
     vcs_uri="NOASSERTION",
@@ -327,6 +352,10 @@ def generate_java_adg_spdx(
     """
     from app.pipeline.maven_plugin_detector import (
         detect_repackaging_plugins,
+    )
+    from app.spdx.dep_capture_reader import (
+        get_module_deps,
+        load_capture,
     )
     from app.spdx.java_generator import JavaSpdxGenerator
     from app.spdx.parser import AdgParser
@@ -409,6 +438,14 @@ def generate_java_adg_spdx(
         vcs_uri=vcs_uri,
     )
 
+    # Phase 2 generates _build SBOMs from the Phase 1 dependency
+    # capture (no source-tree access).  ``source_present`` marks a
+    # co-located dev/test run, where a live-resolution fallback is
+    # permitted if the capture is missing; the enterprise path
+    # (no source tree) fails loudly instead.
+    capture = load_capture(bom_dir)
+    source_present = repo_dir.exists()
+
     results = []
     for jar_path in jar_paths:
         jar_name = jar_path.stem  # e.g. jsoup-1.22.1
@@ -444,26 +481,45 @@ def generate_java_adg_spdx(
             )
             continue
 
-        # Determine module dir for per-module dependency
-        # resolution (Maven: pom.xml, Gradle: build.gradle)
-        pom_dir = None
-        jar_dir = jar_path.parent
-        # Walk up from build output dir to find module root
-        build_files = (
-            "pom.xml", "build.gradle", "build.gradle.kts"
+        # Resolve this JAR's dependency subtree from the Phase 1
+        # capture (no source-tree access).  The module is identified
+        # from artifact metadata that travels with the JAR: its
+        # artifactId / subproject name and its build-output path.
+        artifact_name = (
+            JavaSpdxGenerator._extract_artifact_name(bin_name)
         )
-        for parent in [
-            jar_dir, jar_dir.parent,
-            jar_dir.parent.parent,
-        ]:
-            if any(
-                (parent / bf).exists()
-                for bf in build_files
-            ):
-                pom_dir = str(parent)
-                break
+        build_deps = None
+        if capture is not None:
+            build_deps = get_module_deps(
+                capture, artifact_name, rel_jar,
+            )
 
-        # Analyzed: only source files in this JAR
+        # Decide the _build dependency source.  Per design, the
+        # enterprise path (no source tree) fails loudly when the
+        # capture lacks this module; a co-located dev/test run may
+        # fall back to live resolution from the source tree.
+        pom_dir = None
+        build_ok = True
+        if build_deps is None:
+            if source_present:
+                print(
+                    f"[WARN] {bin_name}: no Phase 1 dependency "
+                    f"metadata; falling back to live resolution "
+                    f"(co-located dev/test path)"
+                )
+                pom_dir = _find_module_dir(jar_path)
+            else:
+                print(
+                    f"[ERROR] {bin_name}: no Phase 1 dependency "
+                    f"metadata and no source tree — cannot "
+                    f"generate _build SBOM (enterprise Phase 2 "
+                    f"requires the capture); skipping _build"
+                )
+                build_ok = False
+
+        # Analyzed: only source files in this JAR.  It never needs
+        # dependencies, so pass deps=[] to keep it off the source
+        # tree entirely.
         analyzed_path = (
             spdx_dir
             / f"{jar_name}_analyzed.spdx.json"
@@ -473,27 +529,31 @@ def generate_java_adg_spdx(
             binary_name=bin_name,
             sbom_type="analyzed",
             jar_files=jar_files,
-            pom_dir=pom_dir,
+            deps=[],
             plugin_detection=plugin_result,
         )
         if result:
             results.append(result)
 
-        # Build: full dependency graph for this module
-        build_path = (
-            spdx_dir
-            / f"{jar_name}_build.spdx.json"
-        )
-        result = gen.generate(
-            output_path=str(build_path),
-            binary_name=bin_name,
-            sbom_type="build",
-            jar_files=jar_files,
-            pom_dir=pom_dir,
-            plugin_detection=plugin_result,
-        )
-        if result:
-            results.append(result)
+        # Build: full dependency graph for this module, from the
+        # captured metadata (build_deps) or the co-located live
+        # fallback (build_deps is None with pom_dir set).
+        if build_ok:
+            build_path = (
+                spdx_dir
+                / f"{jar_name}_build.spdx.json"
+            )
+            result = gen.generate(
+                output_path=str(build_path),
+                binary_name=bin_name,
+                sbom_type="build",
+                jar_files=jar_files,
+                pom_dir=pom_dir,
+                deps=build_deps,
+                plugin_detection=plugin_result,
+            )
+            if result:
+                results.append(result)
 
     return results
 

--- a/app/pipeline/maven_dep_tree_parser.py
+++ b/app/pipeline/maven_dep_tree_parser.py
@@ -1,32 +1,39 @@
-"""
-Maven ``dependency:tree`` DOT format parser.
+r"""
+Maven ``dependency:tree`` text format parser (per-module).
 
-Parses the output of ``mvn dependency:tree -DoutputType=dot``
-into structured dependency metadata.
+Parses the **default text** output of ``mvn dependency:tree`` into
+per-module dependency subtrees for Phase 1 capture.
 
-DOT output format::
+The default text format is used (not DOT, not JSON) because it is the
+only universally-available output that carries the ``optional`` flag:
 
-    digraph "com.example:app:jar:1.0" {
-        "com.example:app:jar:1.0" ->
-            "org.apache:commons-lang3:jar:3.12.0:compile" ;
-        "org.apache:commons-lang3:jar:3.12.0:compile" ->
-            "org.apache:commons-text:jar:1.10.0:compile" ;
-    }
+- **DOT** edges are labeled with scope only
+  (``groupId:artifactId:type:version:scope``) — no ``optional``.
+- **JSON** carries ``optional`` but requires
+  ``maven-dependency-plugin >= 3.7.0``, a toolchain version that is not
+  under our control (Phase 1 runs on the customer's build machine).
+- **text** (the default) has emitted the ``:scope`` coordinate plus an
+  ``(optional)`` suffix consistently across the plugin's 2.x/3.x life,
+  so it imposes no version requirement.
 
-Each node uses the Maven coordinate format:
-``groupId:artifactId:packaging:version[:scope]``
+Text output format (one tree per reactor module)::
 
-The root node (project itself) has no scope suffix.
-Dependency nodes have a scope suffix (compile, runtime,
-provided, test, system, import).
+    [INFO] com.example:app:jar:1.0
+    [INFO] +- org.apache:commons-lang3:jar:3.12.0:compile
+    [INFO] |  \- org.apache:commons-text:jar:1.10.0:compile
+    [INFO] \- org.projectlombok:lombok:jar:1.18.0:provided (optional)
 
-Multi-module projects produce multiple ``digraph`` blocks,
-one per module.
+Each module begins with its root coordinate line
+(``groupId:artifactId:packaging:version`` — no tree-branch prefix and
+no scope suffix). A component shared by two modules appears under
+**both** (no cross-module de-duplication).
 """
 
 import re
 import subprocess
 from pathlib import Path
+
+from app.spdx.maven_parser import parse_dep_tree
 
 
 # Maven dependency scopes that appear in production artifacts.
@@ -35,17 +42,9 @@ _PRODUCTION_SCOPES = frozenset({
     "compile", "runtime", "provided", "system",
 })
 
-# Regex for DOT edge lines:
-#   "group:artifact:type:ver:scope" -> "group:artifact:type:ver:scope" ;
-_EDGE_RE = re.compile(
-    r'"([^"]+)"\s*->\s*"([^"]+)"\s*;'
-)
-
-# Regex for DOT digraph header:
-#   digraph "group:artifact:type:ver" {
-_DIGRAPH_RE = re.compile(
-    r'digraph\s+"([^"]+)"\s*\{'
-)
+# A dependency tree branch line, e.g. ``+- g:a:...`` or ``|  \- g:a:...``
+# or (when the parent is the last child) ``   +- g:a:...``.
+_TREE_LINE_RE = re.compile(r"^[ |]*[+\\]- ")
 
 
 def parse_maven_coordinate(coord):
@@ -84,95 +83,105 @@ def parse_maven_coordinate(coord):
     return None
 
 
-def parse_dot_output(dot_text):
-    """Parse ``mvn dependency:tree -DoutputType=dot`` output.
+def _strip_info_prefix(raw_line):
+    """Remove a leading Maven ``[INFO]`` marker, preserving the tree
+    indentation that follows it.
 
-    Extracts all dependency edges from the DOT graph and
-    builds a list of dependency dicts. The root project node
-    is identified as the digraph name and excluded from the
-    dependency list.
+    The indentation after ``[INFO] `` encodes dependency depth and
+    must not be stripped. Lines without an ``[INFO]`` marker (e.g.
+    raw fixture input) are returned unchanged.
+    """
+    stripped = raw_line.lstrip()
+    if stripped.startswith("[INFO]"):
+        rest = stripped[len("[INFO]"):]
+        if rest.startswith(" "):
+            rest = rest[1:]
+        return rest
+    return raw_line
 
-    Handles multi-module projects (multiple digraph blocks).
+
+def _parse_root_line(line):
+    """Return a module dict if *line* is a reactor module root
+    coordinate, else None.
+
+    A root line is a bare Maven coordinate
+    (``groupId:artifactId:packaging:version``) with no tree-branch
+    prefix and no scope suffix.
+    """
+    if not line or line[0] in "+\\| ":
+        return None
+    parts = line.split(":")
+    if len(parts) != 4:
+        return None
+    if any((not p) or (" " in p) for p in parts):
+        return None
+    coord = parse_maven_coordinate(line)
+    if coord is None:
+        return None
+    return {
+        "key": f"{coord['groupId']}:{coord['artifactId']}",
+        "groupId": coord["groupId"],
+        "artifactId": coord["artifactId"],
+        "version": coord["version"],
+        "packaging": coord["packaging"],
+        "deps": [],
+    }
+
+
+def parse_text_output(dep_tree_text):
+    """Parse default ``mvn dependency:tree`` (text) reactor output
+    into per-module dependency subtrees.
+
+    Dependencies are de-duplicated WITHIN a module only (Maven prints
+    each resolved artifact once per module); there is no
+    de-duplication ACROSS modules, so a component shared by two
+    modules appears under both — which is exactly what per-module
+    ``_build`` SBOMs require.
 
     Args:
-        dot_text: Raw stdout from ``mvn dependency:tree
-            -DoutputType=dot``, possibly including Maven
+        dep_tree_text: Raw stdout from ``mvn dependency:tree``
+            (default text output), possibly including Maven
             ``[INFO]`` log prefix lines.
 
     Returns:
-        A list of dicts, each with keys:
+        A list of module dicts, each with keys:
 
-        - ``groupId``, ``artifactId``, ``version``, ``scope``
-        - ``packaging`` (jar, pom, war, etc.)
-        - ``direct`` (bool) — True if the parent is the
-          project root
-        - ``parent`` — the parent artifactId, or None for
-          direct deps
-        - ``is_test`` (bool) — True if scope is ``test``
-        - ``module`` — the module coordinate that owns this
-          dependency (for multi-module projects)
+        - ``key`` — ``"groupId:artifactId"`` module coordinate
+        - ``groupId``, ``artifactId``, ``version``, ``packaging``
+        - ``deps`` — list of dependency dicts in the shape produced
+          by ``app.spdx.maven_parser.parse_dep_tree`` (``groupId``,
+          ``artifactId``, ``version``, ``scope``, ``direct``,
+          ``optional``, ``parent``, ``depth``).
     """
-    # Strip Maven [INFO] prefixes if present
-    lines = []
-    for raw_line in dot_text.splitlines():
-        line = raw_line.strip()
-        if line.startswith("[INFO] "):
-            line = line[7:]
-        lines.append(line)
-    clean_text = "\n".join(lines)
+    modules = []
+    state = {"current": None, "block": []}
 
-    # Collect root nodes per digraph block
-    roots = set()
-    for match in _DIGRAPH_RE.finditer(clean_text):
-        roots.add(match.group(1))
+    def _flush():
+        current = state["current"]
+        if current is not None:
+            current["deps"] = parse_dep_tree(
+                "\n".join(state["block"])
+            )
+            modules.append(current)
 
-    # Parse all edges
-    seen = set()
-    deps = []
-    for match in _EDGE_RE.finditer(clean_text):
-        parent_coord = match.group(1)
-        child_coord = match.group(2)
+    for raw_line in dep_tree_text.splitlines():
+        content = _strip_info_prefix(raw_line)
 
-        child = parse_maven_coordinate(child_coord)
-        if child is None:
+        root = _parse_root_line(content)
+        if root is not None:
+            _flush()
+            state["current"] = root
+            state["block"] = []
             continue
 
-        parent = parse_maven_coordinate(parent_coord)
-        if parent is None:
-            continue
+        if (
+            state["current"] is not None
+            and _TREE_LINE_RE.match(content)
+        ):
+            state["block"].append("[INFO] " + content)
 
-        # Deduplicate by (groupId, artifactId) — Maven
-        # resolves one version per artifact, so the first
-        # occurrence (nearest/managed) wins.
-        dep_key = (
-            child["groupId"],
-            child["artifactId"],
-        )
-        if dep_key in seen:
-            continue
-        seen.add(dep_key)
-
-        # Direct dependency = parent is a root node
-        is_direct = parent_coord in roots
-
-        scope = child.get("scope", "compile") or "compile"
-
-        deps.append({
-            "groupId": child["groupId"],
-            "artifactId": child["artifactId"],
-            "version": child["version"],
-            "scope": scope,
-            "packaging": child.get("packaging", "jar"),
-            "direct": is_direct,
-            "parent": (
-                None if is_direct
-                else parent["artifactId"]
-            ),
-            "is_test": scope == "test",
-            "module": parent_coord if is_direct else None,
-        })
-
-    return deps
+    _flush()
+    return modules
 
 
 def filter_production_deps(deps):
@@ -181,8 +190,8 @@ def filter_production_deps(deps):
     Removes test-scope dependencies from the list.
 
     Args:
-        deps: List of dependency dicts from
-            ``parse_dot_output()``.
+        deps: List of dependency dicts (e.g. a module's
+            ``deps`` list from ``parse_text_output()``).
 
     Returns:
         A new list containing only dependencies with
@@ -248,9 +257,13 @@ def run_maven_dep_tree(
         )
         return None
 
+    # Use the DEFAULT text output (no -DoutputType): it is the only
+    # universally-available format that carries the ``optional`` flag
+    # and imposes no maven-dependency-plugin version requirement on
+    # the customer's build toolchain (DOT lacks optional; JSON needs
+    # plugin >= 3.7.0).
     base_cmd = [
         "mvn", "dependency:tree",
-        "-DoutputType=dot",
         "-DskipTests",
         "-Dmaven.javadoc.skip=true",
         "-Denforcer.skip=true",
@@ -271,6 +284,8 @@ def run_maven_dep_tree(
         cmd = list(base_cmd)
         if offline:
             cmd.insert(2, "-o")
+        # cmd index 2 is the first option after
+        # ``mvn dependency:tree``; -o is inserted there.
         try:
             result = subprocess.run(
                 cmd,

--- a/app/spdx/dep_capture_reader.py
+++ b/app/spdx/dep_capture_reader.py
@@ -1,0 +1,150 @@
+"""
+Phase 1 dependency-capture reader (Phase 2 consumption).
+
+Phase 2 generates per-module Java ``_build`` SBOMs from the dependency
+metadata Phase 1 captured (``maven_deps.json`` / ``gradle_deps.json``),
+with **no access to the source tree**. This module loads that capture
+and resolves the dependency subtree for a given output JAR.
+
+The capture is the per-module structure produced by
+``app.pipeline.maven_dep_tree_parser.parse_text_output`` (Maven) and
+``app.pipeline.gradle_dep_tree_parser.get_all_gradle_deps`` (Gradle)::
+
+    {"tool": "maven", "modules": [
+        {"key": "g:a", "groupId": "g", "artifactId": "a",
+         "version": "1.0", "packaging": "jar", "deps": [...]}, ...]}
+
+JAR -> module resolution uses artifact metadata that travels with the
+build output (no source tree required):
+
+1. **Primary** — the JAR filename's artifactId (Maven) or the
+   subproject name (Gradle) matches the capture module key.
+2. **Backup** — the module/subproject directory encoded in the JAR's
+   relative path (``<module>/target/...`` for Maven,
+   ``<subproject>/build/libs/...`` for Gradle), used when a custom
+   ``<finalName>`` / ``archivesName`` breaks the filename convention.
+3. **Single-module fallback** — if the capture has exactly one module,
+   it is used.
+"""
+
+import json
+from pathlib import Path
+
+
+_CAPTURE_FILES = {
+    "maven_deps.json": "target",
+    "gradle_deps.json": "build",
+}
+
+
+def load_capture(bom_dir):
+    """Load the Phase 1 dependency capture from *bom_dir*.
+
+    Looks for ``maven_deps.json`` first, then ``gradle_deps.json``.
+
+    Args:
+        bom_dir: Directory containing the Phase 1 capture files.
+
+    Returns:
+        The parsed capture dict (with ``tool`` and ``modules`` keys),
+        or None if no capture file is present.
+    """
+    bom_path = Path(bom_dir)
+    for filename in _CAPTURE_FILES:
+        candidate = bom_path / filename
+        if candidate.exists():
+            with open(candidate, encoding="utf-8") as handle:
+                return json.load(handle)
+    return None
+
+
+def _module_dir_from_jar(jar_rel_path, marker):
+    """Return the module/subproject directory encoded in a JAR's
+    relative path, or None for a root-level artifact.
+
+    The directory immediately preceding *marker* (``target`` for
+    Maven, ``build`` for Gradle) is the module directory.
+    """
+    if not jar_rel_path:
+        return None
+    parts = Path(jar_rel_path).parts
+    for index, part in enumerate(parts):
+        if part == marker:
+            return parts[index - 1] if index > 0 else None
+    return None
+
+
+def _resolve_maven(modules, artifact_name, jar_rel_path):
+    """Resolve a Maven output JAR to its capture module."""
+    if artifact_name:
+        for module in modules:
+            if module.get("artifactId") == artifact_name:
+                return module
+    mod_dir = _module_dir_from_jar(jar_rel_path, "target")
+    if mod_dir:
+        for module in modules:
+            if module.get("artifactId") == mod_dir:
+                return module
+    if len(modules) == 1:
+        return modules[0]
+    return None
+
+
+def _resolve_gradle(modules, artifact_name, jar_rel_path):
+    """Resolve a Gradle output JAR to its capture module."""
+    if artifact_name:
+        want = ":" + artifact_name
+        for module in modules:
+            if module.get("key") == want:
+                return module
+    mod_dir = _module_dir_from_jar(jar_rel_path, "build")
+    if mod_dir:
+        want = ":" + mod_dir
+        for module in modules:
+            if module.get("key") == want:
+                return module
+    else:
+        for module in modules:
+            if module.get("key") == ":":
+                return module
+    if len(modules) == 1:
+        return modules[0]
+    return None
+
+
+def resolve_module(capture, artifact_name, jar_rel_path=None):
+    """Resolve the capture module for an output JAR.
+
+    Args:
+        capture: The capture dict from :func:`load_capture`.
+        artifact_name: The JAR's artifactId (version stripped), e.g.
+            ``"dependency-check-cli"``.
+        jar_rel_path: The JAR path relative to the repository root
+            (e.g. ``"cli/target/dependency-check-cli-9.2.0.jar"``),
+            used for the directory-based backup match.
+
+    Returns:
+        The matching module dict (with a ``deps`` list), or None if no
+        module could be resolved.
+    """
+    if not capture:
+        return None
+    modules = capture.get("modules") or []
+    if not modules:
+        return None
+    if capture.get("tool") == "gradle":
+        return _resolve_gradle(modules, artifact_name, jar_rel_path)
+    return _resolve_maven(modules, artifact_name, jar_rel_path)
+
+
+def get_module_deps(capture, artifact_name, jar_rel_path=None):
+    """Return the dependency list for an output JAR's module.
+
+    Returns:
+        The module's ``deps`` list (parse-tree dict shape), or None if
+        the module could not be resolved from the capture.
+    """
+    module = resolve_module(capture, artifact_name, jar_rel_path)
+    if module is None:
+        return None
+    return module.get("deps", [])

--- a/app/spdx/java_generator.py
+++ b/app/spdx/java_generator.py
@@ -398,6 +398,7 @@ class JavaSpdxGenerator:
         self, output_path, binary_name=None,
         sbom_type="build", jar_files=None,
         pom_dir=None, plugin_detection=None,
+        deps=None,
     ):
         """Generate SPDX for a Java JAR.
 
@@ -413,11 +414,20 @@ class JavaSpdxGenerator:
                 Required; None is an error.
             pom_dir: optional directory containing the
                 module's pom.xml for per-module Maven
-                dependency resolution.
+                dependency resolution. Only used by the
+                co-located dev/test live fallback when
+                *deps* is None.
             plugin_detection: optional ``DetectionResult``
                 from ``maven_plugin_detector``. When present
                 and a shade/assembly plugin is detected,
                 the SPDX ``creationInfo`` is annotated.
+            deps: optional pre-resolved dependency list (the
+                module's subtree from Phase 1 capture). When
+                provided, it is used directly and **no**
+                source-tree resolution is performed (the
+                enterprise Phase 2 path). When None, the
+                generator falls back to live resolution via
+                *pom_dir* (the co-located dev/test path).
 
         Returns output path on success, None on failure.
         """
@@ -479,13 +489,19 @@ class JavaSpdxGenerator:
             f"{test_msg}{strace_msg}"
         )
 
-        # Get dependencies via mvn dependency:tree
-        # or ./gradlew dependencies (auto-detected).
-        # Filter to only runtime deps (compile, runtime, provided).
-        # Exclude test scope - those aren't in the final JAR
-        all_deps = self._get_maven_deps(
-            pom_dir=pom_dir
-        )
+        # Dependency source (CISA build SBOM):
+        #   - enterprise Phase 2: *deps* is the module's subtree from
+        #     Phase 1 capture (no source tree touched).
+        #   - co-located dev/test fallback: *deps* is None, so resolve
+        #     live via mvn dependency:tree / ./gradlew dependencies.
+        # Filter to only runtime deps (compile, runtime, provided);
+        # exclude test scope — those aren't in the final JAR.
+        if deps is not None:
+            all_deps = deps
+        else:
+            all_deps = self._get_maven_deps(
+                pom_dir=pom_dir
+            )
         maven_deps = [
             d for d in all_deps
             if d["scope"] in (

--- a/docs/deep-dive/phase2-consume-dependency-capture-design.md
+++ b/docs/deep-dive/phase2-consume-dependency-capture-design.md
@@ -1,0 +1,348 @@
+# Phase 2 Generates Java SBOMs From Phase 1 Metadata — Design
+
+| | |
+|---|---|
+| **Date** | 2026-06-24 |
+| **Authors** | Ted G. (architect), Cascade AI |
+| **Status** | Draft design — docs only, awaiting approval before any code |
+| **Applies to** | Java (Maven and Gradle) sidecar mode |
+| **Objective** | Phase 2 produces fully accurate Java SBOMs from Phase 1 metadata alone, with no source-tree access; Phase 1 stays fast |
+| **Sub-issue** | `docs/planning/java-phase2-consume-dep-capture-subissue.md` |
+| **Related** | `phase-isolation-build-time-analysis.md`, `dependency-check-module-dependency-structure.md`, `phase2-binary-artifact-dependencies.md` |
+
+---
+
+## Table of Contents
+
+1. [Objective and Hard Constraints](#1-objective-and-hard-constraints)
+2. [Current State (Verified Facts)](#2-current-state-verified-facts)
+3. [What Phase 1 Must Capture](#3-what-phase-1-must-capture)
+4. [Proposed Design](#4-proposed-design)
+5. [Capture Format (Per-Module)](#5-capture-format-per-module)
+6. [When Metadata Is Missing](#6-when-metadata-is-missing)
+7. [Testing Plan](#7-testing-plan)
+8. [Open Decisions for the User](#8-open-decisions-for-the-user)
+
+---
+
+<a id="1-objective-and-hard-constraints"></a>
+
+## 1. Objective and Hard Constraints
+
+**Objective:** Phase 2 produces fully accurate `_build` SBOMs for every
+Java artifact using **only** the metadata Phase 1 collected — with **no
+access to the source tree** — while Phase 1 stays fast.
+
+**Hard constraints:**
+
+- **Phase 2 must never read the source tree.** In the enterprise topology,
+  Phase 1 and Phase 2 run on different machines and the workspace is gone
+  when Phase 2 runs. Phase 2 therefore **cannot** run `mvn dependency:tree`
+  / `gradlew dependencies` (or any source-reading command).
+- **Phase 1 must be thorough *and* fast.** It must capture everything
+  Phase 2 could need, but without adding resolution work. The enhancement
+  here is **parser-only**: it reuses the single `dependency:tree` output
+  Phase 1 already produces.
+- **Duplication in Phase 2 is acceptable.** Re-doing graph-walking work that
+  Phase 1 also did is fine; the only prohibition is touching the source
+  tree.
+- **No golden updates by Cascade.** Diffs are reported for review.
+- **Accuracy baseline:** the standalone (ptrace) solution. The goal is to
+  match its accuracy from metadata alone.
+
+---
+
+<a id="2-current-state-verified-facts"></a>
+
+## 2. Current State (Verified Facts)
+
+**Phase 1 capture (`maven_deps.json`)** is produced by `parse_dot_output()`
+in `app/pipeline/maven_dep_tree_parser.py`. Properties:
+
+- Covers the **whole reactor** (all `digraph` blocks in
+  `mvn dependency:tree -DoutputType=dot`).
+- **Globally de-duplicated** by `(groupId, artifactId)` across all modules.
+- Fields per entry: `groupId`, `artifactId`, `version`, `scope`,
+  `packaging`, `direct`, `parent`, `is_test`, `module`.
+- `module` is set to the owning module's **coordinate** for **direct**
+  deps, and `None` for transitives.
+- `parent` is the parent **artifactId** for transitives, `None` for direct.
+- Does **not** carry the `optional` flag.
+
+**Phase 1 capture (`gradle_deps.json`)** is produced by
+`get_all_gradle_deps()` in `app/pipeline/gradle_dep_tree_parser.py`.
+Properties: globally de-duplicated by `(groupId, artifactId)`; `scope`
+forced to `compile`; `module` set per subproject for subproject deps,
+`None` for root.
+
+**Phase 2 consumption today** (`_generate_java_spdx` in
+`app/pipeline/lang_runners.py`):
+
+- Iterates each output JAR, derives the JAR's module directory
+  (`pom_dir`) by walking up to a build file.
+- Calls `JavaSpdxGenerator.generate(pom_dir=...)`, which runs the resolver
+  **live, per module** via `app/spdx/maven_parser.py:get_maven_deps`
+  (Maven, text output, `parse_dep_tree`) or
+  `app/spdx/gradle_parser.py:get_gradle_deps` (Gradle).
+- The live Maven text parser **keeps `optional`** and does **not**
+  de-duplicate within a module.
+
+**Scope of impact:** Only the `_build` SBOM uses the dependency graph.
+The `_analyzed` SBOM strips build-tool and dependency packages, so it is
+**unaffected** by this change.
+
+**The core defect:** today's Phase 2 dependency step reads the source tree
+(`pom_dir`). Even setting aside the capture's lossiness, this alone makes
+Phase 2 non-runnable in the enterprise split. Fixing it requires Phase 2 to
+obtain its dependency data from Phase 1 metadata instead.
+
+---
+
+<a id="3-what-phase-1-must-capture"></a>
+
+## 3. What Phase 1 Must Capture
+
+Phase 2 emits **one `_build` SBOM per module**, each listing that module's
+**direct** dependencies and their **transitive** closure, hierarchically
+(not flattened). The `dependency-check` deep-dive documents the target
+shape: the `cli` module lists its 10 direct deps and does **not** absorb
+`core`'s transitives (`dependency-check-module-dependency-structure.md`).
+
+To produce this from metadata alone, Phase 1 must capture **per-module**
+dependency subtrees — not one flattened reactor list.
+
+**Why the current capture is insufficient (proof):** `parse_dot_output()`
+de-duplicates globally by `(groupId, artifactId)` across all modules:
+
+```python
+dep_key = (child["groupId"], child["artifactId"])
+if dep_key in seen:        # single `seen` set spans ALL digraph blocks
+    continue
+seen.add(dep_key)
+```
+
+So a third-party component that two modules both depend on is stored
+**once**, attached to whichever module's edge was parsed first.
+Reconstructing per-module from that file would place the component in only
+**one** module's SBOM — a loss the live per-module path does not have. The
+capture also drops the `optional` flag entirely.
+
+**The information is available from the same single invocation — we were
+just asking for the wrong output format.** The `optional` flag is **not
+present in the DOT format at all** (DOT edges are labeled with scope only:
+`groupId:artifactId:type:version:scope`). Per the Apache Maven Dependency
+Plugin *Tree Output Formats* docs, only the **JSON** and **text** formats
+carry `optional`. JSON requires `maven-dependency-plugin >= 3.7.0`, which
+is **not acceptable** here: in the enterprise topology Phase 1 runs on the
+customer's build machine and we do **not** control their Maven or plugin
+version. The **default `text`** format, by contrast, has emitted the
+`:scope` coordinate plus an ` (optional)` suffix consistently across the
+entire 2.x/3.x life of the plugin — **no minimum version, nothing to pin,
+nothing to download**. It also encodes a **complete subtree per module**
+(reactor sections, hierarchy via indentation depth). Phase 1 already runs
+`dependency:tree` once; we simply capture the **default text** output
+instead of DOT and parse per module. Capturing per-module structure is
+therefore **free** in build-time terms, with **zero** dependency on the
+customer's toolchain version.
+
+---
+
+<a id="4-proposed-design"></a>
+
+## 4. Proposed Design
+
+### 4.1 Phase 1 — parser-only thoroughness (no added build time)
+
+Capture the **default `text`** output of the single `dependency:tree`
+invocation Phase 1 already runs (switching away from `-DoutputType=dot`,
+which cannot carry `optional`), and parse it to **retain per-module
+structure** instead of collapsing to a flat, globally-deduped list:
+
+- Segment the reactor text output into per-module blocks (a module begins
+  at its root coordinate line, e.g. `groupId:artifactId:jar:version`), and
+  parse each block into its own complete subtree, **de-duplicating only
+  within a module**, not across modules.
+- Preserve the `optional` flag (the ` (optional)` suffix in text output).
+- Reuse the **proven** text parser `app/spdx/maven_parser.py:parse_dep_tree`
+  — the same parser that already produces today's accurate per-module
+  goldens — applied per module segment, to avoid duplicating parsing logic.
+- Serialize a **per-module** structure (see
+  [Capture Format](#5-capture-format-per-module)).
+
+This reuses the single `dependency:tree` invocation Phase 1 already runs —
+**no new subprocess, no extra build time** — and the **default `text`**
+format imposes **no version requirement** on the customer's Maven/plugin
+(unlike JSON, which needs plugin `>= 3.7.0`). It is safe because nothing
+currently reads the captured file.
+
+> **Format decision (corrected from earlier draft):** an earlier version
+> of this design assumed the DOT output carried `optional`. It does not —
+> DOT carries scope only. The capture therefore uses the **default text**
+> format, which is the most version-robust source of `optional` + per-module
+> hierarchy and requires no control over the customer's build toolchain.
+
+### 4.2 Phase 2 — generate from metadata only
+
+Introduce a focused reader (`app/spdx/dep_capture_reader.py`) so
+`JavaSpdxGenerator` stays within the file-size guideline. For each output
+JAR:
+
+1. Determine the JAR's **module key from the artifact itself** — the JAR
+   path is `<module>/target/<artifactId>-<version>.jar`, so the module is
+   already encoded in the JAR location and filename. This is build-output
+   metadata that travels **with the artifact**; no source tree is needed.
+   The JAR filename (`<artifactId>-<version>`) maps directly to the
+   capture's module coordinate; the treedb `jar_map` is the backup when a
+   custom `<finalName>` breaks that convention.
+2. Load that module's pre-built subtree directly from the capture.
+3. Filter to production scopes (`compile`, `runtime`, `provided`) exactly
+   as today.
+
+The returned list keeps the same dict shape `_get_maven_deps()` returns
+today, so the downstream `_build_spdx` logic (sibling detection,
+relationship emission) is **unchanged**. What is **removed** from Phase 2:
+the `pom.xml`/`build.gradle` existence walk (`@lang_runners.py:447-464`) and
+the live `mvn dependency:tree` / `gradlew dependencies` resolution — those
+are the only source-tree-dependent steps; module identification was never
+one of them.
+
+### 4.3 Artifact naming is an industry standard (Maven + Gradle)
+
+The JAR-to-module mapping relies on documented default conventions, not
+guesswork:
+
+| | Maven | Gradle |
+|---|---|---|
+| **Default JAR name** | `${project.build.finalName}` = `${artifactId}-${version}` | `archiveFileName` = `[archiveBaseName]-[archiveVersion].[ext]`; `archiveBaseName` defaults to `archivesName` = `project.name` |
+| **Default output dir** | `<module>/target/` | `<subproject>/build/libs/` (`libsDirectory` = `$buildDir/libs`) |
+| **Module-name source** | module dir holds `pom.xml`; `artifactId` conventionally matches the dir | `project.name` defaults to the subproject directory name |
+| **Capture key** | `groupId:artifactId` (dep-graph root coordinate) | subproject path, e.g. `:core` |
+
+Sources: Apache Maven **Properties Guide** and **POM Reference**
+(`${project.build.finalName}` defaults to
+`${project.artifactId}-${project.version}`); Gradle **Base Plugin** docs
+(`archivesName` default = `$project.name`, `libsDirectory` = `$buildDir/libs`)
+and the **`Jar` task DSL**. The only deviations are explicit overrides
+(`<finalName>`, `archiveBaseName`/`archivesName`), for which the treedb
+`jar_map` is the backup.
+
+### 4.4 Scope: which build tools this covers
+
+| Language | Build tools | This problem applies? |
+|---|---|---|
+| Java, Kotlin, Scala | Maven, Gradle | **Yes** — JVM dependency resolution is a separate step that today reads the source tree |
+| C/C++, Go, Rust | native toolchains | **No** — Phase 1 captures file I/O **inline** during the build (strace / wrapper); there is no separate Phase 2 resolution step and no source-tree dependence |
+
+Kotlin and Scala route through Maven/Gradle (per
+`app/pipeline/language_validator.py`), so they need no separate handling.
+Other JVM build tools (Ant+Ivy, Bazel, sbt, Mill) are **not supported**
+today; if added, each would need its own artifact-naming convention mapped
+to the capture key.
+
+---
+
+<a id="5-capture-format-per-module"></a>
+
+## 5. Capture Format (Per-Module)
+
+The captured file becomes a mapping from module key to that module's
+dependency list, each entry retaining `optional`:
+
+```json
+{
+  "tool": "maven",
+  "modules": {
+    "com.example:core": [
+      {"groupId": "org.apache.commons", "artifactId": "commons-lang3",
+       "version": "3.14.0", "scope": "compile", "direct": true,
+       "optional": false, "parent": null},
+      {"groupId": "...", "artifactId": "...", "parent": "commons-lang3"}
+    ],
+    "com.example:cli": [
+      {"groupId": "org.apache.commons", "artifactId": "commons-lang3",
+       "version": "3.14.0", "scope": "compile", "direct": true,
+       "optional": false, "parent": null}
+    ]
+  }
+}
+```
+
+`commons-lang3` appears under **both** modules — that is the whole point.
+Maven module key = module coordinate (for example `groupId:artifactId`).
+Gradle module key = subproject path (for example `:core`), with the root
+project under a well-known key. Within a module, de-duplication is by
+`(groupId, artifactId)` (Maven resolves one version per artifact per
+module); **across** modules there is no de-duplication.
+
+This format change is internal (nothing else reads the file). The
+`_analyzed` SBOM is unaffected.
+
+---
+
+<a id="6-when-metadata-is-missing"></a>
+
+## 6. When Metadata Is Missing
+
+In the enterprise split, Phase 2 has no source tree, so there is **no
+source-tree fallback**. If required metadata is absent, Phase 2 must **fail
+loudly** with a clear error rather than silently emit an incomplete SBOM.
+
+A **dev/test convenience** (single-machine runs where the source tree
+happens to be present) may optionally fall back to live resolution, clearly
+logged as a non-enterprise path. Golden files are generated from **sidecar**
+mode where the capture is always present, so the convenience path never
+produces goldens.
+
+---
+
+<a id="7-testing-plan"></a>
+
+## 7. Testing Plan
+
+Unit tests (no Docker, no network, temp dirs only):
+
+- **Per-module parse (Maven):** a multi-`digraph` fixture parses into
+  per-module subtrees with **no cross-module dedup**; a component shared by
+  two modules appears in **both**.
+- **`optional` preserved:** an optional dep retains its flag through parse
+  and into the dependency list.
+- **Per-module parse (Gradle):** a multi-subproject fixture parses into
+  per-subproject lists.
+- **Phase 2 from metadata:** the generator builds a module's `_build` deps
+  from the captured file with **no resolver subprocess** invoked (a mock
+  asserts no subprocess call).
+- **Missing metadata fails loudly:** the enterprise path returns/raises a
+  clear error; no silent empty list.
+- **Shape parity:** the metadata-derived list matches the dict shape
+  `_build_spdx` consumes today, so SBOM construction needs no change.
+
+Integration validation (EC2, sidecar) before merge: run the multi-module
+Java repos (for example `dependency-check`, `logging-log4j2`, `checkstyle`)
+and **enumerate** every `_build` SBOM diff against the golden baseline for
+user review. With faithful per-module capture, the expectation is parity
+with today's per-module output; any differences are reported, never
+auto-applied.
+
+---
+
+<a id="8-open-decisions-for-the-user"></a>
+
+## 8. Open Decisions for the User
+
+1. **Approved (with corrected mechanism):** retain per-module attribution
+   and the `optional` flag from the single `dependency:tree` invocation,
+   at zero added build time. **Corrected mechanism:** capture the
+   **default `text`** output (not DOT — DOT cannot carry `optional`; JSON
+   would require plugin `>= 3.7.0`, a toolchain version we do not control).
+   Text is the universal default and imposes no version requirement.
+2. **JAR → module-key association** (resolved): the module is encoded in the
+   JAR path/filename (`<module>/target/<artifactId>-<version>.jar`), which
+   is artifact metadata — no source tree needed. The treedb `jar_map` is the
+   backup for custom `<finalName>`. Confirm the `<finalName>` backup
+   handling is acceptable.
+3. **Missing-metadata behavior:** fail loudly in the enterprise path, with
+   a live fallback allowed only for co-located dev/test runs (recommended)?
+4. **Sequencing:** Maven first (most multi-module goldens) then Gradle, or
+   both together?
+
+No code will be written until these are settled and you approve.

--- a/docs/planning/java-phase2-consume-dep-capture-subissue.md
+++ b/docs/planning/java-phase2-consume-dep-capture-subissue.md
@@ -1,0 +1,164 @@
+# Main Issue Draft — Java Phase 2: Generate SBOMs From Phase 1 Metadata Without the Source Tree
+
+| | |
+|---|---|
+| **Main issue** | Java Phase 2: Generate SBOMs From Phase 1 Metadata Without the Source Tree |
+| **Epic** | Single epic — this main issue is added to it later by the issues team |
+| **Relationship** | Java realization of SI-4 (`sidecar-phase-isolation-subissues.md`); supersedes US-1 in `phase1-build-speed-subissues.md`; **hosts the Java slice of SI-5** (delivery to Corona), broken out of the all-languages SI-5 |
+| **Applies to** | Java (Maven and Gradle) sidecar mode |
+| **Author** | Ted G. |
+| **Drafted** | 2026-06-24 (Cascade) |
+| **Status** | Draft — docs only, awaiting approval before any code |
+| **Estimate** | ~3 AI-days (implementation + tests), excluding EC2 golden validation |
+| **Planned sub-issues** | (1) Generate from metadata — Maven and Gradle (see `phase2-consume-dependency-capture-design.md` §8); (2) Deliver Java SBOMs to Corona (Java slice of SI-5) |
+| **Design** | `docs/deep-dive/phase2-consume-dependency-capture-design.md` |
+
+---
+
+## Background (verified facts, not judgments)
+
+The confirmed enterprise architecture is **sidecar + phase isolation**,
+with one **non-negotiable constraint**:
+
+- **Phase 2 has no access to the source repository / build workspace.** In
+  the target CI/CD topology, Phase 1 (interception) and Phase 2 (SBOM
+  generation) run on **different machines**, and the source tree is gone by
+  the time Phase 2 runs.
+
+Within that model:
+
+- **Phase 1** performs OmniBOR build interception and **collects** all
+  metadata into the intermediary artifactory. It must be both **thorough**
+  (capture everything Phase 2 could need) and **fast** (minimal build-time
+  impact).
+- **Phase 2** **processes** that collected metadata into SBOMs. It may
+  duplicate some of Phase 1's processing, but it must **never read the
+  source tree**.
+
+Today, for Java, Phase 2 **violates** this constraint:
+
+- Phase 1 (`MavenDepTreeStrategy` / `GradleDepTreeStrategy` in
+  `app/pipeline/interception.py`) writes `maven_deps.json` /
+  `gradle_deps.json`, but **no code reads them** (verified by search).
+- Phase 2 (`_generate_java_spdx` in `app/pipeline/lang_runners.py`)
+  re-runs `mvn dependency:tree` / `gradlew dependencies` **against the
+  source workspace** (`pom_dir`), once per output JAR.
+
+So the current split is incorrect with respect to the hard constraint:
+Phase 2 cannot run at all without the source tree. Separately, the Phase 1
+capture is **lossy** (reactor-wide, globally de-duplicated by
+`(groupId, artifactId)`, and missing the `optional` flag), so it is not yet
+thorough enough for Phase 2 to rely on.
+
+---
+
+## User Story
+
+As a release engineer whose CI/CD runs Phase 1 and Phase 2 on different
+machines,
+
+I want Phase 2 to generate every Java SBOM **solely from the metadata
+Phase 1 stored in the artifactory**,
+
+so that SBOM generation works with **no access to the source tree**, while
+Phase 1 stays fast and the SBOMs remain as accurate as the trusted
+standalone baseline.
+
+---
+
+## Acceptance Criteria
+
+- Given a Phase 2 run with **no source tree present**, when it generates
+  the `_build` SBOM for each output JAR, then it succeeds using **only**
+  Phase 1 metadata and runs **no** `mvn dependency:tree` /
+  `gradlew dependencies` (or any other source-reading command).
+- Given a multi-module reactor where a third-party component is a
+  dependency of **two or more modules**, when Phase 2 generates each
+  module's `_build` SBOM, then that component appears in **every** module
+  that depends on it (no loss from cross-module de-duplication).
+- Given dependencies marked `optional`, when Phase 2 generates the `_build`
+  SBOM, then the `optional` status is preserved (matching today's output).
+- Given Phase 1, when it captures dependency metadata, then it does so with
+  **no additional resolution step** beyond the single `dependency:tree`
+  invocation it already runs — Phase 1 build-time impact does not increase.
+- Given the `_analyzed` SBOM view, when it is generated, then it is
+  **unchanged**, because `_analyzed` does not include the dependency graph.
+- Given each supported multi-module sample repo, when its `_build` SBOMs
+  are generated from metadata, then any differences from the current golden
+  baseline are **enumerated and reported** for human review. Golden files
+  are **not** updated by Cascade.
+- Given the new path, when the test suite runs, then unit tests cover:
+  per-module reconstruction with a shared component, `optional` preserved,
+  metadata-absent fallback, and malformed/empty metadata.
+- Given the change is complete, when verification runs locally, then it
+  meets the project gates (import, flake8, pytest, coverage thresholds).
+
+---
+
+## Explicitly In and Out of Scope
+
+**In scope:**
+
+- A **parser-only** enhancement to Phase 1 so the captured metadata retains
+  per-module attribution and the `optional` flag. This adds **no** build
+  time (same single `dependency:tree -DoutputType=dot` invocation) and is
+  safe because nothing currently reads the captured file.
+- Phase 2 reading that metadata and producing `_build` SBOMs without the
+  source tree (duplicating graph-walking work as needed).
+
+**Out of scope:**
+
+- **No new resolution work added to Phase 1** — Phase 1 must not get slower.
+  Only the parsing of the output it already produces changes.
+- **No golden-file updates by Cascade.** Diffs are reported; the user decides.
+- **No change to the `_analyzed` SBOM view.**
+- Non-Java languages (tracked separately; C/C++, Go, Rust capture I/O inline
+  and have no separate dependency-resolution step).
+
+---
+
+## Why This Is Faithful, Not Best-Effort
+
+The raw `mvn dependency:tree -DoutputType=dot` output already contains a
+**complete subtree per module** (one `digraph` block each); the current
+parser collapses and de-duplicates them, discarding per-module structure.
+Preserving that structure (the in-scope parser change) lets Phase 2
+reconstruct each module's dependencies **faithfully** — including shared
+components and `optional` flags — rather than best-effort. The trusted
+accuracy baseline remains the standalone (ptrace) solution; the goal is to
+match it from metadata alone.
+
+---
+
+## Sub-Issue — Deliver Java SBOMs to Corona (Java slice of SI-5)
+
+Broken out of the all-languages SI-5 so that **all Java work — including
+delivery — completes before C/C++ work begins**. The shared delivery
+mechanism and security/auth model remain with SI-5 in the Build-Based SBOM
+Capture & Delivery main issue; this sub-issue covers wiring the **Java**
+pipeline's generated SBOMs into that intake and proving it end-to-end for
+Java.
+
+**User Story**
+
+As a release manager shipping Java products,
+I want the Java SBOMs produced by Phase 2 delivered automatically to the
+central SBOM system (Corona),
+so that every Java release has a discoverable, correctly filed SBOM with no
+manual steps — before we extend the same delivery to other languages.
+
+**Acceptance Criteria**
+
+- Given a completed Java Phase 2 run, when its `_build` SBOM is ready, then
+  it is delivered to Corona automatically, filed under the correct product,
+  release, and image.
+- Given delivery runs in the enterprise split, when it executes, then it
+  needs only the generated SBOM and captured metadata — **no source tree**.
+- Given existing company intake patterns, when the delivery path is built,
+  then it reuses them (see the
+  [integration wiki](https://github.com/CiscoSecurityServices/gambit/wiki/Omnibor-Build-Based-SBOM-Integration))
+  rather than inventing a new mechanism, and the auth model is the shared
+  one defined in SI-5.
+- Given the Java delivery, when validated end-to-end on a representative
+  Java repo, then the SBOM appears in Corona correctly filed and matches the
+  golden baseline.

--- a/scripts/run_phase_isolation_test.sh
+++ b/scripts/run_phase_isolation_test.sh
@@ -23,6 +23,17 @@ COMPARE_SCRIPT="$SCRIPT_DIR/compare_golden.py"
 # Default: test jsoup (fast, has golden files)
 REPOS="${1:-jsoup}"
 
+# Phase 1 clone control.  By default Phase 1 reuses an existing
+# checkout (--skip-clone) so reruns are fast.  Set P1_SKIP_CLONE=0
+# to clone the pinned tag fresh (required when repos/ is empty,
+# e.g. a clean golden-regression host).
+P1_SKIP_CLONE="${P1_SKIP_CLONE:-1}"
+if [ "$P1_SKIP_CLONE" = "0" ]; then
+    P1_CLONE_FLAG=""
+else
+    P1_CLONE_FLAG="--skip-clone"
+fi
+
 mkdir -p "$LOG_DIR"
 
 # Color output helpers
@@ -62,7 +73,7 @@ run_phase_test() {
         bash -c "echo CONTAINER_ID=\$(hostname) && \
             cd /workspace && python3 app/analyze.py \
             --repo $repo --mode sidecar --phase build \
-            --skip-clone" \
+            $P1_CLONE_FLAG" \
         > "$repo_log_dir/phase1.log" 2>&1
     local p1_rc=$?
     local p1_end
@@ -96,26 +107,32 @@ run_phase_test() {
     fi
     ok "Manifest: $manifest_path"
 
+    # The Phase 1 log prints the in-container path
+    # (/workspace/...).  Host-side file checks need the
+    # host path; the docker run for Phase 2 still gets the
+    # in-container path via --manifest.
+    local manifest_host="${manifest_path/\/workspace/$PROJECT_ROOT}"
+
     # ── Verify manifest content ────────────────────────
-    if [ ! -f "$manifest_path" ]; then
-        fail "Manifest file does not exist: $manifest_path"
+    if [ ! -f "$manifest_host" ]; then
+        fail "Manifest file does not exist: $manifest_host"
         TOTAL_FAIL=$((TOTAL_FAIL + 1))
         return 1
     fi
     info "Manifest contents (summary):"
     # Log key manifest fields for audit trail
-    grep -o '"run_ts": *"[^"]*"' "$manifest_path" | head -1
-    grep -o '"commit_sha": *"[^"]*"' "$manifest_path" | head -1
-    grep -c '"gitoids"' "$manifest_path" | \
+    grep -o '"run_ts": *"[^"]*"' "$manifest_host" | head -1
+    grep -o '"commit_sha": *"[^"]*"' "$manifest_host" | head -1
+    grep -c '"gitoids"' "$manifest_host" | \
         xargs -I{} echo "  gitoid entries present: {}"
-    cp "$manifest_path" "$repo_log_dir/manifest.json"
+    cp "$manifest_host" "$repo_log_dir/manifest.json"
     ok "Manifest validated and archived to logs"
 
     # ── Pre-Phase 2: Clean SPDX output dir ─────────────
     # Ensures any SPDX files found after Phase 2 were
     # produced by Container B, not left over from prior runs.
     local run_ts
-    run_ts=$(grep -o '"run_ts": *"[^"]*"' "$manifest_path" \
+    run_ts=$(grep -o '"run_ts": *"[^"]*"' "$manifest_host" \
         | head -1 | sed 's/.*": *"//;s/"//')
     local spdx_dir="$PROJECT_ROOT/output/spdx/java/$repo/$run_ts"
 

--- a/tests/test_dep_capture_reader.py
+++ b/tests/test_dep_capture_reader.py
@@ -1,0 +1,231 @@
+"""
+Tests for app/spdx/dep_capture_reader.py.
+
+Verifies Phase 2 resolution of an output JAR to its Phase 1
+dependency-capture module, with no source-tree access.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.spdx.dep_capture_reader import (
+    get_module_deps,
+    load_capture,
+    resolve_module,
+)
+
+
+def _maven_capture():
+    return {
+        "tool": "maven",
+        "modules": [
+            {
+                "key": "com.example:core",
+                "groupId": "com.example",
+                "artifactId": "core",
+                "version": "1.0",
+                "packaging": "jar",
+                "deps": [
+                    {"groupId": "org.slf4j",
+                     "artifactId": "slf4j-api",
+                     "version": "2.0.7", "scope": "compile",
+                     "direct": True, "optional": False,
+                     "parent": None},
+                ],
+            },
+            {
+                "key": "com.example:cli",
+                "groupId": "com.example",
+                "artifactId": "cli",
+                "version": "1.0",
+                "packaging": "jar",
+                "deps": [],
+            },
+        ],
+    }
+
+
+def _gradle_capture():
+    return {
+        "tool": "gradle",
+        "modules": [
+            {"key": ":", "project": None, "deps": []},
+            {
+                "key": ":core",
+                "project": "core",
+                "deps": [
+                    {"groupId": "com.google.guava",
+                     "artifactId": "guava", "version": "32.1.3",
+                     "scope": "compile", "direct": True,
+                     "optional": False, "parent": None},
+                ],
+            },
+        ],
+    }
+
+
+class TestLoadCapture(unittest.TestCase):
+    """Tests for load_capture()."""
+
+    def test_loads_maven(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "maven_deps.json"
+            path.write_text(json.dumps(_maven_capture()))
+            capture = load_capture(td)
+        self.assertEqual(capture["tool"], "maven")
+
+    def test_loads_gradle(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "gradle_deps.json"
+            path.write_text(json.dumps(_gradle_capture()))
+            capture = load_capture(td)
+        self.assertEqual(capture["tool"], "gradle")
+
+    def test_prefers_maven_over_gradle(self):
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "maven_deps.json").write_text(
+                json.dumps(_maven_capture())
+            )
+            (Path(td) / "gradle_deps.json").write_text(
+                json.dumps(_gradle_capture())
+            )
+            capture = load_capture(td)
+        self.assertEqual(capture["tool"], "maven")
+
+    def test_missing_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(load_capture(td))
+
+
+class TestResolveMaven(unittest.TestCase):
+    """Maven JAR -> module resolution."""
+
+    def test_match_by_artifact_name(self):
+        module = resolve_module(
+            _maven_capture(), "cli",
+            "cli/target/cli-1.0.jar",
+        )
+        self.assertEqual(module["key"], "com.example:cli")
+
+    def test_match_by_dir_backup(self):
+        """Custom finalName: filename does not match artifactId,
+        so the module directory in the JAR path is used."""
+        module = resolve_module(
+            _maven_capture(), "custom-final-name",
+            "core/target/custom-final-name.jar",
+        )
+        self.assertEqual(module["key"], "com.example:core")
+
+    def test_single_module_fallback(self):
+        capture = {
+            "tool": "maven",
+            "modules": [{
+                "key": "g:a", "groupId": "g",
+                "artifactId": "a", "version": "1.0",
+                "packaging": "jar", "deps": [],
+            }],
+        }
+        module = resolve_module(
+            capture, "unrelated", "target/unrelated.jar",
+        )
+        self.assertEqual(module["key"], "g:a")
+
+    def test_not_found(self):
+        module = resolve_module(
+            _maven_capture(), "nope",
+            "nope/target/nope.jar",
+        )
+        self.assertIsNone(module)
+
+
+class TestResolveGradle(unittest.TestCase):
+    """Gradle JAR -> module resolution."""
+
+    def test_match_by_subproject_name(self):
+        module = resolve_module(
+            _gradle_capture(), "core",
+            "core/build/libs/core-1.0.jar",
+        )
+        self.assertEqual(module["key"], ":core")
+
+    def test_match_by_dir_backup(self):
+        module = resolve_module(
+            _gradle_capture(), "custom",
+            "core/build/libs/custom.jar",
+        )
+        self.assertEqual(module["key"], ":core")
+
+    def test_root_project_jar(self):
+        module = resolve_module(
+            _gradle_capture(), "app",
+            "build/libs/app.jar",
+        )
+        self.assertEqual(module["key"], ":")
+
+    def test_single_module_fallback(self):
+        capture = {
+            "tool": "gradle",
+            "modules": [
+                {"key": ":only", "project": "only",
+                 "deps": []},
+            ],
+        }
+        module = resolve_module(
+            capture, "x", "sub/build/libs/x.jar",
+        )
+        self.assertEqual(module["key"], ":only")
+
+    def test_not_found(self):
+        module = resolve_module(
+            _gradle_capture(), "missing",
+            "missing/build/libs/missing.jar",
+        )
+        self.assertIsNone(module)
+
+
+class TestGetModuleDeps(unittest.TestCase):
+    """Tests for get_module_deps()."""
+
+    def test_returns_deps(self):
+        deps = get_module_deps(
+            _maven_capture(), "core",
+            "core/target/core-1.0.jar",
+        )
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["artifactId"], "slf4j-api")
+
+    def test_found_module_empty_deps(self):
+        deps = get_module_deps(
+            _maven_capture(), "cli",
+            "cli/target/cli-1.0.jar",
+        )
+        self.assertEqual(deps, [])
+
+    def test_not_found_returns_none(self):
+        deps = get_module_deps(
+            _maven_capture(), "missing",
+            "missing/target/missing.jar",
+        )
+        self.assertIsNone(deps)
+
+
+class TestResolveEdgeCases(unittest.TestCase):
+    """Edge cases for resolve_module()."""
+
+    def test_empty_capture(self):
+        self.assertIsNone(resolve_module(None, "x"))
+
+    def test_no_modules(self):
+        self.assertIsNone(
+            resolve_module({"tool": "maven", "modules": []}, "x")
+        )
+
+    def test_no_jar_path(self):
+        module = resolve_module(_maven_capture(), "core")
+        self.assertEqual(module["key"], "com.example:core")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gradle_dep_tree_parser.py
+++ b/tests/test_gradle_dep_tree_parser.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from app.pipeline.gradle_dep_tree_parser import (
-    parse_gradle_output,
     run_gradle_dep_tree,
     find_gradle_subprojects,
 )
@@ -44,119 +43,6 @@ _SINGLE_PROJECT_OUTPUT = (
     '     \\--- com.fasterxml.jackson.core'
     ':jackson-annotations:2.16.0\n'
 )
-
-# ============================================================
-# Fixture: version conflict
-# ============================================================
-
-_VERSION_CONFLICT_OUTPUT = """\
-runtimeClasspath - Runtime classpath of source set 'main'.
-+--- org.slf4j:slf4j-api:2.0.7
-+--- com.example:lib-a:1.0.0
-|    \\--- org.slf4j:slf4j-api:1.7.36 -> 2.0.7 (*)
-\\--- com.example:lib-b:2.0.0
-     \\--- org.slf4j:slf4j-api:2.0.0 -> 2.0.7 (*)
-"""
-
-# ============================================================
-# Fixture: empty output
-# ============================================================
-
-_EMPTY_OUTPUT = """\
-runtimeClasspath - Runtime classpath of source set 'main'.
-No dependencies
-"""
-
-
-# ============================================================
-# Tests: parse_gradle_output
-# ============================================================
-
-class TestParseGradleOutput(unittest.TestCase):
-    """Tests for parse_gradle_output()."""
-
-    def test_single_project_deps(self):
-        deps = parse_gradle_output(
-            _SINGLE_PROJECT_OUTPUT,
-        )
-        names = {d["artifactId"] for d in deps}
-        self.assertIn("slf4j-api", names)
-        self.assertIn("guava", names)
-        self.assertIn("commons-lang3", names)
-        self.assertIn("jackson-databind", names)
-
-    def test_transitive_deps(self):
-        deps = parse_gradle_output(
-            _SINGLE_PROJECT_OUTPUT,
-        )
-        transitive = [
-            d for d in deps if not d["direct"]
-        ]
-        names = {d["artifactId"] for d in transitive}
-        self.assertIn("failureaccess", names)
-        self.assertIn("jackson-core", names)
-
-    def test_direct_deps(self):
-        deps = parse_gradle_output(
-            _SINGLE_PROJECT_OUTPUT,
-        )
-        direct = [d for d in deps if d["direct"]]
-        self.assertEqual(len(direct), 4)
-
-    def test_output_format_has_required_keys(self):
-        deps = parse_gradle_output(
-            _SINGLE_PROJECT_OUTPUT,
-        )
-        required = {
-            "groupId", "artifactId", "version",
-            "scope", "packaging", "direct",
-            "parent", "is_test", "module",
-        }
-        for d in deps:
-            self.assertTrue(
-                required.issubset(d.keys()),
-                f"Missing keys in {d}",
-            )
-
-    def test_packaging_defaults_to_jar(self):
-        deps = parse_gradle_output(
-            _SINGLE_PROJECT_OUTPUT,
-        )
-        for d in deps:
-            self.assertEqual(d["packaging"], "jar")
-
-    def test_version_conflict_resolved(self):
-        deps = parse_gradle_output(
-            _VERSION_CONFLICT_OUTPUT,
-        )
-        slf4j = [
-            d for d in deps
-            if d["artifactId"] == "slf4j-api"
-        ]
-        self.assertEqual(len(slf4j), 1)
-        self.assertEqual(slf4j[0]["version"], "2.0.7")
-
-    def test_empty_output(self):
-        deps = parse_gradle_output(_EMPTY_OUTPUT)
-        self.assertEqual(deps, [])
-
-    def test_empty_string(self):
-        deps = parse_gradle_output("")
-        self.assertEqual(deps, [])
-
-    def test_scope_is_compile(self):
-        deps = parse_gradle_output(
-            _SINGLE_PROJECT_OUTPUT,
-        )
-        for d in deps:
-            self.assertEqual(d["scope"], "compile")
-
-    def test_not_test_scope(self):
-        deps = parse_gradle_output(
-            _SINGLE_PROJECT_OUTPUT,
-        )
-        for d in deps:
-            self.assertFalse(d["is_test"])
 
 
 # ============================================================
@@ -320,8 +206,12 @@ class TestGradleDepTreeStrategy(unittest.TestCase):
                     "/repo", str(bom_dir), {},
                 )
             self.assertTrue(ok)
-            self.assertTrue(
-                (bom_dir / "gradle_deps.json").exists()
+            capture_file = bom_dir / "gradle_deps.json"
+            self.assertTrue(capture_file.exists())
+            capture = json.loads(capture_file.read_text())
+            self.assertEqual(capture["tool"], "gradle")
+            self.assertEqual(
+                capture["modules"][0]["key"], ":",
             )
             substeps_file = (
                 bom_dir / "adg_substeps.json"
@@ -442,58 +332,55 @@ class TestFindGradleSubprojectsEdge(unittest.TestCase):
 
 
 class TestGetAllGradleDeps(unittest.TestCase):
-    """Tests for get_all_gradle_deps."""
+    """Tests for get_all_gradle_deps (per-subproject capture)."""
 
     @patch(
         "app.pipeline.gradle_dep_tree_parser"
         ".run_gradle_dep_tree"
     )
-    def test_subproject_deps_merged(self, mock_run):
+    def test_per_subproject_modules(self, mock_run):
         from app.pipeline.gradle_dep_tree_parser import (
             get_all_gradle_deps,
         )
         mock_run.side_effect = [
             # Root project
-            (
-                "runtimeClasspath\n"
-                "+--- com.a:b:1.0\n"
-            ),
+            "runtimeClasspath\n+--- com.a:b:1.0\n",
             # Subproject
-            (
-                "runtimeClasspath\n"
-                "+--- com.c:d:2.0\n"
-            ),
+            "runtimeClasspath\n+--- com.c:d:2.0\n",
         ]
         with tempfile.TemporaryDirectory() as td:
             s = Path(td) / "settings.gradle"
             s.write_text("include 'sub'\n")
-            deps = get_all_gradle_deps(td)
-        self.assertEqual(len(deps), 2)
+            modules = get_all_gradle_deps(td)
+        self.assertEqual(len(modules), 2)
+        keys = {m["key"] for m in modules}
+        self.assertIn(":", keys)
+        self.assertIn(":sub", keys)
 
     @patch(
         "app.pipeline.gradle_dep_tree_parser"
         ".run_gradle_dep_tree"
     )
-    def test_dedup_across_projects(self, mock_run):
+    def test_no_cross_subproject_dedup(self, mock_run):
+        """A dependency used by two subprojects must appear in
+        BOTH module subtrees (no cross-subproject dedup)."""
         from app.pipeline.gradle_dep_tree_parser import (
             get_all_gradle_deps,
         )
         mock_run.side_effect = [
-            (
-                "runtimeClasspath\n"
-                "+--- com.a:b:1.0\n"
-            ),
-            (
-                "runtimeClasspath\n"
-                "+--- com.a:b:1.0\n"
-            ),
+            "runtimeClasspath\n+--- com.a:b:1.0\n",
+            "runtimeClasspath\n+--- com.a:b:1.0\n",
         ]
         with tempfile.TemporaryDirectory() as td:
             s = Path(td) / "settings.gradle"
             s.write_text("include 'sub'\n")
-            deps = get_all_gradle_deps(td)
-        # Deduped: same groupId:artifactId
-        self.assertEqual(len(deps), 1)
+            modules = get_all_gradle_deps(td)
+        self.assertEqual(len(modules), 2)
+        for module in modules:
+            names = {
+                d["artifactId"] for d in module["deps"]
+            }
+            self.assertIn("b", names)
 
 
 if __name__ == "__main__":

--- a/tests/test_java_pipeline.py
+++ b/tests/test_java_pipeline.py
@@ -1,4 +1,5 @@
 """Tests for Java pipeline functions in runners.py."""
+import json
 import sys
 import tempfile
 import unittest
@@ -637,6 +638,84 @@ class TestGenerateJavaAdgSpdxBranches(unittest.TestCase):
             )
         self.assertEqual(len(result), 2)
         mock_detect.assert_called_once()
+
+    @patch("app.spdx.parser.AdgParser")
+    @patch("app.spdx.java_generator.JavaSpdxGenerator")
+    def test_build_deps_from_capture(
+        self, mock_gen_cls, mock_parser_cls,
+    ):
+        """With a Phase 1 capture present, the _build SBOM is
+        generated from the captured per-module deps directly
+        (no source-tree access / pom_dir)."""
+        mock_gen = MagicMock()
+        mock_gen.generate.side_effect = [
+            "/tmp/analyzed.spdx.json",
+            "/tmp/build.spdx.json",
+        ]
+        mock_gen_cls.return_value = mock_gen
+
+        mock_parser = MagicMock()
+        mock_parser.get_jar_source_files.return_value = {
+            "myapp/target/myapp-1.0.jar": [
+                {"sha1": "a", "file_path": "a.java"},
+            ],
+        }
+        mock_parser.parse_strace_openat_log.return_value = (
+            set()
+        )
+        mock_parser_cls.return_value = mock_parser
+
+        with tempfile.TemporaryDirectory() as td:
+            paths_cfg = {
+                "output_dir": str(Path(td) / "output"),
+                "repos_dir": str(Path(td) / "repos"),
+            }
+            repo_cfg = {
+                "language": "java",
+                "output_binaries": ["target/myapp-1.0.jar"],
+            }
+            jar = (
+                Path(td) / "repos" / "myapp"
+                / "target" / "myapp-1.0.jar"
+            )
+            jar.parent.mkdir(parents=True)
+            jar.write_bytes(b"PK")
+
+            bom_dir = (
+                Path(td) / "output" / "omnibor"
+                / "java" / "myapp" / "ts1"
+            )
+            bom_dir.mkdir(parents=True)
+            captured_dep = {
+                "groupId": "org.slf4j",
+                "artifactId": "slf4j-api",
+                "version": "2.0.7", "scope": "compile",
+                "direct": True, "optional": False,
+                "parent": None,
+            }
+            (bom_dir / "maven_deps.json").write_text(
+                json.dumps({
+                    "tool": "maven",
+                    "modules": [{
+                        "key": "com.example:myapp",
+                        "groupId": "com.example",
+                        "artifactId": "myapp",
+                        "version": "1.0",
+                        "packaging": "jar",
+                        "deps": [captured_dep],
+                    }],
+                })
+            )
+
+            result = _generate_java_adg_spdx(
+                "myapp", repo_cfg, paths_cfg, "ts1",
+            )
+        self.assertEqual(len(result), 2)
+        build_call = mock_gen.generate.call_args_list[1]
+        self.assertEqual(
+            build_call.kwargs["deps"], [captured_dep],
+        )
+        self.assertIsNone(build_call.kwargs["pom_dir"])
 
 
 class TestMainJavaDispatch(unittest.TestCase):

--- a/tests/test_maven_dep_tree_parser.py
+++ b/tests/test_maven_dep_tree_parser.py
@@ -1,7 +1,7 @@
 """
 Tests for app/pipeline/maven_dep_tree_parser.py.
 
-Tests the Maven ``dependency:tree`` DOT format parser
+Tests the Maven ``dependency:tree`` default-text per-module parser
 with realistic fixture data from real Maven projects.
 """
 
@@ -14,7 +14,7 @@ from unittest.mock import patch, MagicMock
 
 from app.pipeline.maven_dep_tree_parser import (
     parse_maven_coordinate,
-    parse_dot_output,
+    parse_text_output,
     filter_production_deps,
     classify_scopes,
     run_maven_dep_tree,
@@ -22,151 +22,70 @@ from app.pipeline.maven_dep_tree_parser import (
 
 
 # ============================================================
-# Fixture: single-module project DOT output
+# Fixture: single-module project text output
 # ============================================================
 
 # Simplified output from dependency-check-core
-_SINGLE_MODULE_DOT = (
-    '[INFO] --- dependency:3.6.1:tree'
-    ' (default-cli) @'
-    ' dependency-check-core ---\n'
-    '[INFO] digraph'
-    ' "org.owasp:dependency-check-core'
-    ':jar:9.0.9" {\n'
-    '[INFO]    "org.owasp:dependency-check'
-    '-core:jar:9.0.9" ->'
-    ' "org.slf4j:slf4j-api'
-    ':jar:2.0.7:compile" ;\n'
-    '[INFO]    "org.owasp:dependency-check'
-    '-core:jar:9.0.9" ->'
-    ' "commons-io:commons-io'
-    ':jar:2.15.1:compile" ;\n'
-    '[INFO]    "org.owasp:dependency-check'
-    '-core:jar:9.0.9" ->'
-    ' "org.apache.commons:commons-lang3'
-    ':jar:3.14.0:compile" ;\n'
-    '[INFO]    "org.owasp:dependency-check'
-    '-core:jar:9.0.9" ->'
-    ' "org.junit.jupiter:junit-jupiter'
-    ':jar:5.10.1:test" ;\n'
-    '[INFO]    "org.apache.commons'
-    ':commons-lang3:jar:3.14.0:compile"'
-    ' -> "org.apache.commons'
-    ':commons-text:jar:1.11.0:compile"'
-    ' ;\n'
-    '[INFO]    "org.junit.jupiter'
-    ':junit-jupiter:jar:5.10.1:test"'
-    ' -> "org.junit.jupiter'
-    ':junit-jupiter-api'
-    ':jar:5.10.1:test" ;\n'
-    '[INFO]    "org.junit.jupiter'
-    ':junit-jupiter-api'
-    ':jar:5.10.1:test" ->'
-    ' "org.opentest4j:opentest4j'
-    ':jar:1.3.0:test" ;\n'
-    '[INFO] }\n'
-)
+_SINGLE_MODULE_TEXT = "\n".join([
+    "[INFO] --- dependency:3.6.1:tree (default-cli) @"
+    " dependency-check-core ---",
+    "[INFO] org.owasp:dependency-check-core:jar:9.0.9",
+    "[INFO] +- org.slf4j:slf4j-api:jar:2.0.7:compile",
+    "[INFO] +- commons-io:commons-io:jar:2.15.1:compile",
+    "[INFO] +- org.apache.commons:commons-lang3:jar:3.14.0"
+    ":compile",
+    "[INFO] |  \\- org.apache.commons:commons-text:jar:1.11.0"
+    ":compile",
+    "[INFO] +- org.projectlombok:lombok:jar:1.18.30:provided"
+    " (optional)",
+    "[INFO] \\- org.junit.jupiter:junit-jupiter:jar:5.10.1:test",
+    "[INFO]    \\- org.junit.jupiter:junit-jupiter-api:jar:5.10.1"
+    ":test",
+    "[INFO]       \\- org.opentest4j:opentest4j:jar:1.3.0:test",
+]) + "\n"
 
 # ============================================================
-# Fixture: multi-module project DOT output
+# Fixture: multi-module project text output
 # ============================================================
+# guava is shared by BOTH the core and web modules; it must
+# appear under each (no cross-module de-duplication).
 
-_MULTI_MODULE_DOT = (
-    '[INFO] --- dependency:3.6.1:tree'
-    ' (default-cli) @ parent ---\n'
-    '[INFO] digraph'
-    ' "com.example:parent:pom:1.0.0"'
-    ' {\n'
-    '[INFO] }\n'
-    '[INFO]\n'
-    '[INFO] --- dependency:3.6.1:tree'
-    ' (default-cli) @ core ---\n'
-    '[INFO] digraph'
-    ' "com.example:core:jar:1.0.0"'
-    ' {\n'
-    '[INFO]    "com.example:core'
-    ':jar:1.0.0" ->'
-    ' "org.slf4j:slf4j-api'
-    ':jar:2.0.7:compile" ;\n'
-    '[INFO]    "com.example:core'
-    ':jar:1.0.0" ->'
-    ' "com.google.guava:guava'
-    ':jar:32.1.3-jre:compile" ;\n'
-    '[INFO] }\n'
-    '[INFO]\n'
-    '[INFO] --- dependency:3.6.1:tree'
-    ' (default-cli) @ web ---\n'
-    '[INFO] digraph'
-    ' "com.example:web:war:1.0.0"'
-    ' {\n'
-    '[INFO]    "com.example:web'
-    ':war:1.0.0" ->'
-    ' "com.example:core'
-    ':jar:1.0.0:compile" ;\n'
-    '[INFO]    "com.example:web'
-    ':war:1.0.0" ->'
-    ' "javax.servlet:javax.servlet-api'
-    ':jar:4.0.1:provided" ;\n'
-    '[INFO]    "com.example:web'
-    ':war:1.0.0" ->'
-    ' "org.mockito:mockito-core'
-    ':jar:5.8.0:test" ;\n'
-    '[INFO]    "org.mockito:mockito-core'
-    ':jar:5.8.0:test" ->'
-    ' "net.bytebuddy:byte-buddy'
-    ':jar:1.14.10:test" ;\n'
-    '[INFO] }\n'
-)
+_MULTI_MODULE_TEXT = "\n".join([
+    "[INFO] --- dependency:3.6.1:tree (default-cli) @ parent ---",
+    "[INFO] com.example:parent:pom:1.0.0",
+    "[INFO] ",
+    "[INFO] --- dependency:3.6.1:tree (default-cli) @ core ---",
+    "[INFO] com.example:core:jar:1.0.0",
+    "[INFO] +- org.slf4j:slf4j-api:jar:2.0.7:compile",
+    "[INFO] \\- com.google.guava:guava:jar:32.1.3-jre:compile",
+    "[INFO] ",
+    "[INFO] --- dependency:3.6.1:tree (default-cli) @ web ---",
+    "[INFO] com.example:web:war:1.0.0",
+    "[INFO] +- com.example:core:jar:1.0.0:compile",
+    "[INFO] +- com.google.guava:guava:jar:32.1.3-jre:compile",
+    "[INFO] +- javax.servlet:javax.servlet-api:jar:4.0.1"
+    ":provided",
+    "[INFO] \\- org.mockito:mockito-core:jar:5.8.0:test",
+    "[INFO]    \\- net.bytebuddy:byte-buddy:jar:1.14.10:test",
+]) + "\n"
 
 # ============================================================
-# Fixture: no-scope root node (DOT format edge case)
+# Fixture: root-only module (no dependencies)
 # ============================================================
 
-_ROOT_ONLY_DOT = """\
-digraph "com.example:app:jar:2.0.0" {
-}
-"""
+_ROOT_ONLY_TEXT = "[INFO] com.example:app:jar:2.0.0\n"
 
 # ============================================================
-# Fixture: version conflict (managed version wins)
+# Fixture: all production + test scopes
 # ============================================================
 
-_VERSION_CONFLICT_DOT = (
-    'digraph "com.example:app:jar:1.0.0"'
-    ' {\n'
-    '    "com.example:app:jar:1.0.0" ->'
-    ' "org.apache:commons-lang3'
-    ':jar:3.14.0:compile" ;\n'
-    '    "com.example:app:jar:1.0.0" ->'
-    ' "com.foo:bar:jar:1.0.0:compile"'
-    ' ;\n'
-    '    "com.foo:bar:jar:1.0.0:compile"'
-    ' -> "org.apache:commons-lang3'
-    ':jar:3.12.0:compile" ;\n'
-    '}\n'
-)
-
-# ============================================================
-# Fixture: optional and system scope
-# ============================================================
-
-_SCOPES_DOT = (
-    'digraph "com.example:app:jar:1.0.0"'
-    ' {\n'
-    '    "com.example:app:jar:1.0.0" ->'
-    ' "com.oracle:ojdbc8'
-    ':jar:21.9.0:system" ;\n'
-    '    "com.example:app:jar:1.0.0" ->'
-    ' "org.slf4j:slf4j-api'
-    ':jar:2.0.7:runtime" ;\n'
-    '    "com.example:app:jar:1.0.0" ->'
-    ' "org.projectlombok:lombok'
-    ':jar:1.18.30:provided" ;\n'
-    '    "com.example:app:jar:1.0.0" ->'
-    ' "org.junit:junit'
-    ':jar:4.13.2:test" ;\n'
-    '}\n'
-)
+_SCOPES_TEXT = "\n".join([
+    "[INFO] com.example:app:jar:1.0.0",
+    "[INFO] +- com.oracle:ojdbc8:jar:21.9.0:system",
+    "[INFO] +- org.slf4j:slf4j-api:jar:2.0.7:runtime",
+    "[INFO] +- org.projectlombok:lombok:jar:1.18.30:provided",
+    "[INFO] \\- org.junit:junit:jar:4.13.2:test",
+]) + "\n"
 
 
 # ============================================================
@@ -232,116 +151,146 @@ class TestParseMavenCoordinate(unittest.TestCase):
 
 
 # ============================================================
-# Tests: parse_dot_output
+# Tests: parse_text_output
 # ============================================================
 
-class TestParseDotOutput(unittest.TestCase):
-    """Tests for parse_dot_output()."""
+class TestParseTextOutput(unittest.TestCase):
+    """Tests for parse_text_output()."""
+
+    @staticmethod
+    def _module(modules, key):
+        return next(m for m in modules if m["key"] == key)
+
+    @staticmethod
+    def _single_deps():
+        return parse_text_output(_SINGLE_MODULE_TEXT)[0]["deps"]
+
+    def test_single_module_key(self):
+        modules = parse_text_output(_SINGLE_MODULE_TEXT)
+        self.assertEqual(len(modules), 1)
+        self.assertEqual(
+            modules[0]["key"],
+            "org.owasp:dependency-check-core",
+        )
+        self.assertEqual(modules[0]["version"], "9.0.9")
 
     def test_single_module_direct_deps(self):
-        deps = parse_dot_output(_SINGLE_MODULE_DOT)
-        direct = [d for d in deps if d["direct"]]
-        self.assertEqual(len(direct), 4)
+        direct = [d for d in self._single_deps() if d["direct"]]
         names = {d["artifactId"] for d in direct}
+        self.assertEqual(len(direct), 5)
         self.assertIn("slf4j-api", names)
         self.assertIn("commons-io", names)
         self.assertIn("commons-lang3", names)
+        self.assertIn("lombok", names)
         self.assertIn("junit-jupiter", names)
 
     def test_single_module_transitive_deps(self):
-        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+        deps = self._single_deps()
         transitive = [d for d in deps if not d["direct"]]
-        self.assertEqual(len(transitive), 3)
         names = {d["artifactId"] for d in transitive}
         self.assertIn("commons-text", names)
         self.assertIn("junit-jupiter-api", names)
         self.assertIn("opentest4j", names)
 
     def test_transitive_parent_set(self):
-        deps = parse_dot_output(_SINGLE_MODULE_DOT)
         text = next(
-            d for d in deps
+            d for d in self._single_deps()
             if d["artifactId"] == "commons-text"
         )
         self.assertEqual(text["parent"], "commons-lang3")
         self.assertFalse(text["direct"])
 
+    def test_nested_transitive_parent(self):
+        opentest = next(
+            d for d in self._single_deps()
+            if d["artifactId"] == "opentest4j"
+        )
+        self.assertEqual(
+            opentest["parent"], "junit-jupiter-api",
+        )
+
     def test_direct_parent_is_none(self):
-        deps = parse_dot_output(_SINGLE_MODULE_DOT)
         slf4j = next(
-            d for d in deps
+            d for d in self._single_deps()
             if d["artifactId"] == "slf4j-api"
         )
         self.assertIsNone(slf4j["parent"])
         self.assertTrue(slf4j["direct"])
 
-    def test_test_scope_flagged(self):
-        deps = parse_dot_output(_SINGLE_MODULE_DOT)
-        test_deps = [d for d in deps if d["is_test"]]
-        self.assertTrue(len(test_deps) >= 1)
-        names = {d["artifactId"] for d in test_deps}
-        self.assertIn("junit-jupiter", names)
-
-    def test_compile_scope_not_test(self):
-        deps = parse_dot_output(_SINGLE_MODULE_DOT)
+    def test_optional_flag_preserved(self):
+        deps = self._single_deps()
+        lombok = next(
+            d for d in deps if d["artifactId"] == "lombok"
+        )
+        self.assertTrue(lombok["optional"])
         slf4j = next(
-            d for d in deps
+            d for d in deps if d["artifactId"] == "slf4j-api"
+        )
+        self.assertFalse(slf4j["optional"])
+
+    def test_scope_parsed(self):
+        slf4j = next(
+            d for d in self._single_deps()
             if d["artifactId"] == "slf4j-api"
         )
-        self.assertFalse(slf4j["is_test"])
         self.assertEqual(slf4j["scope"], "compile")
 
-    def test_multi_module_all_deps(self):
-        deps = parse_dot_output(_MULTI_MODULE_DOT)
-        names = {d["artifactId"] for d in deps}
-        self.assertIn("slf4j-api", names)
-        self.assertIn("guava", names)
-        self.assertIn("javax.servlet-api", names)
-        self.assertIn("mockito-core", names)
-        self.assertIn("byte-buddy", names)
-        # core is a sibling module dependency
-        self.assertIn("core", names)
+    def test_multi_module_keys(self):
+        modules = parse_text_output(_MULTI_MODULE_TEXT)
+        keys = {m["key"] for m in modules}
+        self.assertIn("com.example:parent", keys)
+        self.assertIn("com.example:core", keys)
+        self.assertIn("com.example:web", keys)
+
+    def test_parent_module_has_no_deps(self):
+        modules = parse_text_output(_MULTI_MODULE_TEXT)
+        parent = self._module(modules, "com.example:parent")
+        self.assertEqual(parent["deps"], [])
+
+    def test_shared_component_in_both_modules(self):
+        """A component shared by two modules must appear in BOTH
+        (no cross-module de-duplication)."""
+        modules = parse_text_output(_MULTI_MODULE_TEXT)
+        core = self._module(modules, "com.example:core")
+        web = self._module(modules, "com.example:web")
+        core_names = {d["artifactId"] for d in core["deps"]}
+        web_names = {d["artifactId"] for d in web["deps"]}
+        self.assertIn("guava", core_names)
+        self.assertIn("guava", web_names)
 
     def test_multi_module_provided_scope(self):
-        deps = parse_dot_output(_MULTI_MODULE_DOT)
+        modules = parse_text_output(_MULTI_MODULE_TEXT)
+        web = self._module(modules, "com.example:web")
         servlet = next(
-            d for d in deps
+            d for d in web["deps"]
             if d["artifactId"] == "javax.servlet-api"
         )
         self.assertEqual(servlet["scope"], "provided")
 
-    def test_empty_digraph(self):
-        deps = parse_dot_output(_ROOT_ONLY_DOT)
-        self.assertEqual(deps, [])
-
-    def test_version_conflict_dedup(self):
-        deps = parse_dot_output(_VERSION_CONFLICT_DOT)
-        lang3 = [
-            d for d in deps
-            if d["artifactId"] == "commons-lang3"
-        ]
-        # First occurrence wins (direct dep at 3.14.0)
-        self.assertEqual(len(lang3), 1)
-        self.assertEqual(lang3[0]["version"], "3.14.0")
+    def test_root_only_module_empty_deps(self):
+        modules = parse_text_output(_ROOT_ONLY_TEXT)
+        self.assertEqual(len(modules), 1)
+        self.assertEqual(modules[0]["deps"], [])
 
     def test_no_info_prefix(self):
-        """Works with raw DOT (no [INFO] prefixes)."""
-        raw = (
-            'digraph "a:b:jar:1.0" {\n'
-            '  "a:b:jar:1.0" -> '
-            '"c:d:jar:2.0:compile" ;\n'
-            '}\n'
+        """Works with raw text (no [INFO] prefixes)."""
+        raw = "\n".join([
+            "a.b:c:jar:1.0",
+            "+- d.e:f:jar:2.0:compile",
+        ]) + "\n"
+        modules = parse_text_output(raw)
+        self.assertEqual(len(modules), 1)
+        self.assertEqual(modules[0]["key"], "a.b:c")
+        self.assertEqual(
+            modules[0]["deps"][0]["artifactId"], "f",
         )
-        deps = parse_dot_output(raw)
-        self.assertEqual(len(deps), 1)
-        self.assertEqual(deps[0]["artifactId"], "d")
 
     def test_empty_string(self):
-        self.assertEqual(parse_dot_output(""), [])
+        self.assertEqual(parse_text_output(""), [])
 
     def test_garbage_input(self):
         self.assertEqual(
-            parse_dot_output("not a dot graph"), []
+            parse_text_output("not a dependency tree"), [],
         )
 
 
@@ -352,34 +301,37 @@ class TestParseDotOutput(unittest.TestCase):
 class TestFilterProductionDeps(unittest.TestCase):
     """Tests for filter_production_deps()."""
 
+    @staticmethod
+    def _single_deps():
+        return parse_text_output(_SINGLE_MODULE_TEXT)[0]["deps"]
+
+    @staticmethod
+    def _scope_deps():
+        return parse_text_output(_SCOPES_TEXT)[0]["deps"]
+
     def test_removes_test_scope(self):
-        deps = parse_dot_output(_SINGLE_MODULE_DOT)
-        prod = filter_production_deps(deps)
-        test_deps = [d for d in prod if d["is_test"]]
+        prod = filter_production_deps(self._single_deps())
+        test_deps = [d for d in prod if d["scope"] == "test"]
         self.assertEqual(test_deps, [])
 
     def test_keeps_compile_scope(self):
-        deps = parse_dot_output(_SINGLE_MODULE_DOT)
-        prod = filter_production_deps(deps)
+        prod = filter_production_deps(self._single_deps())
         names = {d["artifactId"] for d in prod}
         self.assertIn("slf4j-api", names)
         self.assertIn("commons-io", names)
 
     def test_keeps_provided_scope(self):
-        deps = parse_dot_output(_SCOPES_DOT)
-        prod = filter_production_deps(deps)
+        prod = filter_production_deps(self._scope_deps())
         names = {d["artifactId"] for d in prod}
         self.assertIn("lombok", names)
 
     def test_keeps_system_scope(self):
-        deps = parse_dot_output(_SCOPES_DOT)
-        prod = filter_production_deps(deps)
+        prod = filter_production_deps(self._scope_deps())
         names = {d["artifactId"] for d in prod}
         self.assertIn("ojdbc8", names)
 
     def test_keeps_runtime_scope(self):
-        deps = parse_dot_output(_SCOPES_DOT)
-        prod = filter_production_deps(deps)
+        prod = filter_production_deps(self._scope_deps())
         names = {d["artifactId"] for d in prod}
         self.assertIn("slf4j-api", names)
 
@@ -394,17 +346,19 @@ class TestFilterProductionDeps(unittest.TestCase):
 class TestClassifyScopes(unittest.TestCase):
     """Tests for classify_scopes()."""
 
+    @staticmethod
+    def _scope_deps():
+        return parse_text_output(_SCOPES_TEXT)[0]["deps"]
+
     def test_scopes_classified(self):
-        deps = parse_dot_output(_SCOPES_DOT)
-        by_scope = classify_scopes(deps)
+        by_scope = classify_scopes(self._scope_deps())
         self.assertIn("system", by_scope)
         self.assertIn("runtime", by_scope)
         self.assertIn("provided", by_scope)
         self.assertIn("test", by_scope)
 
     def test_counts(self):
-        deps = parse_dot_output(_SCOPES_DOT)
-        by_scope = classify_scopes(deps)
+        by_scope = classify_scopes(self._scope_deps())
         self.assertEqual(len(by_scope["system"]), 1)
         self.assertEqual(len(by_scope["test"]), 1)
 
@@ -430,12 +384,12 @@ class TestRunMavenDepTree(unittest.TestCase):
     def test_success(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout=_SINGLE_MODULE_DOT,
+            stdout=_SINGLE_MODULE_TEXT,
         )
         with tempfile.TemporaryDirectory() as td:
             (Path(td) / "pom.xml").touch()
             result = run_maven_dep_tree(td)
-        self.assertEqual(result, _SINGLE_MODULE_DOT)
+        self.assertEqual(result, _SINGLE_MODULE_TEXT)
 
     @patch("app.pipeline.maven_dep_tree_parser"
            ".subprocess.run")
@@ -535,6 +489,9 @@ class TestRunMavenDepTree(unittest.TestCase):
         self.assertIn(
             "-Dcheckstyle.skip=true", cmd,
         )
+        # Default text output is used (DOT cannot carry the
+        # optional flag); -DoutputType must not be forced to dot.
+        self.assertNotIn("-DoutputType=dot", cmd)
 
     @patch("app.pipeline.maven_dep_tree_parser"
            ".subprocess.run")
@@ -552,7 +509,7 @@ class TestRunMavenDepTree(unittest.TestCase):
             ),
             MagicMock(
                 returncode=0,
-                stdout=_SINGLE_MODULE_DOT,
+                stdout=_SINGLE_MODULE_TEXT,
                 stderr="",
             ),
         ]
@@ -560,7 +517,7 @@ class TestRunMavenDepTree(unittest.TestCase):
             (Path(td) / "pom.xml").touch()
             with patch("builtins.print"):
                 result = run_maven_dep_tree(td)
-        self.assertEqual(result, _SINGLE_MODULE_DOT)
+        self.assertEqual(result, _SINGLE_MODULE_TEXT)
         self.assertEqual(mock_run.call_count, 2)
         # First attempt is offline (-o); the fallback is not
         first_cmd = mock_run.call_args_list[0][0][0]
@@ -620,7 +577,7 @@ class TestMavenDepTreeStrategy(unittest.TestCase):
         from app.pipeline.interception import (
             MavenDepTreeStrategy,
         )
-        mock_run.return_value = _SINGLE_MODULE_DOT
+        mock_run.return_value = _SINGLE_MODULE_TEXT
         mock_runner = MagicMock()
         mock_runner.run.return_value = 0
         strategy = MavenDepTreeStrategy(
@@ -633,8 +590,13 @@ class TestMavenDepTreeStrategy(unittest.TestCase):
                     "/repo", str(bom_dir), {},
                 )
             self.assertTrue(ok)
-            self.assertTrue(
-                (bom_dir / "maven_deps.json").exists()
+            capture_file = bom_dir / "maven_deps.json"
+            self.assertTrue(capture_file.exists())
+            capture = json.loads(capture_file.read_text())
+            self.assertEqual(capture["tool"], "maven")
+            self.assertEqual(
+                capture["modules"][0]["key"],
+                "org.owasp:dependency-check-core",
             )
             substeps_file = (
                 bom_dir / "adg_substeps.json"


### PR DESCRIPTION
## Summary

JIRA **#11003** — Java sidecar **Phase 2 now generates `_build` SBOMs solely from Phase 1 metadata**, with **no access to the source tree**. This satisfies the enterprise constraint that Phase 1 (interception) and Phase 2 (SBOM generation) run on different machines.

## What changed

**Phase 1 (parser-only — no added build time):**

- Maven dependency capture switched to the default `dependency:tree` **text** output, which **preserves the `optional` flag** and removes the DOT plugin-version dependency.
- **Per-module / per-subproject** capture retained (no global de-duplication), so a component shared by multiple modules appears in **every** module's subtree.

**Phase 2:**

- New `app/spdx/dep_capture_reader.py` resolves each module's dependency subtree from the captured metadata.
- `java_generator.generate()` accepts a pre-resolved `deps` list and performs **no** source-tree resolution when present; it falls back to live resolution only in the co-located dev/test path (`deps is None`).

**Test tooling:**

- `scripts/run_phase_isolation_test.sh`: parameterized Phase 1 clone (`P1_SKIP_CLONE`) and fixed an in-container vs host manifest-path bug.

## Validation

- **Full two-container phase-isolation regression on all 8 Java repos** (Maven + Gradle): jsoup, crawler4j, checkstyle, logging-log4j2, dependency-check, bc-java, spring-boot, omnibor-java-testapp.
- Output rsynced locally and compared against the **official local golden** baseline: **all 8 IDENTICAL**. No golden files modified.
- Gates: flake8 clean; **1575 passed / 75 skipped**; coverage **98%** overall, every changed file **>= 95%**.

## Scope

- Generic and config-driven; **no language- or repo-specific logic**.
- The `_analyzed` SBOM view is **unchanged** (it does not include the dependency graph).
- Out of scope: non-Java languages; Corona delivery (separate sub-issue).

## Reviewer notes

- Design: `docs/deep-dive/phase2-consume-dependency-capture-design.md`
- Sub-issue draft: `docs/planning/java-phase2-consume-dep-capture-subissue.md`
- 13 files changed; the 3 unrelated planning docs and the stray copy dir were intentionally **excluded** from this PR.

Do not merge — for review.
