### PR TITLE
fix(cloner): verify pinned ref on reuse; pin nmap and testapp to SHAs

### DIFF
--- a/app/config.yaml
+++ b/app/config.yaml
@@ -67,7 +67,7 @@ repos:
     - yasm
   nmap:
     url: https://github.com/nmap/nmap.git
-    branch: master  # EXCEPTION: nmap has no stable release tags; pinning is not possible
+    branch: 508531ed5904c2382ad25e908b75adc1374baaee  # nmap has no release tags; pinned to a commit SHA (upstream-pinning policy)
     language: c-cpp
     build_profile:
       tool: autotools
@@ -393,7 +393,7 @@ repos:
     - '**/build/libs/*.jar'
   bisbom-java-testapp:
     url: https://github.com/tedg-dev/bisbom-java-testapp.git
-    branch: main
+    branch: 44849358dcedc486620eb3cdd78afe147f596c0d  # our testapp has no release tags; pinned to a commit SHA
     language: java
     build_profile:
       tool: maven

--- a/app/pipeline/cloner.py
+++ b/app/pipeline/cloner.py
@@ -4,11 +4,16 @@ Repository cloning for bisbom-gen.
 Handles shallow cloning of target repositories.
 """
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
 
 from app.runner import CommandRunner
+
+# A configured ref that is exactly 40 hex chars is treated as a pinned
+# commit SHA (repos without stable release tags, per upstream-pinning).
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 
 # Instrumentation artifacts that must never persist across runs inside a
 # reused checkout.  Some native builds audit their own working tree (e.g.
@@ -25,42 +30,151 @@ class RepoCloner:
         self.runner = runner or CommandRunner()
 
     def clone(self, repo_name, repo_cfg, paths_cfg):
-        """Clone the target repository if not already present."""
+        """Clone the target repository, pinned to the configured ref.
+
+        The ``branch`` config field may be a branch name, a tag name, or
+        a 40-char commit SHA.  When an existing checkout is found it is
+        verified against the pinned ref and re-cloned if it does not
+        match, so a run always builds exactly the pinned version.
+        """
         repo_dir = (
             Path(paths_cfg["repos_dir"]) / repo_name
         )
-        if repo_dir.exists() and any(
-            repo_dir.iterdir()
-        ):
-            self._clean_stale_capture_dirs(repo_dir)
-            print(
-                "[INFO] Repository already exists "
-                f"at {repo_dir}, skipping clone."
-            )
-            return str(repo_dir)
-
         url = repo_cfg["url"]
-        branch = repo_cfg.get("branch", "master")
+        ref = repo_cfg.get("branch", "master")
+
+        if repo_dir.exists() and any(repo_dir.iterdir()):
+            if self._at_pinned_ref(repo_dir, url, ref):
+                self._clean_stale_capture_dirs(repo_dir)
+                print(
+                    f"[INFO] Repository already at pinned ref "
+                    f"'{ref}' at {repo_dir}, skipping clone."
+                )
+                return str(repo_dir)
+            print(
+                f"[WARN] Checkout at {repo_dir} does not match "
+                f"pinned ref '{ref}'; removing and re-cloning."
+            )
+            shutil.rmtree(repo_dir, ignore_errors=True)
+
+        if _SHA_RE.match(ref):
+            self._clone_commit(repo_name, url, ref, repo_dir)
+        else:
+            self._clone_ref(repo_name, url, ref, repo_dir)
+        return str(repo_dir)
+
+    def _clone_ref(self, repo_name, url, ref, repo_dir):
+        """Shallow-clone a branch or tag, preferring a tag on collision."""
         self.runner.run(
             f"git clone --depth 1 "
-            f"--branch {branch} {url} {repo_dir}",
+            f"--branch {ref} {url} {repo_dir}",
             description=(
-                f"Cloning {repo_name} ({branch})"
+                f"Cloning {repo_name} ({ref})"
             ),
         )
         # Prefer tag over branch when both share a
         # name (avoids Maven SNAPSHOT builds)
         self.runner.run(
             f"git -C {repo_dir} fetch origin "
-            f"tag {branch} --no-tags 2>/dev/null "
+            f"tag {ref} --no-tags 2>/dev/null "
             f"&& git -C {repo_dir} checkout "
-            f"tags/{branch} 2>/dev/null || true",
+            f"tags/{ref} 2>/dev/null || true",
             description=(
-                f"Checkout tag {branch} "
+                f"Checkout tag {ref} "
                 f"(if exists)"
             ),
         )
-        return str(repo_dir)
+
+    def _clone_commit(self, repo_name, url, sha, repo_dir):
+        """Shallow-fetch and checkout an exact commit SHA.
+
+        Used for repositories without stable release tags, which are
+        pinned to a specific commit per the upstream-pinning policy.
+        ``git clone --branch`` cannot check out a bare SHA, so the repo
+        is initialised and the single commit is fetched directly.
+        """
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        self.runner.run(
+            f"git -C {repo_dir} init -q "
+            f"&& git -C {repo_dir} remote add origin {url} "
+            f"&& git -C {repo_dir} fetch --depth 1 origin {sha} "
+            f"&& git -C {repo_dir} checkout -q FETCH_HEAD",
+            description=(
+                f"Cloning {repo_name} @ {sha[:12]}"
+            ),
+        )
+
+    def _at_pinned_ref(self, repo_dir, url, ref):
+        """Return True if the checkout HEAD matches the pinned ref."""
+        head = self.get_commit_sha(repo_dir)
+        if not head:
+            return False
+        target = self._resolve_ref_sha(repo_dir, url, ref)
+        return bool(target) and head.lower() == target.lower()
+
+    @staticmethod
+    def _resolve_ref_sha(repo_dir, url, ref):
+        """Resolve a ref (commit SHA, tag, or branch) to a commit SHA.
+
+        A 40-char SHA resolves to itself.  Tags/branches are resolved
+        locally first (immutable tags are offline-safe), then via the
+        remote as a fallback.  Returns the SHA, or None if unresolved.
+        """
+        if _SHA_RE.match(ref):
+            return ref.lower()
+        for spec in (f"{ref}^{{}}", ref):
+            sha = RepoCloner._rev_parse(repo_dir, spec)
+            if sha:
+                return sha
+        return RepoCloner._ls_remote_sha(url, ref)
+
+    @staticmethod
+    def _rev_parse(repo_dir, spec):
+        """Locally resolve a rev spec to a 40-char SHA, or None."""
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(repo_dir), "rev-parse",
+                 "--verify", "--quiet", spec],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception:
+            return None
+        sha = result.stdout.strip()
+        return sha.lower() if len(sha) == 40 else None
+
+    @staticmethod
+    def _ls_remote_sha(url, ref):
+        """Resolve a ref to a commit SHA via the remote, or None.
+
+        Prefers the peeled entry (``refs/tags/X^{}``) for annotated tags
+        so the result is the underlying commit, not the tag object.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "ls-remote", url,
+                 f"refs/tags/{ref}", f"refs/heads/{ref}", ref],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except Exception:
+            return None
+        if result.returncode != 0:
+            return None
+        peeled = None
+        plain = None
+        for line in result.stdout.splitlines():
+            parts = line.split("\t")
+            if len(parts) != 2:
+                continue
+            sha, name = parts
+            if name.endswith("^{}"):
+                peeled = sha
+            elif plain is None:
+                plain = sha
+        return (peeled or plain or "").lower() or None
 
     @staticmethod
     def _clean_stale_capture_dirs(repo_dir):

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -306,7 +306,9 @@ class TestRepoCloner(unittest.TestCase):
             paths = {"repos_dir": tmpdir}
             cfg = {"url": "x", "branch": "main"}
 
-            with patch("builtins.print"):
+            with patch("builtins.print"), patch.object(
+                RepoCloner, "_at_pinned_ref", return_value=True
+            ):
                 result = cloner.clone(
                     "myrepo", cfg, paths
                 )
@@ -338,7 +340,9 @@ class TestRepoCloner(unittest.TestCase):
             paths = {"repos_dir": tmpdir}
             cfg = {"url": "x", "branch": "main"}
 
-            with patch("builtins.print"):
+            with patch("builtins.print"), patch.object(
+                RepoCloner, "_at_pinned_ref", return_value=True
+            ):
                 cloner.clone("myrepo", cfg, paths)
 
             self.assertFalse(bisbom.exists())
@@ -394,6 +398,179 @@ class TestRepoCloner(unittest.TestCase):
             cloner.clone("repo", cfg, paths)
             call_args = runner.run.call_args
             self.assertIn("master", call_args[0][0])
+
+    def test_reclones_when_ref_mismatch(self):
+        """A checkout not at the pinned ref is wiped and re-cloned."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_dir = Path(tmpdir) / "myrepo"
+            repo_dir.mkdir()
+            (repo_dir / "file.txt").touch()
+
+            runner = MagicMock()
+            runner.run.return_value = 0
+            cloner = RepoCloner(runner)
+            paths = {"repos_dir": tmpdir}
+            cfg = {
+                "url": "https://github.com/x/y.git",
+                "branch": "main",
+            }
+
+            with patch("builtins.print"), patch.object(
+                RepoCloner, "_at_pinned_ref", return_value=False
+            ):
+                cloner.clone("myrepo", cfg, paths)
+
+            self.assertFalse((repo_dir / "file.txt").exists())
+            self.assertIn(
+                "git clone",
+                runner.run.call_args_list[0][0][0],
+            )
+
+    def test_clones_commit_sha(self):
+        """A 40-char SHA ref uses init+fetch, not --branch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = MagicMock()
+            runner.run.return_value = 0
+            cloner = RepoCloner(runner)
+            paths = {"repos_dir": tmpdir}
+            sha = "a" * 40
+            cfg = {
+                "url": "https://github.com/x/y.git",
+                "branch": sha,
+            }
+
+            cloner.clone("sharepo", cfg, paths)
+            self.assertEqual(runner.run.call_count, 1)
+            cmd = runner.run.call_args_list[0][0][0]
+            self.assertIn(
+                f"fetch --depth 1 origin {sha}", cmd
+            )
+            self.assertIn("checkout -q FETCH_HEAD", cmd)
+            self.assertNotIn("--branch", cmd)
+
+    def test_resolve_ref_sha_passthrough(self):
+        """A 40-char SHA resolves to itself (lowercased)."""
+        self.assertEqual(
+            RepoCloner._resolve_ref_sha("x", "url", "A" * 40),
+            "a" * 40,
+        )
+
+    def test_at_pinned_ref_sha_match(self):
+        """_at_pinned_ref matches HEAD against a pinned SHA."""
+        sha = "b" * 40
+        cloner = RepoCloner(MagicMock())
+        with patch.object(
+            RepoCloner, "get_commit_sha", return_value=sha
+        ):
+            self.assertTrue(
+                cloner._at_pinned_ref("d", "url", sha)
+            )
+            self.assertFalse(
+                cloner._at_pinned_ref("d", "url", "c" * 40)
+            )
+
+    def test_at_pinned_ref_no_head(self):
+        """_at_pinned_ref is False when HEAD cannot be read."""
+        cloner = RepoCloner(MagicMock())
+        with patch.object(
+            RepoCloner, "get_commit_sha", return_value=None
+        ):
+            self.assertFalse(
+                cloner._at_pinned_ref("d", "url", "e" * 40)
+            )
+
+    def test_resolve_ref_sha_local_then_remote(self):
+        """Local rev-parse wins; ls-remote is the fallback."""
+        with patch.object(
+            RepoCloner, "_rev_parse", return_value="f" * 40
+        ):
+            self.assertEqual(
+                RepoCloner._resolve_ref_sha("d", "url", "v1"),
+                "f" * 40,
+            )
+        with patch.object(
+            RepoCloner, "_rev_parse", return_value=None
+        ), patch.object(
+            RepoCloner, "_ls_remote_sha", return_value="0" * 40
+        ):
+            self.assertEqual(
+                RepoCloner._resolve_ref_sha("d", "url", "v1"),
+                "0" * 40,
+            )
+
+    def test_ls_remote_sha_prefers_peeled(self):
+        """_ls_remote_sha prefers the peeled (commit) entry."""
+        out = (
+            "1111111111111111111111111111111111111111\t"
+            "refs/tags/v1\n"
+            "2222222222222222222222222222222222222222\t"
+            "refs/tags/v1^{}\n"
+        )
+        with patch(
+            "app.pipeline.cloner.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout=out),
+        ):
+            self.assertEqual(
+                RepoCloner._ls_remote_sha("url", "v1"),
+                "2" * 40,
+            )
+
+    def test_ls_remote_sha_plain_branch(self):
+        """_ls_remote_sha returns the plain SHA for a branch."""
+        out = (
+            "garbage-line-without-a-tab\n"
+            "3333333333333333333333333333333333333333\t"
+            "refs/heads/main\n"
+        )
+        with patch(
+            "app.pipeline.cloner.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout=out),
+        ):
+            self.assertEqual(
+                RepoCloner._ls_remote_sha("url", "main"),
+                "3" * 40,
+            )
+
+    def test_ls_remote_sha_failure(self):
+        """_ls_remote_sha returns None on nonzero exit / error."""
+        with patch(
+            "app.pipeline.cloner.subprocess.run",
+            return_value=MagicMock(returncode=1, stdout=""),
+        ):
+            self.assertIsNone(
+                RepoCloner._ls_remote_sha("url", "x")
+            )
+        with patch(
+            "app.pipeline.cloner.subprocess.run",
+            side_effect=OSError,
+        ):
+            self.assertIsNone(
+                RepoCloner._ls_remote_sha("url", "x")
+            )
+
+    def test_rev_parse_valid_and_invalid(self):
+        """_rev_parse returns a 40-char SHA or None."""
+        with patch(
+            "app.pipeline.cloner.subprocess.run",
+            return_value=MagicMock(stdout="d" * 40 + "\n"),
+        ):
+            self.assertEqual(
+                RepoCloner._rev_parse("d", "HEAD"), "d" * 40
+            )
+        with patch(
+            "app.pipeline.cloner.subprocess.run",
+            return_value=MagicMock(stdout="short\n"),
+        ):
+            self.assertIsNone(
+                RepoCloner._rev_parse("d", "HEAD")
+            )
+        with patch(
+            "app.pipeline.cloner.subprocess.run",
+            side_effect=OSError,
+        ):
+            self.assertIsNone(
+                RepoCloner._rev_parse("d", "HEAD")
+            )
 
     def test_get_commit_sha_valid_repo(self):
         """get_commit_sha returns 40-char SHA for a real git repo."""


### PR DESCRIPTION
## Summary

Closes the cloner reuse gap and pins the two remaining unpinned target
repos, in preparation for the migration to the `CiscoSecurityServices`
GitHub org. OmniBOR (the standard/tooling) is unaffected.

### Cloner reuse gap

- On reuse, `RepoCloner.clone()` verifies the checkout HEAD against the
  configured ref (`_at_pinned_ref`) and re-clones on mismatch — so a run
  always builds exactly the pinned version instead of trusting
  stale/drifted state.
- Adds commit-SHA pin support (`_clone_commit`): a 40-hex `branch` value
  is fetched by SHA (`init` + `fetch --depth 1 origin <sha>` +
  `checkout FETCH_HEAD`), since `git clone --branch` cannot check out a
  bare commit.
- Ref resolution (`_resolve_ref_sha`) is local-first (immutable tags are
  offline-safe) with a peeled-tag-aware `git ls-remote` fallback.

### Repo pinning (upstream-pinning policy)

- `nmap` -> `508531ed5904c2382ad25e908b75adc1374baaee` (no release tags)
- `bisbom-java-testapp` -> `44849358dcedc486620eb3cdd78afe147f596c0d`
  (no release tags)

## Output neutrality

The `nmap` SHA equals the current `master` HEAD, so there is zero
content change now — it only prevents future drift. The cloner change is
behavior-preserving for already-correct checkouts.

## Tests

- +11 cloner tests (SHA clone path, reuse-mismatch re-clone, ref
  resolution local/remote/failure).
- flake8 clean; `cloner.py` 100% coverage; full suite 1900 passed.
