### PR TITLE
docs(planning): split pilot foundation into #11069 + mark A9 backlog (#11066)

### DIFF
--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -56,12 +56,21 @@ PR/issue mapping for recreation once GitHub Issues access returns:
 | A6 | Treedb SBOM-generation speedup (retro) | Delivered | SI-R1 / PRs #189, #187, #191 |
 | A7 | Deliver Java build evidence to Corona (Java delivery slice) | Postponed — out of charter (Corona / Phase 2-incorporation team owns delivery + verification) | SI-5 (Java) |
 | A8 | Build efficiency — fully in-memory JAR class processing (no extract-to-disk) | Deferred (validate on EC2) | US-4 |
-| A9 | Support non-Maven/Gradle Java builds (Ant/Ivy, Bazel, `make`) | Drafting | [java/java-nonmaven-gradle-build-tools-subissue.md](java/java-nonmaven-gradle-build-tools-subissue.md) |
+| A9 | Support non-Maven/Gradle Java builds (Ant/Ivy, Bazel, `make`) | **Backlog** — parentless issue, not in the initial pilot; **excluded from the Main A completion gate** | #11066 (Proposed) / [java/java-nonmaven-gradle-build-tools-subissue.md](java/java-nonmaven-gradle-build-tools-subissue.md) |
 
 **Standing gate (not a sub-issue):** testing — golden validation, the
 `regression-gate`, and multi-distro runs (Ubuntu/RHEL/Alpine) — is a
 **continuous requirement applied to every item above**, not a discrete
 deliverable. No A-row is "done" until it passes these gates.
+
+**A9 exclusion:** A9 is **backlog and parentless** (GitHub issue #11066,
+Proposed) and is **not** part of the Main A completion gate. It is very
+likely not required for the initial pilot: the universal artifact-based
+capture path (`.class` + classpath JAR GitOID via treedb) already covers
+Ant and `make`/`javac` without a declared-graph adapter, and the Ivy/Bazel
+declared-graph adapters are post-pilot accuracy enrichments. The Ivy/Ant
+work (`tedg-dev/omnibor-analysis#201`) is parked as a draft with the
+`backlog` label. **Java delivery completion does not depend on A9.**
 
 ### Main B — C/C++ Sidecar Design: Deep Investigation & Validation
 

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -48,6 +48,7 @@ PR/issue mapping for recreation once GitHub Issues access returns:
 
 | Sub | Title | Status | Maps to |
 |-----|-------|--------|---------|
+| AF | Java Phase 1 capture foundation — build-tool detection + shared treedb helper | Merged (issue **In Review**) | #11069 / PRs #199, #200 |
 | A1 | Phase 2 generates SBOMs from Phase 1 metadata, no source tree (phase-isolation core) | Merged | SI-4 (Java) / #11003 / PR #194 |
 | A2 | Phase 2 output set + hand-off manifest | Scoped | #11004 → [java/java-phase2-11004-handoff-scope.md](java/java-phase2-11004-handoff-scope.md) |
 | A3 | Build efficiency — reuse captured dependency data (no double resolution) | Delivered via A1 | US-1 |
@@ -68,9 +69,12 @@ Proposed) and is **not** part of the Main A completion gate. It is very
 likely not required for the initial pilot: the universal artifact-based
 capture path (`.class` + classpath JAR GitOID via treedb) already covers
 Ant and `make`/`javac` without a declared-graph adapter, and the Ivy/Bazel
-declared-graph adapters are post-pilot accuracy enrichments. The Ivy/Ant
-work (`tedg-dev/omnibor-analysis#201`) is parked as a draft with the
-`backlog` label. **Java delivery completion does not depend on A9.**
+declared-graph adapters are post-pilot accuracy enrichments. The parked
+work is `tedg-dev/omnibor-analysis#201` (Ivy parser, `backlog` label) and
+`#202` (tables non-Maven/Gradle for the pilot, `Proposed` label). The
+generic build-tool detection + shared treedb helper (#199/#200) is **pilot
+foundation** tracked in #11069 (AF), not under A9. **Java delivery
+completion does not depend on A9.**
 
 ### Main B — C/C++ Sidecar Design: Deep Investigation & Validation
 

--- a/docs/planning/github-issues-crosswalk.md
+++ b/docs/planning/github-issues-crosswalk.md
@@ -58,6 +58,12 @@ theme / planning doc) -> **sub-issues** (drafted in the matching planning doc).
 Index labels (**A1**, **A4**, ...) refer to the rows in
 [`README.md`](README.md), the priority-ordered planning index.
 
+**Documentation tracker:** docs-only PRs (e.g. `#192`, `#193`, `#195`,
+`#204`, `#205`, `#206`, `#207`) have no 1:1 theme issue; they are grouped
+under the living documentation tracker **#11071** (In Review), which each
+docs PR references with a `Part of` line. The tracker's status moves with
+docs activity and carries a datetimestamped activity log.
+
 ---
 
 ## Still open / not yet implemented (no PR)
@@ -79,10 +85,11 @@ Index labels (**A1**, **A4**, ...) refer to the rows in
 
 ## Issue structure notes
 
-The 13 themed issues (#11000–#11013) plus the pilot-foundation issue
-**#11069** (In Review, child of #11005) and the parentless A9 backlog
-issue **#11066** are live on the Corona project board (#255). Sub-issue
-parent links are established (#11069 → #11005; #11066 is intentionally
+The 13 themed issues (#11000–#11013), the pilot-foundation issue
+**#11069** (In Review, child of #11005), the parentless A9 backlog issue
+**#11066**, and the living documentation tracker **#11071** (In Review,
+parentless) are live on the Corona project board (#255). Sub-issue parent
+links are established (#11069 → #11005; #11066 and #11071 are intentionally
 parentless). Assignee: `tedg_cisco`.
 
 The current GitHub main issue structure (#11002, #11005, #11008) does not

--- a/docs/planning/github-issues-crosswalk.md
+++ b/docs/planning/github-issues-crosswalk.md
@@ -48,7 +48,7 @@ theme / planning doc) -> **sub-issues** (drafted in the matching planning doc).
 | `tedg-dev/omnibor-analysis#196` | Single-invocation Gradle dependency capture (US-2) | Phase 1 Build-Speed -> **A4** / US-2 | #11006 | Merged |
 | `tedg-dev/omnibor-analysis#200` | Java build-tool detection + `java_build_tool` override | Phase 1 Java capture -> **AF** (pilot foundation) | #11069 | Merged |
 | `tedg-dev/omnibor-analysis#199` | Shared `_generate_java_treedb` helper (DRY) | Phase 1 Java capture -> **AF** (pilot foundation) | #11069 | Merged |
-| `tedg-dev/omnibor-analysis#198` | Main A scope refinement + design draft | Java Main A scope (ref on #11002); foundation ref | #11069 | Merged |
+| `tedg-dev/omnibor-analysis#198` | Main A scope refinement + design draft | Java Main A scope (comment on #11002) | #11002 | Merged |
 | `tedg-dev/omnibor-analysis#204` | C/C++ sidecar docs consolidation + reorg | Planning / docs (Main B enablement) | — | Merged |
 | `tedg-dev/omnibor-analysis#195` | Java build-based SBOM sell doc + diagrams + planning reorg | Java Main A enablement (supporting docs) | — | Merged |
 | `tedg-dev/omnibor-analysis#193` | Phase 1 build-speed design consolidation | Phase 1 Build-Speed (Java) design reference | — | Merged |

--- a/docs/planning/github-issues-crosswalk.md
+++ b/docs/planning/github-issues-crosswalk.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Purpose** | Durable record tying each drafted Main issue and sub-issue to the PR(s) that implement it, so the hierarchy can be recreated and linked once GitHub Projects/Issues access is restored. |
 | **Maintained by** | Cascade (update as PRs merge) |
-| **Last updated** | 2026-07-02 |
+| **Last updated** | 2026-07-08 |
 
 ---
 
@@ -63,7 +63,7 @@ Index labels (**A1**, **A4**, ...) refer to the rows in
 |---|---|---|---|
 | Phase 2 output set + hand-off manifest | Java Phase 2 -> **A2** | #11004 (re-scoped) | Scoped, no PR |
 | In-memory JAR class processing (no extract-to-disk) | Phase 1 Build-Speed -> **A8** / US-4 | #11055 | Deferred (validate on EC2), no PR |
-| Support non-Maven/Gradle Java builds (Ant/Ivy, Bazel, `make`) | Phase 1 Java capture -> **A9** | — | Deferred / idle, no PR |
+| Support non-Maven/Gradle Java builds (Ant/Ivy, Bazel, `make`) | Phase 1 Java capture -> **A9** | #11066 (backlog, Proposed; parentless) | Backlog — **excluded from the Main A gate**. `tedg-dev/omnibor-analysis#202` (Draft, `Proposed` label — tables it for the pilot, fail-fast on ivy/ant/make/bazel); `#201` (Draft, `backlog` label — Ivy parser/reader) |
 | Overlap independent post-build steps (measure first) | Phase 1 Build-Speed -> **A5** / US-3 | #11007 | Optional / low, no PR |
 | Deliver Java build evidence to Corona | **A7** / SI-5 (Java) | — | Postponed — out of charter |
 | Agree on C/C++ build observation | Main B -> **B1** / SI-1 | #11009 | Blocked on Main A |
@@ -76,9 +76,10 @@ Index labels (**A1**, **A4**, ...) refer to the rows in
 
 ## Issue structure notes
 
-All 13 issues (#11000–#11013) are created and live on the Corona project
-board (#255). Sub-issue parent links are established. Assignee:
-`tedg_cisco`.
+The 13 themed issues (#11000–#11013) plus the parentless A9 backlog
+issue **#11066** are created and live on the Corona project board
+(#255). Sub-issue parent links are established (#11066 is intentionally
+parentless). Assignee: `tedg_cisco`.
 
 The current GitHub main issue structure (#11002, #11005, #11008) does not
 map 1:1 to the planning index's Main A / B / C. See the restructuring

--- a/docs/planning/github-issues-crosswalk.md
+++ b/docs/planning/github-issues-crosswalk.md
@@ -34,7 +34,7 @@ theme / planning doc) -> **sub-issues** (drafted in the matching planning doc).
 | Main issue (GitHub title) | Planning doc | Sub-issues | GitHub issue # |
 |---|---|---|---|
 | Java Phase 2: Generate SBOMs From Phase 1 Metadata Without the Source Tree | `java-phase2-consume-dep-capture-subissue.md` | A1 (#11003), A2 (#11004) | #11002 |
-| Phase 1 Build-Speed & Efficiency (Java) | `java/phase1-build-speed-subissues.md` | A4 (#11006), A5 (#11007) | #11005 |
+| Phase 1 Build-Speed & Efficiency (Java) | `java/phase1-build-speed-subissues.md` | AF (#11069), A4 (#11006), A5 (#11007) | #11005 |
 | Faster SBOM Generation for Java Builds (Retrospective) | `java/retro-subissue-java-treedb-perf.md` | SI-R1 | #11000 |
 | Build-Based SBOM Capture & Delivery (Sidecar + Phase Isolation) | `sidecar-phase-isolation-subissues.md` | B1 (#11009), B2 (#11010), B3 (#11011), B4 (#11012), C1/C2 (#11013) | #11008 |
 
@@ -46,6 +46,9 @@ theme / planning doc) -> **sub-issues** (drafted in the matching planning doc).
 |---|---|---|---|---|
 | `tedg-dev/omnibor-analysis#194` | Phase 2 generates SBOMs from Phase 1 metadata, no source tree | Java Phase 2 -> **A1** / SI-4 (Java) | #11003 | Merged |
 | `tedg-dev/omnibor-analysis#196` | Single-invocation Gradle dependency capture (US-2) | Phase 1 Build-Speed -> **A4** / US-2 | #11006 | Merged |
+| `tedg-dev/omnibor-analysis#200` | Java build-tool detection + `java_build_tool` override | Phase 1 Java capture -> **AF** (pilot foundation) | #11069 | Merged |
+| `tedg-dev/omnibor-analysis#199` | Shared `_generate_java_treedb` helper (DRY) | Phase 1 Java capture -> **AF** (pilot foundation) | #11069 | Merged |
+| `tedg-dev/omnibor-analysis#198` | Main A scope refinement + design draft | Java Main A scope (ref on #11002); foundation ref | #11069 | Merged |
 | `tedg-dev/omnibor-analysis#204` | C/C++ sidecar docs consolidation + reorg | Planning / docs (Main B enablement) | — | Merged |
 | `tedg-dev/omnibor-analysis#195` | Java build-based SBOM sell doc + diagrams + planning reorg | Java Main A enablement (supporting docs) | — | Merged |
 | `tedg-dev/omnibor-analysis#193` | Phase 1 build-speed design consolidation | Phase 1 Build-Speed (Java) design reference | — | Merged |
@@ -76,9 +79,10 @@ Index labels (**A1**, **A4**, ...) refer to the rows in
 
 ## Issue structure notes
 
-The 13 themed issues (#11000–#11013) plus the parentless A9 backlog
-issue **#11066** are created and live on the Corona project board
-(#255). Sub-issue parent links are established (#11066 is intentionally
+The 13 themed issues (#11000–#11013) plus the pilot-foundation issue
+**#11069** (In Review, child of #11005) and the parentless A9 backlog
+issue **#11066** are live on the Corona project board (#255). Sub-issue
+parent links are established (#11069 → #11005; #11066 is intentionally
 parentless). Assignee: `tedg_cisco`.
 
 The current GitHub main issue structure (#11002, #11005, #11008) does not


### PR DESCRIPTION
Part of CiscoSecurityServices/gambit#11071

## Summary

Planning-docs update: (1) reattribute the merged pilot foundation to its
own issue, and (2) mark A9 as backlog.

## Changes

- **Pilot foundation split (#11069):** the merged build-tool detection
  (`#200`) and shared `_generate_java_treedb` helper (`#199`) are
  reattributed from the tabled A9 issue to a new pilot-foundation issue
  **#11069** (In Review, sub-issue of #11005). Adds an **AF** row to the
  Main A index and PR-crosswalk rows for #198/#199/#200 (#198 mapped to
  its home issue #11002).
- **A9 -> backlog (#11066):** A9 row changed from "Drafting" to
  **Backlog** (parentless #11066, Proposed), **excluded from the Main A
  completion gate**; new A9-exclusion note explains the universal
  artifact path already covers Ant/`make`, that Ivy/Bazel adapters are
  post-pilot, and that the parked work is #201 (`backlog`) and #202
  (`Proposed`).
- **Crosswalk refresh:** last-updated date; #11005 sub-issues now list
  AF (#11069); the issue-structure note includes #11069 and #11066.

## Scope

Docs only — no code changes. CI `paths-ignore` skips `.md`-only diffs.
