### PR TITLE
refactor: rename omnibor->bisbom internals + hardcoded refs (Stage B/C)

### DIFF
--- a/.windsurf/memories-backup.md
+++ b/.windsurf/memories-backup.md
@@ -71,7 +71,7 @@ The only thing *not* covered by git is the memory database, captured in §3.
 | `code-standards.md` | Cross-language code standards |
 | `golden-file-changelog.md` | Golden-file changelog rules |
 | `golden-spdx-regression.md` | SPDX regression gate |
-| `omnibor-rules.md` | OmniBOR-specific rules |
+| `bisbom-rules.md` | Bisbom-specific rules |
 | `output-binaries.md` | `output_binaries` config rules |
 | `pre-commit.md` | Pre-commit verification gate |
 | `project-context.md` | Project context |
@@ -177,15 +177,15 @@ Content:
 >    (per-repo treedb step before/after, dep_tree time, total
 >    before/after, % improvement). Pull old timings from prior
 >    `output/runtime/java/<repo>` runs and new `adg_substeps.json`.
-> 3. Run against `https://github.com/tedg-dev/omnibor-java-testapp` (add
+> 3. Run against `https://github.com/tedg-dev/bisbom-java-testapp` (add
 >    to `app/config.yaml` via `/add-repo` first).
->    3b. IMPORTANT: `omnibor-java-testapp` has problems because COMPLETE
+>    3b. IMPORTANT: `bisbom-java-testapp` has problems because COMPLETE
 >    ISOLATION between Phase 1 and Phase 2 was not implemented correctly.
 >    See `docs/deep-dive/phase-isolation-build-time-analysis.md` and
 >    related phase-isolation docs before/while running it.
 >
 > EC2: instance `i-02ef4bf118d6bae90`, profile `ted-admin`, alias
-> `omnibor-build`, repo path `/home/ubuntu/omnibor-analysis`. Stopped for
+> `bisbom-build`, repo path `/home/ubuntu/bisbom-gen`. Stopped for
 > the long weekend; restart via `/ec2-start`. `duo-sso --profile
 > ted-admin` to re-auth (~1hr expiry).
 

--- a/.windsurf/rules/CRITICAL.md
+++ b/.windsurf/rules/CRITICAL.md
@@ -98,7 +98,7 @@ Violating any rule marked NEVER is a critical failure.
   `project/release-builds.md` for language-specific flags.
 - [ ] **ALWAYS** import SPDX relationship types from
   `app/spdx/relationships.py` — never hardcode strings.
-- [ ] **ALWAYS** attach the built artifact's OmniBOR GitOID + checksum to
+- [ ] **ALWAYS** attach the built artifact's Bisbom GitOID + checksum to
   its root SPDX package, in EVERY language emitter. A root artifact package
   without a `gitoid` `externalRef` and a `checksums` entry is a critical
   correctness failure. See `project/artifact-identity.md`.
@@ -132,9 +132,9 @@ Violating any rule marked NEVER is a critical failure.
   before any `gh issue` / `gh api .../gambit/...` / `gh project` call.
   The default `tedg-dev` account CANNOT resolve the issues repo.
 - [ ] **Issues live in `CiscoSecurityServices/gambit`** (Corona board
-  `#255`) — NOT in `tedg-dev/omnibor-analysis`. PRs live in
-  `tedg-dev/omnibor-analysis` (account `tedg-dev`); reference cross-repo
-  as `tedg-dev/omnibor-analysis#<n>`.
+  `#255`) — NOT in `tedg-dev/bisbom-gen`. PRs live in
+  `tedg-dev/bisbom-gen` (account `tedg-dev`); reference cross-repo
+  as `tedg-dev/bisbom-gen#<n>`.
 - [ ] **GitHub Issues access is ALWAYS available — it is NOT
   intermittent.** NEVER claim it is unavailable/limited, and NEVER
   defer issue creation to the planning crosswalk as a substitute.

--- a/.windsurf/rules/cascade/behavior.md
+++ b/.windsurf/rules/cascade/behavior.md
@@ -22,7 +22,7 @@ Before making ANY business logic, design, or implementation choice,
 verify the approach follows industry-standard best practices.
 
 1. **Standards compliance** — use established specifications (SPDX 2.3,
-   OmniBOR, PEP, semver, PURL, etc.) not ad-hoc formats
+   Bisbom, PEP, semver, PURL, etc.) not ad-hoc formats
 2. **Recognized patterns** — use well-known design patterns (strategy,
    facade, factory) not novel inventions
 3. **Idiomatic code** — follow language conventions (PEP 8 for Python,

--- a/.windsurf/rules/getting-started.md
+++ b/.windsurf/rules/getting-started.md
@@ -15,7 +15,7 @@ When a new user opens this project, Cascade should:
 2. **Read `project/`** rules — project-specific context, code standards, pipelines
 3. **Read `cascade/`** rules — AI behavior, terminal safety, auto-run policy
 4. **Run `/setup-environment`** to verify the local development environment
-5. **Explain the project** — this is an OmniBOR build interception pipeline that
+5. **Explain the project** — this is an Bisbom build interception pipeline that
    generates SPDX 2.3 SBOMs from instrumented builds (C/C++, Go, Rust, Java)
 6. **Offer to run `/add-repo`** if the user wants to analyze a new GitHub repository
 

--- a/.windsurf/rules/infrastructure/README.md
+++ b/.windsurf/rules/infrastructure/README.md
@@ -1,5 +1,5 @@
 ---
-description: Infrastructure profile system for OmniBOR build hosts
+description: Infrastructure profile system for Bisbom build hosts
 ---
 
 # Infrastructure Profiles

--- a/.windsurf/rules/infrastructure/active-profile.md
+++ b/.windsurf/rules/infrastructure/active-profile.md
@@ -4,8 +4,8 @@ description: Infrastructure profiles for bisbom-gen analysis build hosts
 
 # Build Host Profiles
 
-Each contributor configures their own `~/.ssh/config` to alias `omnibor-build`
-to whichever host they use. The workflows reference `omnibor-build` generically.
+Each contributor configures their own `~/.ssh/config` to alias `bisbom-build`
+to whichever host they use. The workflows reference `bisbom-build` generically.
 
 ---
 
@@ -16,8 +16,8 @@ to whichever host they use. The workflows reference `omnibor-build` generically.
 | Field | Value |
 |-------|-------|
 | **Provider** | AWS EC2 |
-| **Instance Name** | `omnibor-build` |
-| **SSH alias** | `omnibor-build` |
+| **Instance Name** | `bisbom-build` |
+| **SSH alias** | `bisbom-build` |
 | **IP** | `54.215.15.253` (Elastic IP) |
 | **Instance ID** | `i-02ef4bf118d6bae90` |
 | **Region** | `us-west-1` |
@@ -27,12 +27,12 @@ to whichever host they use. The workflows reference `omnibor-build` generically.
 | **EBS** | 50 GB gp3 (3000 IOPS) |
 | **Security Group** | `sg-068fd31b70796c6c3` |
 | **AWS Profile** | `ted-admin` |
-| **Repo path on host** | `/home/ubuntu/omnibor-analysis` |
+| **Repo path on host** | `/home/ubuntu/bisbom-gen` |
 
 ### SSH Config
 
 ```
-Host omnibor-build
+Host bisbom-build
     HostName 54.215.15.253
     User ubuntu
     IdentityFile ~/.ssh/id_ed25519
@@ -61,15 +61,15 @@ aws ec2 stop-instances --profile ted-admin --instance-ids i-02ef4bf118d6bae90 --
 ### Running Analysis
 
 ```bash
-ssh omnibor-build "cd /home/ubuntu/omnibor-analysis && git pull origin main"
-ssh omnibor-build "cd /home/ubuntu/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm bisbom-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
+ssh bisbom-build "cd /home/ubuntu/bisbom-gen && git pull origin main"
+ssh bisbom-build "cd /home/ubuntu/bisbom-gen && docker-compose -f docker/docker-compose.yml run --rm bisbom-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
 ```
 
 ### Syncing Results
 
 ```bash
 # Download results to local machine (all generated artifacts are under output/)
-rsync -avz omnibor-build:/home/ubuntu/omnibor-analysis/output/ output/
+rsync -avz bisbom-build:/home/ubuntu/bisbom-gen/output/ output/
 ```
 
 ### Cost
@@ -91,18 +91,18 @@ rsync -avz omnibor-build:/home/ubuntu/omnibor-analysis/output/ output/
 |-------|-------|
 | **Provider** | Local (SSH-accessible on-prem) |
 | **Hostname** | `corona210.cisco.com` |
-| **SSH alias** | `omnibor-build` |
+| **SSH alias** | `bisbom-build` |
 | **User** | `<userID>` |
 | **OS** | CentOS 7 x86_64 |
 | **Docker** | v24.0.5 + Compose v2.20.2 |
 | **Docker data-root** | `/home/docker` (moved from `/var/lib/docker` — see `/cisco-lab-proxy`) |
-| **Repo path on host** | `/home/<userID>/omnibor-analysis` |
+| **Repo path on host** | `/home/<userID>/bisbom-gen` |
 | **Proxy** | `http://proxy-wsa.esl.cisco.com:80` (see `docs/guides/cisco-lab-proxy.md`) |
 
 ### SSH Config
 
 ```
-Host omnibor-build
+Host bisbom-build
     HostName corona210.cisco.com
     User <userID>
 ```
@@ -116,14 +116,14 @@ Always-on host — no start/stop needed.
 Requires proxy override via `docker-compose.override.yml` (see `/cisco-lab-proxy`).
 
 ```bash
-ssh omnibor-build "cd ~/omnibor-analysis && docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml run --rm bisbom-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
+ssh bisbom-build "cd ~/bisbom-gen && docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml run --rm bisbom-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
 ```
 
 ### Syncing Results
 
 ```bash
-rsync -avz omnibor-build:~/omnibor-analysis/output/ output/
-rsync -avz omnibor-build:~/omnibor-analysis/docs/ docs/
+rsync -avz bisbom-build:~/bisbom-gen/output/ output/
+rsync -avz bisbom-build:~/bisbom-gen/docs/ docs/
 ```
 
 ### Cost
@@ -138,7 +138,7 @@ rsync -avz omnibor-build:~/omnibor-analysis/docs/ docs/
 
 | Field | Value |
 |-------|-------|
-| **Droplet Name** | `omnibor-build-ubuntu-s-1vcpu-2gb-sfo3-01` |
+| **Droplet Name** | `bisbom-build-ubuntu-s-1vcpu-2gb-sfo3-01` |
 | **IP** | `137.184.178.186` |
 | **Droplet ID** | `551297940` |
 | **Power off** | `doctl compute droplet-action power-off 551297940 --wait` |

--- a/.windsurf/rules/infrastructure/ec2-operations.md
+++ b/.windsurf/rules/infrastructure/ec2-operations.md
@@ -11,7 +11,7 @@ the current instance ID dynamically:
 
 ```bash
 aws ec2 describe-instances --profile ted-admin \
-  --filters "Name=tag:Name,Values=*omnibor*" \
+  --filters "Name=tag:Name,Values=*bisbom*" \
   --query "Reservations[].Instances[].{ID:InstanceId,State:State.Name}" \
   --output table --no-cli-pager
 ```

--- a/.windsurf/rules/infrastructure/github-rulesets.md
+++ b/.windsurf/rules/infrastructure/github-rulesets.md
@@ -6,7 +6,7 @@ priority: critical
 
 # GitHub Repository Rulesets
 
-Branch protection on `tedg-dev/omnibor-analysis` is enforced via **GitHub
+Branch protection on `tedg-dev/bisbom-gen` is enforced via **GitHub
 Repository Rulesets** (not legacy branch protection rules). Rulesets provide
 granular per-rule bypass actors, replacing the all-or-nothing
 `enforce_admins` toggle.
@@ -120,25 +120,25 @@ can skip reviews.
 ### View current rulesets
 
 ```bash
-gh api repos/tedg-dev/omnibor-analysis/rulesets --jq '.[] | {id, name, enforcement}'
+gh api repos/tedg-dev/bisbom-gen/rulesets --jq '.[] | {id, name, enforcement}'
 ```
 
 ### View ruleset details
 
 ```bash
-gh api repos/tedg-dev/omnibor-analysis/rulesets/<ID> --jq '.'
+gh api repos/tedg-dev/bisbom-gen/rulesets/<ID> --jq '.'
 ```
 
 ### View legacy branch protection
 
 ```bash
-gh api repos/tedg-dev/omnibor-analysis/branches/main/protection --jq '{enforce_admins: .enforce_admins.enabled, reviews: .required_pull_request_reviews}'
+gh api repos/tedg-dev/bisbom-gen/branches/main/protection --jq '{enforce_admins: .enforce_admins.enabled, reviews: .required_pull_request_reviews}'
 ```
 
 ### Disable a ruleset (emergency only)
 
 ```bash
-gh api repos/tedg-dev/omnibor-analysis/rulesets/<ID> -X PUT --input <json> # set enforcement: disabled
+gh api repos/tedg-dev/bisbom-gen/rulesets/<ID> -X PUT --input <json> # set enforcement: disabled
 ```
 
 ### Add a CI status check (future)

--- a/.windsurf/rules/infrastructure/go-sdk-version.md
+++ b/.windsurf/rules/infrastructure/go-sdk-version.md
@@ -51,13 +51,13 @@ for r in releases[:2]:
 
 2. Rebuild the Docker image on EC2:
    ```bash
-   rsync -avz docker/Dockerfile omnibor-build:/home/ubuntu/omnibor-analysis/docker/Dockerfile
-   ssh omnibor-build "cd /home/ubuntu/omnibor-analysis && docker-compose -f docker/docker-compose.yml build bisbom-env"
+   rsync -avz docker/Dockerfile bisbom-build:/home/ubuntu/bisbom-gen/docker/Dockerfile
+   ssh bisbom-build "cd /home/ubuntu/bisbom-gen && docker-compose -f docker/docker-compose.yml build bisbom-env"
    ```
 
 3. Verify by running a quick Go analysis:
    ```bash
-   ssh omnibor-build "cd /home/ubuntu/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm bisbom-env go version"
+   ssh bisbom-build "cd /home/ubuntu/bisbom-gen && docker-compose -f docker/docker-compose.yml run --rm bisbom-env go version"
    ```
 
 4. Commit the Dockerfile change and merge to main.

--- a/.windsurf/rules/infrastructure/templates/aws-ec2.md
+++ b/.windsurf/rules/infrastructure/templates/aws-ec2.md
@@ -1,5 +1,5 @@
 ---
-description: AWS EC2 instance template for OmniBOR build host
+description: AWS EC2 instance template for Bisbom build host
 ---
 
 # AWS EC2 — Build Host Profile
@@ -12,12 +12,12 @@ Copy this file to `../active-profile.md` and fill in your values.
 |-------|-------|
 | **Provider** | AWS EC2 |
 | **Instance ID** | `i-<YOUR_INSTANCE_ID>` |
-| **SSH alias** | `omnibor-build` |
+| **SSH alias** | `bisbom-build` |
 | **IP** | `<YOUR_ELASTIC_IP or PUBLIC_IP>` |
 | **Region** | `<REGION>` (e.g. us-west-2) |
 | **Instance Type** | `t3.medium` (recommended) |
 | **AMI** | Ubuntu 22.04 x86_64 |
-| **Repo path on host** | `/home/ubuntu/omnibor-analysis` |
+| **Repo path on host** | `/home/ubuntu/bisbom-gen` |
 
 ## Recommended Instance Types
 
@@ -33,7 +33,7 @@ Copy this file to `../active-profile.md` and fill in your values.
 Add to `~/.ssh/config`:
 
 ```
-Host omnibor-build
+Host bisbom-build
     HostName <YOUR_IP>
     User ubuntu
     IdentityFile ~/.ssh/<YOUR_KEY>.pem
@@ -166,7 +166,7 @@ aws ec2 run-instances \
   --instance-type t3.medium \
   --key-name <YOUR_KEY_NAME> \
   --security-group-ids <YOUR_SG_ID> \
-  --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=omnibor-build}]' \
+  --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=bisbom-build}]' \
   --block-device-mappings '[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]'
 
 # Allocate Elastic IP (optional, for stable IP across stop/start)
@@ -177,7 +177,7 @@ aws ec2 associate-address --instance-id i-<ID> --allocation-id eipalloc-<ID>
 Then install Docker:
 
 ```bash
-ssh omnibor-build "curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker ubuntu"
+ssh bisbom-build "curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker ubuntu"
 # Log out and back in for group change
 ```
 
@@ -192,25 +192,25 @@ ssh omnibor-build "curl -fsSL https://get.docker.com | sh && sudo usermod -aG do
 
 ```bash
 # Ensure latest code
-ssh omnibor-build "cd ~/omnibor-analysis && git pull origin main"
+ssh bisbom-build "cd ~/bisbom-gen && git pull origin main"
 
 # Run analysis
-ssh omnibor-build "cd ~/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm bisbom-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
+ssh bisbom-build "cd ~/bisbom-gen && docker-compose -f docker/docker-compose.yml run --rm bisbom-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
 
 # Enter container interactively
-ssh omnibor-build "cd ~/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm bisbom-env bash"
+ssh bisbom-build "cd ~/bisbom-gen && docker-compose -f docker/docker-compose.yml run --rm bisbom-env bash"
 
 # Rebuild Docker image
-ssh omnibor-build "cd ~/omnibor-analysis && docker-compose -f docker/docker-compose.yml build"
+ssh bisbom-build "cd ~/bisbom-gen && docker-compose -f docker/docker-compose.yml build"
 ```
 
 ## Syncing Results
 
 ```bash
 # Download results to local machine (all generated artifacts are under output/)
-rsync -avz omnibor-build:~/omnibor-analysis/output/ output/
+rsync -avz bisbom-build:~/bisbom-gen/output/ output/
 
 # Upload code to instance
 rsync -avz --exclude='.venv' --exclude='output' --exclude='repos' --exclude='.git' \
-  ./ omnibor-build:~/omnibor-analysis/
+  ./ bisbom-build:~/bisbom-gen/
 ```

--- a/.windsurf/rules/infrastructure/templates/digitalocean.md
+++ b/.windsurf/rules/infrastructure/templates/digitalocean.md
@@ -1,5 +1,5 @@
 ---
-description: DigitalOcean droplet template for OmniBOR build host
+description: DigitalOcean droplet template for Bisbom build host
 ---
 
 # DigitalOcean Droplet — Build Host Profile
@@ -12,20 +12,20 @@ Copy this file to `../active-profile.md` and fill in your values.
 |-------|-------|
 | **Provider** | DigitalOcean |
 | **Droplet Name** | `<YOUR_DROPLET_NAME>` |
-| **SSH alias** | `omnibor-build` |
+| **SSH alias** | `bisbom-build` |
 | **IP** | `<YOUR_DROPLET_IP>` |
 | **Droplet ID** | `<YOUR_DROPLET_ID>` |
 | **Region** | `<REGION>` (e.g. SFO3, NYC1) |
 | **Size** | `s-1vcpu-2gb` (minimum) or `s-2vcpu-4gb` (recommended) |
 | **OS** | Ubuntu 22.04 x86_64 |
-| **Repo path on host** | `/root/omnibor-analysis` |
+| **Repo path on host** | `/root/bisbom-gen` |
 
 ## SSH Config
 
 Add to `~/.ssh/config`:
 
 ```
-Host omnibor-build
+Host bisbom-build
     HostName <YOUR_DROPLET_IP>
     User root
     IdentityFile ~/.ssh/<YOUR_KEY>
@@ -61,7 +61,7 @@ doctl compute droplet-action power-off <YOUR_DROPLET_ID> --wait
 ## Creating a New Droplet
 
 ```bash
-doctl compute droplet create omnibor-build \
+doctl compute droplet create bisbom-build \
   --image ubuntu-22-04-x64 \
   --size s-2vcpu-4gb \
   --region sfo3 \
@@ -72,33 +72,33 @@ doctl compute droplet create omnibor-build \
 Then install Docker:
 
 ```bash
-ssh omnibor-build "curl -fsSL https://get.docker.com | sh"
+ssh bisbom-build "curl -fsSL https://get.docker.com | sh"
 ```
 
 ## Running Analysis
 
 ```bash
 # Ensure latest code
-ssh omnibor-build "cd /root/omnibor-analysis && git pull origin main"
+ssh bisbom-build "cd /root/bisbom-gen && git pull origin main"
 
 # Run analysis
-ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm bisbom-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
+ssh bisbom-build "cd /root/bisbom-gen && docker-compose -f docker/docker-compose.yml run --rm bisbom-env python3 /workspace/app/analyze.py --repo <REPO_NAME>"
 
 # Enter container interactively
-ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml run --rm bisbom-env bash"
+ssh bisbom-build "cd /root/bisbom-gen && docker-compose -f docker/docker-compose.yml run --rm bisbom-env bash"
 
 # Rebuild Docker image
-ssh omnibor-build "cd /root/omnibor-analysis && docker-compose -f docker/docker-compose.yml build"
+ssh bisbom-build "cd /root/bisbom-gen && docker-compose -f docker/docker-compose.yml build"
 ```
 
 ## Syncing Results
 
 ```bash
 # Download results to local machine
-rsync -avz omnibor-build:/root/omnibor-analysis/output/ output/
-rsync -avz omnibor-build:/root/omnibor-analysis/docs/ docs/
+rsync -avz bisbom-build:/root/bisbom-gen/output/ output/
+rsync -avz bisbom-build:/root/bisbom-gen/docs/ docs/
 
 # Upload code to droplet
 rsync -avz --exclude='.venv' --exclude='output' --exclude='repos' --exclude='.git' \
-  ./ omnibor-build:/root/omnibor-analysis/
+  ./ bisbom-build:/root/bisbom-gen/
 ```

--- a/.windsurf/rules/infrastructure/templates/local-linux.md
+++ b/.windsurf/rules/infrastructure/templates/local-linux.md
@@ -1,5 +1,5 @@
 ---
-description: Local Linux / WSL2 / bare metal template for OmniBOR build host
+description: Local Linux / WSL2 / bare metal template for Bisbom build host
 ---
 
 # Local Linux — Build Host Profile
@@ -15,7 +15,7 @@ WSL2 on Windows, or a local VM).
 | **Provider** | Local |
 | **SSH alias** | _(none — runs locally)_ |
 | **OS** | Ubuntu 22.04 x86_64 |
-| **Repo path** | `<YOUR_CLONE_PATH>` (e.g. `/home/user/omnibor-analysis`) |
+| **Repo path** | `<YOUR_CLONE_PATH>` (e.g. `/home/user/bisbom-gen`) |
 
 ## Prerequisites
 

--- a/.windsurf/rules/project/artifact-identity.md
+++ b/.windsurf/rules/project/artifact-identity.md
@@ -1,11 +1,11 @@
 ---
-description: Every artifact's SPDX identity MUST carry its OmniBOR gitOID (SHA-256) and a valid raw SHA. Design of record.
+description: Every artifact's SPDX identity MUST carry its Bisbom gitOID (SHA-256) and a valid raw SHA. Design of record.
 ---
 
-# Artifact Identity (OmniBOR Core) — Design of Record
+# Artifact Identity (Bisbom Core) — Design of Record
 
-Recording the OmniBOR identity of **every** artifact is the entire point of
-OmniBOR. This rule is the **design of record** and supersedes any earlier
+Recording the Bisbom identity of **every** artifact is the entire point of
+Bisbom. This rule is the **design of record** and supersedes any earlier
 statement (in this file or elsewhere) that the SPDX checksum is the bomsh
 `SHA1` treedb value, or that we must not re-hash artifacts. Both were mistakes
 and are corrected below.
@@ -30,7 +30,7 @@ alternate encodings of one value:
 |---|---|---|
 | **raw hash** | `SHA-256` of the raw file content | files, objects, packages |
 | **artifact gitOID** | `gitoid:blob:sha256` of the artifact (git-blob framing + `SHA-256`) | files, objects, packages |
-| **Input Manifest gitOID (OMID)** | gitOID of the OmniBOR Input Manifest — the provenance identifier | built artifacts (packages) only |
+| **Input Manifest gitOID (OMID)** | gitOID of the Bisbom Input Manifest — the provenance identifier | built artifacts (packages) only |
 
 The raw hash and the artifact gitOID are **not** the same number: the gitOID
 prepends the git object header (`blob <len>\0`) before hashing. NEVER store the
@@ -40,15 +40,15 @@ gitOID under a `SHA` checksum label — that was the original bug.
 
 `SHA-256` is **mandated**, not merely preferred:
 
-- The OmniBOR specification permits **only** `SHA-256` for Artifact IDs.
+- The Bisbom specification permits **only** `SHA-256` for Artifact IDs.
 - NIST has formally retired `SHA-1`; full transition away is required by 2030,
   and `SHA-1` is disallowed for new signatures now.
 - git's `SHA-1` is actually `SHA-1DC` (collision-detecting), which breaks the
-  universal reproducibility OmniBOR requires.
+  universal reproducibility Bisbom requires.
 
 The identity model MUST be **parameterized by hash algorithm** (default
 `SHA-256`), never hardcoded, so a future migration (e.g. if `SHA-256` is
-broken) is a config change — mirroring OmniBOR's own `HashAlgorithm` design.
+broken) is a config change — mirroring Bisbom's own `HashAlgorithm` design.
 
 ## 4. Topology vs Identity — Why C/C++ Is Automatic and Java Isn't
 
@@ -76,7 +76,7 @@ is irrelevant and Java becomes as automatic as C:
    Maven/Gradle `dep:tree` for external deps). The treedb maps `sha1 → path`.
 2. For every node, read the file at its path and compute `gitoid:blob:sha256`
    and the raw `SHA-256`.
-3. Build each built artifact's Input Manifest per the OmniBOR spec and compute
+3. Build each built artifact's Input Manifest per the Bisbom spec and compute
    its OMID as the `SHA-256` git-blob of that manifest, re-keying bomsh's
    `SHA-1` nodes to our `SHA-256` IDs by joining on file path.
 
@@ -92,7 +92,7 @@ in the SBOM.
   fragile than `bomtrace3`; every `.class` in the JAR must trace back to a
   `.java`. Flag gaps rather than emit a silently-incomplete manifest.
 - **Maven/Gradle dependencies are leaves.** We did not build them; identify
-  them by their JAR's artifact gitOID (+ `purl`). This is correct OmniBOR
+  them by their JAR's artifact gitOID (+ `purl`). This is correct Bisbom
   behavior for externally-built artifacts.
 
 ## 5. Per-Version SPDX Rendering
@@ -146,7 +146,7 @@ the model and surfaced only when we move to 3.0.1.
   `SHA-256` + raw `SHA-256`). This **reverses** the earlier "do not re-hash the
   workspace" instruction: re-hashing in `SHA-256` is required because bomsh's
   treedb is `SHA-1` and cannot supply the mandated algorithm.
-- **OMID** — the OmniBOR Input Manifest, computed canonically per the OmniBOR
+- **OMID** — the Bisbom Input Manifest, computed canonically per the Bisbom
   spec (validated against the reference libraries), not read from bomsh's
   `SHA-1` doc-mapping.
 
@@ -160,7 +160,7 @@ Two distinct mistakes were made and are corrected by this rule:
    value under a `"SHA1"` checksum label on files and packages. That value is
    the artifact's gitOID, **not** its raw `SHA-1` — a consumer verifying the
    checksum gets a mismatch. The raw hash was never stored, and the gitOID was
-   `SHA-1` rather than the OmniBOR-mandated `SHA-256`.
+   `SHA-1` rather than the Bisbom-mandated `SHA-256`.
 
 ## Enforcement
 
@@ -193,6 +193,6 @@ the SPDX 2.3-mandated raw `SHA-1`, see §5.1). The bomsh `SHA-1` treedb is used
 only as a topology bridge and is never surfaced in the SBOM.
 
 Still pending: the Input Manifest gitOID (OMID) canonical computation per the
-OmniBOR spec, and the SPDX 3.0.1 renderer (`verifiedUsing` + `contentIdentifier`,
+Bisbom spec, and the SPDX 3.0.1 renderer (`verifiedUsing` + `contentIdentifier`,
 no SHA-1). Golden SPDX regeneration for the identity change is sequenced under
 USER review per `cascade/golden-file-policy.md`.

--- a/.windsurf/rules/project/bisbom-rules.md
+++ b/.windsurf/rules/project/bisbom-rules.md
@@ -2,13 +2,13 @@
 description: Rules for OmniBOR/Bomsh build interception workflow
 ---
 
-# OmniBOR / Bomsh Rules
+# Bisbom / Bomsh Rules
 
 ## Terminology
 
 - **Build Interception** — instrumenting the compiler/linker to observe what is actually compiled
 - **Bomtrace3** — the preferred tracer (20% overhead vs 2-5x for bomtrace2)
-- **ADG** — Artifact Dependency Graph (OmniBOR's output format)
+- **ADG** — Artifact Dependency Graph (Bisbom's output format)
 - **Treedb** — bomsh's hash-tree database mapping gitoid hashes to file paths
 - **Vendored library** — third-party source compiled into the project (STATIC_LINK)
 - **Build Metadata Extraction** (Yocto SBOM, Maven plugins) is NOT true build interception;
@@ -22,7 +22,7 @@ description: Rules for OmniBOR/Bomsh build interception workflow
 4. Run pre-build steps (autoreconf, configure) WITHOUT bomtrace instrumentation
 5. Run the final `make` step WITH bomtrace3: `bomtrace3 make -j$(nproc)`
 6. `bomsh_create_bom.py` generates ADG from raw logfile → treedb + gitoid mappings
-7. `bomsh_sbom.py` generates OmniBOR SPDX SBOM from ADG
+7. `bomsh_sbom.py` generates Bisbom SPDX SBOM from ADG
 8. `collect_metadata.py` resolves system files in treedb to dpkg packages
 9. `collect_dynamic_libs.py` identifies per-binary dynamic libs via ldd/readelf
 10. `spdx_from_adg.py` generates per-binary ADG SPDX with:
@@ -44,7 +44,7 @@ compilation steps.
 2. Syft SBOM (manifest-based baseline from go.mod/go.sum)
 3. (no apt deps for Go)
 4. Instrumented build: `bomtrace2 -c bomtrace_go.conf go build -a -o <binary> .`
-5a. OmniBOR SPDX via bomsh_sbom.py
+5a. Bisbom SPDX via bomsh_sbom.py
 5b. Metadata collection
 5c. Per-binary ADG SPDX + HTML visualization
 6. SPDX validation (JSON Schema + semantic)
@@ -64,7 +64,7 @@ dependencies, so all crates get STATIC_LINK relationships.
 2. Syft SBOM (manifest-based baseline from Cargo.toml/Cargo.lock)
 3. (no apt deps for Rust)
 4. Instrumented build: `bomtrace2 cargo build --release`
-5a. OmniBOR SPDX via bomsh_sbom.py
+5a. Bisbom SPDX via bomsh_sbom.py
 5b. Metadata collection
 5c. Per-binary ADG SPDX + HTML visualization
 6. SPDX validation (JSON Schema + semantic)
@@ -93,12 +93,12 @@ See: https://github.com/omnibor/bomsh#software-vulnerability-cve-search-for-rust
 
 - Only the final `make` step should be instrumented — configure/autoreconf are not builds
 - bomtrace3 does NOT need bomsh_hook2.py — it has the functionality built in as C code
-- ADG output defaults to `${PWD}/.omnibor` but we redirect to `output/omnibor/<lang>/<repo>/` via `-b` flag
+- ADG output defaults to `${PWD}/.omnibor` but we redirect to `output/bisbom/<lang>/<repo>/` via `-b` flag
 - SPDX v2.3 is the supported version
 - `vendored_dirs` in config.yaml allows per-repo vendored directory patterns
 - `direct_only` mode prevents duplicate deps when a project has both executables and shared libs
 
-## OmniBOR Version Check
+## Bisbom Version Check
 
 Before running a new analysis session (not every repo run):
 

--- a/.windsurf/rules/project/project-context.md
+++ b/.windsurf/rules/project/project-context.md
@@ -1,5 +1,5 @@
 ---
-description: Project context and architecture for omnibor-analysis
+description: Project context and architecture for bisbom-gen
 ---
 
 # Project: bisbom-gen
@@ -30,7 +30,7 @@ and completeness.
   - **docs/issues/** — Upstream bug tracking and workarounds
 - **repos/** — Cloned target repositories (gitignored)
 - **output/** — All generated artifacts (gitignored)
-  - **output/omnibor/{lang}/{repo}/{ts}/** — OmniBOR ADG documents
+  - **output/bisbom/{lang}/{repo}/{ts}/** — Bisbom ADG documents
   - **output/spdx/{lang}/{repo}/{ts}/** — SPDX SBOMs + HTML visualizations
   - **output/binaries/{lang}/{repo}/{ts}/** — Compiled binaries
   - **output/build-logs/{lang}/{repo}/{ts}/** — Build environment logs
@@ -40,7 +40,7 @@ and completeness.
 ## Key Technologies
 
 - **Bomsh/Bomtrace3** — ptrace-based build interception from omnibor/bomsh (Linux x86_64 only, C/C++)
-- **OmniBOR** — Artifact Dependency Graph (ADG) standard (omnibor.io)
+- **Bisbom** — Artifact Dependency Graph (ADG) standard (omnibor.io)
 - **SPDX 2.3** — SBOM format (JSON output)
 - **Syft** — Manifest-based SBOM generation (primary for Go, baseline for C/C++)
 - **Go SDK** — Go 1.23+ installed in the container for building Go targets
@@ -49,12 +49,12 @@ and completeness.
 
 ## Analysis Pipeline (analyze.py)
 
-### C/C++ repos (full OmniBOR instrumentation)
+### C/C++ repos (full Bisbom instrumentation)
 1. Clone target repo
 2. Syft baseline SBOM (manifest-based)
 3. Validate apt dependencies
 4. Instrumented build with bomtrace3
-5a. OmniBOR SPDX via bomsh_sbom.py
+5a. Bisbom SPDX via bomsh_sbom.py
 5b. Metadata collection (collect_metadata.py + collect_dynamic_libs.py)
 5c. Per-binary ADG SPDX with vendored detection + HTML visualization
 6. SPDX validation (JSON Schema + semantic)
@@ -66,7 +66,7 @@ and completeness.
 2. Syft SBOM (manifest-based baseline from go.mod/go.sum)
 3. (no apt deps for Go)
 4. Instrumented build with bomtrace2 (`go build -a` + Go-specific bomtrace.conf)
-5a. OmniBOR SPDX via bomsh_sbom.py
+5a. Bisbom SPDX via bomsh_sbom.py
 5b. Metadata collection
 5c. Per-binary ADG SPDX + HTML visualization
 6. SPDX validation (JSON Schema + semantic)
@@ -94,7 +94,7 @@ and traces the openat syscall. The `-a` flag bypasses Go's build cache.
 | `app/spdx_visualize.py` | D3.js HTML dependency graph generator |
 | `app/collect_metadata.py` | Resolve system files to dpkg packages |
 | `app/collect_dynamic_libs.py` | Per-binary ldd/readelf dynamic lib analysis |
-| `app/compare.py` | Compare OmniBOR SBOM vs binary scanner SBOM |
+| `app/compare.py` | Compare Bisbom SBOM vs binary scanner SBOM |
 | `app/data_loader.py` | Shared data loading utilities |
 | `app/config.py` | Shared config loading, timestamp, lang_subdir |
 | `app/runner.py` | CommandRunner utility |
@@ -136,5 +136,5 @@ and traces the openat syscall. The `-a` flag bypasses Go's build cache.
 - Each repo has a `language` field (`c-cpp`, `go`, `rust`) that determines its output subfolder
 - Go repos use `BomtraceBuilder` with bomtrace2 (Go-specific conf) for instrumented builds
 - Rust repos use `BomtraceBuilder` with bomtrace2 (default conf) for instrumented builds
-- C/C++ repos use `BomtraceBuilder` (bomtrace3 instrumentation) and bomsh for OmniBOR SBOMs
+- C/C++ repos use `BomtraceBuilder` (bomtrace3 instrumentation) and bomsh for Bisbom SBOMs
 - Per-file test coverage must be 95%+, overall 97%+ (enforced in pre-commit.md)

--- a/.windsurf/rules/project/runtime-timing.md
+++ b/.windsurf/rules/project/runtime-timing.md
@@ -46,7 +46,7 @@ and stored for comparison.
 | Timer | What it measures |
 |-------|-----------------|
 | `adg_dur` | `bomsh_create_bom.py` / `bomsh_create_bom_java.py` (+ dep:tree for Java sidecar) |
-| `omnibor_sbom_dur` | `bomsh_sbom.py` → `_omnibor.spdx.json` + metadata patch + HTML viz |
+| `bisbom_sbom_dur` | `bomsh_sbom.py` → `_bisbom.spdx.json` + metadata patch + HTML viz |
 | `metadata_dur` | `collect_metadata.py` + `collect_dynamic_libs.py` |
 | `spdx_gen_dur` | `AdgSpdxGenerator` / `JavaSpdxGenerator` → `_analyzed` + `_build` `.spdx.json` + HTML |
 | `validate_dur` | JSON schema + semantic validation |

--- a/.windsurf/rules/project/supported-languages.md
+++ b/.windsurf/rules/project/supported-languages.md
@@ -7,7 +7,7 @@ description: Languages supported by the current OmniBOR/bomsh version
 This file defines which programming languages are supported by the current
 OmniBOR/bomsh installation for build interception and SPDX generation.
 
-## Current Supported Languages (OmniBOR bomsh v2026.1)
+## Current Supported Languages (Bisbom bomsh v2026.1)
 
 | Language | Config Value | Tracer | Notes |
 |----------|-------------|--------|-------|
@@ -60,7 +60,7 @@ When OmniBOR/bomsh adds support for a new language:
    output/binaries/<lang>/.gitkeep
    output/binary-scan/<lang>/.gitkeep
    output/build-logs/<lang>/.gitkeep
-   output/omnibor/<lang>/.gitkeep
+   output/bisbom/<lang>/.gitkeep
    output/runtime/<lang>/.gitkeep
    output/spdx/<lang>/.gitkeep
    ```

--- a/.windsurf/rules/project/upstream-pinning.md
+++ b/.windsurf/rules/project/upstream-pinning.md
@@ -1,5 +1,5 @@
 ---
-description: Pin upstream OmniBOR build tools to a specific official version
+description: Pin upstream Bisbom build tools to a specific official version
 trigger: always_on
 priority: critical
 ---
@@ -7,7 +7,7 @@ priority: critical
 # Upstream Tool Pinning
 
 This rule governs **build-time tooling** cloned into the Docker image
-(`omnibor/bomsh` and any other upstream OmniBOR-related repos). It is
+(`omnibor/bomsh` and any other upstream Bisbom-related repos). It is
 distinct from `stable-tags.md` (which governs the *analyzed* repos in
 `config.yaml`) and from the golden-file policy (which governs SPDX
 baselines).

--- a/.windsurf/rules/quality/design-principles.md
+++ b/.windsurf/rules/quality/design-principles.md
@@ -15,7 +15,7 @@ takes precedence over speed, convenience, or Cascade's own preferences.
 ### 1. Standards Compliance
 
 - Use established specifications — never invent ad-hoc formats when standards
-  exist (SPDX, OmniBOR, OpenAPI, JSON Schema, semver, PURL, CPE, etc.)
+  exist (SPDX, Bisbom, OpenAPI, JSON Schema, semver, PURL, CPE, etc.)
 - When a standard covers your use case, adopt it fully — do not cherry-pick
   fields or invent extensions without documenting why
 

--- a/.windsurf/rules/quality/lang/c-cpp.md
+++ b/.windsurf/rules/quality/lang/c-cpp.md
@@ -79,7 +79,7 @@ description: C/C++-specific best practices, tooling, and conventions
 - **Test job**: `ctest --test-dir build --output-on-failure`
 - **Static analysis job**: `clang-tidy` on changed files
 
-## Release Builds (OmniBOR)
+## Release Builds (Bisbom)
 
 - `./configure` without `--enable-debug` or `CFLAGS="-g -O0"`
 - `make` with default optimization (typically `-O2`)

--- a/.windsurf/rules/quality/lang/go.md
+++ b/.windsurf/rules/quality/lang/go.md
@@ -64,7 +64,7 @@ description: Go-specific best practices, tooling, and conventions
 - **Test job**: `go test -race -coverprofile=coverage.out ./...`
 - **Race detector**: Always run tests with `-race` in CI
 
-## Release Builds (OmniBOR)
+## Release Builds (Bisbom)
 
 - Always include `-trimpath -ldflags="-s -w"` in `go build`
 - `-trimpath` strips local filesystem paths from the binary

--- a/.windsurf/rules/quality/lang/java.md
+++ b/.windsurf/rules/quality/lang/java.md
@@ -8,7 +8,7 @@ description: Java-specific best practices, tooling, and conventions
 
 - **Java version**: Target Java 17+ (LTS) unless the project requires older.
   Set `<maven.compiler.release>17</maven.compiler.release>` in pom.xml
-- **Build tool**: Maven (preferred for OmniBOR) or Gradle. Pin wrapper
+- **Build tool**: Maven (preferred for Bisbom) or Gradle. Pin wrapper
   versions (`mvnw`, `gradlew`)
 - **Layout**: Follow Maven standard directory layout:
   `src/main/java/`, `src/main/resources/`, `src/test/java/`
@@ -78,7 +78,7 @@ description: Java-specific best practices, tooling, and conventions
 - **Lint job**: `mvn checkstyle:check` or `mvn spotless:check`
 - **Test job**: `mvn test -B` (Surefire) + `mvn verify -B` (Failsafe for ITs)
 
-## Release Builds (OmniBOR)
+## Release Builds (Bisbom)
 
 - Always `mvn package -DskipTests` (skip test execution in release builds)
 - Standard Maven JAR packaging includes `target/classes/` only (main sources)

--- a/.windsurf/rules/quality/lang/rust.md
+++ b/.windsurf/rules/quality/lang/rust.md
@@ -63,7 +63,7 @@ description: Rust-specific best practices, tooling, and conventions
   `needs: check` to fail fast
 - **Warnings as errors**: `RUSTFLAGS: "-Dwarnings"` in the workflow env
 
-## Release Builds (OmniBOR)
+## Release Builds (Bisbom)
 
 - Always `cargo build --release` (never plain `cargo build`)
 - Output path must be `target/release/`, not `target/debug/`

--- a/.windsurf/rules/quality/writing-precision.md
+++ b/.windsurf/rules/quality/writing-precision.md
@@ -56,7 +56,7 @@ enterprise native-build team or a platform/security reviewer).
 <tr><td><strong>native build</strong></td><td>The customer's unmodified build: their source, build files (<code>Makefile</code>/<code>pom.xml</code>/etc.), compiler, build commands, and output binaries. This NEVER changes.</td></tr>
 <tr><td><strong>native build team</strong></td><td>The customer team that owns and runs the native build.</td></tr>
 <tr><td><strong>native build machine / CI runner</strong></td><td>The customer-controlled host/container where the native build executes.</td></tr>
-<tr><td><strong>platform team</strong></td><td>MUST be qualified. Usually the customer's own DevOps/platform team that does one-time setup. NEVER let it read as the OmniBOR vendor.</td></tr>
+<tr><td><strong>platform team</strong></td><td>MUST be qualified. Usually the customer's own DevOps/platform team that does one-time setup. NEVER let it read as the Bisbom vendor.</td></tr>
 <tr><td><strong>analysis harness / our image</strong></td><td>THIS repository's Docker image and pipeline. Distinct from the customer's CI build image. Never conflate the two.</td></tr>
 </tbody>
 </table>

--- a/.windsurf/rules/workflow/github-issue-management.md
+++ b/.windsurf/rules/workflow/github-issue-management.md
@@ -28,9 +28,9 @@ crosswalk mirrors the live board; it is never a stand-in for it.
   gh auth switch --user tedg_cisco
   ```
 
-- **PRs** live in `tedg-dev/omnibor-analysis` and use the `tedg-dev`
+- **PRs** live in `tedg-dev/bisbom-gen` and use the `tedg-dev`
   account. Always reference PRs cross-repo as
-  `tedg-dev/omnibor-analysis#<n>` — never a bare `#<n>`.
+  `tedg-dev/bisbom-gen#<n>` — never a bare `#<n>`.
 - **Project board:** Corona, project number `255`, node id
   `PVT_kwDOEFp5Ds4Bb7Wk`.
 - **Status field** id `PVTSSF_lADOEFp5Ds4Bb7WkzhWoAck`, single-select

--- a/.windsurf/workflows/add-repo.md
+++ b/.windsurf/workflows/add-repo.md
@@ -46,7 +46,7 @@ If this is a **new language** (not an existing one like c-cpp, rust, go, java),
 also create `.gitkeep` files under all output categories:
 
 ```bash
-for dir in binaries binary-scan build-logs omnibor runtime spdx; do
+for dir in binaries binary-scan build-logs bisbom runtime spdx; do
   touch output/$dir/<new-lang>/.gitkeep
 done
 git add output/**/<new-lang>/.gitkeep

--- a/.windsurf/workflows/browse-ec2-files.md
+++ b/.windsurf/workflows/browse-ec2-files.md
@@ -27,13 +27,13 @@ files in the `output/` directory.
 
 2. **Fix file ownership** (Docker creates files as root):
    ```bash
-   ssh ubuntu@<EC2_IP> "sudo chown -R ubuntu:ubuntu ~/omnibor-analysis/output/"
+   ssh ubuntu@<EC2_IP> "sudo chown -R ubuntu:ubuntu ~/bisbom-gen/output/"
    ```
 
 3. **Start filebrowser** on EC2 (port 8080, no auth, serving output/):
    ```bash
    ssh ubuntu@<EC2_IP> "pkill filebrowser 2>/dev/null; rm -f /tmp/filebrowser.db"
-   ssh ubuntu@<EC2_IP> "filebrowser config init -d /tmp/filebrowser.db -r /home/ubuntu/omnibor-analysis/output"
+   ssh ubuntu@<EC2_IP> "filebrowser config init -d /tmp/filebrowser.db -r /home/ubuntu/bisbom-gen/output"
    ssh ubuntu@<EC2_IP> "filebrowser users add admin adminadmin12 --perm.admin -d /tmp/filebrowser.db"
    ssh ubuntu@<EC2_IP> "nohup filebrowser -d /tmp/filebrowser.db -p 8080 -a 0.0.0.0 > /tmp/filebrowser.log 2>&1 &"
    ```

--- a/.windsurf/workflows/ec2-provision.md
+++ b/.windsurf/workflows/ec2-provision.md
@@ -70,7 +70,7 @@ ls -la ~/.ssh/id_ed25519.pub 2>/dev/null || echo "No SSH key found"
 If no key exists:
 
 ```bash
-ssh-keygen -t ed25519 -C "omnibor-build" -f ~/.ssh/id_ed25519 -N ""
+ssh-keygen -t ed25519 -C "bisbom-build" -f ~/.ssh/id_ed25519 -N ""
 ```
 
 ## 3. Create terraform.tfvars
@@ -128,7 +128,7 @@ Add SSH config entry. Determine the correct SSH key path for the platform:
 Add to `~/.ssh/config`:
 
 ```
-Host omnibor-build
+Host bisbom-build
     HostName <ELASTIC_IP>
     User ubuntu
     IdentityFile ~/.ssh/id_ed25519
@@ -140,7 +140,7 @@ Host omnibor-build
 Add to `~/.ssh/config` inside WSL (NOT the Windows `C:\Users\...\.ssh\config`):
 
 ```
-Host omnibor-build
+Host bisbom-build
     HostName <ELASTIC_IP>
     User ubuntu
     IdentityFile ~/.ssh/id_ed25519
@@ -150,13 +150,13 @@ Host omnibor-build
 Test connectivity:
 
 ```bash
-ssh -o ConnectTimeout=10 omnibor-build "echo SSH OK && uname -m"
+ssh -o ConnectTimeout=10 bisbom-build "echo SSH OK && uname -m"
 ```
 
 If port 22 is blocked (Cisco VPN), try port 443:
 
 ```bash
-ssh -p 443 -o ConnectTimeout=10 omnibor-build "echo SSH OK"
+ssh -p 443 -o ConnectTimeout=10 bisbom-build "echo SSH OK"
 ```
 
 If port 443 works, update `~/.ssh/config` to add `Port 443`.
@@ -184,13 +184,13 @@ The EC2 instance runs `user-data.sh` on first boot (~10-20 minutes).
 Check progress:
 
 ```bash
-ssh omnibor-build "tail -20 /var/log/cloud-init-output.log"
+ssh bisbom-build "tail -20 /var/log/cloud-init-output.log"
 ```
 
 If bootstrap is complete, verify Docker and bomtrace:
 
 ```bash
-ssh omnibor-build "docker --version && docker-compose --version"
+ssh bisbom-build "docker --version && docker-compose --version"
 ```
 
 If the repo clone failed during bootstrap (private repo), push code manually:
@@ -199,20 +199,20 @@ If the repo clone failed during bootstrap (private repo), push code manually:
 rsync -avz --exclude '.git' --exclude '__pycache__' --exclude '.venv' \
   --exclude 'output/' --exclude 'repos/' \
   --exclude 'terraform/.terraform/' --exclude 'terraform/terraform.tfstate*' \
-  -e ssh ./ omnibor-build:~/omnibor-analysis/
+  -e ssh ./ bisbom-build:~/bisbom-gen/
 ```
 
 Then build the Docker image:
 
 ```bash
-ssh omnibor-build "cd ~/omnibor-analysis && \
+ssh bisbom-build "cd ~/bisbom-gen && \
   docker-compose -f docker/docker-compose.yml build"
 ```
 
 ## 10. Run a test analysis
 
 ```bash
-ssh omnibor-build "cd ~/omnibor-analysis && \
+ssh bisbom-build "cd ~/bisbom-gen && \
   docker-compose -f docker/docker-compose.yml run --rm bisbom-env \
   python3 /workspace/app/analyze.py --list"
 ```

--- a/.windsurf/workflows/ec2-start.md
+++ b/.windsurf/workflows/ec2-start.md
@@ -18,7 +18,7 @@ Extract these values from the profile and use them in **all subsequent steps**:
 
 - **AWS_PROFILE** — the `AWS Profile` field (e.g. `ted-admin`)
 - **INSTANCE_ID** — the `Instance ID` field
-- **SSH_ALIAS** — the `SSH alias` field (e.g. `omnibor-build`)
+- **SSH_ALIAS** — the `SSH alias` field (e.g. `bisbom-build`)
 - **REPO_PATH** — the `Repo path on host` field
 
 **NEVER hardcode these values.** Always read them from the profile.
@@ -28,7 +28,7 @@ Extract these values from the profile and use them in **all subsequent steps**:
 // turbo
 ```bash
 aws ec2 describe-instances --profile <AWS_PROFILE> \
-  --filters "Name=tag:Name,Values=*omnibor*" \
+  --filters "Name=tag:Name,Values=*bisbom*" \
   --query "Reservations[].Instances[].{ID:InstanceId,State:State.Name,IP:PublicIpAddress,Name:Tags[?Key=='Name'].Value|[0]}" \
   --output table --no-cli-pager
 ```

--- a/.windsurf/workflows/first-time-setup.md
+++ b/.windsurf/workflows/first-time-setup.md
@@ -4,7 +4,7 @@ description: Complete first-time setup for a new contributor cloning this repo
 
 # First-Time Setup
 
-Run this workflow when you've just cloned the omnibor-analysis repository into
+Run this workflow when you've just cloned the bisbom-gen repository into
 a fresh Windsurf IDE installation and want to get everything working.
 
 ## 0. Read all project rules and workflows
@@ -133,8 +133,8 @@ If you have SSH access to any Linux x86_64 server with Docker:
 ```bash
 rsync -avz --exclude '.git' --exclude '__pycache__' --exclude '.venv' \
   --exclude 'output/' --exclude 'repos/' \
-  -e ssh ./ <YOUR_HOST>:~/omnibor-analysis/
-ssh <YOUR_HOST> "cd ~/omnibor-analysis && docker-compose -f docker/docker-compose.yml build"
+  -e ssh ./ <YOUR_HOST>:~/bisbom-gen/
+ssh <YOUR_HOST> "cd ~/bisbom-gen && docker-compose -f docker/docker-compose.yml build"
 ```
 
 ## 5. Verify container tools
@@ -160,7 +160,7 @@ docker-compose -f docker/docker-compose.yml run --rm bisbom-env \
 EC2:
 
 ```bash
-ssh omnibor-build "cd ~/omnibor-analysis && \
+ssh bisbom-build "cd ~/bisbom-gen && \
   docker-compose -f docker/docker-compose.yml run --rm bisbom-env \
   python3 /workspace/app/analyze.py --list"
 ```

--- a/.windsurf/workflows/github-init.md
+++ b/.windsurf/workflows/github-init.md
@@ -11,12 +11,12 @@ This is the **only** time a direct commit to `main` is permitted (see pr-workflo
 
 - The GitHub repository must already exist (created via github.com UI)
 - The remote repo should be **empty** (no README, no .gitignore, no license from GitHub)
-- You must know the GitHub org/user and repo name (e.g., `tedg-cisco/omnibor-analysis`)
+- You must know the GitHub org/user and repo name (e.g., `tedg-dev/bisbom-gen`)
 
 ## 1. Confirm with user before proceeding
 
 **Ask the user:**
-- What is the GitHub remote URL? (e.g., `https://github.com/tedg-cisco/omnibor-analysis.git`)
+- What is the GitHub remote URL? (e.g., `https://github.com/tedg-dev/bisbom-gen.git`)
 - Has the empty repo been created on GitHub?
 - Are they ready to make the initial commit?
 

--- a/.windsurf/workflows/run-analysis.md
+++ b/.windsurf/workflows/run-analysis.md
@@ -1,5 +1,5 @@
 ---
-description: Run OmniBOR build interception analysis on a target repository
+description: Run Bisbom build interception analysis on a target repository
 ---
 
 # Run Analysis
@@ -108,7 +108,7 @@ All generated artifacts (SBOMs, build-logs, runtime metrics) are under `output/`
 1. **Clone** — shallow clone of the target repo
 2. **Syft SBOM** — manifest-based baseline (go.mod/go.sum)
 4. **Instrumented build** — `bomtrace2 -c bomtrace_go.conf go build -a` (watches compile, link + openat)
-5a. **OmniBOR SPDX** — generated from ADG via bomsh_sbom.py
+5a. **Bisbom SPDX** — generated from ADG via bomsh_sbom.py
 5b. **Metadata collection** — component metadata
 5c. **ADG SPDX** — per-binary SPDX + HTML visualization
 6. **SPDX validation** — JSON Schema + semantic validation
@@ -123,10 +123,10 @@ The `<ts>` timestamp is generated once per run and shared across all output type
 
 | Artifact | Path |
 |----------|------|
-| OmniBOR ADG | `output/omnibor/<lang>/<repo>/<ts>/` |
-| Component metadata | `output/omnibor/<lang>/<repo>/<ts>/metadata/component_metadata.json` |
-| Dynamic libs (per binary) | `output/omnibor/<lang>/<repo>/<ts>/metadata/<binary>/dynamic_libs.json` |
-| SPDX SBOM (OmniBOR) | `output/spdx/<lang>/<repo>/<ts>/<repo>_omnibor.spdx.json` |
+| Bisbom ADG | `output/bisbom/<lang>/<repo>/<ts>/` |
+| Component metadata | `output/bisbom/<lang>/<repo>/<ts>/metadata/component_metadata.json` |
+| Dynamic libs (per binary) | `output/bisbom/<lang>/<repo>/<ts>/metadata/<binary>/dynamic_libs.json` |
+| SPDX SBOM (Bisbom) | `output/spdx/<lang>/<repo>/<ts>/<repo>_bisbom.spdx.json` |
 | SPDX SBOM (ADG, per binary) | `output/spdx/<lang>/<repo>/<ts>/<binary>_adg.spdx.json` |
 | Visualization (per binary) | `output/spdx/<lang>/<repo>/<ts>/<binary>_adg.spdx.html` |
 | SPDX SBOM (Syft) | `output/spdx/<lang>/<repo>/<ts>/<repo>_syft.spdx.json` |

--- a/.windsurf/workflows/run-comparison.md
+++ b/.windsurf/workflows/run-comparison.md
@@ -1,10 +1,10 @@
 ---
-description: Compare OmniBOR SPDX SBOM against proprietary binary scan SBOM
+description: Compare Bisbom SPDX SBOM against proprietary binary scan SBOM
 ---
 
 # Run Comparison
 
-Compare an OmniBOR-generated SPDX SBOM against a proprietary binary scanner SPDX SBOM.
+Compare an Bisbom-generated SPDX SBOM against a proprietary binary scanner SPDX SBOM.
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ Or specify files explicitly:
 ```bash
 docker-compose -f docker/docker-compose.yml run --rm bisbom-env python3 /workspace/app/compare.py \
   --repo curl \
-  --bisbom-file /workspace/output/spdx/curl/curl_omnibor_2026-02-10_1430.spdx.json \
+  --bisbom-file /workspace/output/spdx/curl/curl_bisbom_2026-02-10_1430.spdx.json \
   --binary-file /workspace/output/binary-scan/curl/bdba_export.spdx.json
 ```
 

--- a/.windsurf/workflows/setup-environment.md
+++ b/.windsurf/workflows/setup-environment.md
@@ -1,10 +1,10 @@
 ---
-description: Run on every startup to verify the omnibor-analysis environment is ready
+description: Run on every startup to verify the bisbom-gen environment is ready
 ---
 
 # Setup Environment
 
-Run this workflow when opening the omnibor-analysis workspace.
+Run this workflow when opening the bisbom-gen workspace.
 
 ## 0. MANDATORY: Review all project rules
 

--- a/app/pipeline/builder.py
+++ b/app/pipeline/builder.py
@@ -42,7 +42,7 @@ class BomtraceBuilder:
 
     Works for both C/C++ (bomtrace3) and Go (bomtrace2 with
     Go-specific bomtrace.conf).  The tracer binary is specified
-    in the omnibor config section passed to build().
+    in the bisbom config section passed to build().
     """
 
     def __init__(self, runner=None):
@@ -72,7 +72,7 @@ class BomtraceBuilder:
 
     def build(
         self, repo_name, repo_cfg,
-        paths_cfg, omnibor_cfg,
+        paths_cfg, bisbom_cfg,
         run_ts=None, strategy=None,
     ):
         """Run pre-build steps, instrumented build, and ADG generation.
@@ -150,7 +150,7 @@ class BomtraceBuilder:
                 )
             )
         else:
-            tracer = omnibor_cfg["tracer"]
+            tracer = bisbom_cfg["tracer"]
             instrumented = f"{tracer} {make_cmd}"
             env = None
 
@@ -180,14 +180,14 @@ class BomtraceBuilder:
                 adg_ok = bool(
                     strategy.generate_adg(
                         str(repo_dir), str(bom_dir),
-                        omnibor_cfg,
+                        bisbom_cfg,
                     )
                 )
             else:
                 create_bom = (
-                    omnibor_cfg["create_bom_script"]
+                    bisbom_cfg["create_bom_script"]
                 )
-                raw_logfile = omnibor_cfg["raw_logfile"]
+                raw_logfile = bisbom_cfg["raw_logfile"]
                 rc = self.runner.run(
                     f"{create_bom} -r {raw_logfile} "
                     f"-b {bom_dir}",
@@ -296,7 +296,7 @@ class BomtraceBuilder:
 
     def build_java(
         self, repo_name, repo_cfg,
-        paths_cfg, omnibor_java_cfg,
+        paths_cfg, bisbom_java_cfg,
         run_ts=None,
     ):
         """Run Java build with strace, then bomsh_create_bom_java.py.
@@ -326,9 +326,9 @@ class BomtraceBuilder:
         # clean/build subprocess runs).
         self._apply_java_home(repo_cfg)
 
-        strace_opts = omnibor_java_cfg["strace_opts"]
-        strace_log = omnibor_java_cfg["strace_logfile"]
-        create_bom = omnibor_java_cfg["create_bom_script"]
+        strace_opts = bisbom_java_cfg["strace_opts"]
+        strace_log = bisbom_java_cfg["strace_logfile"]
+        create_bom = bisbom_java_cfg["create_bom_script"]
 
         # --- Phase 1a: Clean ---
         clean_cmd = repo_cfg.get("clean_cmd")

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -523,7 +523,7 @@ def _run_phase2_only(
 
     # Use manifest values, fall back to CLI args
     m_repo_cfg = manifest.get("repo_cfg", {})
-    m_omnibor = manifest.get(
+    m_bisbom = manifest.get(
         "bisbom_cfg", bisbom_cfg,
     )
     m_vcs = manifest.get("vcs_uri", vcs_uri)
@@ -537,7 +537,7 @@ def _run_phase2_only(
 
     phase2_steps = run_java_phase2(
         pipeline, repo_name, m_repo_cfg,
-        paths_cfg, m_omnibor, m_ts,
+        paths_cfg, m_bisbom, m_ts,
         vcs_uri=m_vcs,
         commit_sha=m_commit,
         mode=m_mode,

--- a/app/pipeline/spdx_generator.py
+++ b/app/pipeline/spdx_generator.py
@@ -313,7 +313,7 @@ class SpdxGenerator:
 
     def generate(
         self, repo_name, repo_cfg,
-        paths_cfg, omnibor_cfg,
+        paths_cfg, bisbom_cfg,
         run_ts=None,
         vcs_uri=None,
     ):
@@ -357,7 +357,7 @@ class SpdxGenerator:
             return None
 
         files_arg = ",".join(artifact_paths)
-        sbom_script = omnibor_cfg["sbom_script"]
+        sbom_script = bisbom_cfg["sbom_script"]
 
         rc = self.runner.run(
             f"{sbom_script} "
@@ -453,7 +453,7 @@ class SpdxGenerator:
 
     def generate_java(
         self, repo_name, repo_cfg,
-        paths_cfg, omnibor_java_cfg,
+        paths_cfg, bisbom_java_cfg,
         run_ts=None,
     ):
         """Generate SPDX SBOM for Java from bomsh_create_bom_java.py output.

--- a/docker/patches/README-bomsh_java_sourcefile.md
+++ b/docker/patches/README-bomsh_java_sourcefile.md
@@ -3,7 +3,7 @@
 **File:** `scripts/bomsh_create_bom_java.py`
 **Upstream repo:** [omnibor/bomsh](https://github.com/omnibor/bomsh)
 **Date:** 2026-03-26
-**Author:** bisbom-gen project (tedg-dev/omnibor-analysis)
+**Author:** bisbom-gen project (tedg-dev/bisbom-gen)
 
 ## Bug Description
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Runtime Python dependencies for omnibor-analysis app scripts.
+# Runtime Python dependencies for bisbom-gen app scripts.
 # Used by BOTH the Docker container and local development.
 # Keep in sync: Dockerfile installs this file, local .venv installs this file.
 PyYAML==6.0.3

--- a/scripts/run_all_java_sidecar.sh
+++ b/scripts/run_all_java_sidecar.sh
@@ -3,7 +3,7 @@
 # logging each to /tmp/jval/<repo>.log. Each repo runs in its own
 # ephemeral --rm container, so /tmp treedb cannot cross-contaminate.
 set -uo pipefail
-cd /home/ubuntu/omnibor-analysis
+cd /home/ubuntu/bisbom-gen
 
 REPOS="${*:-bc-java checkstyle crawler4j dependency-check jsoup logging-log4j2 spring-boot}"
 mkdir -p /tmp/jval

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -22,5 +22,5 @@ aws_profile = "your-profile-name"
 # Path to your SSH public key
 # ssh_public_key_path = "~/.ssh/id_ed25519.pub"
 
-# Git URL for the omnibor-analysis repository
-# repo_url = "https://github.com/tedg-dev/omnibor-analysis.git"
+# Git URL for the bisbom-gen repository
+# repo_url = "https://github.com/tedg-dev/bisbom-gen.git"

--- a/terraform/user-data.sh
+++ b/terraform/user-data.sh
@@ -18,7 +18,7 @@ echo "=== OmniBOR build host bootstrap starting ==="
 # Cisco VPN blocks port 22 to AWS IPs. Use a drop-in config file
 # to avoid conflicting with the default sshd_config.
 mkdir -p /etc/ssh/sshd_config.d
-cat > /etc/ssh/sshd_config.d/omnibor-ports.conf <<'EOF'
+cat > /etc/ssh/sshd_config.d/bisbom-ports.conf <<'EOF'
 # Listen on both 22 (off-VPN) and 443 (on Cisco VPN)
 Port 22
 Port 443
@@ -45,15 +45,15 @@ chmod +x /usr/local/bin/docker-compose
 # --- Install git and build essentials ---
 apt-get install -y git rsync
 
-# --- Clone omnibor-analysis repo ---
+# --- Clone bisbom-gen repo ---
 # If the repo is private, clone will fail here. User can clone manually via SSH.
-if sudo -u ubuntu git clone ${repo_url} /home/ubuntu/omnibor-analysis 2>/dev/null; then
+if sudo -u ubuntu git clone ${repo_url} /home/ubuntu/bisbom-gen 2>/dev/null; then
   echo "=== Repo cloned, building Docker image ==="
-  cd /home/ubuntu/omnibor-analysis
+  cd /home/ubuntu/bisbom-gen
   sudo -u ubuntu docker-compose -f docker/docker-compose.yml build
 else
   echo "=== Repo clone failed (private repo?) — user must clone manually ==="
-  echo "=== SSH in and run: git clone <repo_url> ~/omnibor-analysis ==="
+  echo "=== SSH in and run: git clone <repo_url> ~/bisbom-gen ==="
 fi
 
 echo "=== OmniBOR build host bootstrap complete ==="

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,7 +17,7 @@ variable "aws_region" {
 variable "project_name" {
   description = "Project name used for resource naming and tagging"
   type        = string
-  default     = "omnibor"
+  default     = "bisbom"
 }
 
 variable "instance_type" {
@@ -45,7 +45,7 @@ variable "ssh_public_key_path" {
 }
 
 variable "repo_url" {
-  description = "Git URL for omnibor-analysis repository (HTTPS or SSH)"
+  description = "Git URL for bisbom-gen repository (HTTPS or SSH)"
   type        = string
-  default     = "https://github.com/tedg-dev/omnibor-analysis.git"
+  default     = "https://github.com/tedg-dev/bisbom-gen.git"
 }

--- a/tests/test_java_pipeline.py
+++ b/tests/test_java_pipeline.py
@@ -45,12 +45,12 @@ class TestRunJavaPipeline(unittest.TestCase):
             "language": "java",
             "url": "https://github.com/test/test.git",
         }
-        omnibor_java_cfg = {
+        bisbom_java_cfg = {
             "strace_opts": "-f",
             "create_bom_script": "bomsh_bom_java.py",
             "strace_logfile": "/tmp/strace.log",
         }
-        return paths_cfg, repo_cfg, omnibor_java_cfg
+        return paths_cfg, repo_cfg, bisbom_java_cfg
 
     @patch(
         "app.pipeline.lang_runners.generate_java_adg_spdx"

--- a/tests/test_phase_isolation.py
+++ b/tests/test_phase_isolation.py
@@ -58,12 +58,12 @@ def _make_cfg(td):
         "build_steps": ["mvn package -DskipTests -q"],
         "output_binaries": ["**/target/*.jar"],
     }
-    omnibor_cfg = {
+    bisbom_cfg = {
         "strace_opts": "-f",
         "create_bom_script": "bomsh_bom_java.py",
         "strace_logfile": "/tmp/strace.log",
     }
-    return paths_cfg, repo_cfg, omnibor_cfg
+    return paths_cfg, repo_cfg, bisbom_cfg
 
 
 # ── _validate_phase_args ─────────────────────────────────


### PR DESCRIPTION
## Summary

Stage B/C of the `omnibor` -> `bisbom` renaming/reorganization, in
preparation for the migration to the `CiscoSecurityServices` GitHub org.
OmniBOR (the standard and the `omnibor/bomsh` tooling) is still used —
only project/product identifiers are renamed. Load-bearing external
identifiers are preserved: `bomsh_omnibor_*`, the `.omnibor` ADG dir,
`OMNIBOR_*` env vars, and the `omnibor/bomsh` upstream repo.

### Stage B — app/ + docker/ + .windsurf/

- Renamed product-internal config params: `omnibor_cfg` -> `bisbom_cfg`,
  `omnibor_java_cfg` -> `bisbom_java_cfg` (builder, spdx_generator);
  manifest `m_omnibor` -> `m_bisbom` (runners).
- Fixed docker patch README attribution (`omnibor-analysis` ->
  `bisbom-gen`).
- Token-aware rename of `.windsurf` rules/workflows, preserving
  load-bearing tokens; restored the historical `omnibor` references in
  the golden-file rebrand-exception section.

### Stage C — hardcoded-ref sweep

- `requirements.txt`, `scripts/`, and `terraform/` (`project_name`
  default `omnibor` -> `bisbom`, `repo_url` default -> `bisbom-gen`).

## Output neutrality

Pure identifier/documentation renames; SPDX output is unchanged. The
golden comparison normalization (`omnibor` <-> `bisbom`) is already in
place, so pre-rename goldens compare equal.

## Tests

flake8 clean; full suite 1890 passed; coverage 99%.
