### PR TITLE
refactor(java): shared _generate_java_treedb helper (A9 Step 1)

### DIFF
--- a/app/pipeline/interception.py
+++ b/app/pipeline/interception.py
@@ -40,6 +40,58 @@ def _write_adg_substeps(bom_path, substeps):
         json.dump(substeps, f, indent=2)
 
 
+def _generate_java_treedb(
+    runner, repo_dir, meta_dir, omnibor_cfg, substeps,
+):
+    """Generate the OmniBOR treedb for a Java workspace.
+
+    Runs ``bomsh_create_bom_java.py`` to map JAR -> class ->
+    source from the built workspace.  This step is
+    **build-tool-agnostic** (it inspects compiled artifacts,
+    not build files) and is shared by every Java sidecar
+    strategy.  Appends a ``treedb`` timing entry to *substeps*.
+
+    Args:
+        runner: ``CommandRunner`` used to invoke the script.
+        repo_dir: Path to the built repository workspace.
+        meta_dir: ``Path`` to the bomsh metadata directory
+            where the treedb is written.
+        omnibor_cfg: The ``omnibor`` config section.
+        substeps: Mutable list of timing dicts; a ``treedb``
+            entry is appended.
+
+    Returns:
+        True on success, False if the script fails.
+    """
+    create_bom = omnibor_cfg.get(
+        "create_bom_script",
+        "bomsh_create_bom_java.py",
+    )
+    treedb_file = meta_dir / "bomsh_omnibor_treedb"
+    t0 = time.monotonic()
+    rc = runner.run(
+        f"{create_bom} -r {repo_dir} -j {treedb_file}",
+        cwd=str(repo_dir),
+        description=(
+            "Generating OmniBOR treedb for Java workspace"
+        ),
+    )
+    treedb_sec = time.monotonic() - t0
+    substeps.append({
+        "name": "treedb",
+        "tool": "bomsh_create_bom_java.py",
+        "wall_sec": round(treedb_sec, 2),
+    })
+    if rc != 0:
+        print("[ERROR] bomsh_create_bom_java.py failed")
+        return False
+    print(
+        f"[OK] OmniBOR treedb written to "
+        f"{treedb_file} ({treedb_sec:.1f}s)"
+    )
+    return True
+
+
 class InterceptionStrategy(ABC):
     """Defines how a build is instrumented for OmniBOR tracing.
 
@@ -333,41 +385,15 @@ class MavenDepTreeStrategy(InterceptionStrategy):
         meta_dir.mkdir(parents=True, exist_ok=True)
 
         # Step 1: Generate OmniBOR treedb via JAR
-        # introspection — same bomsh script as
-        # standalone mode, without strace log.
-        create_bom = omnibor_cfg.get(
-            "create_bom_script",
-            "bomsh_create_bom_java.py",
-        )
-        treedb_file = meta_dir / "bomsh_omnibor_treedb"
-        t0 = time.monotonic()
-        rc = self._runner.run(
-            f"{create_bom} -r {repo_dir} "
-            f"-j {treedb_file}",
-            cwd=str(repo_dir),
-            description=(
-                "Generating OmniBOR treedb "
-                "for Java workspace"
-            ),
-        )
-        treedb_sec = time.monotonic() - t0
-        substeps.append({
-            "name": "treedb",
-            "tool": "bomsh_create_bom_java.py",
-            "wall_sec": round(treedb_sec, 2),
-        })
-        if rc != 0:
-            print(
-                "[ERROR] bomsh_create_bom_java.py "
-                "failed"
-            )
+        # introspection — same bomsh script as standalone
+        # mode, without strace log.  Build-tool-agnostic and
+        # shared by all Java sidecar strategies.
+        if not _generate_java_treedb(
+            self._runner, repo_dir, meta_dir,
+            omnibor_cfg, substeps,
+        ):
             _write_adg_substeps(bom_path, substeps)
             return False
-
-        print(
-            f"[OK] OmniBOR treedb written to "
-            f"{treedb_file} ({treedb_sec:.1f}s)"
-        )
 
         # Step 2: Capture Maven dependency graph (per-module).
         # Default text output is parsed into per-module subtrees so
@@ -472,41 +498,15 @@ class GradleDepTreeStrategy(InterceptionStrategy):
         meta_dir.mkdir(parents=True, exist_ok=True)
 
         # Step 1: Generate OmniBOR treedb via JAR
-        # introspection — same bomsh script as
-        # standalone mode, without strace log.
-        create_bom = omnibor_cfg.get(
-            "create_bom_script",
-            "bomsh_create_bom_java.py",
-        )
-        treedb_file = meta_dir / "bomsh_omnibor_treedb"
-        t0 = time.monotonic()
-        rc = self._runner.run(
-            f"{create_bom} -r {repo_dir} "
-            f"-j {treedb_file}",
-            cwd=str(repo_dir),
-            description=(
-                "Generating OmniBOR treedb "
-                "for Java workspace"
-            ),
-        )
-        treedb_sec = time.monotonic() - t0
-        substeps.append({
-            "name": "treedb",
-            "tool": "bomsh_create_bom_java.py",
-            "wall_sec": round(treedb_sec, 2),
-        })
-        if rc != 0:
-            print(
-                "[ERROR] bomsh_create_bom_java.py "
-                "failed"
-            )
+        # introspection — same bomsh script as standalone
+        # mode, without strace log.  Build-tool-agnostic and
+        # shared by all Java sidecar strategies.
+        if not _generate_java_treedb(
+            self._runner, repo_dir, meta_dir,
+            omnibor_cfg, substeps,
+        ):
             _write_adg_substeps(bom_path, substeps)
             return False
-
-        print(
-            f"[OK] OmniBOR treedb written to "
-            f"{treedb_file} ({treedb_sec:.1f}s)"
-        )
 
         # Step 2: Capture Gradle dependency graph (per-subproject).
         # Captured per subproject so Phase 2 can generate per-module

--- a/tests/test_interception.py
+++ b/tests/test_interception.py
@@ -8,6 +8,7 @@ GradleDepTreeStrategy.
 """
 
 import unittest
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from app.pipeline.interception import (
@@ -18,6 +19,7 @@ from app.pipeline.interception import (
     RustcWrapperStrategy,
     MavenDepTreeStrategy,
     GradleDepTreeStrategy,
+    _generate_java_treedb,
 )
 
 
@@ -312,6 +314,71 @@ class TestInterceptionStrategyABC(unittest.TestCase):
             pass
         with self.assertRaises(TypeError):
             Incomplete()
+
+
+# ============================================================
+# _generate_java_treedb (shared helper)
+# ============================================================
+
+class TestGenerateJavaTreedb(unittest.TestCase):
+    """Tests for the shared _generate_java_treedb helper."""
+
+    def test_success_appends_treedb_substep(self):
+        runner = MagicMock()
+        runner.run.return_value = 0
+        substeps = []
+        with patch("builtins.print"):
+            ok = _generate_java_treedb(
+                runner, "/repo", Path("/bom/meta"),
+                {}, substeps,
+            )
+        self.assertTrue(ok)
+        self.assertEqual(len(substeps), 1)
+        self.assertEqual(substeps[0]["name"], "treedb")
+        self.assertEqual(
+            substeps[0]["tool"], "bomsh_create_bom_java.py",
+        )
+        self.assertIn("wall_sec", substeps[0])
+
+    def test_failure_returns_false_but_records_substep(self):
+        runner = MagicMock()
+        runner.run.return_value = 1
+        substeps = []
+        with patch("builtins.print"):
+            ok = _generate_java_treedb(
+                runner, "/repo", Path("/bom/meta"),
+                {}, substeps,
+            )
+        self.assertFalse(ok)
+        self.assertEqual(len(substeps), 1)
+        self.assertEqual(substeps[0]["name"], "treedb")
+
+    def test_uses_default_create_bom_script(self):
+        runner = MagicMock()
+        runner.run.return_value = 0
+        with patch("builtins.print"):
+            _generate_java_treedb(
+                runner, "/repo", Path("/bom/meta"),
+                {}, [],
+            )
+        cmd_str = runner.run.call_args[0][0]
+        self.assertIn("bomsh_create_bom_java.py", cmd_str)
+        self.assertIn("-r /repo", cmd_str)
+        self.assertIn(
+            "-j /bom/meta/bomsh_omnibor_treedb", cmd_str,
+        )
+
+    def test_honors_config_create_bom_script(self):
+        runner = MagicMock()
+        runner.run.return_value = 0
+        cfg = {"create_bom_script": "/custom/mkbom.py"}
+        with patch("builtins.print"):
+            _generate_java_treedb(
+                runner, "/repo", Path("/bom/meta"),
+                cfg, [],
+            )
+        cmd_str = runner.run.call_args[0][0]
+        self.assertIn("/custom/mkbom.py", cmd_str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Step 1 of the A9 (non-Maven/Gradle) plan** — a refactor intended to be
behavior-preserving that extracts the duplicated, build-tool-agnostic
treedb-generation block from `MavenDepTreeStrategy` and `GradleDepTreeStrategy`
into a shared `_generate_java_treedb()` helper (DRY). This is the foundation
every future Java sidecar adapter (Ivy, Bazel, artifact-only) will reuse.

## Changes

- **`app/pipeline/interception.py`** — new module-level
  `_generate_java_treedb(runner, repo_dir, meta_dir, omnibor_cfg, substeps)`;
  both dep-tree strategies now call it. Runner command, `treedb` substep, and
  failure handling are unchanged at the source level.
- **`tests/test_interception.py`** — 4 direct unit tests for the helper
  (success, failure, default + configured `create_bom_script`).

## Verification (local only)

- `import app` OK; `flake8` clean.
- `pytest`: 1591 passed, 75 skipped.
- Coverage: 99% overall; `interception.py` 95% (meets per-file threshold).
- Existing `generate_adg` unit tests for both strategies pass unchanged.

## Validation status — NOT golden-verified

- **EC2 golden validation has NOT been run.** This touches the Maven/Gradle
  treedb path, so per the golden-file policy it is **not** "golden-clean"
  until validated on EC2 against the project golden baselines.
- Local unit tests passing is **not** equivalent to golden validation.
- Do not treat this PR as merge-ready on a "golden-clean" basis until that
  EC2 validation has run and been reviewed.

## Scope

Generic, no language- or repo-specific logic. No golden baseline files were
modified in this PR.
