### PR TITLE
docs(workflow): GitHub issue-management conventions + planning index update

### DIFF
--- a/.windsurf/rules/workflow/github-issue-management.md
+++ b/.windsurf/rules/workflow/github-issue-management.md
@@ -1,0 +1,190 @@
+---
+description: GitHub issue management conventions (account, parent/sub-issue status pairing, Walk assignment, planning-doc sync, new-work sub-issues, epic assignment)
+---
+
+# GitHub Issue Management
+
+Conventions for managing the gambit issue tracker and the Corona project
+board. These are mandatory and complement `../github-sync.md` (which
+covers keeping issue *content* accurate) and `pr-workflow.md` (PRs).
+
+---
+
+## 1. Account and Location
+
+- **Issues** live under `CiscoSecurityServices/gambit` on github.com
+  (migrated from the former `tedg-cisco` org).
+- **All issue operations** (view, edit, status, labels, project board)
+  MUST use the `gh` account `tedg_cisco`. The default active account
+  `tedg-dev` CANNOT resolve the gambit repo. Before any `gh issue` or
+  `gh api .../gambit/...` call, run:
+
+  ```bash
+  gh auth switch --user tedg_cisco
+  ```
+
+- **PRs** live in `tedg-dev/omnibor-analysis` and use the `tedg-dev`
+  account. Always reference PRs cross-repo as
+  `tedg-dev/omnibor-analysis#<n>` — never a bare `#<n>`.
+- **Project board:** Corona, project number `255`, node id
+  `PVT_kwDOEFp5Ds4Bb7Wk`.
+- **Status field** id `PVTSSF_lADOEFp5Ds4Bb7WkzhWoAck`, single-select
+  options:
+
+  | Status | Option id |
+  |--------|-----------|
+  | Proposed | `eda0e242` |
+  | Ready | `aa3a0c5a` |
+  | In Development | `91c2dd1e` |
+  | Blocked | `e3d7f4ba` |
+  | In Review | `e524005e` |
+  | Ready to Demo | `808db7d3` |
+  | Done | `98236657` |
+
+  Status ordering (least → most advanced): Proposed → Ready →
+  In Development → In Review → Ready to Demo → Done (Blocked is
+  orthogonal). "In Progress" is not a board status — it means
+  **In Development**.
+
+- **Epic** is the single-select field, id
+  `PVTSSF_lADOEFp5Ds4Bb7WkzhWoAdU`; the option `Build-Instrumented SBOM`
+  has id `e3a04db3` (note the option name is singular "SBOM"). See §5
+  for the mandatory epic-assignment rule. Assign with the status command
+  form below, substituting the Epic field id and option id.
+
+- **Walk** is the sprint/iteration field, id
+  `PVTIF_lADOEFp5Ds4Bb7WkzhWoNhw` (type iteration). The **current Walk**
+  is the iteration whose date range includes today. List iterations
+  with:
+
+  ```bash
+  gh api graphql -f query='query{node(id:"PVTIF_lADOEFp5Ds4Bb7WkzhWoNhw"){... on ProjectV2IterationField{configuration{iterations{id title startDate duration}}}}}'
+  ```
+
+  The first entry in `configuration.iterations` is the current/active
+  Walk (completed Walks live under `completedIterations`). Assign an
+  item to a Walk with:
+
+  ```bash
+  gh project item-edit --project-id PVT_kwDOEFp5Ds4Bb7Wk \
+    --id <PVTI_item_id> \
+    --field-id PVTIF_lADOEFp5Ds4Bb7WkzhWoNhw \
+    --iteration-id <iteration_id>
+  ```
+
+  Set status with:
+
+  ```bash
+  gh project item-edit --project-id PVT_kwDOEFp5Ds4Bb7Wk \
+    --id <PVTI_item_id> \
+    --field-id PVTSSF_lADOEFp5Ds4Bb7WkzhWoAck \
+    --single-select-option-id <option_id>
+  ```
+
+  The per-issue `PVTI_...` item id comes from
+  `gh project item-list 255 --owner CiscoSecurityServices --format json`
+  filtered by `.content.number`.
+
+---
+
+## 2. Parent / Sub-Issue Status Pairing (MANDATORY)
+
+Parent issues MUST always be kept in sync with their sub-issues'
+statuses. There is NO convention of leaving a parent behind while its
+children advance. The parent's status is **derived** from the aggregate
+of its sub-issue statuses:
+
+- **As soon as ANY sub-issue reaches `Ready` or `In Development`**, the
+  parent MUST be at least `Ready`.
+- **Once the LAST sub-issue reaches `In Development`** (i.e. EVERY
+  sub-issue is at `In Development` or beyond — `In Review`,
+  `Ready to Demo`, `Done`), the parent MUST move to `In Development`.
+
+In other words: the parent sits at `In Development` only when no
+sub-issue is still below `In Development` (nothing left at `Proposed`
+or `Ready`); otherwise, if at least one sub-issue is `Ready`/`In
+Development`, the parent sits at `Ready`.
+
+**Walk assignment on transition to In Development.** Whenever ANY issue
+or sub-issue reaches `In Development` — whether moved up from `Ready` or
+created directly at `In Development` (see §4) — it MUST be assigned to
+the **current Walk** (the active iteration of the `Walk` field) in the
+same turn. This applies to parents too: when the parent-pairing rule
+above moves a parent to `In Development`, assign that parent to the
+current Walk as well. Use the Walk assignment command in §1.
+
+**Whenever you change a sub-issue's status, re-evaluate and update the
+parent in the same turn.** Verify the true sub-issue set from GitHub —
+not a planning doc — via:
+
+```bash
+gh api graphql -f query='query{repository(owner:"CiscoSecurityServices",name:"gambit"){issue(number:<PARENT>){subIssues(first:50){nodes{number title state}}}}}'
+```
+
+Combine that with the board statuses from `gh project item-list` to
+compute the correct parent status.
+
+---
+
+## 3. Planning Documents Must Stay Current (MANDATORY)
+
+Every document under `docs/planning/` — especially
+`docs/planning/github-issues-crosswalk.md` and
+`docs/planning/README.md` — MUST be kept up to date whenever issues,
+sub-issues, PRs, or statuses change. The crosswalk is the single source
+that maps each Main issue and sub-issue to its implementing PR(s) and
+GitHub number.
+
+When any of the following happen, update the relevant planning doc(s)
+in the same turn (and same PR when code is involved):
+
+- A new issue or sub-issue is created → add it to the crosswalk and the
+  README index with its number, parent, status, and design-doc link.
+- A PR merges → move the row to the PR crosswalk with `Merged`.
+- A status changes → reflect it.
+- Scope, parent link, or acceptance criteria change → reflect it.
+
+Refresh the doc's `Last updated` date on every edit. A stale planning
+doc (e.g. a sub-issue missing from the crosswalk) is a rule violation.
+
+---
+
+## 4. New Work From Bugs or Pivots Needs a Sub-Issue First (MANDATORY)
+
+Any NEW or ADDITIONAL work discovered mid-stream — a bug, a required
+refactor, a design pivot, or scope not covered by the current
+sub-issue — MUST get its own GitHub sub-issue created and moved to
+`In Development` **before** implementation work begins.
+
+- The new sub-issue MUST be linked to the correct parent Main issue.
+- The new sub-issue MUST also be assigned to the `Build-Instrumented
+  SBOM` epic (§5) — the epic assignment is orthogonal to the parent
+  link; both always hold.
+- Do NOT fold unrelated new work into an existing sub-issue's scope.
+- After creating and setting the sub-issue to `In Development`, assign
+  it to the current Walk (§2), set its epic (§5), apply the
+  parent-pairing rule in §2, and update the planning docs per §3.
+
+This guarantees every unit of work is tracked and visible on the board
+before code is written, not retroactively.
+
+---
+
+## 5. Every Issue Belongs to the Build-Instrumented SBOM Epic (MANDATORY)
+
+EVERY issue and sub-issue in this workstream — whether created by us or
+inherited — MUST have its board **Epic** field set to `Build-Instrumented
+SBOM`. This is independent of, and in addition to, the parent/sub-issue
+link: a sub-issue is attached to its Main issue AND carries the epic.
+
+Set the epic with:
+
+```bash
+gh project item-edit --project-id PVT_kwDOEFp5Ds4Bb7Wk \
+  --id <PVTI_item_id> \
+  --field-id PVTSSF_lADOEFp5Ds4Bb7WkzhWoAdU \
+  --single-select-option-id e3a04db3
+```
+
+When creating any new issue, set the epic in the same turn as creating
+it. There is NO exception — do not leave the Epic field empty.

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -58,8 +58,9 @@ PR/issue mapping for recreation once GitHub Issues access returns:
 | A7 | Deliver Java build evidence to Corona (Java delivery slice) | Postponed — out of charter (Corona / Phase 2-incorporation team owns delivery + verification) | SI-5 (Java) |
 | A8 | Build efficiency — fully in-memory JAR class processing (no extract-to-disk) | Deferred (validate on EC2) | US-4 |
 | A9 | Support non-Maven/Gradle Java builds (Ant/Ivy, Bazel, `make`) | **Backlog** — parentless issue, not in the initial pilot; **excluded from the Main A completion gate** | #11066 (Proposed) / [java/java-nonmaven-gradle-build-tools-subissue.md](java/java-nonmaven-gradle-build-tools-subissue.md) |
-| A10 | Build efficiency — inline GitOID capture during the build (eliminate post-build rescan) | Delivered & merged (PR #212); flag off by default until golden-validated (see A11) | US-5 / #11097 (child of #11005, In Development) / PR tedg-dev/omnibor-analysis#212 — [java/phase1-build-speed-subissues.md](java/phase1-build-speed-subissues.md) |
+| A10 | Build efficiency — inline GitOID capture during the build (eliminate post-build rescan) | Delivered & merged (PR #212); flag off by default until golden-validated (see A11) | US-5 / #11097 (child of #11005, In Review) / PR tedg-dev/omnibor-analysis#212 — [java/phase1-build-speed-subissues.md](java/phase1-build-speed-subissues.md) |
 | A11 | Inline-hashing golden-clean validation — MRJAR/multi-module correctness + build-logic JAR exclusion | Implemented on `feat/java-inline-hashing`; golden-clean on all 7 Java repos; PR pending | US-6 / #11100 (child of #11005, In Development) — [java/phase1-build-speed-subissues.md](java/phase1-build-speed-subissues.md) |
+| A12 | Build efficiency — capture the Gradle dependency graph during the build (eliminate the post-build re-resolution) | **In Development** (Walk 21); design doc merged, no code PR yet | #11104 (child of #11005) — [../sidecar/java/gradle-inline-dep-capture-design.md](../sidecar/java/gradle-inline-dep-capture-design.md) |
 
 **Standing gate (not a sub-issue):** testing — golden validation, the
 `regression-gate`, and multi-distro runs (Ubuntu/RHEL/Alpine) — is a

--- a/docs/planning/github-issues-crosswalk.md
+++ b/docs/planning/github-issues-crosswalk.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Purpose** | Durable record tying each drafted Main issue and sub-issue to the PR(s) that implement it, so the hierarchy can be recreated and linked once GitHub Projects/Issues access is restored. |
 | **Maintained by** | Cascade (update as PRs merge) |
-| **Last updated** | 2026-07-16 |
+| **Last updated** | 2026-07-22 |
 
 ---
 
@@ -20,6 +20,12 @@ Always reference PRs with the fully-qualified cross-repo form
 link across repos. The Corona project board is **#255** (renumbered from
 #12 during the org migration).
 
+**Every** issue and sub-issue in this workstream is assigned to the
+`Build-Instrumented SBOM` epic (board Epic field), in addition to its
+parent/sub-issue link. Issue-status changes follow the parent/sub-issue
+pairing and current-Walk rules in
+`.windsurf/rules/workflow/github-issue-management.md`.
+
 ---
 
 ## Hierarchy
@@ -34,7 +40,7 @@ theme / planning doc) -> **sub-issues** (drafted in the matching planning doc).
 | Main issue (GitHub title) | Planning doc | Sub-issues | GitHub issue # |
 |---|---|---|---|
 | Java Phase 2: Generate SBOMs From Phase 1 Metadata Without the Source Tree | `java-phase2-consume-dep-capture-subissue.md` | A1 (#11003), A2 (#11004) | #11002 |
-| Phase 1 Build-Speed & Efficiency (Java) | `java/phase1-build-speed-subissues.md` | AF (#11069), A4 (#11006), A5 (#11007), A10 (#11097), A11 (#11100) | #11005 |
+| Phase 1 Build-Speed & Efficiency (Java) | `java/phase1-build-speed-subissues.md` | AF (#11069), A4 (#11006), A5 (#11007), A10 (#11097), A11 (#11100), A12 (#11104) | #11005 |
 | Faster SBOM Generation for Java Builds (Retrospective) | `java/retro-subissue-java-treedb-perf.md` | SI-R1 | #11000 |
 | Build-Based SBOM Capture & Delivery (Sidecar + Phase Isolation) | `sidecar-phase-isolation-subissues.md` | B1 (#11009), B2 (#11010), B3 (#11011), B4 (#11012), C1/C2 (#11013) | #11008 |
 
@@ -46,7 +52,7 @@ theme / planning doc) -> **sub-issues** (drafted in the matching planning doc).
 |---|---|---|---|---|
 | `tedg-dev/omnibor-analysis#194` | Phase 2 generates SBOMs from Phase 1 metadata, no source tree | Java Phase 2 -> **A1** / SI-4 (Java) | #11003 | Merged |
 | `tedg-dev/omnibor-analysis#196` | Single-invocation Gradle dependency capture (US-2) | Phase 1 Build-Speed -> **A4** / US-2 | #11006 | Merged |
-| `tedg-dev/omnibor-analysis#212` | Java inline-hashing interception (sidecar Phase 1, eliminate post-build rescan) | Phase 1 Build-Speed -> **A10** / US-5 | #11097 (child of #11005, In Development) | Merged (flag off; golden-validation tracked as A11 / #11100) |
+| `tedg-dev/omnibor-analysis#212` | Java inline-hashing interception (sidecar Phase 1, eliminate post-build rescan) | Phase 1 Build-Speed -> **A10** / US-5 | #11097 (child of #11005, In Review) | Merged (flag off; golden-validation tracked as A11 / #11100) |
 | `tedg-dev/omnibor-analysis#200` | Java build-tool detection + `java_build_tool` override | Phase 1 Java capture -> **AF** (pilot foundation) | #11069 | Merged |
 | `tedg-dev/omnibor-analysis#199` | Shared `_generate_java_treedb` helper (DRY) | Phase 1 Java capture -> **AF** (pilot foundation) | #11069 | Merged |
 | `tedg-dev/omnibor-analysis#198` | Main A scope refinement + design draft | Java Main A scope (comment on #11002) | #11002 | Merged |
@@ -76,6 +82,7 @@ docs activity and carries a datetimestamped activity log.
 | Support non-Maven/Gradle Java builds (Ant/Ivy, Bazel, `make`) | Phase 1 Java capture -> **A9** | #11066 (backlog, Proposed; parentless) | Backlog — **excluded from the Main A gate**. `tedg-dev/omnibor-analysis#202` (Draft, `Proposed` label — tables it for the pilot, fail-fast on ivy/ant/make/bazel); `#201` (Draft, `backlog` label — Ivy parser/reader) |
 | Overlap independent post-build steps (measure first) | Phase 1 Build-Speed -> **A5** / US-3 | #11007 | Optional / low, no PR |
 | Inline-hashing golden-clean validation (MRJAR/multi-module correctness + build-logic JAR exclusion) | Phase 1 Build-Speed -> **A11** / US-6 | #11100 (child of #11005, In Development) | Implemented on `feat/java-inline-hashing`, golden-clean on all 7 Java repos; PR pending |
+| Gradle in-build dependency capture (eliminate post-build re-resolution) | Phase 1 Build-Speed -> **A12** | #11104 (child of #11005, In Development, Walk 21) | Design doc merged (`docs/sidecar/java/gradle-inline-dep-capture-design.md`, PR `tedg-dev/omnibor-analysis#213` predecessor); no code PR yet |
 | Deliver Java build evidence to Corona | **A7** / SI-5 (Java) | — | Postponed — out of charter |
 | Agree on C/C++ build observation | Main B -> **B1** / SI-1 | #11009 | Blocked on Main A |
 | Auto-capture C/C++ components | Main B -> **B2** / SI-2 | #11010 | Blocked on Main A |
@@ -89,12 +96,14 @@ docs activity and carries a datetimestamped activity log.
 
 The 13 themed issues (#11000–#11013), the pilot-foundation issue
 **#11069** (In Review, child of #11005), the inline-hashing sub-issues
-**#11097** (In Development) and **#11100** (In Development) — both children
-of #11005, the parentless A9 backlog issue **#11066**, and the living
-documentation tracker **#11071** (In Review, parentless) are live on the
-Corona project board (#255). Sub-issue parent links are established
-(#11069, #11097, #11100 → #11005; #11066 and #11071 are intentionally
-parentless). Assignee: `tedg_cisco`.
+**#11097** (In Review) and **#11100** (In Development) — both children
+of #11005, the Gradle in-build dependency-capture sub-issue **#11104**
+(In Development, Walk 21, child of #11005), the parentless A9 backlog
+issue **#11066**, and the living documentation tracker **#11071**
+(In Review, parentless) are live on the Corona project board (#255).
+Sub-issue parent links are established (#11069, #11097, #11100, #11104 →
+#11005; #11066 and #11071 are intentionally parentless). Every issue
+carries the `Build-Instrumented SBOM` epic. Assignee: `tedg_cisco`.
 
 The current GitHub main issue structure (#11002, #11005, #11008) does not
 map 1:1 to the planning index's Main A / B / C. See the restructuring


### PR DESCRIPTION
## Summary

Adds a dedicated GitHub issue-management rule file and brings the planning
index up to date. **Docs/rules only — no code changes.**

### New rule: `.windsurf/rules/workflow/github-issue-management.md`

- **Account & location** — issue operations use the `tedg_cisco` gh account
  (`CiscoSecurityServices/gambit`); PRs use `tedg-dev` with cross-repo refs.
  Records the Corona board (#255) field/option/iteration IDs.
- **Parent/sub-issue status pairing (MANDATORY)** — a parent is at least
  `Ready` once any sub-issue is `Ready`/`In Development`, and moves to
  `In Development` only once every sub-issue has reached `In Development` or
  beyond.
- **Walk assignment (MANDATORY)** — any issue/sub-issue reaching
  `In Development` is assigned to the current Walk in the same turn.
- **Planning-doc currency (MANDATORY)** — `docs/planning/` (crosswalk +
  README) must be updated on every issue/PR/status change.
- **New-work sub-issues (MANDATORY)** — bugs/pivots/refactors get their own
  sub-issue, set to `In Development` (+ current Walk + epic), before coding.
- **Epic assignment (MANDATORY)** — every issue and sub-issue carries the
  `Build-Instrumented SBOM` epic, in addition to its parent link.

### Planning index updates

- Add **#11104** as **A12** (Gradle in-build dependency capture, child of
  #11005, `In Development`, Walk 21) to the crosswalk and README index.
- Refresh **#11097** to `In Review`.
- Note the mandatory epic assignment; bump the crosswalk `Last updated` date.

## Verification

Docs/rules only; no code paths touched. No test/lint impact.
