### PR TITLE
feat(java): Phase 2 SBOM hand-off manifest (#11004)

### DIFF
--- a/app/pipeline/handoff.py
+++ b/app/pipeline/handoff.py
@@ -1,0 +1,317 @@
+"""
+Phase 2 SBOM hand-off manifest writer, reader, and verifier.
+
+The hand-off manifest (``sbom_handoff_manifest.json``) is a small,
+consumer-agnostic JSON index written at the root of a Phase 2 output
+run directory. It enumerates every SPDX document Phase 2 generated
+(one ``build`` / ``analyzed`` pair per production artifact) and makes
+the set independently verifiable via per-file digests, so any
+downstream consumer can ingest it without reading the source tree,
+the artifacts, or any omnibor-analysis internals.
+
+This module is deliberately **language-agnostic** (Java today,
+reusable by the C/C++ flow) and **config-driven** (no hardcoded
+paths). The producer-side output contract it implements is specified
+in ``docs/sidecar/java/phase2-handoff-contract.md``.
+
+Digest conventions (see the contract):
+
+  * ``sha256`` -- plain ``SHA-256`` hex over the file bytes.
+  * ``gitoid`` -- OmniBOR GitOID IRI ``gitoid:blob:sha256:<hex>``.
+
+Artifact digests are supplied by the caller (sourced from Phase 1
+metadata -- Phase 2 does not re-read the build workspace to compute
+them). SBOM-file digests are computed here over the files Phase 2
+just wrote. All hashing delegates to :mod:`app.spdx.identity` so
+there is a single identity/digest implementation across phases.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.spdx import identity
+
+
+HANDOFF_VERSION = "1.0"
+HANDOFF_FILENAME = "sbom_handoff_manifest.json"
+
+# Producer identity constants (this tool, this phase).
+PRODUCER_TOOL = "omnibor-analysis"
+PRODUCER_PHASE = "phase2"
+
+_REQUIRED_FIELDS = frozenset({
+    "version", "generated_ts", "producer", "repo_name",
+    "language", "commit_sha", "vcs_uri", "build_id", "sboms",
+})
+_REQUIRED_PRODUCER_FIELDS = frozenset({"tool", "phase", "mode"})
+_REQUIRED_SBOM_FIELDS = frozenset({"artifact", "build", "analyzed"})
+_REQUIRED_ARTIFACT_FIELDS = frozenset({"name", "sha256", "gitoid"})
+_REQUIRED_FILE_FIELDS = frozenset({"path", "sha256", "gitoid"})
+
+
+class HandoffError(Exception):
+    """Raised when hand-off manifest construction or validation fails."""
+
+
+def _relpath(target, base_dir):
+    """Return ``target`` as a path relative to ``base_dir``."""
+    return os.path.relpath(str(target), str(base_dir))
+
+
+def _file_record(file_path, manifest_dir):
+    """Build a ``{path, sha256, gitoid}`` record for an SBOM file.
+
+    The file must exist -- an offline enterprise run that produced no
+    SBOM must fail loudly rather than emit an unverifiable manifest.
+    """
+    p = Path(file_path)
+    if not p.is_file():
+        raise HandoffError(
+            f"SBOM file not found (cannot compute digest): {p}"
+        )
+    return {
+        "path": _relpath(p, manifest_dir),
+        "sha256": identity.raw_hash(p),
+        "gitoid": identity.gitoid(p),
+    }
+
+
+def _validate_artifact(artifact):
+    """Validate a caller-supplied ``artifact`` record."""
+    if not isinstance(artifact, dict):
+        raise HandoffError("sboms[].artifact must be a dict")
+    missing = _REQUIRED_ARTIFACT_FIELDS - set(artifact.keys())
+    if missing:
+        raise HandoffError(
+            f"artifact missing required fields: "
+            f"{', '.join(sorted(missing))}"
+        )
+    return {
+        "name": artifact["name"],
+        "sha256": artifact["sha256"],
+        "gitoid": artifact["gitoid"],
+    }
+
+
+def _build_sbom_entry(entry, manifest_dir):
+    """Build one validated ``sboms[]`` entry from a caller spec.
+
+    Expected input spec::
+
+        {
+          "artifact": {"name", "sha256", "gitoid"},  # from Phase 1
+          "build": <path to *_build.spdx.json>,
+          "analyzed": <path to *_analyzed.spdx.json>,
+        }
+    """
+    if not isinstance(entry, dict):
+        raise HandoffError("each sboms[] entry must be a dict")
+    missing = _REQUIRED_SBOM_FIELDS - set(entry.keys())
+    if missing:
+        raise HandoffError(
+            f"sboms[] entry missing required fields: "
+            f"{', '.join(sorted(missing))}"
+        )
+    return {
+        "artifact": _validate_artifact(entry["artifact"]),
+        "build": _file_record(entry["build"], manifest_dir),
+        "analyzed": _file_record(entry["analyzed"], manifest_dir),
+    }
+
+
+def write_handoff_manifest(
+    manifest_dir,
+    *,
+    repo_name,
+    language,
+    mode,
+    commit_sha,
+    vcs_uri,
+    build_id,
+    sboms,
+    source_manifest=None,
+    generated_ts=None,
+):
+    """Write ``sbom_handoff_manifest.json`` for a Phase 2 output run.
+
+    Args:
+        manifest_dir: Run directory; the manifest is written here and
+            all SBOM paths are recorded relative to it.
+        repo_name: Repository name.
+        language: Language string (e.g. ``"java"``).
+        mode: Execution mode (``"sidecar"`` or ``"standalone"``).
+        commit_sha: Source commit SHA.
+        vcs_uri: VCS location the source was obtained from.
+        build_id: Config-driven build / release identifier.
+        sboms: Iterable of entry specs, each with an ``artifact``
+            record (``name``/``sha256``/``gitoid`` from Phase 1) and
+            ``build`` / ``analyzed`` SBOM file paths.
+        source_manifest: Optional relative path to the
+            ``phase1_manifest.json`` this run consumed.
+        generated_ts: Optional ISO-8601 UTC timestamp; defaults to now.
+
+    Returns:
+        Path to the written manifest file.
+
+    Raises:
+        HandoffError: If ``sboms`` is empty or any entry is invalid or
+            references a missing SBOM file.
+    """
+    manifest_dir = Path(manifest_dir)
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+
+    entries = [_build_sbom_entry(e, manifest_dir) for e in sboms]
+    if not entries:
+        raise HandoffError("no SBOMs to record in hand-off manifest")
+
+    if generated_ts is None:
+        generated_ts = datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+    data = {
+        "version": HANDOFF_VERSION,
+        "generated_ts": generated_ts,
+        "producer": {
+            "tool": PRODUCER_TOOL,
+            "phase": PRODUCER_PHASE,
+            "mode": mode,
+        },
+        "repo_name": repo_name,
+        "language": language,
+        "commit_sha": commit_sha,
+        "vcs_uri": vcs_uri,
+        "build_id": build_id,
+        "sboms": entries,
+    }
+    if source_manifest is not None:
+        data["source_manifest"] = source_manifest
+
+    manifest_path = manifest_dir / HANDOFF_FILENAME
+    with open(manifest_path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, sort_keys=False)
+    return manifest_path
+
+
+def read_handoff_manifest(manifest_path):
+    """Read and validate a ``sbom_handoff_manifest.json``.
+
+    Args:
+        manifest_path: Path to the manifest file.
+
+    Returns:
+        Parsed manifest dict.
+
+    Raises:
+        FileNotFoundError: If the manifest file does not exist.
+        HandoffError: If the file is malformed or fails validation.
+    """
+    manifest_path = Path(manifest_path)
+    if not manifest_path.exists():
+        raise FileNotFoundError(
+            f"Hand-off manifest not found: {manifest_path}"
+        )
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError as e:
+        raise HandoffError(
+            f"Malformed JSON in hand-off manifest: {e}"
+        ) from e
+
+    _validate_manifest(data)
+    return data
+
+
+def verify_handoff_manifest(manifest, base_dir):
+    """Verify every SBOM file digest recorded in a loaded manifest.
+
+    Args:
+        manifest: Parsed manifest dict (from read_handoff_manifest).
+        base_dir: Directory the manifest's relative paths resolve
+            against (normally the manifest's own directory).
+
+    Returns:
+        Tuple ``(passed, failed)`` of relative SBOM paths. A path whose
+        file is missing is reported as failed.
+    """
+    base_dir = Path(base_dir)
+    passed = []
+    failed = []
+    for entry in manifest.get("sboms", []):
+        for role in ("build", "analyzed"):
+            record = entry.get(role, {})
+            rel = record.get("path")
+            if rel is None:
+                continue
+            fp = base_dir / rel
+            if not fp.is_file() or (
+                identity.raw_hash(fp) != record.get("sha256")
+            ):
+                failed.append(rel)
+            else:
+                passed.append(rel)
+    return passed, failed
+
+
+def _validate_manifest(data):
+    """Validate a parsed hand-off manifest dict."""
+    if not isinstance(data, dict):
+        raise HandoffError("Hand-off manifest must be a JSON object")
+
+    missing = _REQUIRED_FIELDS - set(data.keys())
+    if missing:
+        raise HandoffError(
+            f"Missing required fields: {', '.join(sorted(missing))}"
+        )
+    if data.get("version") != HANDOFF_VERSION:
+        raise HandoffError(
+            f"Unsupported hand-off manifest version: "
+            f"{data.get('version')} (expected {HANDOFF_VERSION})"
+        )
+
+    producer = data["producer"]
+    if not isinstance(producer, dict):
+        raise HandoffError("producer must be a dict")
+    prod_missing = _REQUIRED_PRODUCER_FIELDS - set(producer.keys())
+    if prod_missing:
+        raise HandoffError(
+            f"producer missing required fields: "
+            f"{', '.join(sorted(prod_missing))}"
+        )
+
+    sboms = data["sboms"]
+    if not isinstance(sboms, list) or not sboms:
+        raise HandoffError("sboms must be a non-empty list")
+    for entry in sboms:
+        _validate_sbom_entry(entry)
+
+
+def _validate_sbom_entry(entry):
+    """Validate one ``sboms[]`` entry from a loaded manifest."""
+    if not isinstance(entry, dict):
+        raise HandoffError("each sboms[] entry must be a dict")
+    missing = _REQUIRED_SBOM_FIELDS - set(entry.keys())
+    if missing:
+        raise HandoffError(
+            f"sboms[] entry missing required fields: "
+            f"{', '.join(sorted(missing))}"
+        )
+    art_missing = _REQUIRED_ARTIFACT_FIELDS - set(entry["artifact"])
+    if art_missing:
+        raise HandoffError(
+            f"artifact missing required fields: "
+            f"{', '.join(sorted(art_missing))}"
+        )
+    for role in ("build", "analyzed"):
+        rec = entry[role]
+        if not isinstance(rec, dict):
+            raise HandoffError(f"sboms[].{role} must be a dict")
+        file_missing = _REQUIRED_FILE_FIELDS - set(rec.keys())
+        if file_missing:
+            raise HandoffError(
+                f"sboms[].{role} missing required fields: "
+                f"{', '.join(sorted(file_missing))}"
+            )

--- a/app/pipeline/lang_runners.py
+++ b/app/pipeline/lang_runners.py
@@ -15,7 +15,10 @@ import sys
 from pathlib import Path
 
 from app.config import lang_subdir
+from app.pipeline import handoff
 from app.pipeline.timing import StepTimer, TimingResult
+from app.spdx import identity
+from app.spdx.identity import IDENTITY_INDEX_FILENAME
 
 logger = logging.getLogger(__name__)
 
@@ -361,11 +364,15 @@ def run_java_phase2(
     pipeline, repo_name, repo_cfg,
     paths_cfg, omnibor_java_cfg, run_ts,
     vcs_uri="NOASSERTION",
+    commit_sha="NOASSERTION",
+    mode="standalone",
+    build_id=None,
 ):
     """Java Phase 2: SPDX generation + validation.
 
     Runs post-build analysis: OmniBOR SBOM, metadata,
-    per-binary SPDX, validation, binary collection.
+    per-binary SPDX, validation, binary collection, and the
+    Phase 2 SBOM hand-off manifest.
 
     Returns list of ``StepMetrics``.
     """
@@ -384,6 +391,9 @@ def run_java_phase2(
                 repo_name, repo_cfg,
                 paths_cfg, run_ts,
                 vcs_uri=vcs_uri,
+                commit_sha=commit_sha,
+                mode=mode,
+                build_id=build_id,
             )
         ),
     )
@@ -394,6 +404,7 @@ def run_java_pipeline(
     paths_cfg, omnibor_java_cfg, run_ts,
     vcs_uri="NOASSERTION",
     mode="standalone",
+    commit_sha="NOASSERTION",
 ):
     """Java pipeline: build + SPDX generation.
 
@@ -419,6 +430,8 @@ def run_java_pipeline(
             pipeline, repo_name, repo_cfg,
             paths_cfg, omnibor_java_cfg, run_ts,
             vcs_uri=vcs_uri,
+            commit_sha=commit_sha,
+            mode=mode,
         )
     )
     return timing
@@ -449,9 +462,75 @@ def _find_module_dir(jar_path):
     return None
 
 
+def _jar_artifact_record(index, jar_path, bin_name):
+    """Resolve a JAR's OmniBOR identity for the hand-off manifest.
+
+    Prefers the Phase-1 identity index (canonical, works offline);
+    falls back to reading the JAR when it is still on disk (co-located
+    run). Returns a ``{name, sha256, gitoid}`` record, or ``None`` when
+    identity is unavailable (offline Phase 2 with no index entry).
+    """
+    record = identity.identity_for_basename(index, bin_name)
+    if record is not None:
+        return {
+            "name": bin_name,
+            "sha256": record["raw"],
+            "gitoid": record["gitoid"],
+        }
+    ident = identity.try_from_file(jar_path)
+    if ident is not None:
+        return {
+            "name": bin_name,
+            "sha256": ident.raw,
+            "gitoid": ident.gitoid,
+        }
+    return None
+
+
+def _emit_handoff_manifest(
+    spdx_dir, repo_name, lang, mode,
+    commit_sha, vcs_uri, build_id, sboms,
+):
+    """Write the Phase 2 SBOM hand-off manifest for a Java run.
+
+    The manifest is a consumer-agnostic output descriptor enumerating
+    every generated SBOM pair (see
+    ``docs/sidecar/java/phase2-handoff-contract.md``). A run that
+    produced no complete pair writes no manifest.
+    """
+    if not sboms:
+        print(
+            f"[WARN] {repo_name}: no complete SBOM pairs — "
+            f"hand-off manifest not written"
+        )
+        return None
+    try:
+        path = handoff.write_handoff_manifest(
+            spdx_dir,
+            repo_name=repo_name,
+            language=lang,
+            mode=mode,
+            commit_sha=commit_sha,
+            vcs_uri=vcs_uri,
+            build_id=build_id,
+            sboms=sboms,
+        )
+    except handoff.HandoffError as exc:
+        print(f"[ERROR] hand-off manifest not written: {exc}")
+        return None
+    print(
+        f"[OK] Hand-off manifest: {path} "
+        f"({len(sboms)} artifact(s))"
+    )
+    return path
+
+
 def generate_java_adg_spdx(
     repo_name, repo_cfg, paths_cfg, run_ts,
     vcs_uri="NOASSERTION",
+    commit_sha="NOASSERTION",
+    mode="standalone",
+    build_id=None,
 ):
     """Generate per-binary Java SPDX.
 
@@ -577,7 +656,16 @@ def generate_java_adg_spdx(
     capture = load_capture(bom_dir)
     source_present = repo_dir.exists()
 
+    # Phase-1 identity index: canonical source for each JAR's raw
+    # SHA-256 + gitOID in the hand-off manifest (works offline, no
+    # workspace re-read). Empty when absent; a co-located fallback
+    # reads the JAR directly (see _jar_artifact_record).
+    identity_index = identity.read_identity_index(
+        bom_dir / "metadata" / "bomsh" / IDENTITY_INDEX_FILENAME
+    )
+
     results = []
+    sboms = []
     for jar_path in jar_paths:
         jar_name = jar_path.stem  # e.g. jsoup-1.22.1
         bin_name = jar_path.name  # e.g. jsoup-1.22.1.jar
@@ -664,8 +752,11 @@ def generate_java_adg_spdx(
             plugin_detection=plugin_result,
             jar_path=str(jar_path),
         )
+        analyzed_ok = bool(result)
         if result:
             results.append(result)
+
+        build_written = False
 
         # Build: full dependency graph for this module, from the
         # captured metadata (build_deps) or the co-located live
@@ -685,9 +776,33 @@ def generate_java_adg_spdx(
                 plugin_detection=plugin_result,
                 jar_path=str(jar_path),
             )
+            build_written = bool(result)
             if result:
                 results.append(result)
 
+        # Record this JAR in the hand-off manifest only when the full
+        # build + analyzed pair was written (the contract requires
+        # both per artifact).
+        if analyzed_ok and build_written:
+            artifact = _jar_artifact_record(
+                identity_index, jar_path, bin_name,
+            )
+            if artifact is not None:
+                sboms.append({
+                    "artifact": artifact,
+                    "analyzed": str(analyzed_path),
+                    "build": str(build_path),
+                })
+            else:
+                print(
+                    f"[WARN] {bin_name}: no OmniBOR identity "
+                    f"available; omitted from hand-off manifest"
+                )
+
+    _emit_handoff_manifest(
+        spdx_dir, repo_name, lang, mode, commit_sha,
+        vcs_uri, build_id or run_ts, sboms,
+    )
     return results
 
 

--- a/app/pipeline/manifest.py
+++ b/app/pipeline/manifest.py
@@ -12,9 +12,10 @@ artifacts without needing config.yaml or the source tree.
 Standalone and Sidecar full modes do not use the manifest.
 """
 
-import hashlib
 import json
 from pathlib import Path
+
+from app.spdx import identity
 
 
 MANIFEST_VERSION = "1.0"
@@ -254,12 +255,11 @@ def _compute_gitoids(artifacts):
 
 
 def _sha256_gitoid(file_path):
-    """Compute SHA-256 gitoid for a file.
+    """Compute the bare git-blob SHA-256 gitoid hex for a file.
 
-    GitOID format: ``blob <size>\\0<content>``
-    hashed with SHA-256.
+    Delegates to :mod:`app.spdx.identity` so a single git-blob /
+    SHA-256 implementation is shared across Phase 1 and Phase 2.
+    Returns bare hex (the Phase 1 manifest stores gitoids without
+    the ``gitoid:blob:sha256:`` IRI prefix).
     """
-    file_path = Path(file_path)
-    content = file_path.read_bytes()
-    header = f"blob {len(content)}\0".encode("ascii")
-    return hashlib.sha256(header + content).hexdigest()
+    return identity.gitoid_hex(file_path)

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -260,6 +260,7 @@ def main():
                 paths_cfg, omnibor_cfg, run_ts,
                 vcs_uri=vcs_uri,
                 mode=mode,
+                commit_sha=commit_sha,
             )
     else:
         timing = run_go_pipeline(
@@ -512,6 +513,8 @@ def _run_phase2_only(
     )
     m_vcs = manifest.get("vcs_uri", vcs_uri)
     m_ts = manifest.get("run_ts", run_ts)
+    m_commit = manifest.get("commit_sha") or "NOASSERTION"
+    m_mode = manifest.get("mode", "sidecar")
     tracer = manifest.get("tracer", "unknown")
 
     timing = TimingResult(tracer=tracer)
@@ -521,6 +524,8 @@ def _run_phase2_only(
         pipeline, repo_name, m_repo_cfg,
         paths_cfg, m_omnibor, m_ts,
         vcs_uri=m_vcs,
+        commit_sha=m_commit,
+        mode=m_mode,
     )
     timing.steps.extend(phase2_steps)
     return timing

--- a/app/spdx/identity.py
+++ b/app/spdx/identity.py
@@ -251,3 +251,37 @@ def write_identity_index(paths, out_path, algo=DEFAULT_ALGO):
         encoding="utf-8",
     )
     return len(index)
+
+
+def read_identity_index(path):
+    """Load a Phase-1 identity index written by :func:`write_identity_index`.
+
+    Returns the ``{artifact_path: {algo, raw, gitoid}}`` mapping, or an
+    empty dict if the index is absent or unreadable (an offline Phase 2
+    with no index simply has no pre-computed identities).
+    """
+    import json
+
+    p = Path(path)
+    if not p.is_file():
+        return {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def identity_for_basename(index, name):
+    """Return the identity record for artifact file ``name``.
+
+    The index is keyed by absolute build-time paths; matching by
+    basename tolerates path-prefix differences between the build host
+    and the analysis host. Returns the record dict (``algo``/``raw``/
+    ``gitoid``) or ``None`` if no path matches.
+    """
+    suffix = f"/{name}"
+    for key, record in index.items():
+        if key == name or key.endswith(suffix):
+            return record
+    return None

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -1,0 +1,299 @@
+"""Tests for the Phase 2 SBOM hand-off manifest module."""
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.pipeline import handoff
+from app.spdx import identity
+
+
+def _write(path, text):
+    """Write text to path, creating parents."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _artifact(name="app-1.0.0.jar"):
+    """A caller-supplied artifact record (Phase 1 sourced)."""
+    return {
+        "name": name,
+        "sha256": "a" * 64,
+        "gitoid": "gitoid:blob:sha256:" + ("b" * 64),
+    }
+
+
+class _HandoffBase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.run_dir = Path(self._tmp.name)
+        self.build = _write(
+            self.run_dir / "app-1.0.0_build.spdx.json",
+            '{"spdxVersion": "SPDX-2.3", "kind": "build"}',
+        )
+        self.analyzed = _write(
+            self.run_dir / "app-1.0.0_analyzed.spdx.json",
+            '{"spdxVersion": "SPDX-2.3", "kind": "analyzed"}',
+        )
+
+    def _sboms(self):
+        return [{
+            "artifact": _artifact(),
+            "build": str(self.build),
+            "analyzed": str(self.analyzed),
+        }]
+
+    def _write_default(self, **overrides):
+        kwargs = {
+            "repo_name": "app",
+            "language": "java",
+            "mode": "sidecar",
+            "commit_sha": "0" * 40,
+            "vcs_uri": "https://example.com/app.git",
+            "build_id": "2026-07-10_1200",
+            "sboms": self._sboms(),
+        }
+        kwargs.update(overrides)
+        return handoff.write_handoff_manifest(self.run_dir, **kwargs)
+
+
+class TestWriteHandoffManifest(_HandoffBase):
+    def test_writes_expected_filename(self):
+        path = self._write_default()
+        self.assertEqual(path.name, handoff.HANDOFF_FILENAME)
+        self.assertTrue(path.is_file())
+
+    def test_top_level_fields(self):
+        data = json.loads(self._write_default().read_text())
+        self.assertEqual(data["version"], handoff.HANDOFF_VERSION)
+        self.assertEqual(data["repo_name"], "app")
+        self.assertEqual(data["language"], "java")
+        self.assertEqual(data["commit_sha"], "0" * 40)
+        self.assertEqual(data["build_id"], "2026-07-10_1200")
+        self.assertIn("generated_ts", data)
+
+    def test_producer_block(self):
+        data = json.loads(self._write_default().read_text())
+        self.assertEqual(data["producer"], {
+            "tool": handoff.PRODUCER_TOOL,
+            "phase": handoff.PRODUCER_PHASE,
+            "mode": "sidecar",
+        })
+
+    def test_artifact_passthrough(self):
+        data = json.loads(self._write_default().read_text())
+        art = data["sboms"][0]["artifact"]
+        self.assertEqual(art, _artifact())
+
+    def test_sbom_paths_are_relative(self):
+        data = json.loads(self._write_default().read_text())
+        entry = data["sboms"][0]
+        self.assertEqual(
+            entry["build"]["path"], "app-1.0.0_build.spdx.json",
+        )
+        self.assertEqual(
+            entry["analyzed"]["path"],
+            "app-1.0.0_analyzed.spdx.json",
+        )
+
+    def test_sbom_digests_match_bytes(self):
+        data = json.loads(self._write_default().read_text())
+        rec = data["sboms"][0]["build"]
+        self.assertEqual(rec["sha256"], identity.raw_hash(self.build))
+        self.assertEqual(rec["gitoid"], identity.gitoid(self.build))
+
+    def test_explicit_generated_ts(self):
+        data = json.loads(
+            self._write_default(generated_ts="2020-01-01T00:00:00Z")
+            .read_text()
+        )
+        self.assertEqual(
+            data["generated_ts"], "2020-01-01T00:00:00Z",
+        )
+
+    def test_source_manifest_included(self):
+        data = json.loads(
+            self._write_default(source_manifest="phase1_manifest.json")
+            .read_text()
+        )
+        self.assertEqual(
+            data["source_manifest"], "phase1_manifest.json",
+        )
+
+    def test_source_manifest_omitted_by_default(self):
+        data = json.loads(self._write_default().read_text())
+        self.assertNotIn("source_manifest", data)
+
+    def test_creates_manifest_dir(self):
+        nested = self.run_dir / "sub" / "run"
+        path = handoff.write_handoff_manifest(
+            nested,
+            repo_name="app", language="java", mode="sidecar",
+            commit_sha="0" * 40, vcs_uri="x", build_id="b",
+            sboms=self._sboms(),
+        )
+        self.assertTrue(path.is_file())
+
+
+class TestWriteHandoffErrors(_HandoffBase):
+    def test_empty_sboms_raises(self):
+        with self.assertRaises(handoff.HandoffError):
+            self._write_default(sboms=[])
+
+    def test_missing_build_file_raises(self):
+        sboms = self._sboms()
+        sboms[0]["build"] = str(self.run_dir / "nope.spdx.json")
+        with self.assertRaises(handoff.HandoffError):
+            self._write_default(sboms=sboms)
+
+    def test_entry_not_dict_raises(self):
+        with self.assertRaises(handoff.HandoffError):
+            self._write_default(sboms=["not-a-dict"])
+
+    def test_entry_missing_field_raises(self):
+        with self.assertRaises(handoff.HandoffError):
+            self._write_default(sboms=[{"artifact": _artifact()}])
+
+    def test_artifact_not_dict_raises(self):
+        sboms = self._sboms()
+        sboms[0]["artifact"] = "nope"
+        with self.assertRaises(handoff.HandoffError):
+            self._write_default(sboms=sboms)
+
+    def test_artifact_missing_field_raises(self):
+        sboms = self._sboms()
+        sboms[0]["artifact"] = {"name": "x"}
+        with self.assertRaises(handoff.HandoffError):
+            self._write_default(sboms=sboms)
+
+
+class TestReadHandoffManifest(_HandoffBase):
+    def test_round_trip(self):
+        path = self._write_default()
+        data = handoff.read_handoff_manifest(path)
+        self.assertEqual(data["repo_name"], "app")
+        self.assertEqual(len(data["sboms"]), 1)
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            handoff.read_handoff_manifest(
+                self.run_dir / "absent.json"
+            )
+
+    def test_malformed_json_raises(self):
+        bad = _write(self.run_dir / "bad.json", "{not json")
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(bad)
+
+    def _write_raw(self, obj):
+        p = self.run_dir / handoff.HANDOFF_FILENAME
+        p.write_text(json.dumps(obj), encoding="utf-8")
+        return p
+
+    def test_non_object_raises(self):
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw([1, 2]))
+
+    def test_missing_top_field_raises(self):
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(
+                self._write_raw({"version": "1.0"})
+            )
+
+    def test_bad_version_raises(self):
+        good = json.loads(self._write_default().read_text())
+        good["version"] = "9.9"
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw(good))
+
+    def test_producer_not_dict_raises(self):
+        good = json.loads(self._write_default().read_text())
+        good["producer"] = "nope"
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw(good))
+
+    def test_producer_missing_field_raises(self):
+        good = json.loads(self._write_default().read_text())
+        good["producer"] = {"tool": "x"}
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw(good))
+
+    def test_sboms_not_list_raises(self):
+        good = json.loads(self._write_default().read_text())
+        good["sboms"] = {}
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw(good))
+
+    def test_entry_missing_field_raises(self):
+        good = json.loads(self._write_default().read_text())
+        good["sboms"] = [{"artifact": _artifact()}]
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw(good))
+
+    def test_entry_not_dict_raises(self):
+        good = json.loads(self._write_default().read_text())
+        good["sboms"] = ["nope"]
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw(good))
+
+    def test_artifact_missing_field_raises(self):
+        good = json.loads(self._write_default().read_text())
+        good["sboms"][0]["artifact"] = {"name": "x"}
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw(good))
+
+    def test_file_record_not_dict_raises(self):
+        good = json.loads(self._write_default().read_text())
+        good["sboms"][0]["build"] = "nope"
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw(good))
+
+    def test_file_record_missing_field_raises(self):
+        good = json.loads(self._write_default().read_text())
+        good["sboms"][0]["build"] = {"path": "x"}
+        with self.assertRaises(handoff.HandoffError):
+            handoff.read_handoff_manifest(self._write_raw(good))
+
+
+class TestVerifyHandoffManifest(_HandoffBase):
+    def test_all_pass(self):
+        data = handoff.read_handoff_manifest(self._write_default())
+        passed, failed = handoff.verify_handoff_manifest(
+            data, self.run_dir,
+        )
+        self.assertEqual(sorted(passed), [
+            "app-1.0.0_analyzed.spdx.json",
+            "app-1.0.0_build.spdx.json",
+        ])
+        self.assertEqual(failed, [])
+
+    def test_missing_file_fails(self):
+        data = handoff.read_handoff_manifest(self._write_default())
+        self.build.unlink()
+        passed, failed = handoff.verify_handoff_manifest(
+            data, self.run_dir,
+        )
+        self.assertIn("app-1.0.0_build.spdx.json", failed)
+        self.assertIn("app-1.0.0_analyzed.spdx.json", passed)
+
+    def test_tampered_file_fails(self):
+        data = handoff.read_handoff_manifest(self._write_default())
+        self.build.write_text("TAMPERED", encoding="utf-8")
+        passed, failed = handoff.verify_handoff_manifest(
+            data, self.run_dir,
+        )
+        self.assertIn("app-1.0.0_build.spdx.json", failed)
+
+    def test_missing_path_key_skipped(self):
+        passed, failed = handoff.verify_handoff_manifest(
+            {"sboms": [{"build": {}, "analyzed": {}}]},
+            self.run_dir,
+        )
+        self.assertEqual((passed, failed), ([], []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -286,6 +286,64 @@ class TestSpdx23FileChecksums(unittest.TestCase):
         )
 
 
+class TestReadIdentityIndex(unittest.TestCase):
+    """Tests for identity.read_identity_index."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+
+    def test_missing_returns_empty(self):
+        self.assertEqual(
+            identity.read_identity_index(self.tmp / "absent.json"),
+            {},
+        )
+
+    def test_valid_returns_mapping(self):
+        p = self.tmp / "idx.json"
+        p.write_text(
+            json.dumps({"/a/x.jar": {"raw": "r", "gitoid": "g"}}),
+            encoding="utf-8",
+        )
+        idx = identity.read_identity_index(p)
+        self.assertEqual(idx["/a/x.jar"]["gitoid"], "g")
+
+    def test_non_dict_returns_empty(self):
+        p = self.tmp / "list.json"
+        p.write_text(json.dumps([1, 2]), encoding="utf-8")
+        self.assertEqual(identity.read_identity_index(p), {})
+
+    def test_malformed_returns_empty(self):
+        p = self.tmp / "bad.json"
+        p.write_text("{not json", encoding="utf-8")
+        self.assertEqual(identity.read_identity_index(p), {})
+
+
+class TestIdentityForBasename(unittest.TestCase):
+    """Tests for identity.identity_for_basename."""
+
+    def test_exact_key_match(self):
+        idx = {"app.jar": {"raw": "r"}}
+        self.assertEqual(
+            identity.identity_for_basename(idx, "app.jar"),
+            {"raw": "r"},
+        )
+
+    def test_suffix_match(self):
+        idx = {"/build/libs/app.jar": {"raw": "r"}}
+        self.assertEqual(
+            identity.identity_for_basename(idx, "app.jar")["raw"],
+            "r",
+        )
+
+    def test_no_match_returns_none(self):
+        idx = {"/build/libs/other.jar": {"raw": "r"}}
+        self.assertIsNone(
+            identity.identity_for_basename(idx, "app.jar")
+        )
+
+
 class TestModuleConstants(unittest.TestCase):
     """Module-level defaults align with the design of record."""
 

--- a/tests/test_java_pipeline.py
+++ b/tests/test_java_pipeline.py
@@ -1112,5 +1112,100 @@ class TestPhase1IdentityIndex(unittest.TestCase):
             mock_persist.assert_not_called()
 
 
+class TestHandoffManifestHelpers(unittest.TestCase):
+    """Tests for the Phase 2 hand-off manifest helpers."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+
+    def test_artifact_record_from_index(self):
+        from app.pipeline.lang_runners import _jar_artifact_record
+
+        index = {
+            "/build/libs/app.jar": {
+                "raw": "r" * 64,
+                "gitoid": "gitoid:blob:sha256:" + "g" * 64,
+            },
+        }
+        rec = _jar_artifact_record(
+            index, self.tmp / "app.jar", "app.jar",
+        )
+        self.assertEqual(rec["sha256"], "r" * 64)
+        self.assertEqual(
+            rec["gitoid"], "gitoid:blob:sha256:" + "g" * 64,
+        )
+
+    def test_artifact_record_file_fallback(self):
+        from app.pipeline.lang_runners import _jar_artifact_record
+        from app.spdx import identity
+
+        jar = self.tmp / "app.jar"
+        jar.write_bytes(b"PK\x03\x04payload")
+        rec = _jar_artifact_record({}, jar, "app.jar")
+        self.assertEqual(rec["sha256"], identity.raw_hash(jar))
+        self.assertEqual(rec["gitoid"], identity.gitoid(jar))
+
+    def test_artifact_record_unavailable(self):
+        from app.pipeline.lang_runners import _jar_artifact_record
+
+        rec = _jar_artifact_record(
+            {}, self.tmp / "gone.jar", "gone.jar",
+        )
+        self.assertIsNone(rec)
+
+    def test_emit_empty_sboms_returns_none(self):
+        from app.pipeline.lang_runners import _emit_handoff_manifest
+
+        result = _emit_handoff_manifest(
+            self.tmp, "app", "java", "sidecar",
+            "sha", "vcs", "bid", [],
+        )
+        self.assertIsNone(result)
+
+    def test_emit_success_writes_manifest(self):
+        from app.pipeline.lang_runners import _emit_handoff_manifest
+        from app.pipeline import handoff
+
+        build = self.tmp / "app_build.spdx.json"
+        analyzed = self.tmp / "app_analyzed.spdx.json"
+        build.write_text("{}", encoding="utf-8")
+        analyzed.write_text("{}", encoding="utf-8")
+        sboms = [{
+            "artifact": {
+                "name": "app.jar",
+                "sha256": "r" * 64,
+                "gitoid": "gitoid:blob:sha256:" + "g" * 64,
+            },
+            "build": str(build),
+            "analyzed": str(analyzed),
+        }]
+        path = _emit_handoff_manifest(
+            self.tmp, "app", "java", "sidecar",
+            "sha", "vcs", "bid", sboms,
+        )
+        self.assertEqual(path.name, handoff.HANDOFF_FILENAME)
+        data = handoff.read_handoff_manifest(path)
+        self.assertEqual(data["build_id"], "bid")
+        self.assertEqual(data["producer"]["mode"], "sidecar")
+
+    def test_emit_handoff_error_returns_none(self):
+        from app.pipeline.lang_runners import _emit_handoff_manifest
+        from app.pipeline import handoff
+
+        sboms = [{"artifact": {}, "build": "x", "analyzed": "y"}]
+        with patch(
+            "app.pipeline.lang_runners.handoff."
+            "write_handoff_manifest",
+            side_effect=handoff.HandoffError("boom"),
+        ):
+            result = _emit_handoff_manifest(
+                self.tmp, "app", "java", "sidecar",
+                "sha", "vcs", "bid", sboms,
+            )
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements the **Phase 2 SBOM hand-off manifest** for Java (`#11004`),
the consumer-agnostic output descriptor specified in
`docs/sidecar/java/phase2-handoff-contract.md` (schema v1.0). Every
Java Phase 2 run now writes `sbom_handoff_manifest.json` alongside the
generated SPDX documents, enumerating each production artifact's
`build`/`analyzed` SPDX pair and making the set independently
verifiable via per-file digests.

## What changed

- **`app/pipeline/handoff.py`** (new): `write_handoff_manifest`,
  `read_handoff_manifest`, `verify_handoff_manifest`, full schema
  validation. Language-agnostic and config-driven. Loud failure on
  empty input or a missing SBOM file.
- **`generate_java_adg_spdx`**: collects each JAR's SBOM pair and emits
  the manifest. Artifact identity (raw SHA-256 + gitOID) is sourced
  from the Phase-1 identity index (offline-safe), with a co-located
  JAR-read fallback. `commit_sha`/`mode`/`build_id` threaded through
  `run_java_phase2`/`run_java_pipeline` and both `runners.py` entry
  points (full pipeline + offline `--phase spdx`).
- **`app/spdx/identity.py`**: `read_identity_index` +
  `identity_for_basename` (identity.py owns the index format).
- **DRY**: all hashing delegates to `app/spdx/identity.py`; no new
  `digests.py` — `manifest.py` now delegates its git-blob hash there
  too, so there is a single digest implementation across phases.

## Verification

- Full suite: **1703 passed / 75 skipped**; flake8 clean.
- Coverage: `handoff.py` 100%, `identity.py` 100%,
  `manifest.py`/`lang_runners.py` 98%, overall 98%.
- **EC2 end-to-end** (sidecar, `omnibor-java-testapp`): manifest
  produced and validated; `verify_handoff_manifest` 0 failures;
  manifest artifact gitoid matches the SPDX root-package gitoid for
  both `build` and `analyzed`.
- **Golden diff: CLEAN** — SPDX output is structurally identical to
  golden (the manifest is a new file; SPDX content is unchanged). No
  golden update required.

## Notes

- Output matches the published contract schema exactly (`producer`,
  `sboms[].artifact{name,sha256,gitoid}`, `build`/`analyzed`
  `{path,sha256,gitoid}`, gitoid IRI form, plain sha256).
- Manifest emission degrades gracefully: no complete pair -> no
  manifest (warn); `HandoffError` -> logged, run continues.

Closes #11004
