### PR TITLE
docs(planning): GitHub Issues PR crosswalk + status refresh

### DIFF
--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -40,15 +40,18 @@ testing) before Main B or Main C begins.
 
 Detail: build-speed sub-issues [java/phase1-build-speed-subissues.md](java/phase1-build-speed-subissues.md)
 (A3–A5) with engineering design [../deep-dive/java/phase1-build-speed-design.md](../deep-dive/java/phase1-build-speed-design.md);
-Java Phase 2 main issue `java/java-phase2-consume-dep-capture-subissue.md`
-(arrives with PR #194); treedb retro [java/retro-subissue-java-treedb-perf.md](java/retro-subissue-java-treedb-perf.md).
+Java Phase 2 main issue `java-phase2-consume-dep-capture-subissue.md`
+(delivered in PR #194); treedb retro [java/retro-subissue-java-treedb-perf.md](java/retro-subissue-java-treedb-perf.md).
+
+PR/issue mapping for recreation once GitHub Issues access returns:
+[github-issues-crosswalk.md](github-issues-crosswalk.md).
 
 | Sub | Title | Status | Maps to |
 |-----|-------|--------|---------|
-| A1 | Phase 2 generates SBOMs from Phase 1 metadata, no source tree (phase-isolation core) | PR open | SI-4 (Java) / #11003 / PR #194 |
+| A1 | Phase 2 generates SBOMs from Phase 1 metadata, no source tree (phase-isolation core) | Merged | SI-4 (Java) / #11003 / PR #194 |
 | A2 | Phase 2 output set + hand-off manifest | Scoped | #11004 → [java/java-phase2-11004-handoff-scope.md](java/java-phase2-11004-handoff-scope.md) |
 | A3 | Build efficiency — reuse captured dependency data (no double resolution) | Delivered via A1 | US-1 |
-| A4 | Build efficiency — single-invocation multi-module Gradle capture | Done (golden-clean); PR pending | US-2 |
+| A4 | Build efficiency — single-invocation multi-module Gradle capture | Merged | US-2 / PR #196 |
 | A5 | Build efficiency — overlap independent post-build steps only when measurable | Conditional (measure first) | US-3 |
 | A6 | Treedb SBOM-generation speedup (retro) | Delivered | SI-R1 / PRs #189, #187, #191 |
 | A7 | Deliver Java build evidence to Corona (Java delivery slice) | Planned | SI-5 (Java) |

--- a/docs/planning/github-issues-crosswalk.md
+++ b/docs/planning/github-issues-crosswalk.md
@@ -1,0 +1,81 @@
+# GitHub Issues Crosswalk & Recreation Record
+
+| | |
+|---|---|
+| **Purpose** | Durable record tying each drafted Main issue and sub-issue to the PR(s) that implement it, so the hierarchy can be recreated and linked once GitHub Projects/Issues access is restored. |
+| **Maintained by** | Cascade (update as PRs merge) |
+| **Last updated** | 2026-06-29 |
+
+---
+
+## Why this exists
+
+GitHub Projects/Issues access is temporarily unavailable, so issues cannot be
+created or updated right now. This file is the single place that maps every
+drafted Main issue and sub-issue to its implementing PR(s). When access
+returns, the issues team uses this to recreate the issue hierarchy and link
+the PRs.
+
+Issues live under the **tedg-cisco** org; PRs live in **tedg-dev/omnibor-analysis**.
+Always reference PRs with the fully-qualified cross-repo form
+`tedg-dev/omnibor-analysis#<n>` — never a bare `#<n>`, which would not link.
+
+---
+
+## Hierarchy
+
+Single **Epic** (created by the issues team) -> **Main issues** (one per
+theme / planning doc) -> **sub-issues** (drafted in the matching planning doc).
+
+---
+
+## Main issues (themes) and their drafts
+
+| Main issue (GitHub title) | Planning doc | Sub-issues | Existing GitHub issue # |
+|---|---|---|---|
+| Build-Based SBOM Capture & Delivery (Sidecar + Phase Isolation) | `sidecar-phase-isolation-subissues.md` | SI-1..SI-5 | — |
+| Phase 1 Build-Speed & Efficiency (Java) | `java/phase1-build-speed-subissues.md` | US-2, US-3 (US-1 moved) | — |
+| Faster SBOM Generation for Java Builds (Retrospective) | `java/retro-subissue-java-treedb-perf.md` | SI-R1 | — |
+| Java Phase 2: Generate SBOMs From Phase 1 Metadata Without the Source Tree | `java-phase2-consume-dep-capture-subissue.md` | (1) Generate from metadata (Maven/Gradle); (2) Deliver Java SBOMs to Corona | Corona #11003; handoff scope #11004 |
+
+---
+
+## PR crosswalk
+
+| PR | Title | Theme -> sub-issue (index label) | Status |
+|---|---|---|---|
+| `tedg-dev/omnibor-analysis#194` | Phase 2 generates SBOMs from Phase 1 metadata, no source tree | Java Phase 2 main issue -> sub (1) Generate from metadata; index **A1**; SI-4 (Java) / Corona #11003 | Merged |
+| `tedg-dev/omnibor-analysis#196` | Single-invocation Gradle dependency capture (US-2) | Phase 1 Build-Speed (Java) -> **US-2**; index **A4** | Merged |
+| `tedg-dev/omnibor-analysis#195` | Java build-based SBOM sell doc + diagrams + planning reorg | Java Main A enablement (supporting docs) | Merged |
+| `tedg-dev/omnibor-analysis#193` | Phase 1 build-speed design consolidation | Phase 1 Build-Speed (Java) design reference | Merged |
+| `tedg-dev/omnibor-analysis#192` | Phase-isolation planning user stories + C/C++ design relocation | Planning / docs | Merged |
+| `tedg-dev/omnibor-analysis#191`, `#189`, `#187` | Treedb SBOM-generation speedup (retro) | Retrospective -> **SI-R1**; index **A6** | Merged |
+
+Index labels (**A1**, **A4**, ...) refer to the rows in
+[`README.md`](README.md), the priority-ordered planning index.
+
+---
+
+## Still open / not yet implemented (no PR)
+
+| Item | Theme -> sub-issue (index label) | Status |
+|---|---|---|
+| Phase 2 output set + hand-off manifest | Java Phase 2 main issue; index **A2**; Corona #11004 | Scoped, no PR |
+| Overlap independent post-build steps (measure first) | Phase 1 Build-Speed (Java) -> **US-3**; index **A5** | Conditional, no PR |
+| Deliver Java build evidence to Corona | Java Phase 2 main issue -> sub (2); index **A7**; SI-5 (Java) | Planned, no PR |
+| Non-Maven/Gradle build-tool support (Ant/Ivy, Bazel, `make`) | Phase 1 Java capture (new sub-issue to draft) | Next R&D, no PR |
+
+---
+
+## Recreation checklist (run when Issues access returns)
+
+1. Create the single **Epic** (issues team).
+2. For each theme above, create **one Main (regular) issue** under the Epic,
+   using its GitHub title from the table.
+3. Under each Main issue, create the **sub-issues** from the matching planning
+   doc, reusing the drafted User Story + Acceptance Criteria.
+4. Link the implementing PR(s) from the **PR crosswalk** to each sub-issue and
+   mark delivered items Done.
+5. In GitHub issue text, use plain **"days"** (never "AI-days"); keep User
+   Story keywords **ALL CAPS** (AS A / I WANT / SO THAT).
+6. Reference PRs as `tedg-dev/omnibor-analysis#<n>` (cross-repo links).


### PR DESCRIPTION
## Summary

Adds a durable **GitHub Issues crosswalk** record under `docs/planning/`, since
Projects/Issues access is temporarily unavailable. Captures the Epic -> Main issue
-> sub-issue hierarchy and ties each drafted issue to its implementing PR(s), so the
issue tree can be recreated and linked once access returns.

## Changes

- **`docs/planning/github-issues-crosswalk.md`** (new) — theme/main-issue table,
  PR crosswalk (#187/#189/#191/#192/#193/#194/#195/#196), open/not-yet-implemented
  items, and a recreation checklist (cross-repo PR refs, plain "days", ALL-CAPS
  user-story keywords).
- **`docs/planning/README.md`** — A1 and A4 statuses refreshed to **Merged**
  (PR #194, PR #196); link to the crosswalk added.

## Scope

Docs-only. No code, no golden files.
