### PR TITLE
docs(c-cpp): fix sidecar-design.md (broken links + strategy ordering)

### DIFF
--- a/docs/deep-dive/c-cpp/sidecar-design.md
+++ b/docs/deep-dive/c-cpp/sidecar-design.md
@@ -1,12 +1,12 @@
 # Sidecar & Phase Isolation — C/C++
 
-> **Parent doc**: `../features/phase-isolation/sidecar-phase-isolation-infrastructure.md`
+> **Parent doc**: `../../features/phase-isolation/sidecar-phase-isolation-infrastructure.md`
 > **Status**: Design proposal — not yet implemented
 > **Date**: 2026-06-12
 
 ---
 
-> **Supported modes**: See `../features/phase-isolation/sidecar-phase-isolation-infrastructure.md` §1
+> **Supported modes**: See `../../features/phase-isolation/sidecar-phase-isolation-infrastructure.md` §1
 > for the authoritative definition of Standalone and Sidecar modes.
 > All modes apply to C/C++.
 
@@ -14,9 +14,9 @@
 
 ## Architecture Diagram
 
-<a href="../architecture/c-cpp-sidecar-mode.png"><img src="../architecture/c-cpp-sidecar-mode.png" width="600" alt="C/C++ Sidecar Mode Architecture — click to enlarge"></a>
+<a href="../../architecture/c-cpp-sidecar-mode.png"><img src="../../architecture/c-cpp-sidecar-mode.png" width="600" alt="C/C++ Sidecar Mode Architecture — click to enlarge"></a>
 
-*Click image to enlarge. Source: [c-cpp-sidecar-mode.drawio](../architecture/c-cpp-sidecar-mode.drawio)*
+*Click image to enlarge. Source: [c-cpp-sidecar-mode.drawio](../../architecture/c-cpp-sidecar-mode.drawio)*
 
 ---
 

--- a/docs/deep-dive/c-cpp/sidecar-design.md
+++ b/docs/deep-dive/c-cpp/sidecar-design.md
@@ -61,14 +61,13 @@ instantiated by any runner.
 
 ## 2. Interception Strategies
 
-### 2.1 Standalone: `PtraceStrategy` (existing)
+This is a **sidecar** design, so the sidecar `CcWrapperStrategy` is the
+primary strategy (§2.1). The standalone `PtraceStrategy` (§2.2) is included
+**only as the existing production baseline** — the sidecar strategy reuses
+its ADG-generation step (identical raw-logfile output), so it is documented
+here for reference, not as the recommended path.
 
-- **Mechanism**: `bomtrace3 make -j$(nproc)` — ptrace-based syscall interception
-- **Capability needed**: `SYS_PTRACE` in Docker
-- **Output**: raw logfile at `/tmp/bomsh_hook_raw_logfile.sha1`
-- **ADG**: `bomsh_create_bom.py -r <raw_logfile> -b <bom_dir>`
-
-### 2.2 Sidecar: `CcWrapperStrategy` (to be wired)
+### 2.1 Sidecar: `CcWrapperStrategy` (primary — to be wired)
 
 - **Mechanism**: `CC=/opt/bomsh/bin/bomsh_cc_wrapper.sh`, `CXX=...`, `AR=...`, `LD=...`
 - **Capability needed**: None (`SYS_PTRACE` not required)
@@ -94,6 +93,17 @@ class CcWrapperStrategy(InterceptionStrategy):
         strategy = PtraceStrategy()
         return strategy.generate_adg(repo_dir, bom_dir, omnibor_cfg)
 ```
+
+### 2.2 Standalone: `PtraceStrategy` (existing baseline — reference only)
+
+- **Mechanism**: `bomtrace3 make -j$(nproc)` — ptrace-based syscall interception
+- **Capability needed**: `SYS_PTRACE` in Docker
+- **Output**: raw logfile at `/tmp/bomsh_hook_raw_logfile.sha1`
+- **ADG**: `bomsh_create_bom.py -r <raw_logfile> -b <bom_dir>`
+- **Role in this design**: retained as the baseline only — the sidecar
+  `CcWrapperStrategy.generate_adg()` delegates to
+  `PtraceStrategy.generate_adg()` because the wrapper output format is
+  identical. It is **not** the recommended path for new sidecar work.
 
 ### 2.3 Wiring `CcWrapperStrategy` to the Pipeline
 


### PR DESCRIPTION
## Summary

Fix broken relative links in `docs/deep-dive/c-cpp/sidecar-design.md`. The
doc lives two levels deep (`docs/deep-dive/c-cpp/`) but referenced sibling
directories with a single `../`, resolving one directory too high.

## Fixes

- **Architecture diagram (the reported break):** the PNG `href`/`img src`
  and the `.drawio` source used `../architecture/...`; the assets are at
  `docs/architecture/`, so the correct path is `../../architecture/...`.
- **Parent-doc / supported-modes references:** used `../features/...`; the
  target is at `docs/features/`, so the correct path is `../../features/...`.

## Notes

Kept as **relative** links (not hardcoded `master` raw URLs) so they render
on GitHub and locally, on any branch or fork.
