### PR TITLE
docs: complete rename of ambiguous container-path product identifiers

### DIFF
--- a/docs/sidecar/async-spdx-architecture.md
+++ b/docs/sidecar/async-spdx-architecture.md
@@ -782,7 +782,7 @@ For enterprise teams that want centralized SBOM management:
 build:
   script:
     - make build
-    - omnibor-intercept --phase build  # Adds ~2 min
+    - bisbom-intercept --phase build  # Adds ~2 min
     - upload-artifact omnibor-treedb
 
 # Pipeline B: Central SBOM pipeline (triggered by Pipeline A)
@@ -803,7 +803,7 @@ For organizations generating SBOMs across hundreds of repos:
 build:
   script:
     - make build
-    - omnibor-intercept --phase build
+    - bisbom-intercept --phase build
     - aws sqs send-message --queue-url $SBOM_QUEUE \
         --message-body '{"repo": "spring-boot", "treedb": "s3://..."}'
 

--- a/docs/sidecar/phase-isolation-gap-analysis.md
+++ b/docs/sidecar/phase-isolation-gap-analysis.md
@@ -192,19 +192,19 @@ before any other libraries.
 # Injected automatically by the webhook — customer never sees this
 spec:
   initContainers:
-    - name: omnibor-init
+    - name: bisbom-init
       image: bisbom-env:init
-      command: ["cp", "/opt/bisbom/libintercept.so", "/omnibor/"]
+      command: ["cp", "/opt/bisbom/libintercept.so", "/bisbom/"]
       volumeMounts:
-        - name: omnibor-lib
-          mountPath: /omnibor
+        - name: bisbom-lib
+          mountPath: /bisbom
     - name: bisbom-sidecar
       image: bisbom-env:sidecar
       restartPolicy: Always    # K8s 1.28+ native sidecar
       volumeMounts:
         - name: workspace
           mountPath: /workspace
-        - name: omnibor-artifacts
+        - name: bisbom-artifacts
           mountPath: /artifacts
   containers:
     - name: build
@@ -213,12 +213,12 @@ spec:
       command: ["make", "-j16"]  # UNCHANGED
       env:
         - name: LD_PRELOAD        # Injected by webhook
-          value: /omnibor/libintercept.so
+          value: /bisbom/libintercept.so
       volumeMounts:
         - name: workspace
           mountPath: /workspace
-        - name: omnibor-lib
-          mountPath: /omnibor
+        - name: bisbom-lib
+          mountPath: /bisbom
 ```
 
 Industry precedent: This is exactly how `EnvProxy` (Vault secret


### PR DESCRIPTION
## Summary

Careful manual pass over the ambiguous product references deferred from the
active-doc identifier sweep (PR #223). Two example blocks were half-renamed;
this completes them and renames the remaining product-branded identifiers,
while preserving legitimate OmniBOR-tooling and generic names.

## Renamed (product identifiers)

**`docs/sidecar/phase-isolation-gap-analysis.md`** — k8s injection example
(the `bisbom-sidecar`/`bisbom-env` names were already renamed; these were
left behind):

- `omnibor-init` -> `bisbom-init` (init-container name)
- `omnibor-lib` -> `bisbom-lib` (shared-volume name, 2x)
- `omnibor-artifacts` -> `bisbom-artifacts` (volume name)
- `/omnibor` shared-volume mount path -> `/bisbom` (cp target, `LD_PRELOAD`
  value, and both `mountPath`s)

**`docs/sidecar/async-spdx-architecture.md`** — CI/CD example command:

- `omnibor-intercept --phase build` -> `bisbom-intercept --phase build` (2x)

## Intentionally KEPT

- `libintercept.so` — generic C interception library filename, not
  product-branded (also used as `/sidecar/libintercept.so` elsewhere)
- `omnibor-treedb` / `$CI_PROJECT_DIR/omnibor-treedb` — the OmniBOR treedb
  artifact (tooling concept, not a product identifier)
- `s3://corona-sbom-intake/omnibor/...` — Corona intake namespace (external
  contract, out of scope for this product rename)
- `https://github.com/omnibor/bomsh` — upstream tooling repo
- Prose "OmniBOR" mentions — the standard name

## Notes

- Docs-only change; no code touched.
- Also removed the now-redundant untracked `docs/performance/` scratch dir
  (superseded by `docs/sidecar/java/enterprise-sbom.md`) — not part of this
  commit since it was never tracked.
