### PR TITLE
feat(java): Ivy report parser + Phase 2 reader support (A9 Step 3)

### DIFF
--- a/app/pipeline/ivy_report_parser.py
+++ b/app/pipeline/ivy_report_parser.py
@@ -1,0 +1,205 @@
+"""
+Parse Ivy resolution-report XML into the shared dependency-capture format.
+
+Ant builds that use Ivy emit one resolution report per *configuration*
+(conf), typically named ``<organisation>-<module>-<conf>.xml`` under the
+Ivy report directory (``${ivy.report.dir}`` / the ``ivy:report`` task
+output). Each report lists the resolved modules with ``organisation``,
+``name``, ``revision``, and the caller chain that pulled them in.
+
+This module turns those reports into the same capture structure produced by
+``app.pipeline.maven_dep_tree_parser`` / ``gradle_dep_tree_parser`` so that
+Phase 2 (``app.spdx.dep_capture_reader`` -> ``java_generator``) can consume
+Ivy captures with no new code path::
+
+    {"tool": "ivy", "modules": [
+        {"key": "g:a", "groupId": "g", "artifactId": "a",
+         "version": "1.0", "packaging": "jar", "deps": [
+             {"groupId": "...", "artifactId": "...", "version": "...",
+              "packaging": "jar", "scope": "compile",
+              "direct": True, "parent": None}, ...]}]}
+
+The report schema (validated against real Ant+Ivy reports)::
+
+    <ivy-report>
+      <info organisation=".." module=".." revision=".." conf=".."/>
+      <dependencies>
+        <module organisation=".." name="..">
+          <revision name="<version>" evicted="..?">
+            <caller organisation=".." name=".."/>
+          </revision>
+        </module>
+      </dependencies>
+    </ivy-report>
+"""
+
+import logging
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Ivy confs are project-defined, but these names are conventional. Map them
+# to the Maven-style scopes Phase 2 understands; everything unrecognized is
+# treated as ``compile`` (the safe production default).
+_CONF_SCOPE = {
+    "test": "test",
+    "runtime": "runtime",
+    "provided": "provided",
+}
+
+
+def _scope_from_conf(conf):
+    """Map an Ivy conf name to a Maven-style scope."""
+    if not conf:
+        return "compile"
+    return _CONF_SCOPE.get(conf.strip().lower(), "compile")
+
+
+def parse_ivy_report(xml_text):
+    """Parse a single Ivy resolution report (one conf).
+
+    Args:
+        xml_text: The report XML as a string.
+
+    Returns:
+        A dict ``{"conf", "scope", "root": (org, name), "root_version",
+        "deps": [...]}``. ``deps`` excludes evicted revisions; each entry
+        carries ``direct`` (a caller equals the root module) and ``parent``
+        (the first non-root caller's name, or None).
+
+    Raises:
+        xml.etree.ElementTree.ParseError: if *xml_text* is not valid XML.
+    """
+    root = ET.fromstring(xml_text)
+    info = root.find("info")
+    root_org = info.get("organisation") if info is not None else None
+    root_name = info.get("module") if info is not None else None
+    root_rev = info.get("revision") if info is not None else None
+    conf = info.get("conf") if info is not None else None
+    scope = _scope_from_conf(conf)
+
+    deps = []
+    deps_el = root.find("dependencies")
+    if deps_el is not None:
+        for module in deps_el.findall("module"):
+            org = module.get("organisation")
+            name = module.get("name")
+            for rev in module.findall("revision"):
+                if rev.get("evicted"):
+                    continue
+                callers = rev.findall("caller")
+                direct = any(
+                    c.get("organisation") == root_org
+                    and c.get("name") == root_name
+                    for c in callers
+                )
+                parent = None
+                if not direct:
+                    for caller in callers:
+                        parent = caller.get("name")
+                        break
+                deps.append({
+                    "groupId": org,
+                    "artifactId": name,
+                    "version": rev.get("name"),
+                    "packaging": "jar",
+                    "scope": scope,
+                    "direct": direct,
+                    "parent": parent,
+                })
+
+    return {
+        "conf": conf,
+        "scope": scope,
+        "root": (root_org, root_name),
+        "root_version": root_rev,
+        "deps": deps,
+    }
+
+
+def _merge_reports(reports):
+    """Merge per-conf reports into one deduplicated dependency list.
+
+    Test-scope reports are dropped. Duplicates (same group/artifact/version)
+    are collapsed; ``direct`` is OR-ed so a dep that is direct in any
+    production conf stays direct.
+    """
+    merged = {}
+    order = []
+    root = (None, None)
+    root_version = None
+    for report in reports:
+        if report["scope"] == "test":
+            continue
+        if report.get("root") and report["root"] != (None, None):
+            root = report["root"]
+        root_version = root_version or report.get("root_version")
+        for dep in report["deps"]:
+            key = (dep["groupId"], dep["artifactId"], dep["version"])
+            existing = merged.get(key)
+            if existing is None:
+                merged[key] = dict(dep)
+                order.append(key)
+            elif dep["direct"]:
+                existing["direct"] = True
+    return [merged[k] for k in order], root, root_version
+
+
+def build_capture(reports):
+    """Build the ``tool="ivy"`` capture dict from parsed conf reports.
+
+    Args:
+        reports: An iterable of dicts from :func:`parse_ivy_report`.
+
+    Returns:
+        A capture dict ``{"tool": "ivy", "modules": [<module>]}`` with a
+        single module (Ant+Ivy projects resolve one root module).
+    """
+    deps, (org, name), root_version = _merge_reports(list(reports))
+    if org and name:
+        key = f"{org}:{name}"
+    else:
+        key = name or ""
+    module = {
+        "key": key,
+        "groupId": org,
+        "artifactId": name,
+        "version": root_version or "",
+        "packaging": "jar",
+        "deps": deps,
+    }
+    return {"tool": "ivy", "modules": [module]}
+
+
+def parse_ivy_report_dir(report_dir):
+    """Parse every Ivy resolution report in *report_dir* into a capture.
+
+    Non-XML files and XML files whose root element is not ``ivy-report``
+    are skipped with a debug log. Files that fail to parse are skipped with
+    a warning (one malformed report must not abort the whole capture).
+
+    Args:
+        report_dir: Directory containing ``*.xml`` Ivy reports.
+
+    Returns:
+        The capture dict from :func:`build_capture` (one module). If no
+        valid reports are found, the module's ``deps`` is empty.
+    """
+    reports = []
+    for path in sorted(Path(report_dir).glob("*.xml")):
+        try:
+            xml_text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Could not read Ivy report %s: %s", path, exc)
+            continue
+        try:
+            report = parse_ivy_report(xml_text)
+        except ET.ParseError as exc:
+            logger.warning("Malformed Ivy report %s: %s", path, exc)
+            continue
+        if report["root"] == (None, None):
+            logger.debug("Skipping non-ivy-report XML: %s", path)
+            continue
+        reports.append(report)
+    return build_capture(reports)

--- a/app/spdx/dep_capture_reader.py
+++ b/app/spdx/dep_capture_reader.py
@@ -34,6 +34,7 @@ from pathlib import Path
 _CAPTURE_FILES = {
     "maven_deps.json": "target",
     "gradle_deps.json": "build",
+    "ivy_deps.json": "build",
 }
 
 
@@ -112,6 +113,22 @@ def _resolve_gradle(modules, artifact_name, jar_rel_path):
     return None
 
 
+def _resolve_ivy(modules, artifact_name, jar_rel_path):
+    """Resolve an Ivy/Ant output JAR to its capture module.
+
+    Ant+Ivy projects resolve a single root module, so the
+    single-module fallback covers the common case; an artifactId
+    match is attempted first for the rare multi-JAR layout.
+    """
+    if artifact_name:
+        for module in modules:
+            if module.get("artifactId") == artifact_name:
+                return module
+    if len(modules) == 1:
+        return modules[0]
+    return None
+
+
 def resolve_module(capture, artifact_name, jar_rel_path=None):
     """Resolve the capture module for an output JAR.
 
@@ -132,8 +149,11 @@ def resolve_module(capture, artifact_name, jar_rel_path=None):
     modules = capture.get("modules") or []
     if not modules:
         return None
-    if capture.get("tool") == "gradle":
+    tool = capture.get("tool")
+    if tool == "gradle":
         return _resolve_gradle(modules, artifact_name, jar_rel_path)
+    if tool == "ivy":
+        return _resolve_ivy(modules, artifact_name, jar_rel_path)
     return _resolve_maven(modules, artifact_name, jar_rel_path)
 
 

--- a/tests/test_dep_capture_reader.py
+++ b/tests/test_dep_capture_reader.py
@@ -66,6 +66,27 @@ def _gradle_capture():
     }
 
 
+def _ivy_capture():
+    return {
+        "tool": "ivy",
+        "modules": [
+            {
+                "key": "org.apache:myapp",
+                "groupId": "org.apache",
+                "artifactId": "myapp",
+                "version": "1.0",
+                "packaging": "jar",
+                "deps": [
+                    {"groupId": "com.google.guava",
+                     "artifactId": "guava",
+                     "version": "32.1.3-jre", "scope": "compile",
+                     "direct": True, "parent": None},
+                ],
+            },
+        ],
+    }
+
+
 class TestLoadCapture(unittest.TestCase):
     """Tests for load_capture()."""
 
@@ -93,6 +114,14 @@ class TestLoadCapture(unittest.TestCase):
             )
             capture = load_capture(td)
         self.assertEqual(capture["tool"], "maven")
+
+    def test_loads_ivy(self):
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "ivy_deps.json").write_text(
+                json.dumps(_ivy_capture())
+            )
+            capture = load_capture(td)
+        self.assertEqual(capture["tool"], "ivy")
 
     def test_missing_returns_none(self):
         with tempfile.TemporaryDirectory() as td:
@@ -183,6 +212,34 @@ class TestResolveGradle(unittest.TestCase):
             "missing/build/libs/missing.jar",
         )
         self.assertIsNone(module)
+
+
+class TestResolveIvy(unittest.TestCase):
+    """Ivy/Ant JAR -> module resolution."""
+
+    def test_match_by_artifact_name(self):
+        module = resolve_module(
+            _ivy_capture(), "myapp", "dist/myapp.jar",
+        )
+        self.assertEqual(module["key"], "org.apache:myapp")
+
+    def test_single_module_fallback(self):
+        module = resolve_module(
+            _ivy_capture(), "other", "build/other.jar",
+        )
+        self.assertEqual(module["key"], "org.apache:myapp")
+
+    def test_not_found_multi_module(self):
+        capture = {
+            "tool": "ivy",
+            "modules": [
+                {"key": "a", "artifactId": "a", "deps": []},
+                {"key": "b", "artifactId": "b", "deps": []},
+            ],
+        }
+        self.assertIsNone(
+            resolve_module(capture, "missing", "x.jar"),
+        )
 
 
 class TestGetModuleDeps(unittest.TestCase):

--- a/tests/test_ivy_report_parser.py
+++ b/tests/test_ivy_report_parser.py
@@ -1,0 +1,224 @@
+"""
+Tests for app.pipeline.ivy_report_parser.
+
+Fixtures mirror the real Ivy resolution-report XML schema validated in the
+A9 design doc (§13.2).
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from xml.etree.ElementTree import ParseError
+
+from app.pipeline.ivy_report_parser import (
+    parse_ivy_report,
+    build_capture,
+    parse_ivy_report_dir,
+)
+
+
+_COMPILE_REPORT = """<?xml version="1.0"?>
+<ivy-report>
+  <info organisation="org.apache" module="myapp" revision="1.0"
+        conf="compile"/>
+  <dependencies>
+    <module organisation="com.google.guava" name="guava">
+      <revision name="32.1.3-jre">
+        <caller organisation="org.apache" name="myapp"/>
+      </revision>
+    </module>
+    <module organisation="com.google.guava" name="failureaccess">
+      <revision name="1.0.1">
+        <caller organisation="com.google.guava" name="guava"/>
+      </revision>
+    </module>
+    <module organisation="junit" name="junit">
+      <revision name="3.8" evicted="evicted: newer revision in compile">
+        <caller organisation="org.apache" name="myapp"/>
+      </revision>
+      <revision name="4.13.2">
+        <caller organisation="org.apache" name="myapp"/>
+      </revision>
+    </module>
+  </dependencies>
+</ivy-report>
+"""
+
+_TEST_REPORT = """<?xml version="1.0"?>
+<ivy-report>
+  <info organisation="org.apache" module="myapp" revision="1.0" conf="test"/>
+  <dependencies>
+    <module organisation="org.mockito" name="mockito-core">
+      <revision name="5.0.0">
+        <caller organisation="org.apache" name="myapp"/>
+      </revision>
+    </module>
+  </dependencies>
+</ivy-report>
+"""
+
+
+def _info_only(conf_attr):
+    return (
+        '<ivy-report><info organisation="o" module="m" revision="1"'
+        + conf_attr
+        + "/><dependencies/></ivy-report>"
+    )
+
+
+class TestParseIvyReport(unittest.TestCase):
+    """Tests for parse_ivy_report()."""
+
+    def setUp(self):
+        self.report = parse_ivy_report(_COMPILE_REPORT)
+        self.deps = {d["artifactId"]: d for d in self.report["deps"]}
+
+    def test_root_and_conf(self):
+        self.assertEqual(self.report["root"], ("org.apache", "myapp"))
+        self.assertEqual(self.report["root_version"], "1.0")
+        self.assertEqual(self.report["conf"], "compile")
+        self.assertEqual(self.report["scope"], "compile")
+
+    def test_evicted_revision_skipped(self):
+        # junit 3.8 is evicted; only 4.13.2 survives.
+        self.assertEqual(self.deps["junit"]["version"], "4.13.2")
+        self.assertEqual(len(self.report["deps"]), 3)
+
+    def test_direct_dependency(self):
+        guava = self.deps["guava"]
+        self.assertTrue(guava["direct"])
+        self.assertIsNone(guava["parent"])
+        self.assertEqual(guava["version"], "32.1.3-jre")
+        self.assertEqual(guava["groupId"], "com.google.guava")
+        self.assertEqual(guava["packaging"], "jar")
+
+    def test_transitive_dependency_parent(self):
+        fa = self.deps["failureaccess"]
+        self.assertFalse(fa["direct"])
+        self.assertEqual(fa["parent"], "guava")
+
+    def test_scope_runtime(self):
+        rep = parse_ivy_report(_info_only(' conf="runtime"'))
+        self.assertEqual(rep["scope"], "runtime")
+
+    def test_scope_provided(self):
+        rep = parse_ivy_report(_info_only(' conf="provided"'))
+        self.assertEqual(rep["scope"], "provided")
+
+    def test_scope_test(self):
+        rep = parse_ivy_report(_info_only(' conf="test"'))
+        self.assertEqual(rep["scope"], "test")
+
+    def test_scope_unknown_defaults_compile(self):
+        rep = parse_ivy_report(_info_only(' conf="weirdconf"'))
+        self.assertEqual(rep["scope"], "compile")
+
+    def test_scope_missing_conf_defaults_compile(self):
+        rep = parse_ivy_report(_info_only(""))
+        self.assertEqual(rep["scope"], "compile")
+
+    def test_no_info_yields_empty_root(self):
+        rep = parse_ivy_report("<ivy-report><dependencies/></ivy-report>")
+        self.assertEqual(rep["root"], (None, None))
+        self.assertEqual(rep["deps"], [])
+
+    def test_invalid_xml_raises(self):
+        with self.assertRaises(ParseError):
+            parse_ivy_report("<not-closed")
+
+
+class TestBuildCapture(unittest.TestCase):
+    """Tests for build_capture()."""
+
+    def test_single_module_shape(self):
+        cap = build_capture([parse_ivy_report(_COMPILE_REPORT)])
+        self.assertEqual(cap["tool"], "ivy")
+        self.assertEqual(len(cap["modules"]), 1)
+        mod = cap["modules"][0]
+        self.assertEqual(mod["key"], "org.apache:myapp")
+        self.assertEqual(mod["version"], "1.0")
+        self.assertEqual(len(mod["deps"]), 3)
+
+    def test_test_conf_dropped(self):
+        cap = build_capture([
+            parse_ivy_report(_COMPILE_REPORT),
+            parse_ivy_report(_TEST_REPORT),
+        ])
+        names = {d["artifactId"] for d in cap["modules"][0]["deps"]}
+        self.assertNotIn("mockito-core", names)
+        self.assertIn("guava", names)
+
+    def test_dedupe_ors_direct(self):
+        # Same dep appears transitive in one conf, direct in another;
+        # merged entry must be direct.
+        transitive = {
+            "conf": "runtime", "scope": "runtime",
+            "root": ("o", "m"), "root_version": "1",
+            "deps": [{
+                "groupId": "g", "artifactId": "a", "version": "1",
+                "packaging": "jar", "scope": "runtime",
+                "direct": False, "parent": "x",
+            }],
+        }
+        direct = {
+            "conf": "compile", "scope": "compile",
+            "root": ("o", "m"), "root_version": "1",
+            "deps": [{
+                "groupId": "g", "artifactId": "a", "version": "1",
+                "packaging": "jar", "scope": "compile",
+                "direct": True, "parent": None,
+            }],
+        }
+        cap = build_capture([transitive, direct])
+        deps = cap["modules"][0]["deps"]
+        self.assertEqual(len(deps), 1)
+        self.assertTrue(deps[0]["direct"])
+
+    def test_empty_reports(self):
+        cap = build_capture([])
+        mod = cap["modules"][0]
+        self.assertEqual(mod["key"], "")
+        self.assertEqual(mod["deps"], [])
+
+
+class TestParseIvyReportDir(unittest.TestCase):
+    """Tests for parse_ivy_report_dir()."""
+
+    def _write(self, tmp, name, text):
+        (Path(tmp) / name).write_text(text, encoding="utf-8")
+
+    def test_parses_and_filters(self):
+        with TemporaryDirectory() as tmp:
+            self._write(tmp, "org.apache-myapp-compile.xml", _COMPILE_REPORT)
+            self._write(tmp, "org.apache-myapp-test.xml", _TEST_REPORT)
+            self._write(tmp, "other.xml", "<foo><bar/></foo>")
+            self._write(tmp, "bad.xml", "<not-closed")
+            cap = parse_ivy_report_dir(tmp)
+        mod = cap["modules"][0]
+        self.assertEqual(cap["tool"], "ivy")
+        self.assertEqual(mod["key"], "org.apache:myapp")
+        names = {d["artifactId"] for d in mod["deps"]}
+        self.assertEqual(names, {"guava", "failureaccess", "junit"})
+        self.assertNotIn("mockito-core", names)
+
+    def test_empty_dir(self):
+        with TemporaryDirectory() as tmp:
+            cap = parse_ivy_report_dir(tmp)
+        self.assertEqual(cap["tool"], "ivy")
+        self.assertEqual(cap["modules"][0]["deps"], [])
+
+    def test_unreadable_entry_skipped(self):
+        # A directory matching *.xml triggers the OSError read path;
+        # one unreadable entry must not abort the whole capture.
+        with TemporaryDirectory() as tmp:
+            self._write(
+                tmp, "org.apache-myapp-compile.xml", _COMPILE_REPORT,
+            )
+            (Path(tmp) / "isdir.xml").mkdir()
+            cap = parse_ivy_report_dir(tmp)
+        names = {d["artifactId"] for d in cap["modules"][0]["deps"]}
+        self.assertEqual(names, {"guava", "failureaccess", "junit"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

**A9 Step 3 (pure pieces):** Ivy resolution-report parser + Phase 2 reader
support. Both are deterministic and fully unit-tested; no build-time runtime.

## What changed

- **`app/pipeline/ivy_report_parser.py`** (new) — parses Ivy resolution-report
  XML (validated schema, design §13.2) into the shared capture format
  (`{"tool": "ivy", "modules": [...]}`). Handles direct vs transitive (caller
  chain), evicted-revision skipping, conf→scope mapping, test-conf drop, and
  per-conf merge/dedupe.
- **`app/spdx/dep_capture_reader.py`** — adds `ivy_deps.json` + `_resolve_ivy`
  dispatch (artifactId match, single-module fallback).
- Tests for both (parser at 100%, reader 97%).

## Deferred (not in this PR)

- `IvyDepCaptureStrategy` + `_select_java_strategy` wiring — deferred until
  #199 (shared `_generate_java_treedb` helper) and #200 (detection) merge, so
  the strategy lands DRY and on the detection seam.
- EC2 golden validation against `apache/ant-ivy` (separately gated).

## Verification

- flake8 clean; full suite **1608 passed, 75 skipped**; total **99%**.
- Independent of #200 (branched off `main`).
