### PR TITLE
docs(planning): refine Main A scope + draft non-MG build-tool sub-issue (A9)

### DIFF
--- a/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
+++ b/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
@@ -129,22 +129,33 @@ avoid copy-paste — DRY).
 
 ---
 
-## 5. Detection design
+## 5. Detection design — **implemented** (`lang_runners._detect_java_build_tool`)
 
-Add `_detect_java_build_tool(repo_dir, repo_cfg)` returning one of
-`gradle` / `maven` / `ivy` / `bazel` / `make`. Precedence and signals:
+`_detect_java_build_tool(repo_dir, repo_cfg=None)` returns one of
+`gradle` / `maven` / `ivy` / `ant` / `bazel` / `make`, or `unknown` when no
+signal matches. Precedence (checked in this order) and signals:
 
-| Tool | Primary signal | Notes |
-|---|---|---|
-| `gradle` | `build.gradle` / `build.gradle.kts` (existing `is_gradle_project`) | unchanged, highest precedence |
-| `bazel` | `WORKSPACE` / `WORKSPACE.bazel` / `MODULE.bazel` + `BUILD`/`BUILD.bazel` | check for `maven_install.json` for enrichment |
-| `ivy` | `ivy.xml` (usually alongside `build.xml`) | Ant + Ivy |
-| `maven` | `pom.xml` | existing default |
-| `make` | `Makefile`/`makefile` with no other Java build file | artifact-only |
+| Order | Tool | Primary signal | Notes |
+|---|---|---|---|
+| 1 | `gradle` | `gradlew` / `build.gradle` / `build.gradle.kts` (existing `is_gradle_project`) | highest precedence |
+| 2 | `maven` | `pom.xml` | checked before Ivy/Ant: a `pom.xml` unambiguously means Maven |
+| 3 | `ivy` | `ivy.xml` (usually alongside `build.xml`) | Ant + Ivy |
+| 4 | `ant` | `build.xml` (no `ivy.xml`) | Ant without a declared graph -> artifact-only |
+| 5 | `bazel` | `WORKSPACE` / `WORKSPACE.bazel` / `MODULE.bazel` | `maven_install.json` enriches (parser deferred) |
+| 6 | `make` | `Makefile` / `makefile` / `GNUmakefile` | lowest — a convenience `Makefile` often coexists with a real tool |
 
-A `build_system` field in `config.yaml` overrides detection (config-driven,
-never repo-name-keyed). Detection is a pure function over the repo file list,
-unit-testable without a real build.
+A **`java_build_tool`** field in `config.yaml` overrides detection
+(config-driven, never repo-name-keyed). An unrecognized override raises
+`ValueError`. The field is **`java_build_tool`**, not `build_system`, because
+`build_system` is already the C/C++ discovery concept
+(autoconf/cmake/meson/make) in `app/repo_discovery`.
+
+Detection is a pure function over the repo's top-level files, unit-testable
+without a real build. `_select_java_strategy` maps `gradle` -> Gradle and
+everything else -> the Maven `dep:tree` strategy for now; a detected tool that
+has no native strategy yet (`ivy`/`ant`/`bazel`/`make`) logs an INFO message
+and falls back to Maven (preserving current golden-clean behavior). Native
+strategies land in Steps 3–5.
 
 ---
 

--- a/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
+++ b/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
@@ -364,8 +364,9 @@ or `JavaSpdxGenerator` — they consume the canonical dep dict unchanged.
   Remaining work is **validation against real repos** (apache/ant unforked
   javac; adapter loads under the image's Ant version; make shim fires), not
   design.
-- **Ivy report location** — varies by project; must be config-overridable and
-  may require running the `ivy:report` task.
+- **Ivy report location** — **resolved (§13.3):** `ant-ivy` writes the report
+  under `${ivy.report.dir}` during `ivy:retrieve`. Keep the path
+  config-overridable; some projects may need an explicit `ivy:report` task.
 - **Bazel toolchain weight** — adding Bazel to the Docker image is heavy;
   gated on USER confirmation (see sub-issue). Ivy can land first.
 - **sbt** remains out of scope (Scala-first).
@@ -374,11 +375,10 @@ or `JavaSpdxGenerator` — they consume the canonical dep dict unchanged.
 
 ## 12. Incremental delivery order
 
-0. **Investigate real repositories** — validate the Ivy report XML,
-   `maven_install.json`, and Ant unforked-`javac` assumptions against actual
-   files, and finalize the verifier-repo list. Prerequisite to steps 3–5; no
-   parser is finalized against an assumed format. (Supplements the design
-   research/validation throughout this doc.)
+0. **Investigate real repositories** — **done; findings recorded in §13**
+   (`maven_install.json` structure, Ivy report XML schema, `ant-ivy` build
+   facts, finalized verifier repos). Remaining: confirm the Bazel example
+   repo path (post toolchain decision) and create `omnibor-java-make-testapp`.
 1. Extract shared `_generate_java_treedb()` helper (pure refactor, golden-clean).
 2. `_detect_java_build_tool()` + config override + unit tests.
 3. Ivy: `ivy_report_parser` + `IvyDepCaptureStrategy` + reader support + tests
@@ -389,3 +389,79 @@ or `JavaSpdxGenerator` — they consume the canonical dep dict unchanged.
    + tests (parser validated against the real lockfile from step 0; after the
    Bazel toolchain decision).
 6. EC2 golden validation per verifier repo — present diffs, await USER review.
+
+---
+
+## 13. Step 0 findings — validated against real artifacts
+
+Evidence gathered by inspecting real repositories (per the "never guess /
+validate against real repos" rule). These confirm the §6/§7/§8.1 designs.
+
+### 13.1 Bazel `maven_install.json` (real: `bazel-contrib/rules_jvm_external`)
+
+Confirmed top-level structure:
+
+| Key | Shape | Use |
+|---|---|---|
+| `artifacts` | `{"group:artifact": {"shasums": {"jar": "<sha256>"}, "version": "x.y.z"}}` | coordinates (split key on `:`) + resolved version + jar digest |
+| `dependencies` | `{"group:artifact": ["group:artifact", ...]}` | adjacency graph -> direct vs transitive + `depth`/`parent` |
+| `__INPUT_ARTIFACTS_HASH` / `__RESOLVED_ARTIFACTS_HASH` | metadata | ignore |
+
+Notes that drive `bazel_lockfile_parser`:
+
+- Classifier artifacts use **4-part keys** (`io.netty:...:jar:linux-x86_64`);
+  the parser must handle 2-part and 4-part keys.
+- The lockfile is **compile-scope only** (no test scope) — matches the
+  capture contract (test already excluded).
+- `shasums.jar` is a **SHA-256**, not a GitOID; treat as a verifiable digest,
+  not the OmniBOR identifier.
+
+### 13.2 Ivy resolution report XML (schema confirmed via authoritative XSLT)
+
+```text
+<ivy-report>
+  <info organisation=".." module=".." revision=".." conf=".."/>
+  <dependencies>
+    <module organisation=".." name="..">
+      <revision name="<version>" status=".." evicted="..">
+        <caller organisation=".." name=".." callerrev=".." rev=".."/>
+        <artifacts><artifact name=".." type="jar" ext="jar"/></artifacts>
+      </revision>
+    </module>
+  </dependencies>
+</ivy-report>
+```
+
+Drives `ivy_report_parser`:
+
+- `module/@organisation` -> `groupId`; `module/@name` -> `artifactId`;
+  `revision/@name` -> `version`.
+- **Direct** iff a `revision/caller` matches the root module
+  (`info/@organisation` + `info/@module`); otherwise transitive (derive
+  `depth`/`parent` from caller chains).
+- **Skip `evicted` revisions** (not part of the resolved graph).
+- One report **per conf**; parse production confs, skip `test`.
+
+### 13.3 `apache/ant-ivy` build facts (real `build.xml`)
+
+- **Resolves via Ivy:** `<target name="resolve">` runs
+  `<ivy:retrieve conf="default,test" .../>` -> a real resolve happens and the
+  XML resolution report is written under `${ivy.report.dir}` (config-driven —
+  confirms the report-location open question).
+- **Unforked `<javac>`:** `compile-core` uses `<javac ... includeantruntime="no">`
+  with **no `fork`** -> in-process compilation, confirming §8.1 (a PATH
+  `javac` shim will not fire for default Ant; the `CompilerAdapter` route is
+  required).
+
+### 13.4 Finalized verifier repos
+
+| Build tool | Repo | Pin | Build entry | Evidence |
+|---|---|---|---|---|
+| Ant + Ivy | `apache/ant-ivy` | release tag (e.g. `2.5.2`) | `ant jar` (resolve -> compile -> jar) | §13.2/§13.3 — real Ivy report + unforked javac |
+| `make`/`javac` (artifact-only) | new `omnibor-java-make-testapp` (we own) | `main` | `make` | controlled `Makefile` -> `javac` -> `jar`; exercises §8.1 PATH shim |
+| Bazel | candidate `bazelbuild/examples` (Java + `rules_jvm_external`) — **exact path TBD** | commit SHA | `bazel build //...` | §13.1 lockfile format; **gated on Bazel toolchain decision** |
+| Ant (no Ivy) | optional `apache/ant` | release tag | bootstrap build | confirms artifact-only path; heavier bootstrap — lower priority |
+
+Bazel repo path is not yet pinned: the previously-assumed
+`bazelbuild/examples/java-maven/maven_install.json` path returned 404 and
+must be re-confirmed before adding (and only after the toolchain decision).

--- a/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
+++ b/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
@@ -1,0 +1,282 @@
+# Engineering Design — Non-Maven/Gradle Java Dependency Adapters
+
+| | |
+|---|---|
+| **Sub-issue** | A9 — Support non-Maven/Gradle Java builds (`../../planning/java/java-nonmaven-gradle-build-tools-subissue.md`) |
+| **Audience** | Cascade + reviewers implementing the Ivy/Bazel adapters |
+| **Author** | Ted G. |
+| **Drafted** | 2026-06-29 (Cascade) |
+| **Status** | Design — no code yet |
+| **Scope** | Phase 1 dependency capture + Phase 2 consumption for Ant/Ivy, Bazel, and `make`/`javac` Java builds |
+
+---
+
+## 1. Goal
+
+Extend Java dependency capture beyond Maven/Gradle **without inventing a
+parallel pipeline**. New build tools plug into the existing strategy pattern
+and produce the **same capture contract** that Phase 2 already consumes.
+
+---
+
+## 2. Architecture recap (what already exists)
+
+Java sidecar capture runs through `InterceptionStrategy.generate_adg()`
+(`app/pipeline/interception.py`). Both `MavenDepTreeStrategy` and
+`GradleDepTreeStrategy` do exactly two things:
+
+1. **Universal treedb step (build-tool-agnostic).** They run
+   `bomsh_create_bom_java.py -r <repo_dir> -j <treedb_file>`, which scans the
+   built workspace and maps JAR -> `.class` -> source using the `SourceFile`
+   bytecode attribute plus path similarity. **This step does not know or care
+   which build tool produced the workspace.**
+2. **Per-ecosystem dependency capture (enrichment).** They run
+   `mvn dependency:tree` / `gradlew dependencies`, parse it, and write a
+   capture file (`maven_deps.json` / `gradle_deps.json`).
+
+Strategy selection happens in `_select_java_strategy()`
+(`app/pipeline/lang_runners.py`): today it checks `is_gradle_project()` and
+otherwise defaults to Maven.
+
+Phase 2 (`generate_java_adg_spdx()` in `lang_runners.py`) reads the capture
+via `app/spdx/dep_capture_reader.py` (`load_capture()` -> `resolve_module()`
+-> `get_module_deps()`) and hands the dependency list to `JavaSpdxGenerator`
+for the per-JAR `_build` SBOM. The treedb drives the `_analyzed` SBOM.
+
+**Key consequence:** the universal layer (step 1) already works for *any*
+Java build. Adapters only need to supply step 2 (the declared graph) in the
+existing contract — or, where there is no declared graph, fall back to the
+artifact-only path.
+
+---
+
+## 3. The capture contract (what adapters must produce)
+
+Every adapter writes a JSON capture file with this shape (matching
+`dep_capture_reader.load_capture()` expectations):
+
+```json
+{
+  "tool": "ivy",
+  "modules": [
+    {
+      "key": "org.apache.ant:ant-ivy",
+      "groupId": "org.apache.ant",
+      "artifactId": "ant-ivy",
+      "version": "2.5.2",
+      "packaging": "jar",
+      "deps": [ { "...dep dict..." } ]
+    }
+  ]
+}
+```
+
+Each entry in `deps` uses the canonical dep-dict shape produced by
+`app/spdx/maven_parser.parse_dep_tree` and consumed by `JavaSpdxGenerator`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `groupId` | str | Group / organization |
+| `artifactId` | str | Artifact / module name |
+| `version` | str | Resolved version |
+| `scope` | str | `compile` / `runtime` / `provided` / `system` (test excluded) |
+| `direct` | bool | Direct vs transitive dependency |
+| `optional` | bool | Optional flag |
+| `parent` | str | Parent coordinate (`""` if direct) |
+| `depth` | int | Tree depth (0 = direct) |
+
+Adapters MUST emit production scopes only (drop `test`), consistent with
+`maven_dep_tree_parser._PRODUCTION_SCOPES`.
+
+---
+
+## 4. Integration points (exact changes)
+
+| Layer | File / symbol | Change |
+|---|---|---|
+| Detection | `lang_runners._select_java_strategy` | Add Ivy / Bazel / `make` branches before the Maven default; add a `_detect_java_build_tool()` helper |
+| Strategy | `app/pipeline/interception.py` | New `IvyDepCaptureStrategy`, `BazelDepCaptureStrategy`, `ArtifactOnlyStrategy` (treedb-only) |
+| Parser | `app/pipeline/ivy_report_parser.py` (new) | Parse Ivy resolution report XML -> capture dict |
+| Parser | `app/pipeline/bazel_lockfile_parser.py` (new) | Parse `maven_install.json` -> capture dict |
+| Phase 2 | `app/spdx/dep_capture_reader.py` | Add `ivy_deps.json` / `bazel_deps.json` to `_CAPTURE_FILES`; add `_resolve_ivy()` / `_resolve_bazel()` dispatch in `resolve_module()` |
+
+All new strategies reuse the **identical treedb step** from the Maven/Gradle
+strategies (extract it into a shared `_generate_java_treedb()` helper to
+avoid copy-paste — DRY).
+
+---
+
+## 5. Detection design
+
+Add `_detect_java_build_tool(repo_dir, repo_cfg)` returning one of
+`gradle` / `maven` / `ivy` / `bazel` / `make`. Precedence and signals:
+
+| Tool | Primary signal | Notes |
+|---|---|---|
+| `gradle` | `build.gradle` / `build.gradle.kts` (existing `is_gradle_project`) | unchanged, highest precedence |
+| `bazel` | `WORKSPACE` / `WORKSPACE.bazel` / `MODULE.bazel` + `BUILD`/`BUILD.bazel` | check for `maven_install.json` for enrichment |
+| `ivy` | `ivy.xml` (usually alongside `build.xml`) | Ant + Ivy |
+| `maven` | `pom.xml` | existing default |
+| `make` | `Makefile`/`makefile` with no other Java build file | artifact-only |
+
+A `build_system` field in `config.yaml` overrides detection (config-driven,
+never repo-name-keyed). Detection is a pure function over the repo file list,
+unit-testable without a real build.
+
+---
+
+## 6. Ivy adapter
+
+**Input (declared graph):** the Ivy *resolution report* XML. Ant builds that
+use Ivy emit per-configuration reports (e.g.
+`<module>-<conf>.xml`) under the Ivy resolution-report directory
+(`ivy:report` task output, or the cache report). The report lists resolved
+modules with `organisation`, `name`, `revision`, and the `conf` they belong
+to.
+
+**Mapping to the dep dict:**
+
+| Ivy report field | Dep-dict field |
+|---|---|
+| `organisation` | `groupId` |
+| `name` | `artifactId` |
+| `revision` | `version` |
+| `conf` (configuration) | `scope` via a config map |
+| caller depth / `caller` | `direct` / `depth` / `parent` |
+
+**Configuration -> scope map** (Ivy configs are project-defined, so use a
+conservative default map, config-overridable):
+
+| Ivy conf | scope |
+|---|---|
+| `compile`, `default`, `master` | `compile` |
+| `runtime` | `runtime` |
+| `provided` | `provided` |
+| `test` | dropped (test excluded) |
+
+**Module shape:** Ant/Ivy projects are typically single-artifact, so the
+capture has one module keyed by the project's `org:name`. If the report
+exposes no module coordinate, key by the repo name and leave `groupId` empty.
+
+**Strategy:** `IvyDepCaptureStrategy.generate_adg()` = shared treedb step +
+locate the resolution report (configurable path) + `ivy_report_parser` ->
+write `ivy_deps.json`.
+
+---
+
+## 7. Bazel adapter
+
+**Input (declared graph):** `rules_jvm_external`'s pinned lockfile
+`maven_install.json`. It enumerates resolved Maven coordinates and the
+dependency edges between them.
+
+**Mapping:** each lockfile artifact coordinate `group:artifact:version` maps
+directly to `groupId` / `artifactId` / `version`; `scope` is `compile`
+(lockfiles do not carry test scope); `direct` vs transitive is derived from
+the lockfile's `dependencies` adjacency (roots = direct), giving `depth` and
+`parent`.
+
+**Module shape:** Bazel does not have Maven-style reactor modules. Use a
+single synthetic module keyed by the Bazel target (or repo name). Phase 2
+JAR -> module resolution falls through to the single-module case in
+`dep_capture_reader` (already handled: "if exactly one module, use it").
+
+**No lockfile present:** if `maven_install.json` is absent (unpinned
+`maven_install`), there is no declared graph — fall back to the artifact-only
+path (Section 8) and log a clear warning. We require pinned lockfiles for
+enrichment (consistent with the project's pinning policy).
+
+**Strategy:** `BazelDepCaptureStrategy.generate_adg()` = shared treedb step +
+`bazel_lockfile_parser` on `maven_install.json` -> write `bazel_deps.json`.
+
+---
+
+## 8. Ant-only and `make`/`javac` — artifact-only path
+
+These builds have **no declared dependency graph**. The design does not fake
+one. Instead:
+
+- **`_analyzed` SBOM** — produced as usual from the treedb (source files
+  compiled into each JAR). Fully accurate, no change needed.
+- **`_build` SBOM** — there is no resolved-coordinate graph, so dependencies
+  are represented as the **classpath JARs the build consumed**, identified by
+  GitOID (and best-effort coordinates parsed from the JAR filename). These
+  JARs are the ones present in the workspace's library directory / on the
+  `javac -classpath`.
+
+`ArtifactOnlyStrategy.generate_adg()` runs only the shared treedb step and
+writes **no** `*_deps.json`. Phase 2 then has `build_deps is None`; rather
+than failing, the design adds an **artifact-only `_build` mode** in
+`generate_java_adg_spdx()` that lists the consumed classpath JARs as
+components (GitOID-identified) when the build tool is `make`/`ant-only`.
+
+**Open implementation question (Section 11):** the cleanest source of the
+consumed classpath JAR set without a declared graph — candidates: (a) the
+treedb already records consumed JARs; (b) scan a configured `lib/` dir; (c)
+parse `javac -classpath` from the build. Prefer (a) if the treedb captures
+it; confirm during implementation.
+
+---
+
+## 9. Phase 2 reader changes
+
+`dep_capture_reader.py`:
+
+```python
+_CAPTURE_FILES = {
+    "maven_deps.json": "target",
+    "gradle_deps.json": "build",
+    "ivy_deps.json": "build",      # Ant default output dir
+    "bazel_deps.json": "bazel-bin",
+}
+```
+
+`resolve_module()` dispatches on `capture["tool"]`: `ivy` and `bazel` both use
+single-module/`artifactId`-match resolution (reuse `_resolve_maven`-style
+logic; Bazel almost always single-module). No change to `get_module_deps()`
+or `JavaSpdxGenerator` — they consume the canonical dep dict unchanged.
+
+---
+
+## 10. Testing plan
+
+- **Unit (no network, no Docker):**
+  - `ivy_report_parser`: fixture Ivy report XML -> expected capture dict,
+    including conf->scope mapping and test-scope exclusion.
+  - `bazel_lockfile_parser`: fixture `maven_install.json` -> expected capture
+    dict, including direct/transitive depth derivation.
+  - `_detect_java_build_tool`: file-list fixtures for each tool + config
+    override.
+  - `dep_capture_reader`: `ivy_deps.json` / `bazel_deps.json` resolution.
+- **Integration (EC2, golden-gated):** the verifier repos from the sub-issue
+  (`apache/ant-ivy`, `apache/ant`, `bazelbuild/examples` java-maven, the
+  `make` test app). SBOMs reviewed against USER-approved golden baselines —
+  never auto-generated.
+- Coverage thresholds (>=97% overall, >=95% per file) apply to new modules.
+
+---
+
+## 11. Open questions / risks
+
+- **Treedb in sidecar for non-MG** — confirm `bomsh_create_bom_java.py -r`
+  produces a complete treedb for Ant/Bazel/`make` workspaces (it is
+  build-tool-agnostic by design, but unverified on these layouts).
+- **Consumed-classpath source** for the artifact-only `_build` path (Section
+  8) — confirm whether the treedb already records consumed JARs.
+- **Ivy report location** — varies by project; must be config-overridable and
+  may require running the `ivy:report` task.
+- **Bazel toolchain weight** — adding Bazel to the Docker image is heavy;
+  gated on USER confirmation (see sub-issue). Ivy + `make` can land first.
+- **sbt** remains out of scope (Scala-first).
+
+---
+
+## 12. Incremental delivery order
+
+1. Extract shared `_generate_java_treedb()` helper (pure refactor, golden-clean).
+2. `_detect_java_build_tool()` + config override + unit tests.
+3. Ivy: `ivy_report_parser` + `IvyDepCaptureStrategy` + reader support + tests.
+4. `make`/Ant-only: `ArtifactOnlyStrategy` + artifact-only `_build` mode + tests.
+5. Bazel: `bazel_lockfile_parser` + `BazelDepCaptureStrategy` + reader support
+   + tests (after the Bazel toolchain decision).
+6. EC2 golden validation per verifier repo — present diffs, await USER review.

--- a/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
+++ b/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
@@ -132,7 +132,7 @@ avoid copy-paste — DRY).
 ## 5. Detection design — **implemented** (`lang_runners._detect_java_build_tool`)
 
 `_detect_java_build_tool(repo_dir, repo_cfg=None)` returns one of
-`gradle` / `maven` / `ivy` / `ant` / `bazel` / `make`, or `unknown` when no
+`gradle` / `maven` / `ivy` / `ant` / `make` / `bazel`, or `unknown` when no
 signal matches. Precedence (checked in this order) and signals:
 
 | Order | Tool | Primary signal | Notes |
@@ -141,8 +141,8 @@ signal matches. Precedence (checked in this order) and signals:
 | 2 | `maven` | `pom.xml` | checked before Ivy/Ant: a `pom.xml` unambiguously means Maven |
 | 3 | `ivy` | `ivy.xml` (usually alongside `build.xml`) | Ant + Ivy |
 | 4 | `ant` | `build.xml` (no `ivy.xml`) | Ant without a declared graph -> artifact-only |
-| 5 | `bazel` | `WORKSPACE` / `WORKSPACE.bazel` / `MODULE.bazel` | `maven_install.json` enriches (parser deferred) |
-| 6 | `make` | `Makefile` / `makefile` / `GNUmakefile` | lowest — a convenience `Makefile` often coexists with a real tool |
+| 5 | `make` | `Makefile` / `makefile` / `GNUmakefile` | artifact-only path |
+| 6 | `bazel` | `WORKSPACE` / `WORKSPACE.bazel` / `MODULE.bazel` | lowest — tiny Java share; native strategy **deferred** |
 
 A **`java_build_tool`** field in `config.yaml` overrides detection
 (config-driven, never repo-name-keyed). An unrecognized override raises

--- a/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
+++ b/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
@@ -48,6 +48,29 @@ Java build. Adapters only need to supply step 2 (the declared graph) in the
 existing contract — or, where there is no declared graph, fall back to the
 artifact-only path.
 
+### 2.1 Investigation findings (grounded in the code)
+
+These were verified by reading the code, not assumed:
+
+- **The treedb step is build-tool-agnostic.** `bomsh_create_bom_java.py`
+  maps JAR -> `.class` -> source using the `.class` `SourceFile` bytecode
+  attribute, with strace/filename-heuristic fallback
+  (`docker/patches/README-bomsh_java_sourcefile.md`). It reads the *built
+  workspace* and never inspects build files, so it is independent of
+  Maven/Gradle/Ant/Bazel/`make`.
+- **The treedb scope is output-JAR -> source only.** `AdgParser`
+  (`app/spdx/parser.py`) shows treedb entries are `{sha1: {file_path,
+  hash_tree, ...}}`, tracing output JAR -> compiled class -> source. The
+  treedb is the basis for the `_analyzed` SBOM.
+- **The treedb does NOT contain the consumed dependency (classpath) JARs.**
+  The Maven/Gradle `_build` dependency graph comes from the *separate*
+  dep:tree capture (`maven_deps.json` / `gradle_deps.json`), not the treedb.
+- **Consumed classpath JARs are observable only via strace** in standalone
+  mode (`AdgParser.parse_strace_openat_log()` records every opened file).
+  Sidecar mode has no equivalent capture.
+
+These findings drive §8 (artifact-only path) and §11.
+
 ---
 
 ## 3. The capture contract (what adapters must produce)
@@ -197,24 +220,39 @@ These builds have **no declared dependency graph**. The design does not fake
 one. Instead:
 
 - **`_analyzed` SBOM** — produced as usual from the treedb (source files
-  compiled into each JAR). Fully accurate, no change needed.
+  compiled into each JAR). Fully accurate, no change needed. **Grounded:**
+  `bomsh_create_bom_java.py` derives JAR -> class -> source from the `.class`
+  `SourceFile` bytecode attribute (with strace/heuristic fallback) — it reads
+  the built workspace and has no build-tool knowledge, so this works
+  unchanged for Ant/`make` (see §2.1).
 - **`_build` SBOM** — there is no resolved-coordinate graph, so dependencies
   are represented as the **classpath JARs the build consumed**, identified by
-  GitOID (and best-effort coordinates parsed from the JAR filename). These
-  JARs are the ones present in the workspace's library directory / on the
-  `javac -classpath`.
+  GitOID (and best-effort coordinates parsed from the JAR filename).
+
+**Grounded constraint (from §2.1): the treedb does NOT record consumed
+classpath JARs** — it records output-JAR -> source provenance only. The
+consumed JARs are therefore sourced differently per mode:
+
+| Mode | Consumed-classpath source | Feasible today? |
+|---|---|---|
+| **Standalone** (strace) | `AdgParser.parse_strace_openat_log()` already records every opened file; filter `.jar` opens, excluding output JARs and JDK/runtime jars | Yes — generic, exists |
+| **Sidecar** (no strace) | No capture exists; needs an explicit, standard classpath-capture step | No — design gap |
+
+So the artifact-only `_build` path is **straightforward in standalone mode**
+but a **genuine gap in sidecar mode** for Ant-only/`make`. Ivy and Bazel do
+not have this gap because they ship a declared graph (Ivy report,
+`maven_install.json`). Recommended scoping: deliver Ivy + Bazel first; treat
+the sidecar artifact-only `_build` path for Ant-only/`make` as a separate,
+explicitly-scoped problem (candidate standard mechanisms: a `javac` classpath
+manifest emitted by the build, or parsing the resolved classpath the build
+used — to be designed, not guessed).
 
 `ArtifactOnlyStrategy.generate_adg()` runs only the shared treedb step and
-writes **no** `*_deps.json`. Phase 2 then has `build_deps is None`; rather
-than failing, the design adds an **artifact-only `_build` mode** in
-`generate_java_adg_spdx()` that lists the consumed classpath JARs as
-components (GitOID-identified) when the build tool is `make`/`ant-only`.
-
-**Open implementation question (Section 11):** the cleanest source of the
-consumed classpath JAR set without a declared graph — candidates: (a) the
-treedb already records consumed JARs; (b) scan a configured `lib/` dir; (c)
-parse `javac -classpath` from the build. Prefer (a) if the treedb captures
-it; confirm during implementation.
+writes **no** `*_deps.json`. In standalone mode an artifact-only `_build`
+mode in `generate_java_adg_spdx()` lists the strace-observed classpath JARs
+as GitOID-identified components; in sidecar mode it emits the `_analyzed`
+SBOM and a clearly-logged, dependency-less `_build` until the capture
+mechanism above is designed.
 
 ---
 
@@ -256,17 +294,32 @@ or `JavaSpdxGenerator` — they consume the canonical dep dict unchanged.
 
 ---
 
-## 11. Open questions / risks
+## 11. Findings (investigated) and remaining open questions
 
-- **Treedb in sidecar for non-MG** — confirm `bomsh_create_bom_java.py -r`
-  produces a complete treedb for Ant/Bazel/`make` workspaces (it is
-  build-tool-agnostic by design, but unverified on these layouts).
-- **Consumed-classpath source** for the artifact-only `_build` path (Section
-  8) — confirm whether the treedb already records consumed JARs.
+**Resolved by investigation (no longer assumptions):**
+
+- **Treedb `_analyzed` layer is build-tool-agnostic — confirmed.**
+  `bomsh_create_bom_java.py` maps JAR -> class -> source via the `.class`
+  `SourceFile` attribute (strace/heuristic fallback), reading the built
+  workspace with no build-tool knowledge
+  (`docker/patches/README-bomsh_java_sourcefile.md`,
+  `AdgParser.get_jar_source_files`). Ant/Bazel/`make` `_analyzed` SBOMs are
+  feasible via the existing treedb step.
+- **Treedb does NOT record consumed dependency JARs — confirmed.** It records
+  output-JAR -> class -> source only; the Maven/Gradle `_build` graph comes
+  from the separate dep:tree capture, not the treedb (`AdgParser`,
+  `dep_capture_reader`). Consumed JARs are observable via
+  `parse_strace_openat_log()` in **standalone mode only** (see §8 table).
+
+**Remaining genuine open questions:**
+
+- **Sidecar artifact-only `_build` capture** — Ant-only/`make` in sidecar
+  mode has no consumed-classpath source; needs a standard mechanism (§8). To
+  be designed before that path is implemented — not guessed.
 - **Ivy report location** — varies by project; must be config-overridable and
   may require running the `ivy:report` task.
 - **Bazel toolchain weight** — adding Bazel to the Docker image is heavy;
-  gated on USER confirmation (see sub-issue). Ivy + `make` can land first.
+  gated on USER confirmation (see sub-issue). Ivy can land first.
 - **sbt** remains out of scope (Scala-first).
 
 ---

--- a/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
+++ b/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
@@ -374,10 +374,18 @@ or `JavaSpdxGenerator` — they consume the canonical dep dict unchanged.
 
 ## 12. Incremental delivery order
 
+0. **Investigate real repositories** — validate the Ivy report XML,
+   `maven_install.json`, and Ant unforked-`javac` assumptions against actual
+   files, and finalize the verifier-repo list. Prerequisite to steps 3–5; no
+   parser is finalized against an assumed format. (Supplements the design
+   research/validation throughout this doc.)
 1. Extract shared `_generate_java_treedb()` helper (pure refactor, golden-clean).
 2. `_detect_java_build_tool()` + config override + unit tests.
-3. Ivy: `ivy_report_parser` + `IvyDepCaptureStrategy` + reader support + tests.
-4. `make`/Ant-only: `ArtifactOnlyStrategy` + artifact-only `_build` mode + tests.
+3. Ivy: `ivy_report_parser` + `IvyDepCaptureStrategy` + reader support + tests
+   (parser validated against the real report from step 0).
+4. `make`/Ant-only: `ArtifactOnlyStrategy` + §8.1 capture + artifact-only
+   `_build` mode + tests.
 5. Bazel: `bazel_lockfile_parser` + `BazelDepCaptureStrategy` + reader support
-   + tests (after the Bazel toolchain decision).
+   + tests (parser validated against the real lockfile from step 0; after the
+   Bazel toolchain decision).
 6. EC2 golden validation per verifier repo — present diffs, await USER review.

--- a/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
+++ b/docs/deep-dive/java/java-nonmaven-gradle-adapter-design.md
@@ -250,9 +250,55 @@ used — to be designed, not guessed).
 `ArtifactOnlyStrategy.generate_adg()` runs only the shared treedb step and
 writes **no** `*_deps.json`. In standalone mode an artifact-only `_build`
 mode in `generate_java_adg_spdx()` lists the strace-observed classpath JARs
-as GitOID-identified components; in sidecar mode it emits the `_analyzed`
-SBOM and a clearly-logged, dependency-less `_build` until the capture
-mechanism above is designed.
+as GitOID-identified components; in sidecar mode it uses the capture designed
+in §8.1.
+
+### 8.1 Sidecar classpath-capture mechanism (design)
+
+In sidecar mode there is no strace, so the consumed classpath JARs for
+Ant-only/`make` are not observed. This mechanism captures them generically,
+consistent with the existing sidecar interception strategies (`CcWrapper`,
+`RustcWrapper`, `GoToolexec`) — i.e. a Java-consistent `javac` interception,
+not a new pipeline.
+
+**Grounded facts (verified, not assumed):**
+
+- **`make`/`javac`** — `javac` runs as a separate process, so the resolved
+  classpath is on its argv (`-classpath` / `-cp` / `@argfile`).
+- **Ant `<javac>`** — defaults to **unforked (in-process) compilation**
+  (Ant manual, Javac task: the "modern compiler ... in unforked mode" is the
+  default; a separate process spawns only with `fork="true"`). A PATH `javac`
+  shim is therefore **not** invoked for default Ant builds.
+- **Ant extension point** — Ant supports a custom compiler via the
+  `build.compiler` property / `CompilerAdapter` interface, settable through
+  `ANT_OPTS` with **no build-file edit**.
+
+**Design — `JavacInterceptStrategy` (feeds the artifact-only `_build` path):**
+
+| Build tool | Interception (no build-file change) | Mechanism |
+|---|---|---|
+| `make` / forked `javac` | Prepend a wrapper dir to `PATH` (env, like `CcWrapperStrategy`) holding a `javac` shim | Shim expands `-cp`/`-classpath`/`@argfile`, appends entries to `classpath_capture.json`, then `exec`s the real `javac` |
+| Ant (unforked, default) | Set `ANT_OPTS=-Dbuild.compiler=<bomsh adapter class>` | A bomsh `CompilerAdapter` records `getJavac().getClasspath()`, then delegates to the default adapter; adapter jar shipped in the image |
+
+**Fallback (no silent guessing):** if neither interception is viable for a
+given project, emit the `_analyzed` SBOM and a **clearly-logged,
+dependency-less `_build`** — never a fabricated graph.
+
+**Capture contract:** `classpath_capture.json` = a deduplicated list of
+`{path, gitoid}` for each consumed JAR, excluding JDK/runtime jars under
+`JAVA_HOME` and output jars under `repos_dir`. Phase 2's artifact-only
+`_build` mode lists these as **GitOID-identified** components (the stable,
+OmniBOR-aligned identifier); Maven coordinates are best-effort from the JAR
+filename with **NOASSERTION** when unknown — never fabricated.
+
+**Validation required (against real repos, not assumed):** confirm
+`apache/ant` builds with unforked `javac`; confirm the `CompilerAdapter`
+loads under the Ant version in the image; confirm the `make` test-app shim
+fires. These are explicit validation steps, not assumptions.
+
+**Why this is generic:** it adds one Java-consistent interception strategy
+alongside the existing CC/RUSTC/toolexec strategies, selected by detection;
+no per-repo logic, all behavior config/detection-driven.
 
 ---
 
@@ -313,9 +359,11 @@ or `JavaSpdxGenerator` — they consume the canonical dep dict unchanged.
 
 **Remaining genuine open questions:**
 
-- **Sidecar artifact-only `_build` capture** — Ant-only/`make` in sidecar
-  mode has no consumed-classpath source; needs a standard mechanism (§8). To
-  be designed before that path is implemented — not guessed.
+- **Sidecar artifact-only `_build` capture** — designed in §8.1 (PATH `javac`
+  shim for `make`; Ant `CompilerAdapter` via `ANT_OPTS` for unforked Ant).
+  Remaining work is **validation against real repos** (apache/ant unforked
+  javac; adapter loads under the image's Ant version; make shim fires), not
+  design.
 - **Ivy report location** — varies by project; must be config-overridable and
   may require running the `ivy:report` task.
 - **Bazel toolchain weight** — adding Bazel to the Docker image is heavy;

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -52,10 +52,16 @@ PR/issue mapping for recreation once GitHub Issues access returns:
 | A2 | Phase 2 output set + hand-off manifest | Scoped | #11004 → [java/java-phase2-11004-handoff-scope.md](java/java-phase2-11004-handoff-scope.md) |
 | A3 | Build efficiency — reuse captured dependency data (no double resolution) | Delivered via A1 | US-1 |
 | A4 | Build efficiency — single-invocation multi-module Gradle capture | Merged | US-2 / PR #196 |
-| A5 | Build efficiency — overlap independent post-build steps only when measurable | Conditional (measure first) | US-3 |
+| A5 | Build efficiency — overlap independent post-build steps only when measurable | Optional / low (measure first) | US-3 |
 | A6 | Treedb SBOM-generation speedup (retro) | Delivered | SI-R1 / PRs #189, #187, #191 |
-| A7 | Deliver Java build evidence to Corona (Java delivery slice) | Planned | SI-5 (Java) |
-| A8 | Testing — golden validation + `regression-gate` + multi-distro across all Java repos | Ongoing | — |
+| A7 | Deliver Java build evidence to Corona (Java delivery slice) | Postponed — out of charter (Corona / Phase 2-incorporation team owns delivery + verification) | SI-5 (Java) |
+| A8 | Build efficiency — fully in-memory JAR class processing (no extract-to-disk) | Deferred (validate on EC2) | US-4 |
+| A9 | Support non-Maven/Gradle Java builds (Ant/Ivy, Bazel, `make`) | Drafting | [java/java-nonmaven-gradle-build-tools-subissue.md](java/java-nonmaven-gradle-build-tools-subissue.md) |
+
+**Standing gate (not a sub-issue):** testing — golden validation, the
+`regression-gate`, and multi-distro runs (Ubuntu/RHEL/Alpine) — is a
+**continuous requirement applied to every item above**, not a discrete
+deliverable. No A-row is "done" until it passes these gates.
 
 ### Main B — C/C++ Sidecar Design: Deep Investigation & Validation
 

--- a/docs/planning/github-issues-crosswalk.md
+++ b/docs/planning/github-issues-crosswalk.md
@@ -61,9 +61,10 @@ Index labels (**A1**, **A4**, ...) refer to the rows in
 | Item | Theme -> sub-issue (index label) | Status |
 |---|---|---|
 | Phase 2 output set + hand-off manifest | Java Phase 2 main issue; index **A2**; Corona #11004 | Scoped, no PR |
-| Overlap independent post-build steps (measure first) | Phase 1 Build-Speed (Java) -> **US-3**; index **A5** | Conditional, no PR |
-| Deliver Java build evidence to Corona | Java Phase 2 main issue -> sub (2); index **A7**; SI-5 (Java) | Planned, no PR |
-| Non-Maven/Gradle build-tool support (Ant/Ivy, Bazel, `make`) | Phase 1 Java capture (new sub-issue to draft) | Next R&D, no PR |
+| Fully in-memory JAR class processing (no extract-to-disk) | Phase 1 Build-Speed (Java) -> **US-4**; index **A8** | Deferred (validate on EC2), no PR |
+| Support non-Maven/Gradle Java builds (Ant/Ivy, Bazel, `make`) | Phase 1 Java capture -> **A9**; see `java/java-nonmaven-gradle-build-tools-subissue.md` | Drafting, no PR |
+| Overlap independent post-build steps (measure first) | Phase 1 Build-Speed (Java) -> **US-3**; index **A5** | Optional / low, no PR |
+| Deliver Java build evidence to Corona | index **A7**; SI-5 (Java) | Postponed — out of charter (Corona / Phase 2-incorporation team) |
 
 ---
 

--- a/docs/planning/java/java-nonmaven-gradle-build-tools-subissue.md
+++ b/docs/planning/java/java-nonmaven-gradle-build-tools-subissue.md
@@ -9,7 +9,7 @@
 | **Applies to** | Java builds using Ant, Ivy, Bazel, or `make`/`javac` |
 | **Author** | Ted G. |
 | **Drafted** | 2026-06-29 (Cascade) |
-| **Status** | Drafting — design + verifier repos; no code yet |
+| **Status** | Step 0 (real-repo validation) done — see design §13; no code yet |
 | **Detailed design** | `../../deep-dive/java/java-nonmaven-gradle-adapter-design.md` (integration points, capture contract, Ivy/Bazel parsers, artifact-only path) |
 
 ---
@@ -51,12 +51,14 @@ Identification is **build-tool-agnostic** because it reads what the build
 Each verifies a real build path and gets golden SBOMs (golden files require
 USER review — never auto-generated/updated).
 
-| Build tool | Repo | Pin | Why |
+Finalized from Step 0 real-artifact validation (see design §13.4):
+
+| Build tool | Repo | Pin | Status / why |
 |---|---|---|---|
-| Ant + Ivy | `apache/ant-ivy` | `2.5.2` | The Ivy project, built with Ant **and** Ivy — exercises both |
-| Ant (no Ivy) | `apache/ant` | `rel/1.10.15` | Ant builds itself, zero external deps — pure artifact-based path |
-| Bazel + lockfile | `bazelbuild/examples` (`java-maven`) | commit SHA (no release tags) | `rules_jvm_external` + `maven_install.json` — Bazel mechanism + lockfile adapter |
-| Plain `make`/`javac` | new `omnibor-java-make-testapp` | `main` (we own it) | Controlled `Makefile` -> `javac` -> `jar` with manual classpath JARs |
+| Ant + Ivy | `apache/ant-ivy` | `2.5.2` | **Confirmed** (§13.3): `ivy:retrieve` produces a real resolution report; unforked `<javac>`. Build: `ant jar`. |
+| Plain `make`/`javac` | new `omnibor-java-make-testapp` | `main` (we own it) | **To create**: controlled `Makefile` -> `javac` -> `jar`; exercises the §8.1 PATH shim |
+| Bazel + lockfile | candidate `bazelbuild/examples` — **exact path TBD** | commit SHA | `rules_jvm_external` + `maven_install.json` (§13.1). Prior `java-maven` path 404'd; re-confirm. **Gated on Bazel toolchain decision.** |
+| Ant (no Ivy) | optional `apache/ant` | release tag | Lower priority — heavier bootstrap; artifact-only path also covered by the `make` test app |
 
 ---
 

--- a/docs/planning/java/java-nonmaven-gradle-build-tools-subissue.md
+++ b/docs/planning/java/java-nonmaven-gradle-build-tools-subissue.md
@@ -88,11 +88,22 @@ USER review — never auto-generated/updated).
 
 ## Proposed work breakdown
 
-1. **Verifier repos + `make` test app** — add the four repos; create
-   `omnibor-java-make-testapp`.
+0. **Investigate real repositories (design research + validation).** Before
+   any parser code, examine **actual build artifacts** from real repos to
+   validate every design assumption and finalize the verifier-repo list:
+   - a real Ivy resolution-report XML (`apache/ant-ivy`) — confirm element
+     names (`organisation`/`name`/`revision`/`conf`) and report location;
+   - a real `maven_install.json` (`bazelbuild/bazel`, `rules_jvm_external`) —
+     confirm structure and direct/transitive edges;
+   - `apache/ant` — confirm unforked `<javac>` (drives §8.1 of the design);
+   - candidate `make`/`javac` Java layouts.
+   This step supplements, and is a prerequisite to, the parser designs below
+   (no parser is finalized against an assumed format).
+1. **Verifier repos + `make` test app** — add the (investigation-confirmed)
+   repos; create `omnibor-java-make-testapp`.
 2. **Confirm Bazel toolchain decision** — gate the Bazel verifier.
-3. **Ivy adapter** — parse the Ivy resolution report.
-4. **Bazel adapter** — parse `maven_install.json`.
+3. **Ivy adapter** — parse the Ivy resolution report (format validated in 0).
+4. **Bazel adapter** — parse `maven_install.json` (format validated in 0).
 5. **Validate artifact-only path** for Ant-only and `make`/`javac`.
 6. **Golden review** — present SBOMs to the USER; never auto-update goldens.
 

--- a/docs/planning/java/java-nonmaven-gradle-build-tools-subissue.md
+++ b/docs/planning/java/java-nonmaven-gradle-build-tools-subissue.md
@@ -1,0 +1,107 @@
+# Sub-Issue Draft — Support Non-Maven/Gradle Java Builds
+
+| | |
+|---|---|
+| **Main issue** | Phase 1 Build-Speed & Efficiency (Java) — capture coverage |
+| **Epic** | Single epic — this main issue is added to it later by the issues team |
+| **Index label** | A9 (see `../README.md`) |
+| **Relationship** | Extends Java Phase 1 dependency capture beyond Maven/Gradle; complements the Java Phase 2 main issue (`../java-phase2-consume-dep-capture-subissue.md`) |
+| **Applies to** | Java builds using Ant, Ivy, Bazel, or `make`/`javac` |
+| **Author** | Ted G. |
+| **Drafted** | 2026-06-29 (Cascade) |
+| **Status** | Drafting — design + verifier repos; no code yet |
+
+---
+
+## Background
+
+Maven and Gradle account for roughly **88% of Java builds** and are fully
+supported today. The remaining tail uses Ant (often with Ivy), Bazel, or a
+hand-rolled `make`/`javac` build. The Java charter is to be **accurate for
+all Java build tooling**, so this sub-issue closes the gap.
+
+`sbt` is intentionally **out of scope**: it is a Scala-first tool, and a
+pure-Java `sbt` project is rare — covering it would test Scala, not Java.
+
+---
+
+## Approach: artifact-based first, declared-graph second
+
+Identification is **build-tool-agnostic** because it reads what the build
+*produces*, not how it was configured:
+
+1. **Universal (works for any build):** the compiled `.class` files and the
+   JARs on the classpath are hashed (GitOID) and resolved via the same
+   treedb path used today. This already gives component-level provenance
+   regardless of build tool.
+2. **Per-ecosystem declared-graph adapter (accuracy boost):** where the build
+   tool produces a resolved dependency graph, parse it to enrich
+   coordinates/scopes — mirroring `maven_dep_tree_parser.py` /
+   `gradle_dep_tree_parser.py`:
+   - **Ivy** — parse the Ivy resolution report (XML).
+   - **Bazel** — parse `rules_jvm_external`'s `maven_install.json` lockfile.
+   - **Ant (no Ivy) / `make`** — no declared graph; rely on the universal
+     artifact-based path.
+
+---
+
+## Verifier repos (to add to `config.yaml`)
+
+Each verifies a real build path and gets golden SBOMs (golden files require
+USER review — never auto-generated/updated).
+
+| Build tool | Repo | Pin | Why |
+|---|---|---|---|
+| Ant + Ivy | `apache/ant-ivy` | `2.5.2` | The Ivy project, built with Ant **and** Ivy — exercises both |
+| Ant (no Ivy) | `apache/ant` | `rel/1.10.15` | Ant builds itself, zero external deps — pure artifact-based path |
+| Bazel + lockfile | `bazelbuild/examples` (`java-maven`) | commit SHA (no release tags) | `rules_jvm_external` + `maven_install.json` — Bazel mechanism + lockfile adapter |
+| Plain `make`/`javac` | new `omnibor-java-make-testapp` | `main` (we own it) | Controlled `Makefile` -> `javac` -> `jar` with manual classpath JARs |
+
+---
+
+## Toolchain implications (decision needed before Docker changes)
+
+- Ant + Ivy: modest additions to the analysis image.
+- **Bazel: heavyweight** — large, slow dependency to add to the image and CI.
+  **Confirm with USER before adding Bazel** to the Docker image; the Ant/Ivy
+  and `make` paths can land first.
+
+---
+
+## Acceptance Criteria
+
+- Given an Ant+Ivy build, when Phase 1 runs, then components are captured and
+  the Ivy resolution report enriches the dependency coordinates.
+- Given a Bazel `rules_jvm_external` build, when Phase 1 runs, then components
+  are captured and `maven_install.json` enriches the coordinates.
+- Given an Ant-only or `make`/`javac` build with no declared graph, when
+  Phase 1 runs, then component-level provenance is still produced from the
+  artifacts.
+- Given any of the above, when the SBOM is produced, then it is reviewed
+  against a USER-approved golden baseline (no auto-generated goldens).
+- Given the changes, when verified locally, then project gates pass (import,
+  `flake8`, `pytest`, coverage thresholds); generic/config-driven, no
+  repo-specific logic.
+
+---
+
+## Proposed work breakdown
+
+1. **Verifier repos + `make` test app** — add the four repos; create
+   `omnibor-java-make-testapp`.
+2. **Confirm Bazel toolchain decision** — gate the Bazel verifier.
+3. **Ivy adapter** — parse the Ivy resolution report.
+4. **Bazel adapter** — parse `maven_install.json`.
+5. **Validate artifact-only path** for Ant-only and `make`/`javac`.
+6. **Golden review** — present SBOMs to the USER; never auto-update goldens.
+
+---
+
+## Open questions
+
+- **Bazel in the image?** Confirm before adding the heavyweight toolchain.
+- **`make` test app shape** — minimal `Makefile` + `javac` + `jar` with 1–2
+  external JARs placed on the classpath manually; confirm scope.
+- **Build-tool detection** — extend the existing detector to recognize
+  `build.xml`/`ivy.xml`, `WORKSPACE`/`BUILD.bazel`, and `Makefile`-driven
+  Java; config can override.

--- a/docs/planning/java/java-nonmaven-gradle-build-tools-subissue.md
+++ b/docs/planning/java/java-nonmaven-gradle-build-tools-subissue.md
@@ -10,6 +10,7 @@
 | **Author** | Ted G. |
 | **Drafted** | 2026-06-29 (Cascade) |
 | **Status** | Drafting — design + verifier repos; no code yet |
+| **Detailed design** | `../../deep-dive/java/java-nonmaven-gradle-adapter-design.md` (integration points, capture contract, Ivy/Bazel parsers, artifact-only path) |
 
 ---
 

--- a/docs/planning/java/phase1-build-speed-subissues.md
+++ b/docs/planning/java/phase1-build-speed-subissues.md
@@ -6,7 +6,7 @@
 | **Epic** | Single epic — this main issue is added to it later by the issues team |
 | **Author** | Ted G. |
 | **Drafted** | 2026-06-24 (Cascade) |
-| **Status** | US-2 delivered (validated golden-clean on bc-java + spring-boot); US-3 conditional; US-1 moved — see below |
+| **Status** | US-2 delivered & merged (PR `tedg-dev/omnibor-analysis#196`, golden-clean on bc-java + spring-boot); US-4 added (deferred, in-memory JAR processing); US-3 optional/low; US-1 moved — see below |
 | **Scope** | **Java builds** (Maven and Gradle). Other languages capture inline during the build and are not affected. |
 | **Detailed design** | `docs/deep-dive/java/phase1-build-speed-design.md` (single engineering reference — design, evidence, code-level plan). |
 
@@ -93,6 +93,10 @@ many times over, which dominates the capture time for those builds.
 
 ## US-3 — Overlap independent post-build steps only when it measurably helps
 
+> **Priority note:** This is **optional / low value**. Earlier wins (faster
+> component hashing, offline resolution, warm daemon) already shrank the gap.
+> Pursue **only** if measurement on a real build host shows a real reduction.
+
 **Applies to:** Java builds
 
 **Estimate:** ~1 AI-day (conditional — only pursued if measurement justifies it)
@@ -118,6 +122,52 @@ where the gain is negligible.
   capture runs, then it stays sequential to avoid needless complexity.
 - Given concurrent execution, when the SBOM is produced, then it is
   identical to the sequential result.
+
+---
+
+## US-4 — Process JAR class files fully in memory (no extract-to-disk)
+
+**Status:** Deferred — implement after EC2 golden validation of the current
+extract-to-disk fast-IO variant. This is the **remaining build-speed item
+with real value.**
+
+**Applies to:** Java builds (Phase 1 component processing of JARs)
+
+**Estimate:** ~1–2 AI-days
+
+**Priority:** Medium-high — eliminates the per-JAR temp-directory extraction
+lifecycle (est. ~5–10s/build for JAR-heavy projects).
+
+**User Story**
+
+As a product build team with many JAR dependencies,
+I want JAR component hashing to read `.class` bytes directly from the archive
+in memory rather than extracting every JAR to a temp directory,
+so that Phase 1 avoids the disk I/O and subprocess churn of extract-to-disk.
+
+**Why this matters**
+
+Component processing currently extracts each JAR (`jar -xf` /
+`zipfile.extractall`) to a temp directory, hashes files on disk, then
+`rmtree`s it. For builds with many JARs this disk lifecycle dominates.
+Reading `.class` entries from the zip in memory and hashing with
+`git_blob_hash_data` removes the entire unbundle -> find -> `rmtree` cycle.
+
+**Acceptance Criteria**
+
+- Given a JAR, when its components are processed, then `.class` GitOIDs are
+  computed from in-memory bytes with no extraction to disk.
+- Given the in-memory path, when its output is compared to the extract-to-disk
+  result, then the GitOIDs and the SBOM are identical (golden-clean).
+- Given a malformed or edge-case archive, when processed, then it fails
+  gracefully with a clear error (no silent skip).
+- Given the change, when validated on a representative multi-JAR build on a
+  real build host, then the SBOM matches the golden baseline.
+
+**Implementation note:** refactor the class-processing path to accept
+in-memory data rather than file paths; mirrors the existing fast-IO /
+classreader patches in `docker/patches/`. Deferred per the follow-up noted in
+`retro-subissue-java-treedb-perf.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

Refines the Main A (Java) plan per review and drafts the non-Maven/Gradle
build-tool R&D sub-issue (A9).

## Changes

- **`README.md`**
  - **A5** (US-3 step overlap) reclassified **Optional / low**.
  - **A7** (deliver to Corona) marked **Postponed — out of charter** (Corona /
    Phase 2-incorporation team owns delivery + verification).
  - **A8** repurposed to **fully in-memory JAR class processing (US-4)** —
    the deferred, high-value build-speed item.
  - **A9** added: **support non-Maven/Gradle Java builds**.
  - Testing reframed as a **standing gate**, not a numbered deliverable.
- **`java/phase1-build-speed-subissues.md`** — adds **US-4** (in-memory JAR
  processing) as a first-class sub-issue; clarifies US-3 as optional; records
  US-2 merge (#196).
- **`java/java-nonmaven-gradle-build-tools-subissue.md`** (new) — A9 draft:
  artifact-based + per-ecosystem adapter approach, verifier repos, Bazel
  toolchain decision, golden-file gating, acceptance criteria, work breakdown.
- **`github-issues-crosswalk.md`** — open-items table updated to match.

## Scope

Docs-only. No code, no golden files.
