### PR TITLE
fix(config): pin nmap and testapp to golden-baseline commits

### DIFF
--- a/app/config.yaml
+++ b/app/config.yaml
@@ -67,7 +67,7 @@ repos:
     - yasm
   nmap:
     url: https://github.com/nmap/nmap.git
-    branch: 508531ed5904c2382ad25e908b75adc1374baaee  # nmap has no release tags; pinned to a commit SHA (upstream-pinning policy)
+    branch: 8f0ebd84ad3b211d9f25f47d69fb81da722b38c1  # nmap has no release tags; pinned to the golden-baseline commit (upstream-pinning policy)
     language: c-cpp
     build_profile:
       tool: autotools
@@ -393,7 +393,7 @@ repos:
     - '**/build/libs/*.jar'
   bisbom-java-testapp:
     url: https://github.com/tedg-dev/bisbom-java-testapp.git
-    branch: 44849358dcedc486620eb3cdd78afe147f596c0d  # our testapp has no release tags; pinned to a commit SHA
+    branch: 93058e537cb8c6b0a32f20f761aaf87822626355  # our testapp has no release tags; pinned to the golden-baseline commit
     language: java
     build_profile:
       tool: maven


### PR DESCRIPTION
## Summary

Corrects the repo pins introduced in #226, which pinned `nmap` and
`bisbom-java-testapp` to today's branch HEAD. The correct reference is
the commit each golden SPDX was generated from (recovered from the
golden `downloadLocation`).

- `nmap`: `508531e` (master HEAD) -> `8f0ebd84` (golden baseline)
- `bisbom-java-testapp`: `4484935` (main HEAD) -> `93058e5` (golden
  baseline)

## Why

`nmap` was previously unpinned (tracked `master`), so its source drifted
after the golden was baselined. Pinning to HEAD captured the drifted
source; EC2 golden validation showed added/removed files and changed
checksums. Pinning to the golden commit eliminates the drift.

## Validation (EC2 run, compared locally)

With `nmap @ 8f0ebd84`:

- Packages / Files (404) / Relationships: identical to golden.
- Source content byte-identical: `git hash-object FPEngine.cc` equals
  the golden's stored gitoid.
- Residual golden diffs are pre-existing and environmental only:
  checksum representation (`gitoid` -> raw `SHA1` + added `SHA256`) and
  three apt package versions (`libc6`, `libgcrypt20`, `liblzma5`). No
  golden files were modified.

Config-only change; no code paths affected.
